### PR TITLE
Card fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ output.log
 quality_output.log
 test_output.log
 .vscode
+.omx
+output

--- a/apps/app/.storybook/preview-head.html
+++ b/apps/app/.storybook/preview-head.html
@@ -1,0 +1,2 @@
+<!-- Keep Storybook iframe checks quiet when the app favicon is not served in dev. -->
+<link rel="icon" href="data:," />

--- a/apps/app/src/integrations/trpc/services.ts
+++ b/apps/app/src/integrations/trpc/services.ts
@@ -1,17 +1,34 @@
-import { serviceFactory } from "@repo/services";
+import { db } from "@repo/db";
+import {
+  createBestPracticesBulkService,
+  createBestPracticesService,
+  createChecklistService,
+  createCodeSnippetsService,
+  createDistillationsService,
+  createGithubProjectsService,
+  createJobsService,
+  createOperationsService,
+  createPipelineRunnerService,
+  createPipelinesService,
+  createRecipesService,
+  createRefinementsService,
+  createRulesService,
+  createSettingsService,
+  createSkillsService,
+} from "@repo/services";
 
-export const bestPracticesService = serviceFactory.createBestPracticesService();
-export const bestPracticesBulkService = serviceFactory.createBestPracticesBulkService();
-export const checklistService = serviceFactory.createChecklistService();
-export const codeSnippetsService = serviceFactory.createCodeSnippetsService();
-export const distillationsService = serviceFactory.createDistillationsService();
-export const githubProjectsService = serviceFactory.createGithubProjectsService();
-export const jobsService = serviceFactory.createJobsService();
-export const operationsService = serviceFactory.createOperationsService();
-export const pipelinesService = serviceFactory.createPipelinesService();
-export const pipelineRunnerService = serviceFactory.createPipelineRunnerService();
-export const recipesService = serviceFactory.createRecipesService();
-export const refinementsService = serviceFactory.createRefinementsService();
-export const rulesService = serviceFactory.createRulesService();
-export const settingsService = serviceFactory.createSettingsService();
-export const skillsService = serviceFactory.createSkillsService();
+export const bestPracticesService = createBestPracticesService(db);
+export const bestPracticesBulkService = createBestPracticesBulkService(db);
+export const checklistService = createChecklistService(db);
+export const codeSnippetsService = createCodeSnippetsService(db);
+export const distillationsService = createDistillationsService(db);
+export const githubProjectsService = createGithubProjectsService(db);
+export const jobsService = createJobsService(db);
+export const operationsService = createOperationsService(db);
+export const pipelinesService = createPipelinesService(db);
+export const pipelineRunnerService = createPipelineRunnerService(db);
+export const recipesService = createRecipesService(db);
+export const refinementsService = createRefinementsService(db);
+export const rulesService = createRulesService(db);
+export const settingsService = createSettingsService(db);
+export const skillsService = createSkillsService(db);

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.stories.tsx
@@ -1,13 +1,73 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Box, Wand2, ShieldCheck, LogOut } from "lucide-react";
-import { NodeCard } from "./NodeCard";
+import {
+  Box,
+  CircleCheck,
+  CircleX,
+  Clock,
+  GitBranch,
+  LoaderCircle,
+  LogOut,
+  ShieldCheck,
+  Terminal,
+  Wand2,
+} from "lucide-react";
+import { useState } from "react";
+import { NodeCard, type NodeTheme } from "./NodeCard";
+
+const passBadge = <span className="text-[10px] font-medium text-green-500">Pass</span>;
+const queuedBadge = <span className="text-[10px] font-medium text-gray-500">Queued</span>;
+
+const sampleBody = (
+  <>
+    <div className="flex items-center justify-between text-[10px] text-gray-500">
+      <span>Checks</span>
+      <span>3 rules</span>
+    </div>
+    <div className="h-1.5 overflow-hidden rounded-full bg-gray-100">
+      <div className="h-full w-2/3 rounded-full bg-emerald-400" />
+    </div>
+    <p className="text-[10px] leading-relaxed text-gray-500">
+      Runs format, lint, and focused tests before continuing.
+    </p>
+  </>
+);
+
+const themeCases: Array<{ icon: React.ElementType; label: string; theme: NodeTheme }> = [
+  { icon: Box, label: "Input", theme: "emerald" },
+  { icon: Wand2, label: "Skill", theme: "violet" },
+  { icon: ShieldCheck, label: "Condition", theme: "amber" },
+  { icon: LogOut, label: "Output", theme: "sky" },
+  { icon: GitBranch, label: "Branch", theme: "orange" },
+  { icon: Terminal, label: "Command", theme: "teal" },
+  { icon: Clock, label: "Schedule", theme: "indigo" },
+];
 
 const meta: Meta<typeof NodeCard> = {
   title: "HarnessCanvas/NodeCard",
   component: NodeCard,
+  tags: ["autodocs"],
   args: {
     icon: Box,
     label: "Example Node",
+    theme: "emerald",
+  },
+  argTypes: {
+    runStatus: {
+      control: "select",
+      options: [undefined, "running", "pass", "fail"],
+    },
+    theme: {
+      control: "select",
+      options: ["emerald", "violet", "amber", "sky", "orange", "teal", "indigo"],
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Canvas node card used inside pipeline graphs. Use these stories to check header alignment, truncation, body spacing, theme colors, selection, run status, and dimmed states before validating the full canvas.",
+      },
+    },
   },
 };
 
@@ -16,61 +76,263 @@ type Story = StoryObj<typeof NodeCard>;
 
 export const Default: Story = {
   args: {},
+  parameters: {
+    docs: {
+      description: {
+        story: "Baseline card with only icon, label, theme, and the rectangular header band.",
+      },
+    },
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    description: "Reads source files and emits a typed snapshot.",
+    icon: Wand2,
+    label: "Source Scanner",
+    theme: "violet",
+  },
+};
+
+export const LongLabel: Story = {
+  args: {
+    description: "Long description should remain readable without destroying layout",
+    headerRight: passBadge,
+    icon: Wand2,
+    label: "Very Long Node Name That Should Not Break The Card Layout",
+    theme: "violet",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Stress case for long titles, long descriptions, and right-side header content.",
+      },
+    },
+  },
+};
+
+export const LongDescription: Story = {
+  args: {
+    description:
+      "This description is intentionally verbose so truncation and vertical centering can be checked at the card boundary.",
+    headerRight: queuedBadge,
+    icon: Terminal,
+    label: "Command Runner",
+    theme: "teal",
+  },
 };
 
 export const Emerald: Story = {
-  args: { theme: "emerald", icon: Box, label: "Input Node" },
+  args: { icon: Box, label: "Input Node", theme: "emerald" },
 };
 
 export const Violet: Story = {
-  args: { theme: "violet", icon: Wand2, label: "Skill Node" },
+  args: { icon: Wand2, label: "Skill Node", theme: "violet" },
 };
 
 export const Amber: Story = {
-  args: { theme: "amber", icon: ShieldCheck, label: "Condition Node" },
+  args: { icon: ShieldCheck, label: "Condition Node", theme: "amber" },
 };
 
 export const Sky: Story = {
-  args: { theme: "sky", icon: LogOut, label: "Output Node" },
+  args: { icon: LogOut, label: "Output Node", theme: "sky" },
 };
 
 export const Selected: Story = {
   args: {
-    theme: "violet",
     icon: Wand2,
     label: "Selected Node",
     selected: true,
+    theme: "violet",
   },
 };
 
 export const WithBody: Story = {
   args: {
-    theme: "emerald",
+    bodyClassName: "space-y-2",
+    children: sampleBody,
     icon: Box,
     label: "Node with Body",
-    bodyClassName: "space-y-2",
-    children: (
-      <p className="text-xs leading-relaxed text-gray-600">Some context description here.</p>
-    ),
+    theme: "emerald",
   },
 };
 
 export const WithHeaderRight: Story = {
   args: {
-    theme: "violet",
+    headerRight: passBadge,
     icon: Wand2,
     label: "Node with Status",
-    headerRight: <span className="text-[10px] font-medium text-green-500">✓ Pass</span>,
+    theme: "violet",
+  },
+};
+
+export const EditableLabel: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Interactive case for inline title editing through the onLabelChange callback.",
+      },
+    },
+  },
+  render: () => {
+    const [label, setLabel] = useState("Editable Node");
+    const handleLabelChange = (value: string) => setLabel(value);
+
+    return (
+      <NodeCard
+        description="Click the title and type."
+        headerRight={queuedBadge}
+        icon={Terminal}
+        label={label}
+        theme="teal"
+        onLabelChange={handleLabelChange}
+      />
+    );
+  },
+};
+
+export const Running: Story = {
+  args: {
+    description: "Executing pipeline checks.",
+    headerRight: <LoaderCircle className="h-3.5 w-3.5 animate-spin text-blue-500" />,
+    icon: Terminal,
+    label: "Running Node",
+    runStatus: "running",
+    theme: "sky",
+  },
+};
+
+export const Passed: Story = {
+  args: {
+    description: "All checks completed.",
+    headerRight: <CircleCheck className="h-3.5 w-3.5 text-green-500" />,
+    icon: ShieldCheck,
+    label: "Passed Node",
+    runStatus: "pass",
+    theme: "emerald",
+  },
+};
+
+export const Failed: Story = {
+  args: {
+    description: "One check needs attention.",
+    headerRight: <CircleX className="h-3.5 w-3.5 text-red-500" />,
+    icon: ShieldCheck,
+    label: "Failed Node",
+    runStatus: "fail",
+    theme: "amber",
+  },
+};
+
+export const Dimmed: Story = {
+  args: {
+    description: "Disabled while another branch runs.",
+    dimmed: true,
+    headerRight: queuedBadge,
+    icon: GitBranch,
+    label: "Dimmed Node",
+    theme: "orange",
   },
 };
 
 export const AllThemes: Story = {
   render: () => (
     <div className="flex flex-wrap gap-4 p-4">
-      <NodeCard theme="emerald" icon={Box} label="Input" />
-      <NodeCard theme="violet" icon={Wand2} label="Skill" />
-      <NodeCard theme="amber" icon={ShieldCheck} label="Condition" />
-      <NodeCard theme="sky" icon={LogOut} label="Output" />
+      {themeCases.map(({ icon, label, theme }) => (
+        <NodeCard key={theme} icon={icon} label={label} theme={theme} />
+      ))}
+    </div>
+  ),
+};
+
+export const ContentMatrix: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Compact visual matrix for checking header-only, description, long content, body, selected, and dimmed variants together.",
+      },
+    },
+  },
+  render: () => (
+    <div className="grid max-w-5xl grid-cols-[repeat(auto-fit,minmax(18rem,18rem))] gap-4 p-4">
+      <NodeCard icon={Box} label="Header Only" theme="emerald" />
+      <NodeCard
+        description="Single-line description."
+        icon={Wand2}
+        label="With Description"
+        theme="violet"
+      />
+      <NodeCard
+        description="Long description should truncate cleanly inside the rectangular band."
+        headerRight={passBadge}
+        icon={Terminal}
+        label="Very Long Node Name That Should Not Break The Header"
+        theme="teal"
+      />
+      <NodeCard bodyClassName="space-y-2" icon={ShieldCheck} label="With Body" theme="amber">
+        {sampleBody}
+      </NodeCard>
+      <NodeCard
+        selected
+        description="Selected item in the canvas."
+        icon={GitBranch}
+        label="Selected"
+        theme="orange"
+      />
+      <NodeCard
+        dimmed
+        description="Unavailable during execution."
+        headerRight={queuedBadge}
+        icon={Clock}
+        label="Dimmed"
+        theme="indigo"
+      />
+    </div>
+  ),
+};
+
+export const RunStatusMatrix: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Run-state matrix covering queued, running, pass, and fail visual treatments.",
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-wrap gap-4 p-4">
+      <NodeCard
+        description="Waiting for execution."
+        headerRight={queuedBadge}
+        icon={Clock}
+        label="Queued"
+        theme="indigo"
+      />
+      <NodeCard
+        description="Pipeline is running."
+        headerRight={<LoaderCircle className="h-3.5 w-3.5 animate-spin text-blue-500" />}
+        icon={Terminal}
+        label="Running"
+        runStatus="running"
+        theme="sky"
+      />
+      <NodeCard
+        description="All checks passed."
+        headerRight={<CircleCheck className="h-3.5 w-3.5 text-green-500" />}
+        icon={ShieldCheck}
+        label="Passed"
+        runStatus="pass"
+        theme="emerald"
+      />
+      <NodeCard
+        description="Fix required."
+        headerRight={<CircleX className="h-3.5 w-3.5 text-red-500" />}
+        icon={ShieldCheck}
+        label="Failed"
+        runStatus="fail"
+        theme="amber"
+      />
     </div>
   ),
 };

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
@@ -107,7 +107,7 @@ export const NodeCard = ({
   return (
     <Card
       className={cn(
-        "transition-all duration-200",
+        "w-72 shrink-0 gap-0 py-0 transition-all duration-200 data-[size=sm]:gap-0 data-[size=sm]:py-0",
         selected ? cn("ring-2 shadow-lg", t.ringSelected) : cn("ring-1 hover:ring-2", t.ring),
         runStatus === "running" &&
           "ring-2 ring-blue-500 shadow-[0_0_12px_rgba(59,130,246,0.4)] animate-pulse",
@@ -117,32 +117,36 @@ export const NodeCard = ({
       )}
       size="sm"
     >
-      <CardHeader className={cn("pb-2", t.headerBg)}>
-        <div className="flex items-center gap-2">
+      <CardHeader className={cn("flex min-h-14 items-center rounded-none px-3 py-2", t.headerBg)}>
+        <div className="flex w-full min-w-0 items-center gap-3">
           <div
-            className={cn("flex h-7 w-7 shrink-0 items-center justify-center rounded-md", t.iconBg)}
+            className={cn("flex h-8 w-8 shrink-0 items-center justify-center rounded-md", t.iconBg)}
           >
             <Icon className={cn("h-4 w-4", t.iconColor)} />
           </div>
-          <div className="flex flex-col flex-1 min-w-0">
+          <div className="flex min-h-8 flex-1 min-w-0 flex-col justify-center">
             {handleChange ? (
               <input
-                className="nodrag nopan bg-transparent text-xs font-semibold w-full focus:outline-none"
+                className="nodrag nopan w-full bg-transparent text-xs font-semibold leading-tight focus:outline-none"
                 value={label}
                 onChange={handleChange}
                 onMouseDown={handleMouseDown}
               />
             ) : (
-              <CardTitle className="text-xs font-semibold truncate">{label}</CardTitle>
+              <CardTitle className="truncate text-xs font-semibold leading-tight">
+                {label}
+              </CardTitle>
             )}
             {description && (
-              <CardDescription className="text-[10px] truncate">{description}</CardDescription>
+              <CardDescription className="truncate text-[10px] leading-tight">
+                {description}
+              </CardDescription>
             )}
           </div>
-          {headerRight && <CardAction>{headerRight}</CardAction>}
+          {headerRight && <CardAction className="shrink-0 self-center">{headerRight}</CardAction>}
         </div>
       </CardHeader>
-      {children && <CardContent className={cn("pt-0", bodyClassName)}>{children}</CardContent>}
+      {children && <CardContent className={cn("px-3 py-3", bodyClassName)}>{children}</CardContent>}
     </Card>
   );
 };

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
@@ -29,6 +29,32 @@ describe("NodeCard", () => {
     expect(screen.getByText("Status")).toBeInTheDocument();
   });
 
+  it("keeps header affordances visible for long labels", () => {
+    const { container } = render(
+      <NodeCard
+        description="Long description should remain readable without destroying layout"
+        headerRight={<span>Status</span>}
+        icon={Box}
+        label="Very Long Node Name That Should Not Break The Card Layout"
+        theme="violet"
+      />
+    );
+
+    expect(container.firstChild).toHaveClass("w-72", "data-[size=sm]:py-0");
+    expect(container.querySelector('[data-slot="card-header"] > div')).toHaveClass(
+      "w-full",
+      "min-w-0"
+    );
+    expect(container.querySelector('[data-slot="card-header"]')).toHaveClass(
+      "min-h-14",
+      "rounded-none"
+    );
+    expect(container.querySelector('[data-slot="card-action"]')).toHaveClass(
+      "shrink-0",
+      "self-center"
+    );
+  });
+
   it("applies selected ring for each theme", () => {
     const { container, rerender } = render(
       <NodeCard selected icon={Box} label="Node" theme="emerald" />

--- a/apps/server/src/services.ts
+++ b/apps/server/src/services.ts
@@ -1,16 +1,31 @@
-import { serviceFactory, listDirectory } from "@repo/services";
+import { db } from "@repo/db";
+import {
+  createBestPracticesBulkService,
+  createBestPracticesService,
+  createChecklistService,
+  createCodeSnippetsService,
+  createDistillationsService,
+  createJobsService,
+  createOperationsService,
+  createPipelineRunnerService,
+  createPipelinesService,
+  createRecipesService,
+  createRulesService,
+  createSkillsService,
+  listDirectory,
+} from "@repo/services";
 
-export const bestPracticesService = serviceFactory.createBestPracticesService();
-export const bestPracticesBulkService = serviceFactory.createBestPracticesBulkService();
-export const checklistService = serviceFactory.createChecklistService();
-export const codeSnippetsService = serviceFactory.createCodeSnippetsService();
-export const distillationsService = serviceFactory.createDistillationsService();
-export const jobsService = serviceFactory.createJobsService();
-export const operationsService = serviceFactory.createOperationsService();
-export const pipelinesService = serviceFactory.createPipelinesService();
-export const pipelineRunnerService = serviceFactory.createPipelineRunnerService();
-export const recipesService = serviceFactory.createRecipesService();
-export const rulesService = serviceFactory.createRulesService();
-export const skillsService = serviceFactory.createSkillsService();
+export const bestPracticesService = createBestPracticesService(db);
+export const bestPracticesBulkService = createBestPracticesBulkService(db);
+export const checklistService = createChecklistService(db);
+export const codeSnippetsService = createCodeSnippetsService(db);
+export const distillationsService = createDistillationsService(db);
+export const jobsService = createJobsService(db);
+export const operationsService = createOperationsService(db);
+export const pipelinesService = createPipelinesService(db);
+export const pipelineRunnerService = createPipelineRunnerService(db);
+export const recipesService = createRecipesService(db);
+export const rulesService = createRulesService(db);
+export const skillsService = createSkillsService(db);
 
 export { listDirectory };

--- a/packages/agent/src/claude/runClaude.ts
+++ b/packages/agent/src/claude/runClaude.ts
@@ -175,8 +175,15 @@ export const runClaude = async ({
     const events: ClaudeStreamEvent[] = [];
     const streamState = { lineBuf: "" };
     const stderrChunks: Buffer[] = [];
+    const { stdout, stderr, stdin } = child;
 
-    child.stdout!.on("data", (chunk: Buffer) => {
+    if (!stdout || !stderr || !stdin) {
+      reject(new Error("claude process stdio streams are unavailable"));
+
+      return;
+    }
+
+    stdout.on("data", (chunk: Buffer) => {
       streamState.lineBuf += chunk.toString("utf8");
       const lines = streamState.lineBuf.split("\n");
       streamState.lineBuf = lines.pop() ?? "";
@@ -194,10 +201,10 @@ export const runClaude = async ({
       }
     });
 
-    child.stderr!.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+    stderr.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
 
-    child.stdin!.write(truncatedPrompt);
-    child.stdin!.end();
+    stdin.write(truncatedPrompt);
+    stdin.end();
 
     const timer = setTimeout(() => {
       child.kill("SIGTERM");

--- a/packages/services/src/settingsService/createSettingsService.unit.test.ts
+++ b/packages/services/src/settingsService/createSettingsService.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import type { DbConnection } from "@repo/models";
 
 const mockDao = {
   get: vi.fn().mockResolvedValue({
@@ -22,9 +23,12 @@ vi.mock("@repo/models", () => ({
 
 import { createSettingsService } from "./createSettingsService";
 
+// The DAO factory is mocked above, so the service only needs a typed db token.
+const mockDb = {} as DbConnection;
+
 describe("createSettingsService", () => {
   it("get delegates to dao.get", async () => {
-    const svc = createSettingsService({} as never);
+    const svc = createSettingsService(mockDb);
     const result = await svc.get();
     expect(mockDao.get).toHaveBeenCalled();
     expect(result).toEqual({
@@ -36,7 +40,7 @@ describe("createSettingsService", () => {
   });
 
   it("update delegates to dao.update", async () => {
-    const svc = createSettingsService({} as never);
+    const svc = createSettingsService(mockDb);
     const data = { defaultApiKey: "new-key" } as never;
     await svc.update(data);
     expect(mockDao.update).toHaveBeenCalledWith(data);


### PR DESCRIPTION
## 概述

  本 PR 主要包含三部分：

  1. 修复本地 app/server 服务初始化问题
  2. 修复 settings service 单测里的数据库 mock 问题
  3. 改进 Canvas `NodeCard` 的真实画布布局和 Storybook 覆盖

  ## 主要改动

  ### 服务初始化修复

  - 在 `apps/app/src/integrations/trpc/services.ts` 中显式注入 `db` 创建各类 service
  - 在 `apps/server/src/services.ts` 中同步改为 `createXxxService(db)`
  - 避免继续依赖旧的 `serviceFactory` 调用方式

  ### Claude runner 安全检查

  - 在 `packages/agent/src/claude/runClaude.ts` 中保留上游已有 spawn 结构
  - 增加 `stdout`、`stderr`、`stdin` 可用性检查
  - 避免 child process stdio 不存在时继续写入导致运行时异常

  ### settings service 单测修复

  - 为 `createSettingsService.unit.test.ts` 补充明确的 typed `mockDb`
  - 替代未定义变量和 `{} as never` 这类类型绕过
  - 保持 DAO factory mock 负责隔离真实数据库访问

  ### NodeCard 布局与 Storybook

  - 固定 `NodeCard` 宽度为 `288px`
  - 整理 header/body spacing
  - 将 header 调整为完整矩形色带
  - 保证长标题、长描述、右侧状态区域不会互相挤压
  - 增加 Storybook autodocs
  - 补充多种 stories：
    - 默认状态
    - 长标题
    - 长描述
    - headerRight
    - body 内容
    - editable label
    - running/pass/fail
    - dimmed
    - 所有主题
    - 内容矩阵
    - 运行状态矩阵
  - 新增长标题布局回归测试
  - 为 Storybook iframe 添加空 favicon，避免 dev 下 `/favicon.ico` 404 干扰控制台验证

  ### 本地产物忽略

  - 忽略 `.omx`
  - 忽略 `output`

  这些是本地 agent 记忆和 Playwright/调试截图产物，不应进入版本管理。

  ## 特意排除的内容

  - 未提交无明确依赖变更来源的 `bun.lockb`
  - 未保留 `{} as never` 的测试绕过写法

  ## 验证

  已在本地执行：

  ```sh
  bun run check-types

  结果：通过，18/18 tasks successful。

  cd apps/app
  bun run test src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx

  结果：通过，6 tests passed。

  cd packages/services
  bun run test src/settingsService/createSettingsService.unit.test.ts

  结果：通过，3 tests passed。

  另外使用真实 Canvas 做过冒烟验证：

  - 在 http://localhost:9430/canvas 通过右键菜单创建节点
  - 创建了 代码文件、扫描垃圾代码、Check 代码清理
  - 无控制台错误
  - operations/recipes tRPC 请求返回 200
  - NodeCard computed CSS width 为 288px
  - React Flow 缩放只影响屏幕显示尺寸，不是组件 CSS 宽度失控