### PR TITLE
feat: 增加 Canvas 工作台、修复控件并补齐 Storybook 场景

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,10 @@ test_output.log
 .vscode
 .omx
 output
+
+# Local agent/context files
+AGENTS.md
+
+# Local browser/test artifacts
+.playwright-cli/
+storybook-static/

--- a/apps/app/.storybook/preview.tsx
+++ b/apps/app/.storybook/preview.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastStoreProvider } from "../src/store/toastProvider";
+import "../src/lib/i18n";
 import "../src/styles.css";
 
 const rootRoute = createRootRoute();

--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -320,6 +320,29 @@
     "redo": "Redo",
     "run": "Run",
     "aiMode": "AI Mode",
+    "emptyState": {
+      "title": "Start with a node",
+      "description": "Add an input object, Operation, or Recipe to shape the first pipeline path.",
+      "quickAdd": "Quick add node",
+      "contextHint": "You can also right-click blank canvas space to create nodes."
+    },
+    "quickAdd": {
+      "title": "Quick add node",
+      "open": "Quick add node",
+      "close": "Close quick add",
+      "searchPlaceholder": "Search nodes, Operations, or Recipes...",
+      "objects": "Object nodes",
+      "operations": "Operations",
+      "recipes": "Recipes",
+      "noResults": "No matching nodes"
+    },
+    "status": {
+      "nodeCount": "{{count}} nodes",
+      "edgeCount": "{{count}} edges",
+      "zoom": "Zoom {{zoom}}",
+      "selectedNode": "Selected {{label}}",
+      "noSelection": "No node selected"
+    },
     "contextMenu": {
       "addCodeFile": "Add Code File",
       "addFolder": "Add Folder",

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -320,6 +320,29 @@
     "redo": "重做",
     "run": "运行",
     "aiMode": "AI 模式",
+    "emptyState": {
+      "title": "从一个节点开始",
+      "description": "添加输入对象、Operation 或 Recipe，搭出第一条流水线。",
+      "quickAdd": "快速新建节点",
+      "contextHint": "也可以在画布空白处右键创建节点。"
+    },
+    "quickAdd": {
+      "title": "快速新建节点",
+      "open": "快速新建节点",
+      "close": "关闭快速新建",
+      "searchPlaceholder": "搜索节点、Operation 或 Recipe...",
+      "objects": "对象节点",
+      "operations": "Operation",
+      "recipes": "Recipe",
+      "noResults": "没有匹配的节点"
+    },
+    "status": {
+      "nodeCount": "{{count}} 个节点",
+      "edgeCount": "{{count}} 条连线",
+      "zoom": "缩放 {{zoom}}",
+      "selectedNode": "选中 {{label}}",
+      "noSelection": "未选中节点"
+    },
     "contextMenu": {
       "addCodeFile": "添加 Code File",
       "addFolder": "添加 Folder",

--- a/apps/app/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { HarnessCanvasStoreProvider } from "../_store";
+import { CanvasEmptyState } from "./CanvasEmptyState";
+
+const meta: Meta<typeof CanvasEmptyState> = {
+  title: "CanvasPage/CanvasEmptyState",
+  component: CanvasEmptyState,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <HarnessCanvasStoreProvider pipeline={null}>
+        <div className="relative h-96 w-full bg-slate-50">
+          <Story />
+        </div>
+      </HarnessCanvasStoreProvider>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Empty-canvas entry card shown when the pipeline has no nodes. It gives first-time users a quick-add action and a right-click creation hint without blocking canvas interactions outside the card.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CanvasEmptyState>;
+
+export const Default: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story: "Centered first-run card with the same quick-add action used by the toolbar.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.tsx
@@ -1,0 +1,32 @@
+import { MousePointer2, Plus } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import { Button } from "@repo/ui/button";
+import { useHarnessCanvasStore } from "../_store";
+
+export const CanvasEmptyState = () => {
+  const { t } = useTranslation();
+  const store = useHarnessCanvasStore();
+  const openQuickAdd = useStore(store, (state) => state.openQuickAdd);
+  const handleOpenQuickAdd = () => openQuickAdd();
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center px-4">
+      <div className="pointer-events-auto w-[min(24rem,100%)] rounded-lg border border-dashed border-border bg-background/90 px-5 py-5 text-center shadow-sm backdrop-blur-sm">
+        <div className="mx-auto mb-3 flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <Plus className="size-5" />
+        </div>
+        <h2 className="text-sm font-semibold text-foreground">{t("canvas.emptyState.title")}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{t("canvas.emptyState.description")}</p>
+        <Button className="mt-4" size="sm" onClick={handleOpenQuickAdd}>
+          <Plus className="size-3.5" />
+          {t("canvas.emptyState.quickAdd")}
+        </Button>
+        <div className="mt-3 flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
+          <MousePointer2 className="size-3.5" />
+          <span>{t("canvas.emptyState.contextHint")}</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/app/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.unit.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "@/test/test-wrapper";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { createHarnessCanvasStore, HarnessCanvasStoreContext } from "../_store/harnessCanvasStore";
+import { CanvasEmptyState } from "./CanvasEmptyState";
+
+const renderEmptyState = () => {
+  const store = createHarnessCanvasStore();
+  render(
+    <HarnessCanvasStoreContext.Provider value={store}>
+      <CanvasEmptyState />
+    </HarnessCanvasStoreContext.Provider>
+  );
+
+  return store;
+};
+
+describe("CanvasEmptyState", () => {
+  it("opens quick add from the primary action", async () => {
+    const user = userEvent.setup();
+    const store = renderEmptyState();
+
+    await user.click(screen.getByRole("button", { name: /Quick add node|快速新建节点/ }));
+
+    expect(store.getState().isQuickAddOpen).toBe(true);
+  });
+
+  it("shows the right-click creation hint", () => {
+    renderEmptyState();
+
+    expect(screen.getByText(/right-click blank canvas|画布空白处右键/)).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/pages/CanvasPage/CanvasEmptyState/index.ts
+++ b/apps/app/src/pages/CanvasPage/CanvasEmptyState/index.ts
@@ -1,0 +1,1 @@
+export * from "./CanvasEmptyState";

--- a/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.stories.tsx
@@ -5,6 +5,7 @@ import { CanvasFloatingMenu } from "./CanvasFloatingMenu";
 const meta: Meta<typeof CanvasFloatingMenu> = {
   title: "CanvasPage/CanvasFloatingMenu",
   component: CanvasFloatingMenu,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <HarnessCanvasStoreProvider pipeline={null}>
@@ -12,7 +13,24 @@ const meta: Meta<typeof CanvasFloatingMenu> = {
       </HarnessCanvasStoreProvider>
     ),
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Floating Canvas persistence controls for the current pipeline, including save/create affordances and run-console toggles.",
+      },
+    },
+  },
 };
 export default meta;
 type Story = StoryObj<typeof CanvasFloatingMenu>;
-export const Default: Story = { args: {} };
+export const Default: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story: "Default floating menu with no loaded pipeline.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.tsx
@@ -164,7 +164,9 @@ export const CanvasFloatingMenu = () => {
       <input
         ref={fileInputRef}
         accept=".json"
+        aria-label="Import canvas JSON"
         className="hidden"
+        name="canvasImportFile"
         type="file"
         onChange={handleFileChange}
       />

--- a/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.stories.tsx
@@ -6,6 +6,7 @@ import { CanvasFlow } from "./CanvasFlow";
 const meta: Meta<typeof CanvasFlow> = {
   title: "CanvasPage/CanvasFlow",
   component: CanvasFlow,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <HarnessCanvasStoreProvider pipeline={null}>
@@ -15,7 +16,24 @@ const meta: Meta<typeof CanvasFlow> = {
       </HarnessCanvasStoreProvider>
     ),
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "React Flow surface for Canvas nodes, edges, controls, default viewport, zoom tracking, and MiniMap visibility.",
+      },
+    },
+  },
 };
 export default meta;
 type Story = StoryObj<typeof CanvasFlow>;
-export const Default: Story = { args: {} };
+export const Default: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story: "Empty flow surface using the shared default viewport configuration.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
@@ -1,7 +1,15 @@
+import { useCallback, useEffect, useRef } from "react";
 import { useStore } from "zustand";
 import { useHarnessCanvasStore } from "../_store";
 import { useHotkeys } from "react-hotkeys-hook";
-import { ReactFlow, Background, Controls, BackgroundVariant } from "@xyflow/react";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  BackgroundVariant,
+  MiniMap,
+  type OnMove,
+} from "@xyflow/react";
 import { CompoundNode } from "../CompoundNode";
 import { CodeFileNode } from "../CodeFileNode";
 import { ErrorNode } from "../ErrorNode";
@@ -10,6 +18,8 @@ import { GitHubProjectNode } from "../GitHubProjectNode";
 import { OperationNode } from "../OperationNode";
 import { OutputProjectPathNode } from "../OutputProjectPathNode";
 import { OutputLocalPathNode } from "../OutputLocalPathNode";
+import { DEFAULT_CANVAS_VIEWPORT } from "../utils/canvasViewport";
+import { getScreenViewportCenter, getViewportRectCenter } from "../utils/nodePosition";
 
 // Must be defined outside the component to prevent React Flow infinite re-renders
 const nodeTypes = {
@@ -29,14 +39,15 @@ const defaultEdgeOptions = {
   style: { stroke: "#94a3b8", strokeWidth: 2 },
 };
 
-const fitViewOpts = { padding: 0.15 };
 const proOpts = { hideAttribution: false };
 
 export const CanvasFlow = () => {
   const store = useHarnessCanvasStore();
+  const flowViewportRef = useRef<HTMLDivElement>(null);
 
   const nodes = useStore(store, (s) => s.nodes);
   const edges = useStore(store, (s) => s.edges);
+  const isConsoleOpen = useStore(store, (s) => s.isConsoleOpen);
   const handleNodesChange = useStore(store, (s) => s.handleNodesChange);
   const handleEdgesChange = useStore(store, (s) => s.handleEdgesChange);
   const handleConnect = useStore(store, (s) => s.handleConnect);
@@ -52,6 +63,22 @@ export const CanvasFlow = () => {
   const handleFlowPaneContextMenu = useStore(store, (s) => s.handleFlowPaneContextMenu);
   const handleFlowNodeDrag = useStore(store, (s) => s.handleFlowNodeDrag);
   const handleFlowNodeDragStop = useStore(store, (s) => s.handleFlowNodeDragStop);
+  const setViewportZoom = useStore(store, (s) => s.setViewportZoom);
+  const setViewportScreenCenterGetter = useStore(store, (s) => s.setViewportScreenCenterGetter);
+
+  const getFlowViewportScreenCenter = useCallback(() => {
+    const rect = flowViewportRef.current?.getBoundingClientRect();
+
+    return rect ? getViewportRectCenter(rect) : getScreenViewportCenter();
+  }, []);
+
+  useEffect(() => {
+    setViewportScreenCenterGetter(getFlowViewportScreenCenter);
+  }, [getFlowViewportScreenCenter, setViewportScreenCenterGetter]);
+
+  const handleFlowMove: OnMove = (_event, viewport) => {
+    setViewportZoom(viewport.zoom);
+  };
 
   useHotkeys(
     "mod+z",
@@ -71,36 +98,48 @@ export const CanvasFlow = () => {
   );
 
   return (
-    <ReactFlow
-      fitView
-      className="bg-slate-50/50"
-      defaultEdgeOptions={defaultEdgeOptions}
-      deleteKeyCode={["Backspace", "Delete"]}
-      edges={edges}
-      fitViewOptions={fitViewOpts}
-      nodes={nodes}
-      nodeTypes={nodeTypes}
-      proOptions={proOpts}
-      onConnect={handleConnect}
-      onConnectEnd={handleFlowConnectEnd}
-      onConnectStart={handleFlowConnectStart}
-      onEdgeClick={handleFlowEdgeClick}
-      onEdgesChange={handleEdgesChange}
-      onInit={handleFlowInit}
-      onNodeClick={handleFlowNodeClick}
-      onNodeContextMenu={handleFlowNodeContextMenu}
-      onNodeDrag={handleFlowNodeDrag}
-      onNodeDragStop={handleFlowNodeDragStop}
-      onNodesChange={handleNodesChange}
-      onPaneClick={handleFlowPaneClick}
-      onPaneContextMenu={handleFlowPaneContextMenu}
-    >
-      <Background color="#cbd5e1" gap={24} size={1.5} variant={BackgroundVariant.Dots} />
-      <Controls
-        showInteractive
-        className="border-gray-200! bg-white! shadow-sm!"
-        position="bottom-left"
-      />
-    </ReactFlow>
+    <div ref={flowViewportRef} className="h-full w-full" data-testid="canvas-flow-viewport">
+      <ReactFlow
+        className="bg-slate-50/50"
+        defaultEdgeOptions={defaultEdgeOptions}
+        defaultViewport={DEFAULT_CANVAS_VIEWPORT}
+        deleteKeyCode={["Backspace", "Delete"]}
+        edges={edges}
+        nodes={nodes}
+        nodeTypes={nodeTypes}
+        proOptions={proOpts}
+        onConnect={handleConnect}
+        onConnectEnd={handleFlowConnectEnd}
+        onConnectStart={handleFlowConnectStart}
+        onEdgeClick={handleFlowEdgeClick}
+        onEdgesChange={handleEdgesChange}
+        onInit={handleFlowInit}
+        onMove={handleFlowMove}
+        onNodeClick={handleFlowNodeClick}
+        onNodeContextMenu={handleFlowNodeContextMenu}
+        onNodeDrag={handleFlowNodeDrag}
+        onNodeDragStop={handleFlowNodeDragStop}
+        onNodesChange={handleNodesChange}
+        onPaneClick={handleFlowPaneClick}
+        onPaneContextMenu={handleFlowPaneContextMenu}
+      >
+        <Background color="#cbd5e1" gap={24} size={1.5} variant={BackgroundVariant.Dots} />
+        <Controls
+          showInteractive
+          className="border-gray-200! bg-white! shadow-sm!"
+          position="bottom-left"
+        />
+        {nodes.length > 1 && !isConsoleOpen && (
+          <MiniMap
+            pannable
+            zoomable
+            className="border border-border bg-background/90 shadow-sm"
+            nodeBorderRadius={6}
+            nodeColor="#94a3b8"
+            position="bottom-right"
+          />
+        )}
+      </ReactFlow>
+    </div>
   );
 };

--- a/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.unit.test.tsx
@@ -1,8 +1,13 @@
-import { render } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ReactFlowProvider } from "@xyflow/react";
 import type * as XyFlowReact from "@xyflow/react";
-import { HarnessCanvasStoreProvider } from "../_store";
+import type { PipelineNode } from "../_store/canvasSlice";
+import {
+  createHarnessCanvasStore,
+  HarnessCanvasStoreContext,
+  HarnessCanvasStoreProvider,
+} from "../_store";
 import { CanvasFlow } from "./CanvasFlow";
 
 vi.mock("@xyflow/react", async (importOriginal) => {
@@ -10,11 +15,46 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 
   return {
     ...actual,
-    ReactFlow: ({ children }: React.PropsWithChildren) => (
-      <div data-testid="react-flow">{children}</div>
-    ),
+    ReactFlow: ({
+      children,
+      defaultViewport,
+      fitView,
+      onMove,
+    }: React.PropsWithChildren<{
+      defaultViewport?: { zoom: number };
+      fitView?: boolean;
+      onMove?: XyFlowReact.OnMove;
+    }>) => {
+      const handleMouseMove = () => onMove?.(null, { x: 0, y: 0, zoom: 0.6 });
+
+      return (
+        <div
+          data-auto-fit={String(fitView ?? false)}
+          data-testid="react-flow"
+          data-zoom={defaultViewport?.zoom}
+          onMouseMove={handleMouseMove}
+        >
+          {children}
+        </div>
+      );
+    },
+    MiniMap: () => <div data-testid="mini-map" />,
   };
 });
+
+const makeNode = (id: string): PipelineNode =>
+  ({
+    id,
+    type: "code-file",
+    position: { x: 0, y: 0 },
+    data: {
+      label: id,
+      nodeType: "code-file",
+      filePath: "",
+      language: "typescript",
+      description: "",
+    },
+  }) as PipelineNode;
 
 const wrapper = ({ children }: React.PropsWithChildren) => (
   <HarnessCanvasStoreProvider pipeline={null}>
@@ -22,9 +62,87 @@ const wrapper = ({ children }: React.PropsWithChildren) => (
   </HarnessCanvasStoreProvider>
 );
 
+const renderWithStore = (nodes: PipelineNode[], isConsoleOpen = false) => {
+  const store = createHarnessCanvasStore(nodes, []);
+  store.setState({ isConsoleOpen });
+
+  render(
+    <HarnessCanvasStoreContext.Provider value={store}>
+      <ReactFlowProvider>
+        <CanvasFlow />
+      </ReactFlowProvider>
+    </HarnessCanvasStoreContext.Provider>
+  );
+};
+
 describe("CanvasFlow", () => {
   it("renders without crashing", () => {
     const { container } = render(<CanvasFlow />, { wrapper });
     expect(container.firstChild).toBeTruthy();
+    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-zoom", "1.25");
+  });
+
+  it("shows MiniMap when multiple nodes exist and the console is closed", () => {
+    renderWithStore([makeNode("a"), makeNode("b")]);
+
+    expect(screen.getByTestId("mini-map")).toBeInTheDocument();
+    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-auto-fit", "false");
+  });
+
+  it("hides MiniMap for a single node", () => {
+    renderWithStore([makeNode("a")]);
+
+    expect(screen.queryByTestId("mini-map")).not.toBeInTheDocument();
+  });
+
+  it("hides MiniMap while the console is open", () => {
+    renderWithStore([makeNode("a"), makeNode("b")], true);
+
+    expect(screen.queryByTestId("mini-map")).not.toBeInTheDocument();
+  });
+
+  it("records viewport zoom changes", () => {
+    const store = createHarnessCanvasStore([], []);
+
+    render(
+      <HarnessCanvasStoreContext.Provider value={store}>
+        <ReactFlowProvider>
+          <CanvasFlow />
+        </ReactFlowProvider>
+      </HarnessCanvasStoreContext.Provider>
+    );
+
+    screen.getByTestId("react-flow").dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+
+    expect(store.getState().viewportZoom).toBe(0.6);
+  });
+
+  it("registers the React Flow viewport center for quick-add placement", async () => {
+    const store = createHarnessCanvasStore([], []);
+    const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 240,
+      y: 72,
+      left: 240,
+      top: 72,
+      width: 960,
+      height: 640,
+      right: 1200,
+      bottom: 712,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    render(
+      <HarnessCanvasStoreContext.Provider value={store}>
+        <ReactFlowProvider>
+          <CanvasFlow />
+        </ReactFlowProvider>
+      </HarnessCanvasStoreContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(store.getState().getViewportScreenCenter()).toEqual({ x: 720, y: 392 });
+    });
+
+    rectSpy.mockRestore();
   });
 });

--- a/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.stories.tsx
@@ -1,21 +1,43 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Refine } from "@refinedev/core";
 import { ReactFlowProvider } from "@xyflow/react";
 import { HarnessCanvasStoreProvider } from "../_store";
+import { canvasStoryDataProvider } from "../storybookData";
 import { CanvasInner } from "./CanvasInner";
 
 const meta: Meta<typeof CanvasInner> = {
   title: "CanvasPage/CanvasInner",
   component: CanvasInner,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <HarnessCanvasStoreProvider pipeline={null}>
-        <ReactFlowProvider>
-          <Story />
-        </ReactFlowProvider>
-      </HarnessCanvasStoreProvider>
+      <Refine dataProvider={canvasStoryDataProvider}>
+        <HarnessCanvasStoreProvider pipeline={null}>
+          <ReactFlowProvider>
+            <Story />
+          </ReactFlowProvider>
+        </HarnessCanvasStoreProvider>
+      </Refine>
     ),
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Canvas shell that layers the title pill, floating save menu, toolbar, flow surface, empty state, quick add, status bar, context menus, inspection card, and run console.",
+      },
+    },
+  },
 };
 export default meta;
 type Story = StoryObj<typeof CanvasInner>;
-export const Default: Story = { args: {} };
+export const Default: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story: "Default empty CanvasInner layout with the empty-state card and status bar visible.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
@@ -10,6 +10,9 @@ import { NodeContextMenu } from "../NodeContextMenu";
 import { CanvasFloatingMenu } from "../CanvasFloatingMenu";
 import { RunConsole } from "../RunConsole";
 import { LlmContentCard } from "../LlmContentCard/LlmContentCard";
+import { CanvasEmptyState } from "../CanvasEmptyState";
+import { CanvasQuickAdd } from "../CanvasQuickAdd";
+import { CanvasStatusBar } from "../CanvasStatusBar";
 
 export const CanvasInner = () => {
   const { t } = useTranslation();
@@ -20,6 +23,7 @@ export const CanvasInner = () => {
   const connectionMenu = useStore(store, (state) => state.connectionMenu);
   const nodeContextMenu = useStore(store, (state) => state.nodeContextMenu);
   const isConsoleOpen = useStore(store, (state) => state.isConsoleOpen);
+  const nodes = useStore(store, (state) => state.nodes);
   const setPipelineName = useStore(store, (state) => state.setPipelineName);
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -30,10 +34,12 @@ export const CanvasInner = () => {
     <div className="relative h-full w-full">
       <CanvasFloatingMenu />
 
-      <div className="pointer-events-none absolute left-16 right-4 top-4 z-40 flex items-center justify-between">
-        <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-gray-200 bg-white/90 px-4 py-1.5 shadow-sm backdrop-blur-sm">
+      <div className="pointer-events-none absolute left-16 top-4 z-40 flex w-[clamp(6rem,calc(50vw-16rem),14rem)] items-center max-[700px]:left-3 max-[700px]:top-[3.25rem] max-[700px]:w-[min(16rem,calc(100vw-1.5rem))]">
+        <div className="pointer-events-auto flex w-full min-w-0 items-center gap-2 rounded-full border border-gray-200 bg-white/90 px-3 py-1.5 shadow-sm backdrop-blur-sm">
           <Input
-            className="w-48 bg-transparent text-sm font-medium text-gray-700 outline-none placeholder:text-gray-400 border-none shadow-none"
+            aria-label={t("canvas.pipelineTitle")}
+            className="h-7 min-w-0 w-full border-none bg-transparent text-sm font-medium text-gray-700 shadow-none outline-none placeholder:text-gray-400"
+            name="pipelineName"
             placeholder={t("canvas.pipelineTitlePlaceholder")}
             value={pipelineName}
             onChange={handleNameChange}
@@ -44,6 +50,12 @@ export const CanvasInner = () => {
       <CanvasToolbar />
 
       <CanvasFlow />
+
+      {nodes.length === 0 && <CanvasEmptyState />}
+
+      <CanvasQuickAdd />
+
+      <CanvasStatusBar />
 
       {contextMenu && <CanvasContextMenu />}
 

--- a/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
@@ -1,9 +1,10 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ReactFlowProvider } from "@xyflow/react";
 import type * as XyFlowReact from "@xyflow/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HarnessCanvasStoreProvider } from "../_store";
+import type { PipelineNode } from "../_store/canvasSlice";
 import { CanvasInner } from "./CanvasInner";
 
 vi.mock("@xyflow/react", async (importOriginal) => {
@@ -21,11 +22,44 @@ vi.mock("@/services/pipelinesService", () => ({
   updatePipeline: vi.fn(),
 }));
 
+vi.mock("@refinedev/core", () => ({
+  useList: () => ({ result: { data: [] } }),
+  useUpdate: () => ({ mutate: vi.fn(), mutation: { isPending: false } }),
+  useCreate: () => ({ mutate: vi.fn(), mutation: { isPending: false } }),
+}));
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 });
 
-const wrapper = ({ children }: React.PropsWithChildren) => (
+const existingNode = {
+  id: "node-1",
+  type: "code-file",
+  position: { x: 0, y: 0 },
+  data: {
+    label: "Source File",
+    nodeType: "code-file",
+    filePath: "src/index.ts",
+    language: "typescript",
+    description: "",
+  },
+} as PipelineNode;
+
+const makeWrapper =
+  (nodes: PipelineNode[] = []) =>
+  ({ children }: React.PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>
+      <HarnessCanvasStoreProvider pipeline={{ id: "pipe-1", name: "Pipeline", nodes, edges: [] }}>
+        <ReactFlowProvider>{children}</ReactFlowProvider>
+      </HarnessCanvasStoreProvider>
+    </QueryClientProvider>
+  );
+
+const wrapper = makeWrapper();
+
+const wrapperWithNode = makeWrapper([existingNode]);
+
+const wrapperWithoutPipeline = ({ children }: React.PropsWithChildren) => (
   <QueryClientProvider client={queryClient}>
     <HarnessCanvasStoreProvider pipeline={null}>
       <ReactFlowProvider>{children}</ReactFlowProvider>
@@ -35,7 +69,19 @@ const wrapper = ({ children }: React.PropsWithChildren) => (
 
 describe("CanvasInner", () => {
   it("renders without crashing", () => {
-    const { container } = render(<CanvasInner />, { wrapper });
+    const { container } = render(<CanvasInner />, { wrapper: wrapperWithoutPipeline });
     expect(container.firstChild).toBeTruthy();
+  });
+
+  it("shows the canvas empty state when there are no nodes", () => {
+    render(<CanvasInner />, { wrapper });
+
+    expect(screen.getByText(/Start with a node|从一个节点开始/)).toBeInTheDocument();
+  });
+
+  it("hides the canvas empty state after nodes exist", () => {
+    render(<CanvasInner />, { wrapper: wrapperWithNode });
+
+    expect(screen.queryByText(/Start with a node|从一个节点开始/)).not.toBeInTheDocument();
   });
 });

--- a/apps/app/src/pages/CanvasPage/CanvasPage.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasPage.stories.tsx
@@ -1,20 +1,200 @@
+import { useRef } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { HarnessCanvasStoreProvider } from "./_store";
+import { Refine } from "@refinedev/core";
+import type { PipelineEdge, PipelineNode } from "./_store";
 import { CanvasPageContent } from "./CanvasPageContent";
+import {
+  HarnessCanvasStoreContext,
+  createHarnessCanvasStore,
+  type HarnessCanvasStore,
+} from "./_store";
+import { canvasStoryDataProvider } from "./storybookData";
 
-const meta: Meta<typeof CanvasPageContent> = {
-  title: "Pages/CanvasPage",
-  component: CanvasPageContent,
-  decorators: [
-    (Story) => (
-      <HarnessCanvasStoreProvider>
+const sourceNode = {
+  id: "source-file",
+  type: "code-file",
+  position: { x: 80, y: 120 },
+  data: {
+    label: "Source File",
+    nodeType: "code-file",
+    filePath: "src/index.ts",
+    language: "typescript",
+    description: "Pipeline source",
+  },
+} as PipelineNode;
+
+const operationNode = {
+  id: "review-op",
+  type: "operation",
+  position: { x: 420, y: 120 },
+  data: {
+    label: "Review Code",
+    nodeType: "operation",
+    operationId: "review-code",
+    operationName: "Review Code",
+    status: "idle",
+    config: {},
+  },
+} as PipelineNode;
+
+const connectedEdge = {
+  id: "source-to-review",
+  source: "source-file",
+  target: "review-op",
+  type: "default",
+  animated: true,
+  data: {},
+} as PipelineEdge;
+
+interface CanvasStoryProps {
+  nodes?: PipelineNode[];
+  edges?: PipelineEdge[];
+  isQuickAddOpen?: boolean;
+  isConsoleOpen?: boolean;
+  isTestRunning?: boolean;
+  selectedNodeId?: string | null;
+}
+
+const CanvasStory = ({
+  nodes = [],
+  edges = [],
+  isQuickAddOpen = false,
+  isConsoleOpen = false,
+  isTestRunning = false,
+  selectedNodeId = null,
+}: CanvasStoryProps) => {
+  const storeRef = useRef<HarnessCanvasStore | null>(null);
+
+  if (!storeRef.current) {
+    storeRef.current = createHarnessCanvasStore(nodes, edges, "story-pipeline", "Story Pipeline");
+    storeRef.current.setState({
+      isQuickAddOpen,
+      isConsoleOpen,
+      isTestRunning,
+      selectedNodeId,
+      activeJobId: isConsoleOpen ? "job-story" : null,
+      runningNodeId: isTestRunning ? "review-op" : null,
+      nodeRunStatuses: isTestRunning ? { "review-op": "running" } : {},
+    });
+  }
+
+  return (
+    <Refine dataProvider={canvasStoryDataProvider}>
+      <HarnessCanvasStoreContext.Provider value={storeRef.current}>
         <div style={{ width: "100vw", height: "100vh" }}>
-          <Story />
+          <CanvasPageContent />
         </div>
-      </HarnessCanvasStoreProvider>
-    ),
-  ],
+      </HarnessCanvasStoreContext.Provider>
+    </Refine>
+  );
+};
+
+const meta: Meta<typeof CanvasStory> = {
+  title: "Pages/CanvasPage",
+  component: CanvasStory,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Full Canvas workbench scenarios covering the empty state, toolbar quick-add, connected nodes, run console, and MiniMap visibility. Mock Refine data keeps Operation and Recipe lists available in Storybook.",
+      },
+    },
+  },
 };
 export default meta;
-type Story = StoryObj<typeof CanvasPageContent>;
-export const Default: Story = {};
+
+type Story = StoryObj<typeof CanvasStory>;
+
+export const EmptyCanvas: Story = {
+  args: {
+    nodes: [],
+    edges: [],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "First-run canvas with the empty-state card and 125% default zoom in the status bar.",
+      },
+    },
+  },
+};
+
+export const QuickAddOpen: Story = {
+  args: {
+    nodes: [],
+    edges: [],
+    isQuickAddOpen: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Empty canvas with the toolbar quick-add dialog open and populated from mock data.",
+      },
+    },
+  },
+};
+
+export const ConnectedNodes: Story = {
+  args: {
+    nodes: [sourceNode, operationNode],
+    edges: [connectedEdge],
+    selectedNodeId: "source-file",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Two connected nodes with the source selected, useful for checking status bar and graph readability.",
+      },
+    },
+  },
+};
+
+export const RunningWithConsole: Story = {
+  args: {
+    nodes: [sourceNode, operationNode],
+    edges: [connectedEdge],
+    isConsoleOpen: true,
+    isTestRunning: true,
+    selectedNodeId: "review-op",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Run-state scenario with the console open and the active operation marked running.",
+      },
+    },
+  },
+};
+
+export const MiniMapVisible: Story = {
+  args: {
+    nodes: [sourceNode, operationNode],
+    edges: [connectedEdge],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Multiple-node canvas where the MiniMap should be visible while the console is closed.",
+      },
+    },
+  },
+};
+
+export const MiniMapHidden: Story = {
+  args: {
+    nodes: [sourceNode],
+    edges: [],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Single-node canvas where the MiniMap should remain hidden.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/CanvasPageContent/CanvasPageContent.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasPageContent/CanvasPageContent.stories.tsx
@@ -1,21 +1,43 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Refine } from "@refinedev/core";
 import { ReactFlowProvider } from "@xyflow/react";
 import { HarnessCanvasStoreProvider } from "../_store";
+import { canvasStoryDataProvider } from "../storybookData";
 import { CanvasPageContent } from "./CanvasPageContent";
 
 const meta: Meta<typeof CanvasPageContent> = {
   title: "CanvasPage/CanvasPageContent",
   component: CanvasPageContent,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <HarnessCanvasStoreProvider pipeline={null}>
-        <ReactFlowProvider>
-          <Story />
-        </ReactFlowProvider>
-      </HarnessCanvasStoreProvider>
+      <Refine dataProvider={canvasStoryDataProvider}>
+        <HarnessCanvasStoreProvider pipeline={null}>
+          <ReactFlowProvider>
+            <Story />
+          </ReactFlowProvider>
+        </HarnessCanvasStoreProvider>
+      </Refine>
     ),
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Top-level Canvas content wrapper that provides React Flow context and clips the workbench to the available viewport.",
+      },
+    },
+  },
 };
 export default meta;
 type Story = StoryObj<typeof CanvasPageContent>;
-export const Default: Story = { args: {} };
+export const Default: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story: "Full Canvas content wrapper in its default empty state.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/CanvasQuickAdd/CanvasQuickAdd.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasQuickAdd/CanvasQuickAdd.stories.tsx
@@ -2,23 +2,24 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Refine } from "@refinedev/core";
 import { createHarnessCanvasStore, HarnessCanvasStoreContext } from "../_store";
 import { canvasStoryDataProvider } from "../storybookData";
-import { CanvasContextMenu } from "./CanvasContextMenu";
+import { CanvasQuickAdd } from "./CanvasQuickAdd";
 
-const meta: Meta<typeof CanvasContextMenu> = {
-  title: "CanvasPage/CanvasContextMenu",
-  component: CanvasContextMenu,
+const meta: Meta<typeof CanvasQuickAdd> = {
+  title: "CanvasPage/CanvasQuickAdd",
+  component: CanvasQuickAdd,
   tags: ["autodocs"],
   decorators: [
     (Story) => {
       const store = createHarnessCanvasStore();
       store.setState({
-        contextMenu: { screenX: 200, screenY: 120, flowX: 100, flowY: 80 },
+        isQuickAddOpen: true,
+        screenToFlowPosition: (position) => position,
       });
 
       return (
         <Refine dataProvider={canvasStoryDataProvider}>
           <HarnessCanvasStoreContext.Provider value={store}>
-            <div className="relative h-96 w-full bg-slate-50">
+            <div className="relative h-[32rem] w-full bg-slate-50">
               <Story />
             </div>
           </HarnessCanvasStoreContext.Provider>
@@ -30,19 +31,21 @@ const meta: Meta<typeof CanvasContextMenu> = {
     docs: {
       description: {
         component:
-          "Blank-canvas context menu for creating object nodes, Operation nodes, Recipes, and compound groups at the pointer position.",
+          "Toolbar quick-add dialog for creating object nodes, Operations, and Recipes at the current viewport center. Stories use local mock Refine data so the menu is stable without a running API.",
       },
     },
   },
 };
+
 export default meta;
-type Story = StoryObj<typeof CanvasContextMenu>;
-export const Default: Story = {
+type Story = StoryObj<typeof CanvasQuickAdd>;
+
+export const Open: Story = {
   args: {},
   parameters: {
     docs: {
       description: {
-        story: "Open blank-canvas context menu backed by local Operation and Recipe story data.",
+        story: "Open quick-add menu with object nodes, mocked Operations, and mocked Recipes.",
       },
     },
   },

--- a/apps/app/src/pages/CanvasPage/CanvasQuickAdd/CanvasQuickAdd.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasQuickAdd/CanvasQuickAdd.tsx
@@ -1,0 +1,244 @@
+import { useState, type ElementType } from "react";
+import { useTranslation } from "react-i18next";
+import { useList } from "@refinedev/core";
+import type { Operation, Recipe } from "@repo/schemas";
+import type { BuiltinNodeType } from "@repo/pipeline-engine/schemas";
+import { BookOpen, FileCode, Folder, FolderOutput, HardDrive, Search, Zap, X } from "lucide-react";
+import { useStore } from "zustand";
+import { Button } from "@repo/ui/button";
+import { Input } from "@repo/ui/input";
+import { cn } from "@repo/ui/lib/utils";
+import { SiGitHubIcon } from "@/components/icons/SiGitHubIcon";
+import { ResourceName } from "@/integrations/refine/dataProvider";
+import { useHarnessCanvasStore } from "../_store";
+import { getNodeMeta } from "../utils/nodeTypeMeta";
+
+const QUICK_ADD_OBJECT_TYPES: BuiltinNodeType[] = ["code-file", "folder", "github-project"];
+
+const TYPE_ICONS: Record<string, ElementType> = {
+  "code-file": FileCode,
+  folder: Folder,
+  "github-project": SiGitHubIcon,
+  "output-project-path": FolderOutput,
+  "output-local-path": HardDrive,
+};
+
+const normalizeSearch = (value: string) => value.trim().toLowerCase();
+
+const includesSearch = (values: Array<string | null | undefined>, query: string) =>
+  values.some((value) => value?.toLowerCase().includes(query));
+
+export const CanvasQuickAdd = () => {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const store = useHarnessCanvasStore();
+  const isOpen = useStore(store, (state) => state.isQuickAddOpen);
+  const closeQuickAdd = useStore(store, (state) => state.closeQuickAdd);
+  const createObjectNodeAtViewportCenter = useStore(
+    store,
+    (state) => state.createObjectNodeAtViewportCenter
+  );
+  const createOperationNodeAtViewportCenter = useStore(
+    store,
+    (state) => state.createOperationNodeAtViewportCenter
+  );
+  const createRecipeNodeAtViewportCenter = useStore(
+    store,
+    (state) => state.createRecipeNodeAtViewportCenter
+  );
+
+  const { result: operationsResult } = useList<Operation>({
+    resource: ResourceName.operations,
+  });
+  const { result: recipesResult } = useList<Recipe>({ resource: ResourceName.recipes });
+
+  const operations = operationsResult?.data ?? [];
+  const recipes = recipesResult?.data ?? [];
+  const search = normalizeSearch(query);
+
+  const objectItems = QUICK_ADD_OBJECT_TYPES.filter((type) => {
+    const meta = getNodeMeta(type);
+
+    return search === "" || includesSearch([meta?.label, meta?.shortLabel, type], search);
+  });
+
+  const operationItems = operations.filter((operation) =>
+    search === ""
+      ? true
+      : includesSearch([operation.name, operation.description, "operation"], search)
+  );
+
+  const recipeItems = recipes
+    .map((recipe) => ({
+      recipe,
+      operation: operations.find((operation) => operation.id === recipe.operationId),
+    }))
+    .filter(
+      (item): item is { recipe: Recipe; operation: Operation } => item.operation !== undefined
+    )
+    .filter(({ recipe, operation }) =>
+      search === ""
+        ? true
+        : includesSearch([recipe.name, recipe.description, operation.name, "recipe"], search)
+    );
+
+  const hasResults = objectItems.length > 0 || operationItems.length > 0 || recipeItems.length > 0;
+
+  const handleClose = () => {
+    setQuery("");
+    closeQuickAdd();
+  };
+
+  const handleQueryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(event.target.value);
+  };
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      handleClose();
+    }
+  };
+
+  const handleCreateObjectNode = (type: BuiltinNodeType) => {
+    createObjectNodeAtViewportCenter(type);
+    setQuery("");
+  };
+
+  const handleCreateOperationNode = (operation: Operation) => {
+    createOperationNodeAtViewportCenter(operation);
+    setQuery("");
+  };
+
+  const handleCreateRecipeNode = (recipe: Recipe, operation: Operation) => {
+    createRecipeNodeAtViewportCenter(recipe, operation);
+    setQuery("");
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      aria-label={t("canvas.quickAdd.title")}
+      className="absolute left-1/2 top-14 z-50 w-[min(28rem,calc(100vw-2rem))] -translate-x-1/2 rounded-lg border border-border bg-background shadow-lg"
+      role="dialog"
+    >
+      <div className="flex items-center gap-2 border-b px-3 py-2">
+        <Search className="size-4 shrink-0 text-muted-foreground" />
+        <Input
+          autoFocus
+          aria-label={t("canvas.quickAdd.searchPlaceholder")}
+          className="h-8 border-none bg-transparent px-0 shadow-none focus-visible:ring-0"
+          name="canvasQuickAddSearch"
+          placeholder={t("canvas.quickAdd.searchPlaceholder")}
+          value={query}
+          onChange={handleQueryChange}
+          onKeyDown={handleSearchKeyDown}
+        />
+        <Button
+          aria-label={t("canvas.quickAdd.close")}
+          className="size-7"
+          size="icon"
+          title={t("canvas.quickAdd.close")}
+          variant="ghost"
+          onClick={handleClose}
+        >
+          <X className="size-4" />
+        </Button>
+      </div>
+
+      <div className="max-h-[calc(100vh-8rem)] overflow-y-auto overscroll-contain md:max-h-[22rem]">
+        <div className="space-y-3 p-2">
+          {objectItems.length > 0 && (
+            <section>
+              <div className="px-2 py-1 text-[11px] font-semibold uppercase text-muted-foreground">
+                {t("canvas.quickAdd.objects")}
+              </div>
+              <div className="space-y-0.5">
+                {objectItems.map((type) => {
+                  const Icon = TYPE_ICONS[type];
+                  const meta = getNodeMeta(type)!;
+
+                  return (
+                    <button
+                      key={type}
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      type="button"
+                      onClick={() => handleCreateObjectNode(type)}
+                    >
+                      <span
+                        className={cn(
+                          "flex size-6 shrink-0 items-center justify-center rounded",
+                          meta.iconBg
+                        )}
+                      >
+                        <Icon className="size-3.5 text-white" />
+                      </span>
+                      <span className="min-w-0 flex-1 truncate font-medium">{meta.label}</span>
+                      <span className="text-xs text-muted-foreground">{meta.shortLabel}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {operationItems.length > 0 && (
+            <section>
+              <div className="px-2 py-1 text-[11px] font-semibold uppercase text-muted-foreground">
+                {t("canvas.quickAdd.operations")}
+              </div>
+              <div className="space-y-0.5">
+                {operationItems.map((operation) => (
+                  <button
+                    key={operation.id}
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    type="button"
+                    onClick={() => handleCreateOperationNode(operation)}
+                  >
+                    <span className="flex size-6 shrink-0 items-center justify-center rounded bg-violet-500">
+                      <Zap className="size-3.5 text-white" />
+                    </span>
+                    <span className="min-w-0 flex-1 truncate font-medium">{operation.name}</span>
+                    <span className="text-xs text-muted-foreground">OP</span>
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {recipeItems.length > 0 && (
+            <section>
+              <div className="px-2 py-1 text-[11px] font-semibold uppercase text-muted-foreground">
+                {t("canvas.quickAdd.recipes")}
+              </div>
+              <div className="space-y-0.5">
+                {recipeItems.map(({ recipe, operation }) => (
+                  <button
+                    key={recipe.id}
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    type="button"
+                    onClick={() => handleCreateRecipeNode(recipe, operation)}
+                  >
+                    <span className="flex size-6 shrink-0 items-center justify-center rounded bg-amber-500">
+                      <BookOpen className="size-3.5 text-white" />
+                    </span>
+                    <span className="min-w-0 flex-1 truncate font-medium">{recipe.name}</span>
+                    <span className="max-w-28 truncate text-xs text-muted-foreground">
+                      {operation.name}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {!hasResults && (
+            <div className="px-2 py-8 text-center text-sm text-muted-foreground">
+              {t("canvas.quickAdd.noResults")}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/app/src/pages/CanvasPage/CanvasQuickAdd/CanvasQuickAdd.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasQuickAdd/CanvasQuickAdd.unit.test.tsx
@@ -1,0 +1,91 @@
+import { render } from "@/test/test-wrapper";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Operation, Recipe } from "@repo/schemas";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHarnessCanvasStore, HarnessCanvasStoreContext } from "../_store/harnessCanvasStore";
+import { CanvasQuickAdd } from "./CanvasQuickAdd";
+
+const operations = [
+  {
+    id: "review-code",
+    name: "Review Code",
+    description: "Find correctness issues",
+    config: {},
+    acceptedObjectTypes: ["file"],
+  },
+] as Operation[];
+
+const recipes = [
+  {
+    id: "strict-review",
+    name: "Strict Review",
+    description: "Review with stronger checks",
+    operationId: "review-code",
+    bestPracticeId: "bp-strict",
+  },
+] as Recipe[];
+
+vi.mock("@refinedev/core", () => ({
+  useList: ({ resource }: { resource: string }) => ({
+    result: {
+      data: resource === "operations" ? operations : recipes,
+    },
+  }),
+}));
+
+const renderQuickAdd = () => {
+  const store = createHarnessCanvasStore();
+  store.setState({
+    isQuickAddOpen: true,
+    getViewportScreenCenter: () => ({ x: 700, y: 500 }),
+    screenToFlowPosition: (pos) => ({ x: pos.x / 2, y: pos.y / 2 }),
+  });
+
+  render(
+    <HarnessCanvasStoreContext.Provider value={store}>
+      <CanvasQuickAdd />
+    </HarnessCanvasStoreContext.Provider>
+  );
+
+  return store;
+};
+
+describe("CanvasQuickAdd", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "innerWidth", { configurable: true, value: 1000 });
+    Object.defineProperty(globalThis, "innerHeight", { configurable: true, value: 800 });
+  });
+
+  it("filters object nodes, operations, and recipes by search text", async () => {
+    const user = userEvent.setup();
+    renderQuickAdd();
+
+    expect(screen.getByText("代码文件")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Review Code\s*OP/ })).toBeInTheDocument();
+    expect(screen.getByText("Strict Review")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText(/Search nodes|搜索节点/), "strict");
+
+    expect(screen.queryByText("代码文件")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Review Code\s*OP/ })).not.toBeInTheDocument();
+    expect(screen.getByText("Strict Review")).toBeInTheDocument();
+  });
+
+  it("creates the selected item centered in the viewport and closes", async () => {
+    const user = userEvent.setup();
+    const store = renderQuickAdd();
+
+    await user.click(screen.getByRole("button", { name: /Review Code\s*OP/ }));
+
+    const state = store.getState();
+    expect(state.nodes).toHaveLength(1);
+    expect(state.nodes[0]).toMatchObject({
+      type: "operation",
+      origin: [0.5, 0.5],
+      position: { x: 350, y: 250 },
+      data: { label: "Review Code" },
+    });
+    expect(state.isQuickAddOpen).toBe(false);
+  });
+});

--- a/apps/app/src/pages/CanvasPage/CanvasQuickAdd/index.ts
+++ b/apps/app/src/pages/CanvasPage/CanvasQuickAdd/index.ts
@@ -1,0 +1,1 @@
+export * from "./CanvasQuickAdd";

--- a/apps/app/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { PipelineEdge, PipelineNode } from "../_store";
+import { createHarnessCanvasStore, HarnessCanvasStoreContext } from "../_store";
+import { CanvasStatusBar } from "./CanvasStatusBar";
+
+const sourceNode = {
+  id: "source-file",
+  type: "code-file",
+  position: { x: 0, y: 0 },
+  data: {
+    label: "Source File",
+    nodeType: "code-file",
+    filePath: "src/index.ts",
+    language: "typescript",
+    description: "Pipeline source",
+  },
+} as PipelineNode;
+
+const reviewNode = {
+  id: "review-op",
+  type: "operation",
+  position: { x: 320, y: 0 },
+  data: {
+    label: "Review Code",
+    nodeType: "operation",
+    operationId: "review-code",
+    operationName: "Review Code",
+    status: "idle",
+    config: {},
+  },
+} as PipelineNode;
+
+const edge = {
+  id: "source-to-review",
+  source: "source-file",
+  target: "review-op",
+  data: {},
+} as PipelineEdge;
+
+const renderStatusBar = (
+  nodes: PipelineNode[],
+  edges: PipelineEdge[],
+  selectedNodeId: string | null,
+  viewportZoom: number
+) => {
+  const store = createHarnessCanvasStore(nodes, edges);
+  store.setState({ selectedNodeId, viewportZoom });
+
+  return (
+    <HarnessCanvasStoreContext.Provider value={store}>
+      <div className="relative h-24 w-full bg-slate-50">
+        <CanvasStatusBar />
+      </div>
+    </HarnessCanvasStoreContext.Provider>
+  );
+};
+
+const meta: Meta<typeof CanvasStatusBar> = {
+  title: "CanvasPage/CanvasStatusBar",
+  component: CanvasStatusBar,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Small canvas state readout pinned to the bottom of the canvas. It shows node count, edge count, current zoom, and the selected node label.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CanvasStatusBar>;
+
+export const EmptyCanvas: Story = {
+  render: () => renderStatusBar([], [], null, 1.25),
+  parameters: {
+    docs: {
+      description: {
+        story: "Empty-canvas state at the default 125% zoom.",
+      },
+    },
+  },
+};
+
+export const WithSelection: Story = {
+  render: () => renderStatusBar([sourceNode, reviewNode], [edge], "source-file", 0.8),
+  parameters: {
+    docs: {
+      description: {
+        story: "Connected canvas state with one selected node and a non-default zoom value.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import { useHarnessCanvasStore } from "../_store";
+import { formatZoomPercent } from "../utils/canvasViewport";
+
+export const CanvasStatusBar = () => {
+  const { t } = useTranslation();
+  const store = useHarnessCanvasStore();
+  const nodes = useStore(store, (state) => state.nodes);
+  const edges = useStore(store, (state) => state.edges);
+  const selectedNodeId = useStore(store, (state) => state.selectedNodeId);
+  const viewportZoom = useStore(store, (state) => state.viewportZoom);
+  const selectedNode = nodes.find((node) => node.id === selectedNodeId);
+
+  return (
+    <div className="pointer-events-none absolute bottom-3 left-1/2 z-20 -translate-x-1/2">
+      <div className="flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-full border border-border bg-background/90 px-3 py-1 text-xs text-muted-foreground shadow-sm backdrop-blur-sm">
+        <span className="whitespace-nowrap">
+          {t("canvas.status.nodeCount", { count: nodes.length })}
+        </span>
+        <span className="text-border">|</span>
+        <span className="whitespace-nowrap">
+          {t("canvas.status.edgeCount", { count: edges.length })}
+        </span>
+        <span className="text-border">|</span>
+        <span className="whitespace-nowrap">
+          {t("canvas.status.zoom", { zoom: formatZoomPercent(viewportZoom) })}
+        </span>
+        <span className="text-border">|</span>
+        <span className="max-w-56 truncate">
+          {selectedNode
+            ? t("canvas.status.selectedNode", { label: selectedNode.data.label })
+            : t("canvas.status.noSelection")}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/apps/app/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.unit.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "@/test/test-wrapper";
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { PipelineEdge, PipelineNode } from "../_store/canvasSlice";
+import { createHarnessCanvasStore, HarnessCanvasStoreContext } from "../_store/harnessCanvasStore";
+import { CanvasStatusBar } from "./CanvasStatusBar";
+
+const node = {
+  id: "node-1",
+  type: "code-file",
+  position: { x: 0, y: 0 },
+  data: {
+    label: "Source File",
+    nodeType: "code-file",
+    filePath: "src/index.ts",
+    language: "typescript",
+    description: "",
+  },
+} as PipelineNode;
+
+const edge = {
+  id: "edge-1",
+  source: "node-1",
+  target: "node-2",
+  data: {},
+} as PipelineEdge;
+
+describe("CanvasStatusBar", () => {
+  it("shows node count, edge count, zoom, and selected node label", () => {
+    const store = createHarnessCanvasStore([node], [edge]);
+    store.setState({ selectedNodeId: "node-1", viewportZoom: 1.25 });
+
+    render(
+      <HarnessCanvasStoreContext.Provider value={store}>
+        <CanvasStatusBar />
+      </HarnessCanvasStoreContext.Provider>
+    );
+
+    expect(screen.getByText(/1 (nodes|个节点)/)).toBeInTheDocument();
+    expect(screen.getByText(/1 (edges|条连线)/)).toBeInTheDocument();
+    expect(screen.getByText(/(Zoom|缩放) 125%/)).toBeInTheDocument();
+    expect(screen.getByText(/(Selected|选中) Source File/)).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/pages/CanvasPage/CanvasStatusBar/index.ts
+++ b/apps/app/src/pages/CanvasPage/CanvasStatusBar/index.ts
@@ -1,0 +1,1 @@
+export * from "./CanvasStatusBar";

--- a/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.stories.tsx
@@ -5,6 +5,7 @@ import { CanvasToolbar } from "./CanvasToolbar";
 const meta: Meta<typeof CanvasToolbar> = {
   title: "CanvasPage/CanvasToolbar",
   component: CanvasToolbar,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <HarnessCanvasStoreProvider pipeline={null}>
@@ -12,7 +13,24 @@ const meta: Meta<typeof CanvasToolbar> = {
       </HarnessCanvasStoreProvider>
     ),
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Compact canvas action bar for zoom, fit view, layout, history, quick add, deletion, and test-run controls.",
+      },
+    },
+  },
 };
 export default meta;
 type Story = StoryObj<typeof CanvasToolbar>;
-export const Default: Story = { args: {} };
+export const Default: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story: "Default toolbar state with no selected node and no saved pipeline id.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx
@@ -1,6 +1,16 @@
 import { useStore } from "zustand";
 import { useHarnessCanvasStore } from "../_store";
-import { ZoomIn, ZoomOut, Maximize2, Trash2, Undo2, Redo2, Play, AlignLeft } from "lucide-react";
+import {
+  ZoomIn,
+  ZoomOut,
+  Maximize2,
+  Trash2,
+  Undo2,
+  Redo2,
+  Play,
+  AlignLeft,
+  Plus,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@repo/ui/button";
 import { Separator } from "@repo/ui/separator";
@@ -15,6 +25,8 @@ export const CanvasToolbar = () => {
   const handleFitView = useStore(store, (state) => state.handleFitView);
   const handleZoomIn = useStore(store, (state) => state.handleZoomIn);
   const handleZoomOut = useStore(store, (state) => state.handleZoomOut);
+  const isQuickAddOpen = useStore(store, (state) => state.isQuickAddOpen);
+  const toggleQuickAdd = useStore(store, (state) => state.toggleQuickAdd);
   const pipelineId = useStore(store, (state) => state.pipelineId);
   const isRunning = useStore(store, (state) => state.isRunning);
   const handleDeleteSelected = useStore(store, (state) => state.handleDeleteSelected);
@@ -22,6 +34,7 @@ export const CanvasToolbar = () => {
   const handleRedo = useStore(store, (state) => state.handleRedo);
   const handleFormatLayout = useStore(store, (state) => state.formatLayout);
   const handleRunTest = useStore(store, (state) => state.handleRunTest);
+  const handleToggleQuickAdd = () => toggleQuickAdd();
 
   return (
     <div className="absolute left-1/2 top-3 z-10 -translate-x-1/2">
@@ -96,6 +109,28 @@ export const CanvasToolbar = () => {
         >
           <Redo2 className="h-4 w-4" />
         </Button>
+
+        <Separator className="mx-1 h-5" orientation="vertical" />
+
+        {/* Quick add */}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label={t("canvas.quickAdd.open")}
+                aria-pressed={isQuickAddOpen}
+                className="h-7 w-7 text-primary hover:bg-primary/10"
+                size="icon"
+                title={t("canvas.quickAdd.open")}
+                variant="ghost"
+                onClick={handleToggleQuickAdd}
+              />
+            }
+          >
+            <Plus className="h-4 w-4" />
+          </TooltipTrigger>
+          <TooltipContent>{t("canvas.quickAdd.open")}</TooltipContent>
+        </Tooltip>
 
         <Separator className="mx-1 h-5" orientation="vertical" />
 

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.stories.tsx
@@ -6,6 +6,7 @@ import { CodeFileNode } from "./CodeFileNode";
 const meta: Meta<typeof CodeFileNode> = {
   title: "HarnessCanvas/CodeFileNode",
   component: CodeFileNode,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <HarnessCanvasStoreProvider>
@@ -17,6 +18,14 @@ const meta: Meta<typeof CodeFileNode> = {
       </HarnessCanvasStoreProvider>
     ),
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Canvas node card for a single source file object. Use these stories to check path display, inline editing, selection state, and empty-path fallback.",
+      },
+    },
+  },
 };
 
 export default meta;
@@ -32,6 +41,13 @@ export const Default: Story = {
       description: "应用入口文件",
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Code-file node with path, language, and description populated.",
+      },
+    },
+  },
 };
 
 export const Selected: Story = {
@@ -44,6 +60,13 @@ export const Selected: Story = {
       language: "typescript",
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Selected code-file node state inside a React Flow context.",
+      },
+    },
+  },
 };
 
 export const NoPath: Story = {
@@ -53,6 +76,13 @@ export const NoPath: Story = {
       label: "新文件",
       filePath: "",
       language: "python",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "New code-file node before a file path has been selected.",
+      },
     },
   },
 };

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
@@ -58,7 +58,9 @@ export const CodeFileNode = ({ id, data, selected }: CodeFileNodeProps) => {
       >
         <div className="flex items-center gap-1 rounded-md border border-slate-100 bg-slate-50 px-2 py-1">
           <input
+            aria-label="Code file path"
             className="nodrag nopan font-mono text-[11px] font-semibold text-slate-700 bg-transparent focus:outline-none flex-1 min-w-0"
+            name={`${id}-filePath`}
             placeholder="src/file.tsx"
             value={data.filePath}
             onChange={handleFilePathChange}
@@ -76,7 +78,9 @@ export const CodeFileNode = ({ id, data, selected }: CodeFileNodeProps) => {
             <FolderOpen className="h-3.5 w-3.5" />
           </button>
           <input
+            aria-label="Code file language"
             className="nodrag nopan w-12 shrink-0 rounded bg-orange-100 px-1 py-0.5 font-mono text-[10px] font-medium text-orange-700 focus:outline-none focus:bg-orange-50 text-right"
+            name={`${id}-language`}
             placeholder="ts"
             value={data.language ?? ""}
             onChange={handleLanguageChange}
@@ -86,7 +90,9 @@ export const CodeFileNode = ({ id, data, selected }: CodeFileNodeProps) => {
           />
         </div>
         <textarea
+          aria-label="Code file description"
           className="nodrag nopan text-[11px] text-slate-500 bg-transparent w-full resize-none focus:outline-none focus:bg-slate-50 focus:ring-1 focus:ring-slate-200 rounded px-1"
+          name={`${id}-description`}
           placeholder="文件描述..."
           rows={2}
           value={data.description ?? ""}

--- a/apps/app/src/pages/CanvasPage/CompoundNode/CompoundNode.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CompoundNode/CompoundNode.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { HarnessCanvasStoreProvider } from "../_store";
+import { CompoundNode } from "./CompoundNode";
+
+const meta: Meta<typeof CompoundNode> = {
+  title: "CanvasPage/CompoundNode",
+  component: CompoundNode,
+  tags: ["autodocs"],
+  args: {
+    id: "group-1",
+    data: {
+      label: "Review Group",
+      nodeType: "compound",
+      childNodeIds: ["source-file", "review-op"],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <HarnessCanvasStoreProvider>
+        <ReactFlowProvider>
+          <div className="h-48 w-80 p-4">
+            <Story />
+          </div>
+        </ReactFlowProvider>
+      </HarnessCanvasStoreProvider>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Compound node frame used to group related Canvas nodes. Docs stories check selected and child-count states.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CompoundNode>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Group frame with two child nodes.",
+      },
+    },
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    selected: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Selected group frame state.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/ConnectionMenu/ConnectionMenu.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/ConnectionMenu/ConnectionMenu.stories.tsx
@@ -1,19 +1,65 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { HarnessCanvasStoreProvider } from "../_store";
+import { Refine } from "@refinedev/core";
+import type { PipelineNode } from "../_store";
+import { createHarnessCanvasStore, HarnessCanvasStoreContext } from "../_store";
+import { canvasStoryDataProvider } from "../storybookData";
 import { ConnectionMenu } from "./ConnectionMenu";
+
+const sourceNode = {
+  id: "source-file",
+  type: "code-file",
+  position: { x: 80, y: 120 },
+  data: {
+    label: "Source File",
+    nodeType: "code-file",
+    filePath: "src/index.ts",
+    language: "typescript",
+    description: "Pipeline source",
+  },
+} as PipelineNode;
 
 const meta: Meta<typeof ConnectionMenu> = {
   title: "CanvasPage/ConnectionMenu",
   component: ConnectionMenu,
-  args: { screenX: 200, screenY: 200, flowX: 100, flowY: 100, onClose: () => undefined },
+  tags: ["autodocs"],
   decorators: [
-    (Story) => (
-      <HarnessCanvasStoreProvider pipeline={null}>
-        <Story />
-      </HarnessCanvasStoreProvider>
-    ),
+    (Story) => {
+      const store = createHarnessCanvasStore([sourceNode], []);
+      store.setState({
+        connectStart: { nodeId: sourceNode.id, handleId: null, handleType: "source" },
+        connectionMenu: { screenX: 220, screenY: 120, flowX: 180, flowY: 120 },
+      });
+
+      return (
+        <Refine dataProvider={canvasStoryDataProvider}>
+          <HarnessCanvasStoreContext.Provider value={store}>
+            <div className="relative h-96 w-full bg-slate-50">
+              <Story />
+            </div>
+          </HarnessCanvasStoreContext.Provider>
+        </Refine>
+      );
+    },
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Connection-end menu shown after dragging from a node handle to empty canvas space. It offers compatible target node types, Operations, Recipes, and output endpoints.",
+      },
+    },
+  },
 };
 export default meta;
 type Story = StoryObj<typeof ConnectionMenu>;
-export const Default: Story = { args: {} };
+export const Default: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Open connection menu from a code-file source node using local Operation and Recipe data.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/ErrorNode/ErrorNode.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/ErrorNode/ErrorNode.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { ErrorNode } from "./ErrorNode";
+
+const meta: Meta<typeof ErrorNode> = {
+  title: "CanvasPage/ErrorNode",
+  component: ErrorNode,
+  tags: ["autodocs"],
+  args: {
+    id: "unknown-node",
+    type: "legacy-node",
+    data: {},
+  },
+  decorators: [
+    (Story) => (
+      <ReactFlowProvider>
+        <div className="p-6">
+          <Story />
+        </div>
+      </ReactFlowProvider>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Fallback node shown when the Canvas receives an unknown or unsupported node type.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ErrorNode>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Unknown-node fallback with type and id visible.",
+      },
+    },
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    selected: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Selected fallback node state.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.stories.tsx
@@ -6,6 +6,7 @@ import { FolderNode } from "./FolderNode";
 const meta: Meta<typeof FolderNode> = {
   title: "HarnessCanvas/FolderNode",
   component: FolderNode,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <HarnessCanvasStoreProvider>
@@ -17,6 +18,14 @@ const meta: Meta<typeof FolderNode> = {
       </HarnessCanvasStoreProvider>
     ),
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Canvas node card for a folder object. Stories cover configured, selected, and empty-path states.",
+      },
+    },
+  },
 };
 
 export default meta;
@@ -31,6 +40,13 @@ export const Default: Story = {
       description: "应用源码目录",
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Folder node with a local folder path and description.",
+      },
+    },
+  },
 };
 
 export const Selected: Story = {
@@ -42,6 +58,13 @@ export const Selected: Story = {
       folderPath: "apps/app/src/components",
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Selected folder node state.",
+      },
+    },
+  },
 };
 
 export const NoPath: Story = {
@@ -50,6 +73,13 @@ export const NoPath: Story = {
       nodeType: "folder",
       label: "新文件夹",
       folderPath: "",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "New folder node before a folder path has been selected.",
+      },
     },
   },
 };

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderTreePreview.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderTreePreview.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Refine } from "@refinedev/core";
+import { canvasStoryDataProvider } from "../storybookData";
+import { FolderTreePreview } from "./FolderTreePreview";
+
+const meta: Meta<typeof FolderTreePreview> = {
+  title: "CanvasPage/FolderNode/FolderTreePreview",
+  component: FolderTreePreview,
+  tags: ["autodocs"],
+  args: {
+    folderPath: "/workspace/ordine",
+    excludedPaths: ["packages"],
+    onExclude: () => undefined,
+  },
+  decorators: [
+    (Story) => (
+      <Refine dataProvider={canvasStoryDataProvider}>
+        <div className="w-80 p-6">
+          <Story />
+        </div>
+      </Refine>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Compact folder preview embedded inside project and folder nodes, including excluded directory affordances.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FolderTreePreview>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Folder preview with one path already excluded.",
+      },
+    },
+  },
+};
+
+export const EmptyPath: Story = {
+  args: {
+    folderPath: "",
+    excludedPaths: [],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "No preview is rendered until a folder path is available.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubConnectDialog.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubConnectDialog.stories.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { GitHubConnectDialog } from "./GitHubConnectDialog";
+
+const GitHubConnectDialogStory = (args: React.ComponentProps<typeof GitHubConnectDialog>) => {
+  const [open, setOpen] = useState(args.open);
+  const handleClose = () => setOpen(false);
+
+  return <GitHubConnectDialog {...args} open={open} onClose={handleClose} />;
+};
+
+const meta: Meta<typeof GitHubConnectDialog> = {
+  title: "CanvasPage/GitHubProjectNode/GitHubConnectDialog",
+  component: GitHubConnectDialog,
+  tags: ["autodocs"],
+  args: {
+    open: true,
+    initialUrl: "https://github.com/woodfish/ordine",
+    onClose: () => undefined,
+    onConnect: () => undefined,
+  },
+  decorators: [
+    (Story) => (
+      <div className="relative min-h-[28rem] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Dialog for connecting a GitHub repository by URL. The Storybook story stops before network verification.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof GitHubConnectDialog>;
+
+export const Open: Story = {
+  render: (args) => <GitHubConnectDialogStory {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story: "URL-entry step for connecting a repository.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.stories.tsx
@@ -6,6 +6,7 @@ import { GitHubProjectNode } from "./GitHubProjectNode";
 const meta: Meta<typeof GitHubProjectNode> = {
   title: "HarnessCanvas/GitHubProjectNode",
   component: GitHubProjectNode,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <HarnessCanvasStoreProvider>
@@ -17,6 +18,14 @@ const meta: Meta<typeof GitHubProjectNode> = {
       </HarnessCanvasStoreProvider>
     ),
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Canvas node card for a GitHub project object. Stories cover configured repository, selected, and empty-repo setup states.",
+      },
+    },
+  },
 };
 
 export default meta;
@@ -33,6 +42,13 @@ export const Default: Story = {
       description: "主项目仓库",
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "GitHub project node with owner, repository, branch, and description populated.",
+      },
+    },
+  },
 };
 
 export const Selected: Story = {
@@ -46,6 +62,13 @@ export const Selected: Story = {
       branch: "main",
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Selected GitHub project node state.",
+      },
+    },
+  },
 };
 
 export const NoRepo: Story = {
@@ -55,6 +78,13 @@ export const NoRepo: Story = {
       label: "新项目",
       owner: "",
       repo: "",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "New GitHub project node before a repository has been selected or connected.",
+      },
     },
   },
 };

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubTokenDialog.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubTokenDialog.stories.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { GitHubTokenDialog } from "./GitHubTokenDialog";
+
+const GitHubTokenDialogStory = (args: React.ComponentProps<typeof GitHubTokenDialog>) => {
+  const [open, setOpen] = useState(args.open);
+  const handleClose = () => setOpen(false);
+
+  return <GitHubTokenDialog {...args} open={open} onClose={handleClose} />;
+};
+
+const meta: Meta<typeof GitHubTokenDialog> = {
+  title: "CanvasPage/GitHubProjectNode/GitHubTokenDialog",
+  component: GitHubTokenDialog,
+  tags: ["autodocs"],
+  args: {
+    open: true,
+    onClose: () => undefined,
+    onTokenSaved: () => undefined,
+  },
+  decorators: [
+    (Story) => (
+      <div className="relative min-h-[30rem] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: "Dialog for storing a GitHub Personal Access Token in local browser storage.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof GitHubTokenDialog>;
+
+export const Open: Story = {
+  render: (args) => <GitHubTokenDialogStory {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story: "Token-entry dialog before verification or save actions.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/PickLocalFolderDialog.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/PickLocalFolderDialog.stories.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Refine } from "@refinedev/core";
+import { canvasStoryDataProvider } from "../storybookData";
+import { PickLocalFolderDialog } from "./PickLocalFolderDialog";
+
+const PickLocalFolderDialogStory = (args: React.ComponentProps<typeof PickLocalFolderDialog>) => {
+  const [open, setOpen] = useState(args.open);
+  const handleClose = () => setOpen(false);
+
+  return <PickLocalFolderDialog {...args} open={open} onClose={handleClose} />;
+};
+
+const meta: Meta<typeof PickLocalFolderDialog> = {
+  title: "CanvasPage/GitHubProjectNode/PickLocalFolderDialog",
+  component: PickLocalFolderDialog,
+  tags: ["autodocs"],
+  args: {
+    open: true,
+    initialPath: "/workspace/ordine",
+    onClose: () => undefined,
+    onPick: () => undefined,
+  },
+  decorators: [
+    (Story) => (
+      <Refine dataProvider={canvasStoryDataProvider}>
+        <div className="relative min-h-[28rem] p-6">
+          <Story />
+        </div>
+      </Refine>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: "Dialog for binding a project node to a local folder instead of GitHub.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PickLocalFolderDialog>;
+
+export const Open: Story = {
+  render: (args) => <PickLocalFolderDialogStory {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story: "Local folder picker with a prefilled path.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/PickProjectDialog.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/PickProjectDialog.stories.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Refine } from "@refinedev/core";
+import { canvasStoryDataProvider } from "../storybookData";
+import { PickProjectDialog } from "./PickProjectDialog";
+
+const PickProjectDialogStory = (args: React.ComponentProps<typeof PickProjectDialog>) => {
+  const [open, setOpen] = useState(args.open);
+  const handleClose = () => setOpen(false);
+
+  return <PickProjectDialog {...args} open={open} onClose={handleClose} />;
+};
+
+const meta: Meta<typeof PickProjectDialog> = {
+  title: "CanvasPage/GitHubProjectNode/PickProjectDialog",
+  component: PickProjectDialog,
+  tags: ["autodocs"],
+  args: {
+    open: true,
+    onClose: () => undefined,
+    onPick: () => undefined,
+  },
+  decorators: [
+    (Story) => (
+      <Refine dataProvider={canvasStoryDataProvider}>
+        <div className="relative min-h-[28rem] p-6">
+          <Story />
+        </div>
+      </Refine>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Dialog for selecting an existing GitHub project from the user's project library.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PickProjectDialog>;
+
+export const Open: Story = {
+  render: (args) => <PickProjectDialogStory {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story: "Project library picker populated by Storybook mock GitHub projects.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/LlmContentCard/LlmContentCard.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/LlmContentCard/LlmContentCard.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { createHarnessCanvasStore, HarnessCanvasStoreContext, type PipelineNode } from "../_store";
+import { LlmContentCard } from "./LlmContentCard";
+
+const operationNode = {
+  id: "review-op",
+  type: "operation",
+  position: { x: 0, y: 0 },
+  data: {
+    label: "Review Code",
+    nodeType: "operation",
+    operationId: "review-code",
+    operationName: "Review Code",
+    status: "running",
+    config: {},
+  },
+} as PipelineNode;
+
+const withInspectionStore = (Story: React.ComponentType) => {
+  const store = createHarnessCanvasStore([operationNode]);
+  store.setState({
+    inspectingNodeId: "review-op",
+    nodeRunStatuses: { "review-op": "running" },
+    nodeLlmContent: {
+      "review-op":
+        "### Review\n\n- No blocking issue in this story.\n- Add focused tests before merging behavior changes.",
+    },
+  });
+
+  return (
+    <HarnessCanvasStoreContext.Provider value={store}>
+      <div className="relative h-96 w-full rounded-md border bg-slate-50">
+        <Story />
+      </div>
+    </HarnessCanvasStoreContext.Provider>
+  );
+};
+
+const meta: Meta<typeof LlmContentCard> = {
+  title: "CanvasPage/LlmContentCard",
+  component: LlmContentCard,
+  tags: ["autodocs"],
+  decorators: [withInspectionStore],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Floating inspector card for LLM output captured from a running or completed operation node.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LlmContentCard>;
+
+export const WithContent: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Inspector with markdown content for the active operation node.",
+      },
+    },
+  },
+};
+
+export const WaitingForContent: Story = {
+  decorators: [
+    (Story) => {
+      const store = createHarnessCanvasStore([operationNode]);
+      store.setState({
+        inspectingNodeId: "review-op",
+        nodeRunStatuses: { "review-op": "running" },
+        nodeLlmContent: {},
+      });
+
+      return (
+        <HarnessCanvasStoreContext.Provider value={store}>
+          <div className="relative h-96 w-full rounded-md border bg-slate-50">
+            <Story />
+          </div>
+        </HarnessCanvasStoreContext.Provider>
+      );
+    },
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story: "Running state before the first LLM content chunk arrives.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
@@ -127,7 +127,9 @@ export const NodeCard = ({
           <div className="flex min-h-8 flex-1 min-w-0 flex-col justify-center">
             {handleChange ? (
               <input
+                aria-label="Node label"
                 className="nodrag nopan w-full bg-transparent text-xs font-semibold leading-tight focus:outline-none"
+                name="nodeLabel"
                 value={label}
                 onChange={handleChange}
                 onMouseDown={handleMouseDown}

--- a/apps/app/src/pages/CanvasPage/NodeContextMenu/NodeContextMenu.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeContextMenu/NodeContextMenu.stories.tsx
@@ -1,19 +1,65 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { HarnessCanvasStoreProvider } from "../_store";
+import { Refine } from "@refinedev/core";
+import type { PipelineNode } from "../_store";
+import { createHarnessCanvasStore, HarnessCanvasStoreContext } from "../_store";
+import { canvasStoryDataProvider } from "../storybookData";
 import { NodeContextMenu } from "./NodeContextMenu";
+
+const sourceNode = {
+  id: "node-1",
+  type: "code-file",
+  position: { x: 80, y: 120 },
+  data: {
+    label: "Source File",
+    nodeType: "code-file",
+    filePath: "src/index.ts",
+    language: "typescript",
+    description: "Pipeline source",
+  },
+} as PipelineNode;
 
 const meta: Meta<typeof NodeContextMenu> = {
   title: "CanvasPage/NodeContextMenu",
   component: NodeContextMenu,
-  args: { screenX: 200, screenY: 200, nodeId: "node-1", onClose: () => undefined },
+  tags: ["autodocs"],
   decorators: [
-    (Story) => (
-      <HarnessCanvasStoreProvider pipeline={null}>
-        <Story />
-      </HarnessCanvasStoreProvider>
-    ),
+    (Story) => {
+      const store = createHarnessCanvasStore([sourceNode], []);
+      store.setState({
+        nodeContextMenu: { screenX: 220, screenY: 120, nodeId: sourceNode.id },
+        selectedNodeId: sourceNode.id,
+      });
+
+      return (
+        <Refine dataProvider={canvasStoryDataProvider}>
+          <HarnessCanvasStoreContext.Provider value={store}>
+            <div className="relative h-96 w-full bg-slate-50">
+              <Story />
+            </div>
+          </HarnessCanvasStoreContext.Provider>
+        </Refine>
+      );
+    },
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Node-level context menu for duplicating, deleting, grouping, ungrouping, and adding compatible downstream nodes from a selected Canvas node.",
+      },
+    },
+  },
 };
 export default meta;
 type Story = StoryObj<typeof NodeContextMenu>;
-export const Default: Story = { args: {} };
+export const Default: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Open node context menu for a selected code-file node with downstream actions available.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/OperationNode/BestPracticeSelect/BestPracticeSelect.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/OperationNode/BestPracticeSelect/BestPracticeSelect.stories.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { canvasStoryBestPractices } from "../../storybookData";
+import { BestPracticeSelect } from "./BestPracticeSelect";
+
+const BestPracticeSelectStory = (args: React.ComponentProps<typeof BestPracticeSelect>) => {
+  const [value, setValue] = useState(args.value);
+  const handleValueChange = (id: string | undefined, name: string | undefined) => {
+    args.onValueChange(id, name);
+    setValue(id);
+  };
+
+  return <BestPracticeSelect {...args} value={value} onValueChange={handleValueChange} />;
+};
+
+const bestPractices = canvasStoryBestPractices.map(({ id, title }) => ({ id, title }));
+
+const meta: Meta<typeof BestPracticeSelect> = {
+  title: "CanvasPage/OperationNode/BestPracticeSelect",
+  component: BestPracticeSelect,
+  tags: ["autodocs"],
+  args: {
+    bestPractices,
+    value: "bp-strict-review",
+    onValueChange: () => undefined,
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: "Small selector used by operation nodes to choose a Best Practice preset.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BestPracticeSelect>;
+
+export const Selected: Story = {
+  render: (args) => <BestPracticeSelectStory {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story: "Best Practice selector with a current value.",
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    value: undefined,
+  },
+  render: (args) => <BestPracticeSelectStory {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story: "Selector before a Best Practice has been chosen.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Refine } from "@refinedev/core";
+import { ReactFlowProvider } from "@xyflow/react";
+import type { OperationNodeData } from "@repo/pipeline-engine/schemas";
+import { createHarnessCanvasStore, HarnessCanvasStoreContext, type PipelineNode } from "../_store";
+import { canvasStoryDataProvider } from "../storybookData";
+import { OperationNode } from "./OperationNode";
+
+const baseData: OperationNodeData = {
+  label: "Review Code",
+  nodeType: "operation",
+  operationId: "review-code",
+  operationName: "Review Code",
+  status: "idle",
+  config: {},
+  bestPracticeId: "bp-strict-review",
+  bestPracticeName: "Strict Review",
+};
+
+const withCanvasProviders = (Story: React.ComponentType, context: { args: OperationNodeProps }) => {
+  const nodeId = context.args.id ?? "review-op";
+  const node = {
+    id: nodeId,
+    type: "operation",
+    position: { x: 0, y: 0 },
+    data: context.args.data ?? baseData,
+  } as PipelineNode;
+  const store = createHarnessCanvasStore([node]);
+
+  store.setState({
+    isTestRunning: context.args.data?.status === "running",
+    nodeRunStatuses: context.args.data?.status === "running" ? { [nodeId]: "running" } : {},
+  });
+
+  return (
+    <Refine dataProvider={canvasStoryDataProvider}>
+      <HarnessCanvasStoreContext.Provider value={store}>
+        <ReactFlowProvider>
+          <div className="p-6">
+            <Story />
+          </div>
+        </ReactFlowProvider>
+      </HarnessCanvasStoreContext.Provider>
+    </Refine>
+  );
+};
+
+type OperationNodeProps = React.ComponentProps<typeof OperationNode>;
+
+const meta: Meta<typeof OperationNode> = {
+  title: "CanvasPage/OperationNode",
+  component: OperationNode,
+  tags: ["autodocs"],
+  args: {
+    id: "review-op",
+    data: baseData,
+  },
+  decorators: [withCanvasProviders],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Operation node used to run a configured operation or recipe. The Docs stories load mocked Operations and Best Practices through the Canvas Storybook data provider.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof OperationNode>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Configured operation node with runtime and best-practice selectors.",
+      },
+    },
+  },
+};
+
+export const Running: Story = {
+  args: {
+    data: {
+      ...baseData,
+      status: "running",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Operation node while a pipeline run is active.",
+      },
+    },
+  },
+};
+
+export const LoopEnabled: Story = {
+  args: {
+    data: {
+      ...baseData,
+      loopEnabled: true,
+      maxLoopCount: 3,
+      loopConditionPrompt: "No blocking review findings remain.",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Operation node with retry loop controls expanded.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
@@ -248,9 +248,11 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
                   最大次数
                 </span>
                 <input
+                  aria-label="Maximum loop count"
                   className="nodrag nopan h-5 w-14 rounded border border-amber-200 bg-white px-1.5 text-[10px] text-amber-800 focus:outline-none focus:ring-1 focus:ring-amber-300"
                   max={20}
                   min={1}
+                  name={`${id}-maxLoopCount`}
                   type="number"
                   value={data.maxLoopCount ?? 3}
                   onChange={handleMaxLoopChange}
@@ -259,7 +261,9 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
               <div className="space-y-0.5">
                 <span className="text-[10px] font-medium text-amber-700">验收条件</span>
                 <textarea
+                  aria-label="Loop acceptance condition"
                   className="nodrag nopan w-full rounded border border-amber-200 bg-white px-1.5 py-1 text-[10px] text-amber-800 placeholder:text-amber-300 focus:outline-none focus:ring-1 focus:ring-amber-300"
+                  name={`${id}-loopCondition`}
                   placeholder="描述输出需要满足的条件..."
                   rows={2}
                   value={data.loopConditionPrompt ?? ""}

--- a/apps/app/src/pages/CanvasPage/OutputLocalPathNode/FolderBrowser.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputLocalPathNode/FolderBrowser.stories.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Refine } from "@refinedev/core";
+import { canvasStoryDataProvider } from "../storybookData";
+import { FolderBrowser } from "./FolderBrowser";
+
+const FolderBrowserStory = (args: React.ComponentProps<typeof FolderBrowser>) => {
+  const [open, setOpen] = useState(args.open);
+  const handleOpenChange = (value: boolean) => setOpen(value);
+  const handleSelect = (path: string) => {
+    args.onSelect(path);
+    setOpen(false);
+  };
+
+  return (
+    <FolderBrowser {...args} open={open} onOpenChange={handleOpenChange} onSelect={handleSelect} />
+  );
+};
+
+const meta: Meta<typeof FolderBrowser> = {
+  title: "CanvasPage/OutputLocalPathNode/FolderBrowser",
+  component: FolderBrowser,
+  tags: ["autodocs"],
+  args: {
+    open: true,
+    mode: "folder",
+    onOpenChange: () => undefined,
+    onSelect: () => undefined,
+  },
+  decorators: [
+    (Story) => (
+      <Refine dataProvider={canvasStoryDataProvider}>
+        <div className="relative min-h-[28rem] p-6">
+          <Story />
+        </div>
+      </Refine>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Dialog used by local output nodes and local project selection to browse folders or files.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FolderBrowser>;
+
+export const FolderMode: Story = {
+  render: (args) => <FolderBrowserStory {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story: "Folder-selection mode using mocked filesystem entries.",
+      },
+    },
+  },
+};
+
+export const FileMode: Story = {
+  args: {
+    mode: "file",
+  },
+  render: (args) => <FolderBrowserStory {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story: "File-selection mode showing files and folders together.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Refine } from "@refinedev/core";
+import { ReactFlowProvider } from "@xyflow/react";
+import { HarnessCanvasStoreProvider } from "../_store";
+import { canvasStoryDataProvider } from "../storybookData";
+import { OutputLocalPathNode } from "./OutputLocalPathNode";
+
+const meta: Meta<typeof OutputLocalPathNode> = {
+  title: "CanvasPage/OutputLocalPathNode",
+  component: OutputLocalPathNode,
+  tags: ["autodocs"],
+  args: {
+    id: "output-local",
+    data: {
+      label: "Write Local Report",
+      nodeType: "output-local-path",
+      localPath: "/workspace/ordine/output",
+      outputFileName: "review.md",
+      outputMode: "overwrite",
+      description: "Writes the review result to a local markdown file.",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Refine dataProvider={canvasStoryDataProvider}>
+        <HarnessCanvasStoreProvider>
+          <ReactFlowProvider>
+            <div className="p-6">
+              <Story />
+            </div>
+          </ReactFlowProvider>
+        </HarnessCanvasStoreProvider>
+      </Refine>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Output node for writing pipeline artifacts to a local filesystem path. The folder browser uses Canvas Storybook mock filesystem data.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof OutputLocalPathNode>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Local output node with path, file name, write mode, and description.",
+      },
+    },
+  },
+};
+
+export const ErrorIfExists: Story = {
+  args: {
+    data: {
+      label: "Write Protected Report",
+      nodeType: "output-local-path",
+      localPath: "/workspace/ordine/output",
+      outputFileName: "review.md",
+      outputMode: "error_if_exists",
+      description: "Stops the run if the output file already exists.",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Warning state for the strict file-exists mode.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { HarnessCanvasStoreProvider } from "../_store";
+import { OutputProjectPathNode } from "./OutputProjectPathNode";
+
+const meta: Meta<typeof OutputProjectPathNode> = {
+  title: "CanvasPage/OutputProjectPathNode",
+  component: OutputProjectPathNode,
+  tags: ["autodocs"],
+  args: {
+    id: "output-project",
+    data: {
+      label: "Write Project File",
+      nodeType: "output-project-path",
+      projectId: "project-ordine",
+      path: "docs/review.md",
+      description: "Writes the output back into the selected project.",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <HarnessCanvasStoreProvider>
+        <ReactFlowProvider>
+          <div className="p-6">
+            <Story />
+          </div>
+        </ReactFlowProvider>
+      </HarnessCanvasStoreProvider>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: "Output node for writing pipeline artifacts to a project-relative path.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof OutputProjectPathNode>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Project-path output node with project id, path, and description.",
+      },
+    },
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    selected: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Selected project-path output node state.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/RunConsole/RunConsole.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/RunConsole/RunConsole.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Refine } from "@refinedev/core";
+import {
+  createHarnessCanvasStore,
+  HarnessCanvasStoreContext,
+  type PipelineEdge,
+  type PipelineNode,
+} from "../_store";
+import { canvasStoryDataProvider } from "../storybookData";
+import { RunConsole } from "./RunConsole";
+
+const sourceNode = {
+  id: "source-file",
+  type: "code-file",
+  position: { x: 0, y: 0 },
+  data: {
+    label: "Source File",
+    nodeType: "code-file",
+    filePath: "src/index.ts",
+    language: "typescript",
+  },
+} as PipelineNode;
+
+const operationNode = {
+  id: "review-op",
+  type: "operation",
+  position: { x: 320, y: 0 },
+  data: {
+    label: "Review Code",
+    nodeType: "operation",
+    operationId: "review-code",
+    operationName: "Review Code",
+    status: "running",
+    config: {},
+  },
+} as PipelineNode;
+
+const edge = {
+  id: "source-to-review",
+  source: "source-file",
+  target: "review-op",
+  type: "default",
+  data: {},
+} as PipelineEdge;
+
+const withRunConsoleStore = (Story: React.ComponentType) => {
+  const store = createHarnessCanvasStore([sourceNode, operationNode], [edge]);
+  store.setState({
+    activeJobId: "job-story",
+    isConsoleOpen: true,
+    isTestRunning: true,
+    runningNodeId: "review-op",
+    nodeRunStatuses: { "review-op": "running" },
+  });
+
+  return (
+    <Refine dataProvider={canvasStoryDataProvider}>
+      <HarnessCanvasStoreContext.Provider value={store}>
+        <div className="relative h-80 w-full overflow-hidden rounded-md border bg-slate-50">
+          <Story />
+        </div>
+      </HarnessCanvasStoreContext.Provider>
+    </Refine>
+  );
+};
+
+const meta: Meta<typeof RunConsole> = {
+  title: "CanvasPage/RunConsole",
+  component: RunConsole,
+  tags: ["autodocs"],
+  decorators: [withRunConsoleStore],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Bottom run console for active pipeline jobs. Storybook uses mocked `jobs` and `jobs/traces` responses, so the console can render in Docs without a backend.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RunConsole>;
+
+export const Running: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Console open with a running job, visible logs, and structured node status updates.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/RunConsole/RunConsole.tsx
+++ b/apps/app/src/pages/CanvasPage/RunConsole/RunConsole.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { Terminal, X, ChevronUp, ChevronDown, Loader2 } from "lucide-react";
 import { Button } from "@repo/ui/button";
 import { ScrollArea } from "@repo/ui/scroll-area";
@@ -122,10 +122,12 @@ export const RunConsole = () => {
       },
     },
   });
-  const traceLogs = (tracesResult.data?.traces ?? []).map((trace) => trace.message);
+  const traces = tracesResult.data?.traces;
+  const traceLogs = useMemo(() => (traces ?? []).map((trace) => trace.message), [traces]);
 
-  // Process new structured log lines during render (ref-driven, no useEffect)
-  if (traceLogs.length > processedLogCount.current) {
+  useEffect(() => {
+    if (traceLogs.length <= processedLogCount.current) return;
+
     const newLogs = traceLogs.slice(processedLogCount.current);
     processedLogCount.current = traceLogs.length;
 
@@ -135,11 +137,13 @@ export const RunConsole = () => {
       onNodeFail: markNodeFailed,
       onLlmContent: setNodeLlmContent,
     });
+  }, [traceLogs, markNodeRunning, markNodePassed, markNodeFailed, setNodeLlmContent]);
 
+  useEffect(() => {
     if (job && isTerminalStatus(job.status)) {
       stopTestRun();
     }
-  }
+  }, [job, stopTestRun]);
 
   // Auto-scroll to bottom
   useEffect(() => {

--- a/apps/app/src/pages/CanvasPage/RunConsole/StatusIcon.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/RunConsole/StatusIcon.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { JobStatus } from "./types";
+import { StatusIcon } from "./StatusIcon";
+
+const statuses: JobStatus[] = ["queued", "running", "done", "failed", "cancelled", "expired"];
+
+const meta: Meta<typeof StatusIcon> = {
+  title: "CanvasPage/RunConsole/StatusIcon",
+  component: StatusIcon,
+  tags: ["autodocs"],
+  args: {
+    status: "running",
+  },
+  argTypes: {
+    status: {
+      control: "select",
+      options: statuses,
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: "Compact icon used by the run console to represent job status.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StatusIcon>;
+
+export const Running: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Single running-state icon with spinner animation.",
+      },
+    },
+  },
+};
+
+export const Matrix: Story = {
+  render: () => (
+    <div className="flex items-center gap-4 p-4">
+      {statuses.map((status) => (
+        <div key={status} className="flex items-center gap-1 text-xs">
+          <StatusIcon status={status} />
+          <span>{status}</span>
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "All job statuses shown together for visual comparison.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
@@ -13,12 +13,21 @@ import { ResultAsync } from "neverthrow";
 import i18n from "@/lib/i18n";
 import type { ReactFlowInstance, OnConnectStartParams } from "@xyflow/react";
 import type { FinalConnectionState, XYPosition } from "@xyflow/system";
+import {
+  CONNECTION_MENU_NODE_OFFSET,
+  NODE_CONTEXT_CONNECT_OFFSET,
+  QUICK_ADD_NODE_ORIGIN,
+  getScreenViewportCenter,
+  offsetPosition,
+} from "../utils/nodePosition";
 
 export interface ActionsSlice {
   exportCanvas: () => void;
   importCanvas: (data: { nodes: PipelineNode[]; edges: PipelineEdge[] }) => void;
   fitView: (options?: { padding?: number }) => void;
   screenToFlowPosition: (pos: XYPosition) => XYPosition;
+  getViewportScreenCenter: () => XYPosition;
+  setViewportScreenCenterGetter: (getter: () => XYPosition) => void;
   handleFitView: () => void;
   handleZoomIn: () => void;
   handleZoomOut: () => void;
@@ -55,6 +64,9 @@ export interface ActionsSlice {
   createObjectNode: (type: NodeType) => void;
   createOperationNode: (operation: Operation) => void;
   createRecipeNode: (recipe: Recipe, operation: Operation) => void;
+  createObjectNodeAtViewportCenter: (type: NodeType) => void;
+  createOperationNodeAtViewportCenter: (operation: Operation) => void;
+  createRecipeNodeAtViewportCenter: (recipe: Recipe, operation: Operation) => void;
   dismissContextMenu: () => void;
   handleContextMenuOpenChange: (open: boolean) => void;
   connectObjectNode: (type: NodeType) => void;
@@ -111,6 +123,10 @@ export const createActionsSlice = (
   },
   fitView: () => {},
   screenToFlowPosition: (pos) => pos,
+  getViewportScreenCenter: () => getScreenViewportCenter(),
+  setViewportScreenCenterGetter: (getter) => {
+    set({ getViewportScreenCenter: getter });
+  },
   handleFitView: () => {
     get().fitView({ padding: 0.1 });
   },
@@ -127,6 +143,7 @@ export const createActionsSlice = (
       connectionMenu: null,
       nodeContextMenu: null,
       connectStart: null,
+      isQuickAddOpen: false,
     });
   },
 
@@ -138,6 +155,7 @@ export const createActionsSlice = (
       connectionMenu: null,
       nodeContextMenu: null,
       connectStart: null,
+      isQuickAddOpen: false,
     });
   },
 
@@ -149,6 +167,7 @@ export const createActionsSlice = (
       connectionMenu: null,
       nodeContextMenu: null,
       connectStart: null,
+      isQuickAddOpen: false,
     });
   },
 
@@ -440,6 +459,47 @@ export const createActionsSlice = (
     });
   },
 
+  createObjectNodeAtViewportCenter: (type) => {
+    const position = get().screenToFlowPosition(get().getViewportScreenCenter());
+    get().addNodeAndAutoConnect({
+      id: `${type}-${Date.now()}`,
+      type,
+      origin: QUICK_ADD_NODE_ORIGIN,
+      position,
+      data: makeDefaultNodeData(type as BuiltinNodeType),
+    });
+    set({ isQuickAddOpen: false });
+  },
+
+  createOperationNodeAtViewportCenter: (operation) => {
+    const position = get().screenToFlowPosition(get().getViewportScreenCenter());
+    get().addNodeAndAutoConnect({
+      id: `op-${operation.id}-${Date.now()}`,
+      type: "operation",
+      origin: QUICK_ADD_NODE_ORIGIN,
+      position,
+      data: makeOperationNodeData(operation),
+    });
+    set({ isQuickAddOpen: false });
+  },
+
+  createRecipeNodeAtViewportCenter: (recipe, operation) => {
+    const position = get().screenToFlowPosition(get().getViewportScreenCenter());
+    get().addNodeAndAutoConnect({
+      id: `op-recipe-${Date.now()}`,
+      type: "operation",
+      origin: QUICK_ADD_NODE_ORIGIN,
+      position,
+      data: {
+        ...makeOperationNodeData(operation),
+        label: recipe.name,
+        bestPracticeId: recipe.bestPracticeId,
+        bestPracticeName: recipe.name,
+      },
+    });
+    set({ isQuickAddOpen: false });
+  },
+
   // TODO: Find if it should be use
   dismissContextMenu: () => {
     set({ connectStart: null, contextMenu: null });
@@ -457,7 +517,10 @@ export const createActionsSlice = (
     get().addNodeAndAutoConnect({
       id: `${type}-${Date.now()}`,
       type,
-      position: { x: connectionMenu.flowX + 40, y: connectionMenu.flowY - 40 },
+      position: offsetPosition(
+        { x: connectionMenu.flowX, y: connectionMenu.flowY },
+        CONNECTION_MENU_NODE_OFFSET
+      ),
       data: makeDefaultNodeData(type as BuiltinNodeType),
     });
   },
@@ -468,7 +531,10 @@ export const createActionsSlice = (
     get().addNodeAndAutoConnect({
       id: `op-${operation.id}-${Date.now()}`,
       type: "operation",
-      position: { x: connectionMenu.flowX + 40, y: connectionMenu.flowY - 40 },
+      position: offsetPosition(
+        { x: connectionMenu.flowX, y: connectionMenu.flowY },
+        CONNECTION_MENU_NODE_OFFSET
+      ),
       data: makeOperationNodeData(operation),
     });
   },
@@ -479,7 +545,10 @@ export const createActionsSlice = (
     get().addNodeAndAutoConnect({
       id: `op-recipe-${Date.now()}`,
       type: "operation",
-      position: { x: connectionMenu.flowX + 40, y: connectionMenu.flowY - 40 },
+      position: offsetPosition(
+        { x: connectionMenu.flowX, y: connectionMenu.flowY },
+        CONNECTION_MENU_NODE_OFFSET
+      ),
       data: {
         ...makeOperationNodeData(operation),
         label: recipe.name,
@@ -557,7 +626,7 @@ export const createActionsSlice = (
     get().addNode({
       id: newId,
       type,
-      position: { x: node.position.x + 280, y: node.position.y },
+      position: offsetPosition(node.position, NODE_CONTEXT_CONNECT_OFFSET),
       data: makeDefaultNodeData(type as BuiltinNodeType),
     });
     get().handleConnect({
@@ -578,7 +647,7 @@ export const createActionsSlice = (
     get().addNode({
       id: newId,
       type: "operation",
-      position: { x: node.position.x + 280, y: node.position.y },
+      position: offsetPosition(node.position, NODE_CONTEXT_CONNECT_OFFSET),
       data: makeOperationNodeData(operation),
     });
     get().handleConnect({
@@ -599,7 +668,7 @@ export const createActionsSlice = (
     get().addNode({
       id: newId,
       type: "operation",
-      position: { x: node.position.x + 280, y: node.position.y },
+      position: offsetPosition(node.position, NODE_CONTEXT_CONNECT_OFFSET),
       data: {
         ...makeOperationNodeData(operation),
         label: recipe.name,

--- a/apps/app/src/pages/CanvasPage/_store/canvasSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/canvasSlice.ts
@@ -20,6 +20,7 @@ import {
 } from "@repo/pipeline-engine/schemas";
 
 import { computeAutoLayout } from "./autoLayout";
+import { DUPLICATE_NODE_OFFSET, offsetPosition } from "../utils/nodePosition";
 
 /**
  * Sort nodes so that parents (compound nodes) appear before their children.
@@ -247,7 +248,7 @@ export const createCanvasSlice = (
       const newNode: PipelineNode = {
         ...source,
         id: newId,
-        position: { x: source.position.x + 40, y: source.position.y + 40 },
+        position: offsetPosition(source.position, DUPLICATE_NODE_OFFSET),
         selected: false,
         data: { ...source.data },
       };

--- a/apps/app/src/pages/CanvasPage/_store/uiSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/uiSlice.ts
@@ -1,5 +1,6 @@
 import type { NodeRunStatus } from "@repo/pipeline-engine/schemas";
 import type { HarnessCanvasStoreSlice } from "./harnessCanvasStore";
+import { DEFAULT_CANVAS_VIEWPORT } from "../utils/canvasViewport";
 
 export interface NodeRunState {
   runStatus: NodeRunStatus | undefined;
@@ -30,6 +31,7 @@ export interface ConnectStartState {
 export interface UISlice {
   pipelineId: string | null;
   pipelineName: string;
+  viewportZoom: number;
   sidebarPanel: SidebarPanel;
   isSidebarOpen: boolean;
   isPropertiesPanelOpen: boolean;
@@ -40,6 +42,7 @@ export interface UISlice {
   nodeContextMenu: NodeContextMenuState | null;
   connectStart: ConnectStartState | null;
   shouldIgnorePaneClick: boolean;
+  isQuickAddOpen: boolean;
 
   // Pipeline test run state
   isTestRunning: boolean;
@@ -62,8 +65,12 @@ export interface UISlice {
   closeConnectionMenu: () => void;
   openNodeContextMenu: (state: NodeContextMenuState) => void;
   closeNodeContextMenu: () => void;
+  openQuickAdd: () => void;
+  closeQuickAdd: () => void;
+  toggleQuickAdd: () => void;
   handleConnectStart: (state: ConnectStartState | null) => void;
   setPipelineName: (name: string) => void;
+  setViewportZoom: (zoom: number) => void;
 
   // Pipeline run actions
   startTestRun: () => void;
@@ -92,6 +99,7 @@ export const createUISlice = (
 ): UISlice => ({
   pipelineId,
   pipelineName,
+  viewportZoom: DEFAULT_CANVAS_VIEWPORT.zoom,
   sidebarPanel: "components",
   isSidebarOpen: true,
   isPropertiesPanelOpen: false,
@@ -102,6 +110,7 @@ export const createUISlice = (
   nodeContextMenu: null,
   connectStart: null,
   shouldIgnorePaneClick: false,
+  isQuickAddOpen: false,
   // Pipeline test run state defaults
   isTestRunning: false,
   isRunning: false,
@@ -161,12 +170,40 @@ export const createUISlice = (
     set({ nodeContextMenu: null });
   },
 
+  openQuickAdd: () => {
+    set({
+      isQuickAddOpen: true,
+      contextMenu: null,
+      connectionMenu: null,
+      nodeContextMenu: null,
+      connectStart: null,
+    });
+  },
+
+  closeQuickAdd: () => {
+    set({ isQuickAddOpen: false });
+  },
+
+  toggleQuickAdd: () => {
+    set((state) => ({
+      isQuickAddOpen: !state.isQuickAddOpen,
+      contextMenu: null,
+      connectionMenu: null,
+      nodeContextMenu: null,
+      connectStart: null,
+    }));
+  },
+
   handleConnectStart: (state) => {
     set({ connectStart: state });
   },
 
   setPipelineName: (name) => {
     set({ pipelineName: name });
+  },
+
+  setViewportZoom: (zoom) => {
+    set({ viewportZoom: zoom });
   },
 
   startTestRun: () => {
@@ -218,6 +255,7 @@ export const createUISlice = (
       connectionMenu: null,
       nodeContextMenu: null,
       connectStart: null,
+      isQuickAddOpen: false,
     });
   },
 
@@ -226,6 +264,7 @@ export const createUISlice = (
       connectStart: null,
       connectionMenu: null,
       contextMenu: state,
+      isQuickAddOpen: false,
     });
   },
 
@@ -235,6 +274,7 @@ export const createUISlice = (
       connectionMenu: null,
       nodeContextMenu: { screenX, screenY, nodeId },
       connectStart: null,
+      isQuickAddOpen: false,
     });
   },
 

--- a/apps/app/src/pages/CanvasPage/storybookData.ts
+++ b/apps/app/src/pages/CanvasPage/storybookData.ts
@@ -1,0 +1,323 @@
+import type {
+  BaseRecord,
+  CreateParams,
+  CreateResponse,
+  CustomParams,
+  CustomResponse,
+  DataProvider,
+  DeleteOneParams,
+  DeleteOneResponse,
+  GetListParams,
+  GetListResponse,
+  GetManyParams,
+  GetManyResponse,
+  GetOneParams,
+  GetOneResponse,
+  UpdateParams,
+  UpdateResponse,
+} from "@refinedev/core";
+import type { BestPractice, GithubProject, Job, JobTrace, Operation, Recipe } from "@repo/schemas";
+import type { PipelineData } from "@repo/pipeline-engine/schemas";
+import { ResourceName } from "@/integrations/refine/dataProvider";
+
+export const canvasStoryOperations: Operation[] = [
+  {
+    id: "review-code",
+    name: "Review Code",
+    description: "Find correctness issues before merging.",
+    config: { inputs: [], outputs: [] },
+    acceptedObjectTypes: ["file", "folder", "project"],
+  },
+  {
+    id: "clean-code",
+    name: "Clean Code",
+    description: "Rewrite obvious clutter and keep behavior stable.",
+    config: { inputs: [], outputs: [] },
+    acceptedObjectTypes: ["file", "folder"],
+  },
+  {
+    id: "project-map",
+    name: "Project Map",
+    description: "Summarize a repository's module structure.",
+    config: { inputs: [], outputs: [] },
+    acceptedObjectTypes: ["project"],
+  },
+];
+
+export const canvasStoryBestPractices: BestPractice[] = [
+  {
+    id: "bp-strict-review",
+    title: "Strict Review",
+    condition: "Block correctness regressions before merge.",
+    content: "Review changed code for defects, missing tests, and risky assumptions.",
+    category: "review",
+    language: "typescript",
+    codeSnippet: "",
+    tags: ["review", "quality"],
+  },
+  {
+    id: "bp-slop-cleanup",
+    title: "Slop Cleanup",
+    condition: "Generated code contains noisy abstractions or vague naming.",
+    content: "Remove low-signal wrappers and keep behavior stable.",
+    category: "refactor",
+    language: "typescript",
+    codeSnippet: "",
+    tags: ["cleanup"],
+  },
+];
+
+export const canvasStoryRecipes: Recipe[] = [
+  {
+    id: "strict-review",
+    name: "Strict Review",
+    description: "Review with stronger checks.",
+    operationId: "review-code",
+    bestPracticeId: "bp-strict-review",
+  },
+  {
+    id: "slop-cleanup",
+    name: "Slop Cleanup",
+    description: "Remove low-signal generated code patterns.",
+    operationId: "clean-code",
+    bestPracticeId: "bp-slop-cleanup",
+  },
+];
+
+export const canvasStoryGithubProjects: GithubProject[] = [
+  {
+    id: "project-ordine",
+    name: "ordine",
+    description: "AI-first pipeline orchestration workspace.",
+    owner: "woodfish",
+    repo: "ordine",
+    branch: "main",
+    githubUrl: "https://github.com/woodfish/ordine",
+    isPrivate: false,
+  },
+  {
+    id: "project-private",
+    name: "internal-tools",
+    description: "Private automation tools.",
+    owner: "woodfish",
+    repo: "internal-tools",
+    branch: "develop",
+    githubUrl: "https://github.com/woodfish/internal-tools-private",
+    isPrivate: true,
+  },
+];
+
+const canvasStoryFilesystem = [
+  { name: "apps", type: "directory", path: "/workspace/ordine/apps" },
+  { name: "packages", type: "directory", path: "/workspace/ordine/packages" },
+  { name: "README.md", type: "file", path: "/workspace/ordine/README.md" },
+  { name: "app", type: "directory", path: "/workspace/ordine/apps/app" },
+  { name: "server", type: "directory", path: "/workspace/ordine/apps/server" },
+  { name: "src", type: "directory", path: "/workspace/ordine/apps/app/src" },
+  { name: "package.json", type: "file", path: "/workspace/ordine/apps/app/package.json" },
+];
+
+export const canvasStoryJobs: Job[] = [
+  {
+    id: "job-story",
+    title: "Story pipeline run",
+    type: "pipeline_run",
+    status: "running",
+    parentJobId: null,
+    error: null,
+    startedAt: new Date("2026-04-08T16:00:00.000Z"),
+    finishedAt: null,
+  },
+  {
+    id: "job-done-story",
+    title: "Completed story pipeline run",
+    type: "pipeline_run",
+    status: "done",
+    parentJobId: null,
+    error: null,
+    startedAt: new Date("2026-04-08T16:00:00.000Z"),
+    finishedAt: new Date("2026-04-08T16:00:05.000Z"),
+  },
+];
+
+export const canvasStoryJobTraces: JobTrace[] = [
+  {
+    id: 1,
+    jobId: "job-story",
+    level: "info",
+    message: "[2026-04-08T16:00:00.000Z] Starting Story Pipeline",
+    createdAt: new Date("2026-04-08T16:00:00.000Z"),
+  },
+  {
+    id: 2,
+    jobId: "job-story",
+    level: "info",
+    message: "[2026-04-08T16:00:01.000Z] @@NODE_START::review-op",
+    createdAt: new Date("2026-04-08T16:00:01.000Z"),
+  },
+  {
+    id: 3,
+    jobId: "job-story",
+    level: "info",
+    message: "[2026-04-08T16:00:02.000Z] Running Review Code",
+    createdAt: new Date("2026-04-08T16:00:02.000Z"),
+  },
+  {
+    id: 4,
+    jobId: "job-story",
+    level: "info",
+    message:
+      "[2026-04-08T16:00:03.000Z] @@LLM_CONTENT::review-op::### Review\nNo blocking issues in this Storybook scenario.",
+    createdAt: new Date("2026-04-08T16:00:03.000Z"),
+  },
+];
+
+export const canvasStoryPipeline: PipelineData = {
+  id: "story-pipeline",
+  name: "Story Pipeline",
+  description: "Canvas Storybook pipeline fixture.",
+  tags: ["storybook"],
+  timeoutMs: null,
+  createdAt: new Date("2026-04-08T16:00:00.000Z"),
+  updatedAt: new Date("2026-04-08T16:00:00.000Z"),
+  nodes: [],
+  edges: [],
+};
+
+const getFilterValue = (params: GetListParams, field: string): unknown => {
+  const filter = params.filters?.find((item) => "field" in item && item.field === field);
+
+  return filter && "value" in filter ? filter.value : undefined;
+};
+
+const getCanvasStoryRecords = (resource: string, params?: GetListParams): BaseRecord[] => {
+  if (resource === ResourceName.operations) return canvasStoryOperations;
+  if (resource === ResourceName.recipes) return canvasStoryRecipes;
+  if (resource === ResourceName.bestPractices) return canvasStoryBestPractices;
+  if (resource === ResourceName.githubProjects) return canvasStoryGithubProjects;
+  if (resource === ResourceName.jobs) return canvasStoryJobs;
+  if (resource === ResourceName.pipelines) return [canvasStoryPipeline];
+  if (resource === ResourceName.filesystem) {
+    const path = params ? getFilterValue(params, "path") : undefined;
+    if (!path) return canvasStoryFilesystem;
+
+    return canvasStoryFilesystem.filter((entry) => entry.path.startsWith(String(path)));
+  }
+
+  return [];
+};
+
+const findCanvasStoryRecord = (resource: string, id: string): BaseRecord => {
+  const records = getCanvasStoryRecords(resource);
+  const record = records.find((item) => String(item.id) === id);
+
+  return record ?? { id };
+};
+
+const getCanvasStoryList = <TData extends BaseRecord = BaseRecord>(
+  params: GetListParams
+): Promise<GetListResponse<TData>> => {
+  const data = getCanvasStoryRecords(params.resource, params);
+
+  return Promise.resolve({
+    data: data as TData[],
+    total: data.length,
+  });
+};
+
+const getCanvasStoryMany = <TData extends BaseRecord = BaseRecord>(
+  params: GetManyParams
+): Promise<GetManyResponse<TData>> => {
+  const ids = new Set(params.ids.map(String));
+  const data = getCanvasStoryRecords(params.resource).filter((record) =>
+    ids.has(String(record.id))
+  );
+
+  return Promise.resolve({ data: data as TData[] });
+};
+
+const getCanvasStoryOne = <TData extends BaseRecord = BaseRecord>(
+  params: GetOneParams
+): Promise<GetOneResponse<TData>> => {
+  const data = findCanvasStoryRecord(params.resource, String(params.id));
+
+  return Promise.resolve({ data: data as TData });
+};
+
+const createCanvasStoryRecord = <TData extends BaseRecord = BaseRecord, TVariables = object>(
+  params: CreateParams<TVariables>
+): Promise<CreateResponse<TData>> => {
+  const variables = params.variables as Record<string, unknown>;
+  const id = typeof variables.id === "string" ? variables.id : `${params.resource}-story-created`;
+
+  return Promise.resolve({ data: { id, ...variables } as TData });
+};
+
+const updateCanvasStoryRecord = <TData extends BaseRecord = BaseRecord, TVariables = object>(
+  params: UpdateParams<TVariables>
+): Promise<UpdateResponse<TData>> => {
+  const existing = findCanvasStoryRecord(params.resource, String(params.id));
+  const variables = params.variables as Record<string, unknown>;
+
+  return Promise.resolve({ data: { ...existing, ...variables, id: params.id } as TData });
+};
+
+const deleteCanvasStoryRecord = <TData extends BaseRecord = BaseRecord, TVariables = object>(
+  params: DeleteOneParams<TVariables>
+): Promise<DeleteOneResponse<TData>> => {
+  const existing = findCanvasStoryRecord(params.resource, String(params.id));
+
+  return Promise.resolve({ data: existing as TData });
+};
+
+const getStoryJobTraces = (jobId: string) => {
+  if (!jobId) return canvasStoryJobTraces;
+
+  return canvasStoryJobTraces.filter((trace) => trace.jobId === jobId);
+};
+
+const getPayloadJobId = (payload: unknown): string => {
+  if (payload && typeof payload === "object" && "jobId" in payload) {
+    const jobId = (payload as { jobId?: unknown }).jobId;
+
+    return typeof jobId === "string" ? jobId : "";
+  }
+
+  return "";
+};
+
+const getCanvasStoryCustom = <
+  TData extends BaseRecord = BaseRecord,
+  TQuery = unknown,
+  TPayload = unknown,
+>(
+  params: CustomParams<TQuery, TPayload>
+): Promise<CustomResponse<TData>> => {
+  if (params.url === "jobs/traces") {
+    const jobId = getPayloadJobId(params.payload);
+    const traces = getStoryJobTraces(jobId).map(({ message }) => ({ message }));
+
+    return Promise.resolve({ data: { traces } as unknown as TData });
+  }
+
+  if (params.url === "jobs/agentRuns" || params.url === "jobs/agentRunSpans") {
+    return Promise.resolve({ data: { items: [] } as unknown as TData });
+  }
+
+  if (params.url === "pipelines/run") {
+    return Promise.resolve({ data: { jobId: "job-story" } as unknown as TData });
+  }
+
+  return Promise.resolve({ data: {} as TData });
+};
+
+export const canvasStoryDataProvider: DataProvider = {
+  getList: getCanvasStoryList,
+  getMany: getCanvasStoryMany,
+  getOne: getCanvasStoryOne,
+  create: createCanvasStoryRecord,
+  update: updateCanvasStoryRecord,
+  deleteOne: deleteCanvasStoryRecord,
+  getApiUrl: () => "",
+  custom: getCanvasStoryCustom,
+};

--- a/apps/app/src/pages/CanvasPage/utils/canvasViewport.ts
+++ b/apps/app/src/pages/CanvasPage/utils/canvasViewport.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_CANVAS_VIEWPORT = { x: 0, y: 0, zoom: 1.25 } as const;
+
+export const formatZoomPercent = (zoom: number) => `${Math.round(zoom * 100)}%`;

--- a/apps/app/src/pages/CanvasPage/utils/nodePosition.ts
+++ b/apps/app/src/pages/CanvasPage/utils/nodePosition.ts
@@ -1,0 +1,53 @@
+import type { NodeOrigin, XYPosition } from "@xyflow/system";
+
+export const CONNECTION_MENU_NODE_OFFSET = { x: 40, y: -40 } as const;
+export const DUPLICATE_NODE_OFFSET = { x: 40, y: 40 } as const;
+export const NODE_CONTEXT_CONNECT_OFFSET = { x: 280, y: 0 } as const;
+export const QUICK_ADD_NODE_ORIGIN: NodeOrigin = [0.5, 0.5];
+
+interface ScreenViewportSize {
+  innerWidth: number;
+  innerHeight: number;
+}
+
+interface ViewportRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+const DEFAULT_SCREEN_VIEWPORT: ScreenViewportSize = {
+  innerWidth: 1280,
+  innerHeight: 720,
+};
+
+const getCurrentScreenViewport = (): ScreenViewportSize => {
+  if (typeof globalThis.innerWidth === "number" && typeof globalThis.innerHeight === "number") {
+    return {
+      innerWidth: globalThis.innerWidth,
+      innerHeight: globalThis.innerHeight,
+    };
+  }
+
+  return DEFAULT_SCREEN_VIEWPORT;
+};
+
+export const offsetPosition = (position: XYPosition, offset: Readonly<XYPosition>): XYPosition => ({
+  x: position.x + offset.x,
+  y: position.y + offset.y,
+});
+
+export const getScreenViewportCenter = (viewport?: ScreenViewportSize): XYPosition => {
+  const screenViewport = viewport ?? getCurrentScreenViewport();
+
+  return {
+    x: screenViewport.innerWidth / 2,
+    y: screenViewport.innerHeight / 2,
+  };
+};
+
+export const getViewportRectCenter = (rect: ViewportRect): XYPosition => ({
+  x: rect.left + rect.width / 2,
+  y: rect.top + rect.height / 2,
+});

--- a/apps/app/src/pages/CanvasPage/utils/nodePosition.unit.test.ts
+++ b/apps/app/src/pages/CanvasPage/utils/nodePosition.unit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONNECTION_MENU_NODE_OFFSET,
+  DUPLICATE_NODE_OFFSET,
+  NODE_CONTEXT_CONNECT_OFFSET,
+  QUICK_ADD_NODE_ORIGIN,
+  getScreenViewportCenter,
+  getViewportRectCenter,
+  offsetPosition,
+} from "./nodePosition";
+
+describe("nodePosition", () => {
+  it("keeps named offsets stable", () => {
+    expect(CONNECTION_MENU_NODE_OFFSET).toEqual({ x: 40, y: -40 });
+    expect(DUPLICATE_NODE_OFFSET).toEqual({ x: 40, y: 40 });
+    expect(NODE_CONTEXT_CONNECT_OFFSET).toEqual({ x: 280, y: 0 });
+    expect(QUICK_ADD_NODE_ORIGIN).toEqual([0.5, 0.5]);
+  });
+
+  it("applies offsets without mutating the source position", () => {
+    const position = { x: 100, y: 200 };
+    const result = offsetPosition(position, NODE_CONTEXT_CONNECT_OFFSET);
+
+    expect(result).toEqual({ x: 380, y: 200 });
+    expect(position).toEqual({ x: 100, y: 200 });
+  });
+
+  it("returns the current screen viewport center", () => {
+    expect(getScreenViewportCenter({ innerWidth: 1000, innerHeight: 800 })).toEqual({
+      x: 500,
+      y: 400,
+    });
+  });
+
+  it("returns the center of an offset viewport rect", () => {
+    expect(getViewportRectCenter({ left: 240, top: 72, width: 960, height: 640 })).toEqual({
+      x: 720,
+      y: 392,
+    });
+  });
+
+});


### PR DESCRIPTION
## 主要变更

1. feat(canvas): 增加工作台快速新建与状态栏
2. test(canvas): 补齐 Storybook 文档场景
3. fix(canvas): 修复运行控制台和表单控件问题

*这个 PR 是从我的 \canvas-workbench-v1-pr\ 分支提交的。*
