### PR TITLE
fix(canvas): 优化节点卡片动态端口连线

### DIFF
--- a/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
@@ -1,4 +1,4 @@
-import type { Ref } from "react";
+import { useMemo, type Ref } from "react";
 import { useStore } from "zustand";
 import { useHarnessCanvasStore } from "../_store";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -12,6 +12,7 @@ import { OperationNode } from "../OperationNode";
 import { OutputProjectPathNode } from "../OutputProjectPathNode";
 import { OutputLocalPathNode } from "../OutputLocalPathNode";
 import { DEFAULT_CANVAS_VIEWPORT } from "../utils/canvasViewport";
+import { decorateEdgesWithPortHandles } from "../NodeCard";
 
 // Must be defined outside the component to prevent React Flow infinite re-renders
 const nodeTypes = {
@@ -42,6 +43,11 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
 
   const nodes = useStore(store, (s) => s.nodes);
   const edges = useStore(store, (s) => s.edges);
+  const connectStart = useStore(store, (s) => s.connectStart);
+  const portRoutedEdges = useMemo(
+    () => decorateEdgesWithPortHandles(nodes, edges, connectStart),
+    [connectStart, edges, nodes]
+  );
   const isConsoleOpen = useStore(store, (s) => s.isConsoleOpen);
   const handleNodesChange = useStore(store, (s) => s.handleNodesChange);
   const handleEdgesChange = useStore(store, (s) => s.handleEdgesChange);
@@ -84,7 +90,7 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
         defaultEdgeOptions={defaultEdgeOptions}
         defaultViewport={DEFAULT_CANVAS_VIEWPORT}
         deleteKeyCode={["Backspace", "Delete"]}
-        edges={edges}
+        edges={portRoutedEdges}
         nodes={nodes}
         nodeTypes={nodeTypes}
         proOptions={proOpts}

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { useState } from "react";
 import { FileCode, FolderOpen } from "lucide-react";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
@@ -1,11 +1,10 @@
-import { useState } from "react";
-import { Handle, Position } from "@xyflow/react";
+import { memo, useState } from "react";
 import { FileCode, FolderOpen } from "lucide-react";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useHarnessCanvasStore, selectNodeRunState } from "../_store";
 import type { CodeFileNodeData } from "@repo/pipeline-engine/schemas";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodePortCounts } from "../NodeCard";
 import { FolderBrowser } from "../OutputLocalPathNode/FolderBrowser";
 
 export interface CodeFileNodeProps {
@@ -20,6 +19,7 @@ export const CodeFileNode = ({ id, data, selected }: CodeFileNodeProps) => {
   const store = useHarnessCanvasStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
+  const { rightPortCount } = useNodePortCounts(id);
   const [browserOpen, setBrowserOpen] = useState(false);
 
   const handleLabelChange = (v: string) => updateNodeData(id, { label: v });
@@ -46,11 +46,13 @@ export const CodeFileNode = ({ id, data, selected }: CodeFileNodeProps) => {
   return (
     <div className="group relative" style={{ overflow: "visible" }}>
       <NodeCard
+        rightHandle
         bodyClassName="space-y-2"
         description="Code File"
         dimmed={dimmed}
         icon={FileCode}
         label={data.label}
+        rightHandleCount={rightPortCount}
         runStatus={runStatus}
         selected={selected}
         theme="orange"
@@ -106,13 +108,6 @@ export const CodeFileNode = ({ id, data, selected }: CodeFileNodeProps) => {
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
         onSelect={handleFileSelect}
-      />
-
-      {/* Object nodes only emit connections — no target handle */}
-      <Handle
-        className="absolute h-3.5 w-3.5 rounded-full bg-orange-500 border-[3px] border-white shadow-sm transition-all hover:scale-110 -right-1.5 top-1/2 -mt-1.5"
-        position={Position.Right}
-        type="source"
       />
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.unit.test.tsx
@@ -7,6 +7,8 @@ vi.mock("@xyflow/react", () => ({
   Handle: () => null,
   Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
   ReactFlowProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  useNodeId: () => "test",
+  useUpdateNodeInternals: () => () => undefined,
 }));
 
 vi.mock("@refinedev/core", () => ({

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { useState } from "react";
 import { Folder, FolderOpen, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
@@ -1,12 +1,11 @@
-import { useState } from "react";
-import { Handle, Position } from "@xyflow/react";
+import { memo, useState } from "react";
 import { Folder, FolderOpen, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useHarnessCanvasStore, selectNodeRunState } from "../_store";
 import type { FolderNodeData } from "@repo/pipeline-engine/schemas";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodePortCounts } from "../NodeCard";
 import { FolderBrowser } from "../OutputLocalPathNode/FolderBrowser";
 import { FolderTreePreview } from "./FolderTreePreview";
 import { Input } from "@repo/ui/input";
@@ -28,6 +27,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
   const handleNodeAddExcludedPath = useStore(store, (s) => s.handleNodeAddExcludedPath);
   const handleNodeRemoveExcludedPath = useStore(store, (s) => s.handleNodeRemoveExcludedPath);
+  const { rightPortCount } = useNodePortCounts(id);
   const [browserOpen, setBrowserOpen] = useState(false);
 
   const excludedPaths: string[] = Array.isArray(data.excludedPaths) ? data.excludedPaths : [];
@@ -58,11 +58,13 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
   return (
     <div className="group relative" style={{ overflow: "visible" }}>
       <NodeCard
+        rightHandle
         bodyClassName="space-y-2"
         description="Folder"
         dimmed={dimmed}
         icon={Folder}
         label={data.label}
+        rightHandleCount={rightPortCount}
         runStatus={runStatus}
         selected={selected}
         theme="orange"
@@ -134,13 +136,6 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
         onSelect={handleFolderSelect}
-      />
-
-      {/* Object nodes only emit connections — no target handle */}
-      <Handle
-        className="absolute h-3.5 w-3.5 rounded-full bg-orange-400 border-[3px] border-white shadow-sm transition-all hover:scale-110 -right-1.5 top-1/2 -mt-1.5"
-        position={Position.Right}
-        type="source"
       />
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.unit.test.tsx
@@ -8,6 +8,8 @@ vi.mock("@xyflow/react", () => ({
   Handle: () => null,
   Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
   ReactFlowProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  useNodeId: () => "test",
+  useUpdateNodeInternals: () => () => undefined,
 }));
 
 vi.mock("@refinedev/core", () => ({

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { useState } from "react";
 import { Link2, Lock, Globe, BookMarked, FolderOpen, FolderInput, X, Eye } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx
@@ -1,12 +1,11 @@
-import { useState } from "react";
-import { Handle, Position } from "@xyflow/react";
+import { memo, useState } from "react";
 import { Link2, Lock, Globe, BookMarked, FolderOpen, FolderInput, X, Eye } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useHarnessCanvasStore, selectNodeRunState } from "../_store";
 import type { GitHubProjectNodeData } from "@repo/pipeline-engine/schemas";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodePortCounts } from "../NodeCard";
 import { FolderTreePreview } from "../FolderNode/FolderTreePreview";
 import { SiGitHubIcon } from "@/components/icons/SiGitHubIcon";
 import { GitHubConnectDialog, type ConnectedRepoInfo } from "./GitHubConnectDialog";
@@ -38,6 +37,7 @@ export const GitHubProjectNode = ({ id, data, selected }: GitHubProjectNodeProps
   const handleGitHubProjectLocalFolder = useStore(store, (s) => s.handleGitHubProjectLocalFolder);
   const handleNodeAddExcludedPath = useStore(store, (s) => s.handleNodeAddExcludedPath);
   const handleNodeRemoveExcludedPath = useStore(store, (s) => s.handleNodeRemoveExcludedPath);
+  const { rightPortCount } = useNodePortCounts(id);
 
   const isLocal = data.sourceType === "local";
   const isConnected = isLocal ? !!data.localPath : !!(data.owner && data.repo);
@@ -76,11 +76,13 @@ export const GitHubProjectNode = ({ id, data, selected }: GitHubProjectNodeProps
   return (
     <div className="group relative" style={{ overflow: "visible" }}>
       <NodeCard
+        rightHandle
         bodyClassName="space-y-2"
         description="GitHub Project"
         dimmed={dimmed}
         icon={SiGitHubIcon}
         label={data.label}
+        rightHandleCount={rightPortCount}
         runStatus={runStatus}
         selected={selected}
         theme="orange"
@@ -233,13 +235,6 @@ export const GitHubProjectNode = ({ id, data, selected }: GitHubProjectNodeProps
           </>
         )}
       </NodeCard>
-
-      {/* Object nodes only emit connections — no target handle */}
-      <Handle
-        className="absolute h-3.5 w-3.5 rounded-full bg-orange-600 border-[3px] border-white shadow-sm transition-all hover:scale-110 -right-1.5 top-1/2 -mt-1.5"
-        position={Position.Right}
-        type="source"
-      />
 
       <PickProjectDialog open={pickOpen} onClose={handlePickClose} onPick={handlePick} />
 

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
@@ -6,8 +6,11 @@ import {
   CardContent,
   CardAction,
 } from "@repo/ui/card";
+import { Handle, Position, useNodeId, useUpdateNodeInternals } from "@xyflow/react";
 import { cn } from "@repo/ui/lib/utils";
 import type { NodeRunStatus } from "@repo/pipeline-engine/schemas";
+import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { getNodePortOffsets, makeNodePortId, type NodePortSide } from "./nodePorts";
 
 export type NodeTheme = "emerald" | "violet" | "amber" | "sky" | "orange" | "teal" | "indigo";
 
@@ -18,6 +21,7 @@ const themeMap = {
     headerBg: "bg-emerald-50/50",
     iconBg: "bg-emerald-100",
     iconColor: "text-emerald-600",
+    handleColor: "before:!bg-emerald-500",
   },
   violet: {
     ring: "ring-violet-500/20",
@@ -25,6 +29,7 @@ const themeMap = {
     headerBg: "bg-violet-50/50",
     iconBg: "bg-violet-100",
     iconColor: "text-violet-600",
+    handleColor: "before:!bg-violet-500",
   },
   amber: {
     ring: "ring-amber-500/20",
@@ -32,6 +37,7 @@ const themeMap = {
     headerBg: "bg-amber-50/50",
     iconBg: "bg-amber-100",
     iconColor: "text-amber-600",
+    handleColor: "before:!bg-amber-500",
   },
   sky: {
     ring: "ring-sky-500/20",
@@ -39,6 +45,7 @@ const themeMap = {
     headerBg: "bg-sky-50/50",
     iconBg: "bg-sky-100",
     iconColor: "text-sky-600",
+    handleColor: "before:!bg-sky-500",
   },
   orange: {
     ring: "ring-orange-500/20",
@@ -46,6 +53,7 @@ const themeMap = {
     headerBg: "bg-orange-50/50",
     iconBg: "bg-orange-100",
     iconColor: "text-orange-600",
+    handleColor: "before:!bg-orange-500",
   },
   teal: {
     ring: "ring-teal-500/20",
@@ -53,6 +61,7 @@ const themeMap = {
     headerBg: "bg-teal-50/50",
     iconBg: "bg-teal-100",
     iconColor: "text-teal-600",
+    handleColor: "before:!bg-teal-500",
   },
   indigo: {
     ring: "ring-indigo-500/20",
@@ -60,10 +69,15 @@ const themeMap = {
     headerBg: "bg-indigo-50/50",
     iconBg: "bg-indigo-100",
     iconColor: "text-indigo-600",
+    handleColor: "before:!bg-indigo-500",
   },
 } satisfies Record<NodeTheme, object>;
 
 export interface NodeCardProps {
+  leftHandle?: boolean;
+  rightHandle?: boolean;
+  leftHandleCount?: number;
+  rightHandleCount?: number;
   selected?: boolean;
   theme: NodeTheme;
   icon: React.ElementType;
@@ -86,69 +100,178 @@ export interface NodeCardProps {
 
 const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
 
-export const NodeCard = ({
-  selected,
-  theme,
-  icon: Icon,
-  label,
-  headerRight,
-  children,
-  bodyClassName,
-  description,
-  onLabelChange,
-  runStatus,
-  dimmed,
-}: NodeCardProps) => {
-  const t = themeMap[theme] ?? themeMap.emerald;
-  const handleChange = onLabelChange
-    ? (e: React.ChangeEvent<HTMLInputElement>) => onLabelChange(e.target.value)
-    : undefined;
+const nodePortClassName =
+  "node-card-port absolute !top-[calc(50%+var(--node-port-offset))] !z-10 !h-5 !w-5 rounded-full !border-0 !bg-transparent !opacity-100 transition-opacity duration-150 ease-out before:content-[''] before:absolute before:left-1/2 before:top-1/2 before:h-2 before:w-2 before:-translate-x-1/2 before:-translate-y-1/2 before:rounded-full before:shadow-[0_0_0_3px_rgba(255,255,255,0.95),0_2px_7px_rgba(15,23,42,0.22)] before:transition-transform before:duration-200 hover:before:scale-125";
 
-  return (
-    <Card
-      className={cn(
-        "w-72 shrink-0 gap-0 py-0 transition-all duration-200 data-[size=sm]:gap-0 data-[size=sm]:py-0",
-        selected ? cn("ring-2 shadow-lg", t.ringSelected) : cn("ring-1 hover:ring-2", t.ring),
-        runStatus === "running" &&
-          "ring-2 ring-blue-500 shadow-[0_0_12px_rgba(59,130,246,0.4)] animate-pulse",
-        runStatus === "pass" && "ring-2 ring-green-500",
-        runStatus === "fail" && "ring-2 ring-red-500",
-        dimmed && "opacity-40 pointer-events-none"
-      )}
-      size="sm"
-    >
-      <CardHeader className={cn("flex min-h-14 items-center rounded-none px-3 py-2", t.headerBg)}>
-        <div className="flex w-full min-w-0 items-center gap-3">
-          <div
-            className={cn("flex h-8 w-8 shrink-0 items-center justify-center rounded-md", t.iconBg)}
+const getNodePortStyle = (offset: number) =>
+  ({
+    "--node-port-offset": `${offset}px`,
+  }) as React.CSSProperties;
+
+const getNodePortPosition = (side: NodePortSide) =>
+  side === "left" ? Position.Left : Position.Right;
+
+export const NodeCard = memo(
+  ({
+    leftHandle,
+    rightHandle,
+    leftHandleCount = 1,
+    rightHandleCount = 1,
+    selected,
+    theme,
+    icon: Icon,
+    label,
+    headerRight,
+    children,
+    bodyClassName,
+    description,
+    onLabelChange,
+    runStatus,
+    dimmed,
+  }: NodeCardProps) => {
+    const t = themeMap[theme] ?? themeMap.emerald;
+    const nodeId = useNodeId();
+    const updateNodeInternals = useUpdateNodeInternals();
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
+    const [cardMaxPortSpread, setCardMaxPortSpread] = useState<number | undefined>(undefined);
+    const [isLabelEditing, setIsLabelEditing] = useState(false);
+    const handleChange = onLabelChange
+      ? (e: React.ChangeEvent<HTMLInputElement>) => onLabelChange(e.target.value)
+      : undefined;
+    const handleLabelClick = () => setIsLabelEditing(true);
+    const handleLabelBlur = () => setIsLabelEditing(false);
+    const leftPortOffsets = getNodePortOffsets(leftHandleCount, cardMaxPortSpread);
+    const rightPortOffsets = getNodePortOffsets(rightHandleCount, cardMaxPortSpread);
+
+    useLayoutEffect(() => {
+      const card = wrapperRef.current?.querySelector<HTMLElement>('[data-slot="card"]');
+      if (!card) {
+        return;
+      }
+
+      const updateCardMaxPortSpread = () => {
+        const height = card.offsetHeight;
+        const nextMaxSpread =
+          Number.isFinite(height) && height > 0 ? Math.floor(height / 2) : undefined;
+        setCardMaxPortSpread((currentMaxSpread) =>
+          currentMaxSpread === nextMaxSpread ? currentMaxSpread : nextMaxSpread
+        );
+      };
+
+      updateCardMaxPortSpread();
+
+      if (typeof ResizeObserver === "undefined") {
+        return;
+      }
+
+      const observer = new ResizeObserver(updateCardMaxPortSpread);
+      observer.observe(card);
+
+      return () => observer.disconnect();
+    }, []);
+
+    useEffect(() => {
+      if (!nodeId) {
+        return;
+      }
+
+      updateNodeInternals(nodeId);
+    }, [
+      cardMaxPortSpread,
+      leftHandle,
+      leftHandleCount,
+      nodeId,
+      rightHandle,
+      rightHandleCount,
+      updateNodeInternals,
+    ]);
+
+    return (
+      <div ref={wrapperRef} className="relative">
+        <Card
+          className={cn(
+            "w-72 shrink-0 gap-0 py-0 transition-all duration-200 data-[size=sm]:gap-0 data-[size=sm]:py-0",
+            selected ? cn("ring-2 shadow-lg", t.ringSelected) : cn("ring-1 hover:ring-2", t.ring),
+            runStatus === "running" &&
+              "ring-2 ring-blue-500 shadow-[0_0_12px_rgba(59,130,246,0.4)] animate-pulse",
+            runStatus === "pass" && "ring-2 ring-green-500",
+            runStatus === "fail" && "ring-2 ring-red-500",
+            dimmed && "opacity-40 pointer-events-none"
+          )}
+          size="sm"
+        >
+          <CardHeader
+            className={cn("flex min-h-14 items-center rounded-none px-3 py-2", t.headerBg)}
           >
-            <Icon className={cn("h-4 w-4", t.iconColor)} />
-          </div>
-          <div className="flex min-h-8 flex-1 min-w-0 flex-col justify-center">
-            {handleChange ? (
-              <input
-                aria-label="Node label"
-                className="nodrag nopan w-full bg-transparent text-xs font-semibold leading-tight focus:outline-none"
-                name="nodeLabel"
-                value={label}
-                onChange={handleChange}
-                onMouseDown={handleMouseDown}
-              />
-            ) : (
-              <CardTitle className="truncate text-xs font-semibold leading-tight">
-                {label}
-              </CardTitle>
-            )}
-            {description && (
-              <CardDescription className="truncate text-[10px] leading-tight">
-                {description}
-              </CardDescription>
-            )}
-          </div>
-          {headerRight && <CardAction className="shrink-0 self-center">{headerRight}</CardAction>}
-        </div>
-      </CardHeader>
-      {children && <CardContent className={cn("px-3 py-3", bodyClassName)}>{children}</CardContent>}
-    </Card>
-  );
-};
+            <div className="flex w-full min-w-0 items-center gap-3">
+              <div
+                className={cn(
+                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-md",
+                  t.iconBg
+                )}
+              >
+                <Icon className={cn("h-4 w-4", t.iconColor)} />
+              </div>
+              <div className="flex min-h-8 flex-1 min-w-0 flex-col justify-center">
+                {handleChange ? (
+                  <input
+                    aria-label="Node label"
+                    className={cn(
+                      "nodrag nopan w-auto max-w-full bg-transparent text-xs font-semibold leading-tight [field-sizing:content] focus:outline-none",
+                      isLabelEditing ? "select-text" : "cursor-default select-none"
+                    )}
+                    name="nodeLabel"
+                    readOnly={!isLabelEditing}
+                    value={label}
+                    onBlur={handleLabelBlur}
+                    onChange={handleChange}
+                    onClick={handleLabelClick}
+                    onMouseDown={handleMouseDown}
+                  />
+                ) : (
+                  <CardTitle className="truncate text-xs font-semibold leading-tight">
+                    {label}
+                  </CardTitle>
+                )}
+                {description && (
+                  <CardDescription className="truncate text-[10px] leading-tight">
+                    {description}
+                  </CardDescription>
+                )}
+              </div>
+              {headerRight && (
+                <CardAction className="shrink-0 self-center">{headerRight}</CardAction>
+              )}
+            </div>
+          </CardHeader>
+          {children && (
+            <CardContent className={cn("px-3 py-3", bodyClassName)}>{children}</CardContent>
+          )}
+        </Card>
+        {leftHandle &&
+          leftPortOffsets.map((offset, index) => (
+            <Handle
+              key={makeNodePortId("left", index)}
+              className={cn(nodePortClassName, "!left-2.5 before:!left-0", t.handleColor)}
+              id={makeNodePortId("left", index)}
+              position={getNodePortPosition("left")}
+              style={getNodePortStyle(offset)}
+              type="target"
+            />
+          ))}
+        {rightHandle &&
+          rightPortOffsets.map((offset, index) => (
+            <Handle
+              key={makeNodePortId("right", index)}
+              className={cn(nodePortClassName, "!right-2.5 before:!left-full", t.handleColor)}
+              id={makeNodePortId("right", index)}
+              position={getNodePortPosition("right")}
+              style={getNodePortStyle(offset)}
+              type="source"
+            />
+          ))}
+      </div>
+    );
+  }
+);
+NodeCard.displayName = "NodeCard";

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
@@ -1,115 +1,57 @@
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-  CardAction,
-} from "@repo/ui/card";
-import { Handle, Position, useNodeId, useUpdateNodeInternals } from "@xyflow/react";
-import { cn } from "@repo/ui/lib/utils";
-import type { NodeRunStatus } from "@repo/pipeline-engine/schemas";
-import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { getNodePortOffsets, makeNodePortId, type NodePortSide } from "./nodePorts";
+import { memo, useLayoutEffect, useRef, useState } from "react";
+import { NodeCardFrame, type NodeCardFrameProps } from "./NodeCardFrame";
+import { NodeCardPorts } from "./NodeCardPorts";
 
-export type NodeTheme = "emerald" | "violet" | "amber" | "sky" | "orange" | "teal" | "indigo";
+export type { NodeTheme } from "./nodeCardTheme";
 
-const themeMap = {
-  emerald: {
-    ring: "ring-emerald-500/20",
-    ringSelected: "ring-emerald-500",
-    headerBg: "bg-emerald-50/50",
-    iconBg: "bg-emerald-100",
-    iconColor: "text-emerald-600",
-    handleColor: "before:!bg-emerald-500",
-  },
-  violet: {
-    ring: "ring-violet-500/20",
-    ringSelected: "ring-violet-500",
-    headerBg: "bg-violet-50/50",
-    iconBg: "bg-violet-100",
-    iconColor: "text-violet-600",
-    handleColor: "before:!bg-violet-500",
-  },
-  amber: {
-    ring: "ring-amber-500/20",
-    ringSelected: "ring-amber-500",
-    headerBg: "bg-amber-50/50",
-    iconBg: "bg-amber-100",
-    iconColor: "text-amber-600",
-    handleColor: "before:!bg-amber-500",
-  },
-  sky: {
-    ring: "ring-sky-500/20",
-    ringSelected: "ring-sky-500",
-    headerBg: "bg-sky-50/50",
-    iconBg: "bg-sky-100",
-    iconColor: "text-sky-600",
-    handleColor: "before:!bg-sky-500",
-  },
-  orange: {
-    ring: "ring-orange-500/20",
-    ringSelected: "ring-orange-500",
-    headerBg: "bg-orange-50/50",
-    iconBg: "bg-orange-100",
-    iconColor: "text-orange-600",
-    handleColor: "before:!bg-orange-500",
-  },
-  teal: {
-    ring: "ring-teal-500/20",
-    ringSelected: "ring-teal-500",
-    headerBg: "bg-teal-50/50",
-    iconBg: "bg-teal-100",
-    iconColor: "text-teal-600",
-    handleColor: "before:!bg-teal-500",
-  },
-  indigo: {
-    ring: "ring-indigo-500/20",
-    ringSelected: "ring-indigo-500",
-    headerBg: "bg-indigo-50/50",
-    iconBg: "bg-indigo-100",
-    iconColor: "text-indigo-600",
-    handleColor: "before:!bg-indigo-500",
-  },
-} satisfies Record<NodeTheme, object>;
-
-export interface NodeCardProps {
+export interface NodeCardProps extends NodeCardFrameProps {
   leftHandle?: boolean;
   rightHandle?: boolean;
   leftHandleCount?: number;
   rightHandleCount?: number;
-  selected?: boolean;
-  theme: NodeTheme;
-  icon: React.ElementType;
-  label: string;
-  /** Right side of the header row (e.g. status indicator) */
-  headerRight?: React.ReactNode;
-  /** Card body content */
-  children?: React.ReactNode;
-  /** Additional className for the body wrapper */
-  bodyClassName?: string;
-  /** Description below the label inside header */
-  description?: string;
-  /** When provided, the label becomes an inline editable input */
-  onLabelChange?: (value: string) => void;
-  /** Run status for pipeline test mode */
-  runStatus?: NodeRunStatus;
-  /** Whether the node is disabled during a test run */
-  dimmed?: boolean;
 }
 
-const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
+const useCardMaxPortSpread = (
+  wrapperRef: React.RefObject<HTMLDivElement | null>,
+  enabled: boolean
+) => {
+  const [cardMaxPortSpread, setCardMaxPortSpread] = useState<number | undefined>(undefined);
 
-const nodePortClassName =
-  "node-card-port absolute !top-[calc(50%+var(--node-port-offset))] !z-10 !h-5 !w-5 rounded-full !border-0 !bg-transparent !opacity-100 transition-opacity duration-150 ease-out before:content-[''] before:absolute before:left-1/2 before:top-1/2 before:h-2 before:w-2 before:-translate-x-1/2 before:-translate-y-1/2 before:rounded-full before:shadow-[0_0_0_3px_rgba(255,255,255,0.95),0_2px_7px_rgba(15,23,42,0.22)] before:transition-transform before:duration-200 hover:before:scale-125";
+  useLayoutEffect(() => {
+    if (!enabled) {
+      setCardMaxPortSpread(undefined);
 
-const getNodePortStyle = (offset: number) =>
-  ({
-    "--node-port-offset": `${offset}px`,
-  }) as React.CSSProperties;
+      return;
+    }
 
-const getNodePortPosition = (side: NodePortSide) =>
-  side === "left" ? Position.Left : Position.Right;
+    const card = wrapperRef.current?.querySelector<HTMLElement>('[data-slot="card"]');
+    if (!card) {
+      return;
+    }
+
+    const updateCardMaxPortSpread = () => {
+      const height = card.offsetHeight;
+      const nextMaxSpread =
+        Number.isFinite(height) && height > 0 ? Math.floor(height / 2) : undefined;
+      setCardMaxPortSpread((currentMaxSpread) =>
+        currentMaxSpread === nextMaxSpread ? currentMaxSpread : nextMaxSpread
+      );
+    };
+
+    updateCardMaxPortSpread();
+
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver(updateCardMaxPortSpread);
+    observer.observe(card);
+
+    return () => observer.disconnect();
+  }, [enabled, wrapperRef]);
+
+  return cardMaxPortSpread;
+};
 
 export const NodeCard = memo(
   ({
@@ -119,7 +61,7 @@ export const NodeCard = memo(
     rightHandleCount = 1,
     selected,
     theme,
-    icon: Icon,
+    icon,
     label,
     headerRight,
     children,
@@ -129,147 +71,36 @@ export const NodeCard = memo(
     runStatus,
     dimmed,
   }: NodeCardProps) => {
-    const t = themeMap[theme] ?? themeMap.emerald;
-    const nodeId = useNodeId();
-    const updateNodeInternals = useUpdateNodeInternals();
+    const hasPorts = Boolean(leftHandle || rightHandle);
     const wrapperRef = useRef<HTMLDivElement | null>(null);
-    const [cardMaxPortSpread, setCardMaxPortSpread] = useState<number | undefined>(undefined);
-    const [isLabelEditing, setIsLabelEditing] = useState(false);
-    const handleChange = onLabelChange
-      ? (e: React.ChangeEvent<HTMLInputElement>) => onLabelChange(e.target.value)
-      : undefined;
-    const handleLabelClick = () => setIsLabelEditing(true);
-    const handleLabelBlur = () => setIsLabelEditing(false);
-    const leftPortOffsets = getNodePortOffsets(leftHandleCount, cardMaxPortSpread);
-    const rightPortOffsets = getNodePortOffsets(rightHandleCount, cardMaxPortSpread);
-
-    useLayoutEffect(() => {
-      const card = wrapperRef.current?.querySelector<HTMLElement>('[data-slot="card"]');
-      if (!card) {
-        return;
-      }
-
-      const updateCardMaxPortSpread = () => {
-        const height = card.offsetHeight;
-        const nextMaxSpread =
-          Number.isFinite(height) && height > 0 ? Math.floor(height / 2) : undefined;
-        setCardMaxPortSpread((currentMaxSpread) =>
-          currentMaxSpread === nextMaxSpread ? currentMaxSpread : nextMaxSpread
-        );
-      };
-
-      updateCardMaxPortSpread();
-
-      if (typeof ResizeObserver === "undefined") {
-        return;
-      }
-
-      const observer = new ResizeObserver(updateCardMaxPortSpread);
-      observer.observe(card);
-
-      return () => observer.disconnect();
-    }, []);
-
-    useEffect(() => {
-      if (!nodeId) {
-        return;
-      }
-
-      updateNodeInternals(nodeId);
-    }, [
-      cardMaxPortSpread,
-      leftHandle,
-      leftHandleCount,
-      nodeId,
-      rightHandle,
-      rightHandleCount,
-      updateNodeInternals,
-    ]);
+    const cardMaxPortSpread = useCardMaxPortSpread(wrapperRef, hasPorts);
 
     return (
       <div ref={wrapperRef} className="relative">
-        <Card
-          className={cn(
-            "w-72 shrink-0 gap-0 py-0 transition-all duration-200 data-[size=sm]:gap-0 data-[size=sm]:py-0",
-            selected ? cn("ring-2 shadow-lg", t.ringSelected) : cn("ring-1 hover:ring-2", t.ring),
-            runStatus === "running" &&
-              "ring-2 ring-blue-500 shadow-[0_0_12px_rgba(59,130,246,0.4)] animate-pulse",
-            runStatus === "pass" && "ring-2 ring-green-500",
-            runStatus === "fail" && "ring-2 ring-red-500",
-            dimmed && "opacity-40 pointer-events-none"
-          )}
-          size="sm"
+        <NodeCardFrame
+          bodyClassName={bodyClassName}
+          description={description}
+          dimmed={dimmed}
+          headerRight={headerRight}
+          icon={icon}
+          label={label}
+          runStatus={runStatus}
+          selected={selected}
+          theme={theme}
+          onLabelChange={onLabelChange}
         >
-          <CardHeader
-            className={cn("flex min-h-14 items-center rounded-none px-3 py-2", t.headerBg)}
-          >
-            <div className="flex w-full min-w-0 items-center gap-3">
-              <div
-                className={cn(
-                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-md",
-                  t.iconBg
-                )}
-              >
-                <Icon className={cn("h-4 w-4", t.iconColor)} />
-              </div>
-              <div className="flex min-h-8 flex-1 min-w-0 flex-col justify-center">
-                {handleChange ? (
-                  <input
-                    aria-label="Node label"
-                    className={cn(
-                      "nodrag nopan w-auto max-w-full bg-transparent text-xs font-semibold leading-tight [field-sizing:content] focus:outline-none",
-                      isLabelEditing ? "select-text" : "cursor-default select-none"
-                    )}
-                    name="nodeLabel"
-                    readOnly={!isLabelEditing}
-                    value={label}
-                    onBlur={handleLabelBlur}
-                    onChange={handleChange}
-                    onClick={handleLabelClick}
-                    onMouseDown={handleMouseDown}
-                  />
-                ) : (
-                  <CardTitle className="truncate text-xs font-semibold leading-tight">
-                    {label}
-                  </CardTitle>
-                )}
-                {description && (
-                  <CardDescription className="truncate text-[10px] leading-tight">
-                    {description}
-                  </CardDescription>
-                )}
-              </div>
-              {headerRight && (
-                <CardAction className="shrink-0 self-center">{headerRight}</CardAction>
-              )}
-            </div>
-          </CardHeader>
-          {children && (
-            <CardContent className={cn("px-3 py-3", bodyClassName)}>{children}</CardContent>
-          )}
-        </Card>
-        {leftHandle &&
-          leftPortOffsets.map((offset, index) => (
-            <Handle
-              key={makeNodePortId("left", index)}
-              className={cn(nodePortClassName, "!left-2.5 before:!left-0", t.handleColor)}
-              id={makeNodePortId("left", index)}
-              position={getNodePortPosition("left")}
-              style={getNodePortStyle(offset)}
-              type="target"
-            />
-          ))}
-        {rightHandle &&
-          rightPortOffsets.map((offset, index) => (
-            <Handle
-              key={makeNodePortId("right", index)}
-              className={cn(nodePortClassName, "!right-2.5 before:!left-full", t.handleColor)}
-              id={makeNodePortId("right", index)}
-              position={getNodePortPosition("right")}
-              style={getNodePortStyle(offset)}
-              type="source"
-            />
-          ))}
+          {children}
+        </NodeCardFrame>
+        {hasPorts && (
+          <NodeCardPorts
+            cardMaxPortSpread={cardMaxPortSpread}
+            leftHandle={leftHandle}
+            leftHandleCount={leftHandleCount}
+            rightHandle={rightHandle}
+            rightHandleCount={rightHandleCount}
+            theme={theme}
+          />
+        )}
       </div>
     );
   }

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
@@ -67,7 +67,7 @@ export const NodeCard = memo(
     children,
     bodyClassName,
     description,
-    onLabelChange,
+    onLabelChange: handleLabelChange,
     runStatus,
     dimmed,
   }: NodeCardProps) => {
@@ -87,7 +87,7 @@ export const NodeCard = memo(
           runStatus={runStatus}
           selected={selected}
           theme={theme}
-          onLabelChange={onLabelChange}
+          onLabelChange={handleLabelChange}
         >
           {children}
         </NodeCardFrame>

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
@@ -1,7 +1,17 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Box } from "lucide-react";
 import { NodeCard } from "./NodeCard";
+
+const xyflowMocks = vi.hoisted(() => {
+  const updateNodeInternals = vi.fn();
+
+  return {
+    updateNodeInternals,
+    useNodeId: vi.fn(() => "node-id"),
+    useUpdateNodeInternals: vi.fn(() => updateNodeInternals),
+  };
+});
 
 vi.mock("@xyflow/react", () => ({
   Handle: ({
@@ -26,14 +36,25 @@ vi.mock("@xyflow/react", () => ({
     />
   ),
   Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
-  useNodeId: () => "node-id",
-  useUpdateNodeInternals: () => () => undefined,
+  useNodeId: xyflowMocks.useNodeId,
+  useUpdateNodeInternals: xyflowMocks.useUpdateNodeInternals,
 }));
 
 describe("NodeCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders label", () => {
     render(<NodeCard icon={Box} label="Test Node" theme="emerald" />);
     expect(screen.getByText("Test Node")).toBeInTheDocument();
+  });
+
+  it("does not call React Flow hooks when ports are disabled", () => {
+    render(<NodeCard icon={Box} label="Standalone Node" theme="emerald" />);
+
+    expect(xyflowMocks.useNodeId).not.toHaveBeenCalled();
+    expect(xyflowMocks.useUpdateNodeInternals).not.toHaveBeenCalled();
   });
 
   it("renders children in body", () => {

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
@@ -203,4 +203,22 @@ describe("NodeCard", () => {
     fireEvent.blur(input);
     expect(input).toHaveAttribute("readonly");
   });
+
+  it("enables editable label when focused by keyboard", () => {
+    const handleLabelChange = vi.fn();
+    render(
+      <NodeCard
+        icon={Box}
+        label="Keyboard Editable Node"
+        theme="emerald"
+        onLabelChange={handleLabelChange}
+      />
+    );
+
+    const input = screen.getByLabelText("Node label");
+    expect(input).toHaveAttribute("readonly");
+
+    fireEvent.focus(input);
+    expect(input).not.toHaveAttribute("readonly");
+  });
 });

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
@@ -1,7 +1,34 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { Box } from "lucide-react";
 import { NodeCard } from "./NodeCard";
+
+vi.mock("@xyflow/react", () => ({
+  Handle: ({
+    className,
+    id,
+    position,
+    style,
+    type,
+  }: {
+    className?: string;
+    id?: string;
+    position?: string;
+    style?: React.CSSProperties;
+    type?: string;
+  }) => (
+    <div
+      className={className}
+      data-handleid={id}
+      data-offset={style?.["--node-port-offset" as keyof React.CSSProperties]}
+      data-position={position}
+      data-testid={`${type}-handle`}
+    />
+  ),
+  Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
+  useNodeId: () => "node-id",
+  useUpdateNodeInternals: () => () => undefined,
+}));
 
 describe("NodeCard", () => {
   it("renders label", () => {
@@ -20,8 +47,12 @@ describe("NodeCard", () => {
 
   it("does not render body wrapper when no children", () => {
     const { container } = render(<NodeCard icon={Box} label="Node" theme="emerald" />);
-    // Card should only have header when no children
-    expect(container.firstChild?.childNodes).toHaveLength(1);
+    const wrapper = container.firstElementChild;
+    const card = wrapper?.firstElementChild;
+
+    expect(wrapper).toHaveClass("relative");
+    expect(card).toHaveAttribute("data-slot", "card");
+    expect(card?.childNodes).toHaveLength(1);
   });
 
   it("renders headerRight slot", () => {
@@ -40,7 +71,11 @@ describe("NodeCard", () => {
       />
     );
 
-    expect(container.firstChild).toHaveClass("w-72", "data-[size=sm]:py-0");
+    expect(container.firstElementChild).toHaveClass("relative");
+    expect(container.querySelector('[data-slot="card"]')).toHaveClass(
+      "w-72",
+      "data-[size=sm]:py-0"
+    );
     expect(container.querySelector('[data-slot="card-header"] > div')).toHaveClass(
       "w-full",
       "min-w-0"
@@ -59,15 +94,92 @@ describe("NodeCard", () => {
     const { container, rerender } = render(
       <NodeCard selected icon={Box} label="Node" theme="emerald" />
     );
-    expect(container.firstChild).toHaveClass("ring-emerald-500");
+    expect(container.querySelector('[data-slot="card"]')).toHaveClass("ring-emerald-500");
 
     rerender(<NodeCard selected icon={Box} label="Node" theme="violet" />);
-    expect(container.firstChild).toHaveClass("ring-violet-500");
+    expect(container.querySelector('[data-slot="card"]')).toHaveClass("ring-violet-500");
 
     rerender(<NodeCard selected icon={Box} label="Node" theme="amber" />);
-    expect(container.firstChild).toHaveClass("ring-amber-500");
+    expect(container.querySelector('[data-slot="card"]')).toHaveClass("ring-amber-500");
 
     rerender(<NodeCard selected icon={Box} label="Node" theme="sky" />);
-    expect(container.firstChild).toHaveClass("ring-sky-500");
+    expect(container.querySelector('[data-slot="card"]')).toHaveClass("ring-sky-500");
+  });
+
+  it("renders one small center port per enabled side by default", () => {
+    render(<NodeCard leftHandle rightHandle icon={Box} label="Node" theme="orange" />);
+
+    expect(screen.getByTestId("target-handle")).toHaveClass(
+      "!left-2.5",
+      "!h-5",
+      "!w-5",
+      "!bg-transparent",
+      "before:!left-0",
+      "before:!bg-orange-500"
+    );
+    expect(screen.getByTestId("source-handle")).toHaveClass(
+      "!right-2.5",
+      "!h-5",
+      "!w-5",
+      "!bg-transparent",
+      "before:!left-full",
+      "before:!bg-orange-500"
+    );
+    expect(screen.getByTestId("target-handle")).toHaveAttribute("data-handleid", "left-port-0");
+    expect(screen.getByTestId("target-handle")).toHaveAttribute("data-offset", "0px");
+    expect(screen.getByTestId("source-handle")).toHaveAttribute("data-handleid", "right-port-0");
+    expect(screen.getByTestId("source-handle")).toHaveAttribute("data-offset", "0px");
+  });
+
+  it("splits ports into multiple vertical slots", () => {
+    render(
+      <NodeCard
+        leftHandle
+        rightHandle
+        icon={Box}
+        label="Node"
+        leftHandleCount={2}
+        rightHandleCount={3}
+        theme="violet"
+      />
+    );
+
+    const targetHandles = screen.getAllByTestId("target-handle");
+    const sourceHandles = screen.getAllByTestId("source-handle");
+
+    expect(targetHandles).toHaveLength(2);
+    expect(sourceHandles).toHaveLength(3);
+    expect(targetHandles.map((handle) => handle.dataset.handleid)).toEqual([
+      "left-port-0",
+      "left-port-1",
+    ]);
+    expect(targetHandles.map((handle) => handle.dataset.offset)).toEqual(["-28px", "28px"]);
+    expect(sourceHandles.map((handle) => handle.dataset.handleid)).toEqual([
+      "right-port-0",
+      "right-port-1",
+      "right-port-2",
+    ]);
+    expect(sourceHandles.map((handle) => handle.dataset.offset)).toEqual(["-36px", "0px", "36px"]);
+  });
+
+  it("keeps editable label read-only until clicked", () => {
+    const handleLabelChange = vi.fn();
+    render(
+      <NodeCard
+        icon={Box}
+        label="Editable Node"
+        theme="emerald"
+        onLabelChange={handleLabelChange}
+      />
+    );
+
+    const input = screen.getByLabelText("Node label");
+    expect(input).toHaveAttribute("readonly");
+
+    fireEvent.click(input);
+    expect(input).not.toHaveAttribute("readonly");
+
+    fireEvent.blur(input);
+    expect(input).toHaveAttribute("readonly");
   });
 });

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCardFrame.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCardFrame.tsx
@@ -1,0 +1,112 @@
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardAction,
+} from "@repo/ui/card";
+import { cn } from "@repo/ui/lib/utils";
+import type { NodeRunStatus } from "@repo/pipeline-engine/schemas";
+import { memo, useState } from "react";
+import { themeMap, type NodeTheme } from "./nodeCardTheme";
+
+export interface NodeCardFrameProps {
+  selected?: boolean;
+  theme: NodeTheme;
+  icon: React.ElementType;
+  label: string;
+  headerRight?: React.ReactNode;
+  children?: React.ReactNode;
+  bodyClassName?: string;
+  description?: string;
+  onLabelChange?: (value: string) => void;
+  runStatus?: NodeRunStatus;
+  dimmed?: boolean;
+}
+
+const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
+
+export const NodeCardFrame = memo(
+  ({
+    selected,
+    theme,
+    icon: Icon,
+    label,
+    headerRight,
+    children,
+    bodyClassName,
+    description,
+    onLabelChange,
+    runStatus,
+    dimmed,
+  }: NodeCardFrameProps) => {
+    const t = themeMap[theme] ?? themeMap.emerald;
+    const [isLabelEditing, setIsLabelEditing] = useState(false);
+    const handleChange = onLabelChange
+      ? (e: React.ChangeEvent<HTMLInputElement>) => onLabelChange(e.target.value)
+      : undefined;
+    const handleLabelClick = () => setIsLabelEditing(true);
+    const handleLabelBlur = () => setIsLabelEditing(false);
+
+    return (
+      <Card
+        className={cn(
+          "w-72 shrink-0 gap-0 py-0 transition-all duration-200 data-[size=sm]:gap-0 data-[size=sm]:py-0",
+          selected ? cn("ring-2 shadow-lg", t.ringSelected) : cn("ring-1 hover:ring-2", t.ring),
+          runStatus === "running" &&
+            "ring-2 ring-blue-500 shadow-[0_0_12px_rgba(59,130,246,0.4)] animate-pulse",
+          runStatus === "pass" && "ring-2 ring-green-500",
+          runStatus === "fail" && "ring-2 ring-red-500",
+          dimmed && "opacity-40 pointer-events-none"
+        )}
+        size="sm"
+      >
+        <CardHeader className={cn("flex min-h-14 items-center rounded-none px-3 py-2", t.headerBg)}>
+          <div className="flex w-full min-w-0 items-center gap-3">
+            <div
+              className={cn(
+                "flex h-8 w-8 shrink-0 items-center justify-center rounded-md",
+                t.iconBg
+              )}
+            >
+              <Icon className={cn("h-4 w-4", t.iconColor)} />
+            </div>
+            <div className="flex min-h-8 flex-1 min-w-0 flex-col justify-center">
+              {handleChange ? (
+                <input
+                  aria-label="Node label"
+                  className={cn(
+                    "nodrag nopan w-auto max-w-full bg-transparent text-xs font-semibold leading-tight [field-sizing:content] focus:outline-none",
+                    isLabelEditing ? "select-text" : "cursor-default select-none"
+                  )}
+                  name="nodeLabel"
+                  readOnly={!isLabelEditing}
+                  value={label}
+                  onBlur={handleLabelBlur}
+                  onChange={handleChange}
+                  onClick={handleLabelClick}
+                  onMouseDown={handleMouseDown}
+                />
+              ) : (
+                <CardTitle className="truncate text-xs font-semibold leading-tight">
+                  {label}
+                </CardTitle>
+              )}
+              {description && (
+                <CardDescription className="truncate text-[10px] leading-tight">
+                  {description}
+                </CardDescription>
+              )}
+            </div>
+            {headerRight && <CardAction className="shrink-0 self-center">{headerRight}</CardAction>}
+          </div>
+        </CardHeader>
+        {children && (
+          <CardContent className={cn("px-3 py-3", bodyClassName)}>{children}</CardContent>
+        )}
+      </Card>
+    );
+  }
+);
+NodeCardFrame.displayName = "NodeCardFrame";

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCardFrame.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCardFrame.tsx
@@ -47,6 +47,7 @@ export const NodeCardFrame = memo(
       ? (e: React.ChangeEvent<HTMLInputElement>) => onLabelChange(e.target.value)
       : undefined;
     const handleLabelClick = () => setIsLabelEditing(true);
+    const handleLabelFocus = () => setIsLabelEditing(true);
     const handleLabelBlur = () => setIsLabelEditing(false);
 
     return (
@@ -86,6 +87,7 @@ export const NodeCardFrame = memo(
                   onBlur={handleLabelBlur}
                   onChange={handleChange}
                   onClick={handleLabelClick}
+                  onFocus={handleLabelFocus}
                   onMouseDown={handleMouseDown}
                 />
               ) : (

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCardPorts.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCardPorts.tsx
@@ -1,0 +1,83 @@
+import { Handle, Position, useNodeId, useUpdateNodeInternals } from "@xyflow/react";
+import { cn } from "@repo/ui/lib/utils";
+import { useEffect } from "react";
+import { getNodePortOffsets, makeNodePortId, type NodePortSide } from "./nodePorts";
+import { themeMap, type NodeTheme } from "./nodeCardTheme";
+
+export interface NodeCardPortsProps {
+  cardMaxPortSpread?: number;
+  leftHandle?: boolean;
+  leftHandleCount: number;
+  rightHandle?: boolean;
+  rightHandleCount: number;
+  theme: NodeTheme;
+}
+
+const nodePortClassName =
+  "node-card-port absolute !top-[calc(50%+var(--node-port-offset))] !z-10 !h-5 !w-5 rounded-full !border-0 !bg-transparent !opacity-100 transition-opacity duration-150 ease-out before:content-[''] before:absolute before:left-1/2 before:top-1/2 before:h-2 before:w-2 before:-translate-x-1/2 before:-translate-y-1/2 before:rounded-full before:shadow-[0_0_0_3px_rgba(255,255,255,0.95),0_2px_7px_rgba(15,23,42,0.22)] before:transition-transform before:duration-200 hover:before:scale-125";
+
+const getNodePortStyle = (offset: number) =>
+  ({
+    "--node-port-offset": `${offset}px`,
+  }) as React.CSSProperties;
+
+const getNodePortPosition = (side: NodePortSide) =>
+  side === "left" ? Position.Left : Position.Right;
+
+export const NodeCardPorts = ({
+  cardMaxPortSpread,
+  leftHandle,
+  leftHandleCount,
+  rightHandle,
+  rightHandleCount,
+  theme,
+}: NodeCardPortsProps) => {
+  const t = themeMap[theme] ?? themeMap.emerald;
+  const nodeId = useNodeId();
+  const updateNodeInternals = useUpdateNodeInternals();
+  const leftPortOffsets = getNodePortOffsets(leftHandleCount, cardMaxPortSpread);
+  const rightPortOffsets = getNodePortOffsets(rightHandleCount, cardMaxPortSpread);
+
+  useEffect(() => {
+    if (!nodeId) {
+      return;
+    }
+
+    updateNodeInternals(nodeId);
+  }, [
+    cardMaxPortSpread,
+    leftHandle,
+    leftHandleCount,
+    nodeId,
+    rightHandle,
+    rightHandleCount,
+    updateNodeInternals,
+  ]);
+
+  return (
+    <>
+      {leftHandle &&
+        leftPortOffsets.map((offset, index) => (
+          <Handle
+            key={makeNodePortId("left", index)}
+            className={cn(nodePortClassName, "!left-2.5 before:!left-0", t.handleColor)}
+            id={makeNodePortId("left", index)}
+            position={getNodePortPosition("left")}
+            style={getNodePortStyle(offset)}
+            type="target"
+          />
+        ))}
+      {rightHandle &&
+        rightPortOffsets.map((offset, index) => (
+          <Handle
+            key={makeNodePortId("right", index)}
+            className={cn(nodePortClassName, "!right-2.5 before:!left-full", t.handleColor)}
+            id={makeNodePortId("right", index)}
+            position={getNodePortPosition("right")}
+            style={getNodePortStyle(offset)}
+            type="source"
+          />
+        ))}
+    </>
+  );
+};

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCardPorts.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCardPorts.tsx
@@ -1,4 +1,4 @@
-import { Handle, Position, useNodeId, useUpdateNodeInternals } from "@xyflow/react";
+import { Handle as ReactFlowPort, Position, useNodeId, useUpdateNodeInternals } from "@xyflow/react";
 import { cn } from "@repo/ui/lib/utils";
 import { useEffect } from "react";
 import { getNodePortOffsets, makeNodePortId, type NodePortSide } from "./nodePorts";
@@ -37,6 +37,12 @@ export const NodeCardPorts = ({
   const updateNodeInternals = useUpdateNodeInternals();
   const leftPortOffsets = getNodePortOffsets(leftHandleCount, cardMaxPortSpread);
   const rightPortOffsets = getNodePortOffsets(rightHandleCount, cardMaxPortSpread);
+  const leftPortClassName = cn(nodePortClassName, "!left-2.5 before:!left-0", t.handleColor);
+  const rightPortClassName = cn(
+    nodePortClassName,
+    "!right-2.5 before:!left-full",
+    t.handleColor
+  );
 
   useEffect(() => {
     if (!nodeId) {
@@ -58,9 +64,9 @@ export const NodeCardPorts = ({
     <>
       {leftHandle &&
         leftPortOffsets.map((offset, index) => (
-          <Handle
+          <ReactFlowPort
             key={makeNodePortId("left", index)}
-            className={cn(nodePortClassName, "!left-2.5 before:!left-0", t.handleColor)}
+            className={leftPortClassName}
             id={makeNodePortId("left", index)}
             position={getNodePortPosition("left")}
             style={getNodePortStyle(offset)}
@@ -69,9 +75,9 @@ export const NodeCardPorts = ({
         ))}
       {rightHandle &&
         rightPortOffsets.map((offset, index) => (
-          <Handle
+          <ReactFlowPort
             key={makeNodePortId("right", index)}
-            className={cn(nodePortClassName, "!right-2.5 before:!left-full", t.handleColor)}
+            className={rightPortClassName}
             id={makeNodePortId("right", index)}
             position={getNodePortPosition("right")}
             style={getNodePortStyle(offset)}

--- a/apps/app/src/pages/CanvasPage/NodeCard/index.ts
+++ b/apps/app/src/pages/CanvasPage/NodeCard/index.ts
@@ -1,1 +1,3 @@
 export * from "./NodeCard";
+export * from "./nodePorts";
+export * from "./useNodePortCounts";

--- a/apps/app/src/pages/CanvasPage/NodeCard/nodeCardTheme.ts
+++ b/apps/app/src/pages/CanvasPage/NodeCard/nodeCardTheme.ts
@@ -1,0 +1,60 @@
+export type NodeTheme = "emerald" | "violet" | "amber" | "sky" | "orange" | "teal" | "indigo";
+
+export const themeMap = {
+  emerald: {
+    ring: "ring-emerald-500/20",
+    ringSelected: "ring-emerald-500",
+    headerBg: "bg-emerald-50/50",
+    iconBg: "bg-emerald-100",
+    iconColor: "text-emerald-600",
+    handleColor: "before:!bg-emerald-500",
+  },
+  violet: {
+    ring: "ring-violet-500/20",
+    ringSelected: "ring-violet-500",
+    headerBg: "bg-violet-50/50",
+    iconBg: "bg-violet-100",
+    iconColor: "text-violet-600",
+    handleColor: "before:!bg-violet-500",
+  },
+  amber: {
+    ring: "ring-amber-500/20",
+    ringSelected: "ring-amber-500",
+    headerBg: "bg-amber-50/50",
+    iconBg: "bg-amber-100",
+    iconColor: "text-amber-600",
+    handleColor: "before:!bg-amber-500",
+  },
+  sky: {
+    ring: "ring-sky-500/20",
+    ringSelected: "ring-sky-500",
+    headerBg: "bg-sky-50/50",
+    iconBg: "bg-sky-100",
+    iconColor: "text-sky-600",
+    handleColor: "before:!bg-sky-500",
+  },
+  orange: {
+    ring: "ring-orange-500/20",
+    ringSelected: "ring-orange-500",
+    headerBg: "bg-orange-50/50",
+    iconBg: "bg-orange-100",
+    iconColor: "text-orange-600",
+    handleColor: "before:!bg-orange-500",
+  },
+  teal: {
+    ring: "ring-teal-500/20",
+    ringSelected: "ring-teal-500",
+    headerBg: "bg-teal-50/50",
+    iconBg: "bg-teal-100",
+    iconColor: "text-teal-600",
+    handleColor: "before:!bg-teal-500",
+  },
+  indigo: {
+    ring: "ring-indigo-500/20",
+    ringSelected: "ring-indigo-500",
+    headerBg: "bg-indigo-50/50",
+    iconBg: "bg-indigo-100",
+    iconColor: "text-indigo-600",
+    handleColor: "before:!bg-indigo-500",
+  },
+} satisfies Record<NodeTheme, object>;

--- a/apps/app/src/pages/CanvasPage/NodeCard/nodePorts.ts
+++ b/apps/app/src/pages/CanvasPage/NodeCard/nodePorts.ts
@@ -197,11 +197,20 @@ export const decorateEdgesWithPortHandles = (
   const sourceHandleByEdgeId = makePortAssignments(nodes, edges, "right", pendingConnection);
   const targetHandleByEdgeId = makePortAssignments(nodes, edges, "left", pendingConnection);
 
-  return edges.map((edge) => ({
-    ...edge,
-    sourceHandle:
-      sourceHandleByEdgeId.get(edge.id) ?? edge.sourceHandle ?? makeNodePortId("right", 0),
-    targetHandle:
-      targetHandleByEdgeId.get(edge.id) ?? edge.targetHandle ?? makeNodePortId("left", 0),
-  }));
+  return edges.map((edge) => {
+    const sourceHandle =
+      sourceHandleByEdgeId.get(edge.id) ?? edge.sourceHandle ?? makeNodePortId("right", 0);
+    const targetHandle =
+      targetHandleByEdgeId.get(edge.id) ?? edge.targetHandle ?? makeNodePortId("left", 0);
+
+    if (edge.sourceHandle === sourceHandle && edge.targetHandle === targetHandle) {
+      return edge;
+    }
+
+    return {
+      ...edge,
+      sourceHandle,
+      targetHandle,
+    };
+  });
 };

--- a/apps/app/src/pages/CanvasPage/NodeCard/nodePorts.ts
+++ b/apps/app/src/pages/CanvasPage/NodeCard/nodePorts.ts
@@ -87,10 +87,21 @@ export const getNodePortCounts = (
   edges: PipelineEdge[],
   nodeId: string,
   pendingConnection?: PendingNodePortConnection | null
-) => ({
-  leftPortCount: getNodePortCount(edges, nodeId, "left", pendingConnection),
-  rightPortCount: getNodePortCount(edges, nodeId, "right", pendingConnection),
-});
+) => {
+  const { leftConnectionCount, rightConnectionCount } = edges.reduce(
+    (counts, edge) => ({
+      leftConnectionCount: counts.leftConnectionCount + (edge.target === nodeId ? 1 : 0),
+      rightConnectionCount: counts.rightConnectionCount + (edge.source === nodeId ? 1 : 0),
+    }),
+    { leftConnectionCount: 0, rightConnectionCount: 0 }
+  );
+  const pendingSide = getPendingPortSide(pendingConnection, nodeId);
+
+  return {
+    leftPortCount: Math.max(1, leftConnectionCount + (pendingSide === "left" ? 1 : 0)),
+    rightPortCount: Math.max(1, rightConnectionCount + (pendingSide === "right" ? 1 : 0)),
+  };
+};
 
 const getNodeHeight = (node: PipelineNode): number => {
   const styleHeight =

--- a/apps/app/src/pages/CanvasPage/NodeCard/nodePorts.ts
+++ b/apps/app/src/pages/CanvasPage/NodeCard/nodePorts.ts
@@ -1,0 +1,196 @@
+import type { PipelineEdge, PipelineNode } from "../_store/canvasSlice";
+
+export type NodePortSide = "left" | "right";
+
+export interface PendingNodePortConnection {
+  nodeId: string;
+  handleId?: string | null;
+  handleType?: "source" | "target" | null;
+}
+
+const DEFAULT_NODE_HEIGHT = 120;
+const MAX_PORT_SPREAD = 42;
+const MIN_PORT_SPREAD = 28;
+const PORT_SPREAD_STEP = 8;
+const EXTENDED_PORT_GAP = 28;
+const EXTENDED_PORT_THRESHOLD = 4;
+
+export const makeNodePortId = (side: NodePortSide, index: number) => `${side}-port-${index}`;
+
+const getNodePortIndex = (side: NodePortSide, handleId?: string | null): number | null => {
+  const prefix = `${side}-port-`;
+  if (!handleId?.startsWith(prefix)) {
+    return null;
+  }
+
+  const index = Number.parseInt(handleId.slice(prefix.length), 10);
+
+  return Number.isInteger(index) && index >= 0 ? index : null;
+};
+
+const getPendingPortSide = (
+  pendingConnection: PendingNodePortConnection | null | undefined,
+  nodeId: string
+): NodePortSide | null => {
+  if (!pendingConnection || pendingConnection.nodeId !== nodeId) {
+    return null;
+  }
+
+  if (pendingConnection.handleType === "source") {
+    return "right";
+  }
+
+  return pendingConnection.handleType === "target" ? "left" : null;
+};
+
+const clampPortSpread = (spread: number, maxSpread?: number): number => {
+  if (!Number.isFinite(maxSpread) || maxSpread === undefined || maxSpread < 0) {
+    return spread;
+  }
+
+  return Math.min(spread, maxSpread);
+};
+
+export const getNodePortOffsets = (count: number, maxSpread?: number): number[] => {
+  const safeCount = Math.max(1, count);
+
+  if (safeCount === 1) {
+    return [0];
+  }
+
+  const spread =
+    safeCount > EXTENDED_PORT_THRESHOLD
+      ? ((safeCount - 1) * EXTENDED_PORT_GAP) / 2
+      : Math.min(MAX_PORT_SPREAD, MIN_PORT_SPREAD + (safeCount - 2) * PORT_SPREAD_STEP);
+  const clampedSpread = clampPortSpread(spread, maxSpread);
+
+  return Array.from({ length: safeCount }, (_item, index) =>
+    Math.round(-clampedSpread + (clampedSpread * 2 * index) / (safeCount - 1))
+  );
+};
+
+export const getNodePortCount = (
+  edges: PipelineEdge[],
+  nodeId: string,
+  side: NodePortSide,
+  pendingConnection?: PendingNodePortConnection | null
+): number => {
+  const connectionCount = edges.filter((edge) =>
+    side === "left" ? edge.target === nodeId : edge.source === nodeId
+  ).length;
+  const pendingConnectionCount = getPendingPortSide(pendingConnection, nodeId) === side ? 1 : 0;
+
+  return Math.max(1, connectionCount + pendingConnectionCount);
+};
+
+export const getNodePortCounts = (
+  edges: PipelineEdge[],
+  nodeId: string,
+  pendingConnection?: PendingNodePortConnection | null
+) => ({
+  leftPortCount: getNodePortCount(edges, nodeId, "left", pendingConnection),
+  rightPortCount: getNodePortCount(edges, nodeId, "right", pendingConnection),
+});
+
+const getNodeHeight = (node: PipelineNode): number => {
+  const styleHeight =
+    typeof node.style?.height === "number"
+      ? node.style.height
+      : Number.parseFloat(String(node.style?.height ?? ""));
+  const measuredHeight = node.measured?.height;
+
+  return Number.isFinite(styleHeight) && styleHeight > 0
+    ? styleHeight
+    : (measuredHeight ?? DEFAULT_NODE_HEIGHT);
+};
+
+const getNodeCenterY = (node: PipelineNode): number => node.position.y + getNodeHeight(node) / 2;
+
+const getOtherNodeId = (edge: PipelineEdge, side: NodePortSide): string =>
+  side === "left" ? edge.source : edge.target;
+
+const getSideEdges = (edges: PipelineEdge[], nodeId: string, side: NodePortSide): PipelineEdge[] =>
+  edges.filter((edge) => (side === "left" ? edge.target === nodeId : edge.source === nodeId));
+
+const getEdgePortHandleId = (edge: PipelineEdge, side: NodePortSide): string | null | undefined =>
+  side === "left" ? edge.targetHandle : edge.sourceHandle;
+
+const compareByOtherNodeY =
+  (nodeById: Map<string, PipelineNode>, side: NodePortSide) =>
+  (a: PipelineEdge, b: PipelineEdge): number => {
+    const aNode = nodeById.get(getOtherNodeId(a, side));
+    const bNode = nodeById.get(getOtherNodeId(b, side));
+    const aY = aNode ? getNodeCenterY(aNode) : 0;
+    const bY = bNode ? getNodeCenterY(bNode) : 0;
+    const yDelta = aY - bY;
+
+    return yDelta === 0 ? a.id.localeCompare(b.id) : yDelta;
+  };
+
+const makePortAssignments = (
+  nodes: PipelineNode[],
+  edges: PipelineEdge[],
+  side: NodePortSide,
+  pendingConnection?: PendingNodePortConnection | null
+): Map<string, string> => {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const assignments = new Map<string, string>();
+
+  for (const node of nodes) {
+    const sideEdges = [...getSideEdges(edges, node.id, side)].sort(
+      compareByOtherNodeY(nodeById, side)
+    );
+    const hasPendingConnection = getPendingPortSide(pendingConnection, node.id) === side;
+    const slotCount = Math.max(1, sideEdges.length + (hasPendingConnection ? 1 : 0));
+    const pendingIndex = hasPendingConnection
+      ? getNodePortIndex(side, pendingConnection?.handleId)
+      : null;
+    const usedIndexes = new Set<number>();
+    const autoAssignedEdges: PipelineEdge[] = [];
+
+    if (pendingIndex !== null && pendingIndex < slotCount) {
+      usedIndexes.add(pendingIndex);
+    }
+
+    for (const edge of sideEdges) {
+      const explicitIndex = getNodePortIndex(side, getEdgePortHandleId(edge, side));
+      if (explicitIndex !== null && explicitIndex < slotCount && !usedIndexes.has(explicitIndex)) {
+        assignments.set(edge.id, makeNodePortId(side, explicitIndex));
+        usedIndexes.add(explicitIndex);
+      } else {
+        autoAssignedEdges.push(edge);
+      }
+    }
+
+    const availableIndexes = Array.from({ length: slotCount }, (_item, index) => index)
+      .filter((index) => !usedIndexes.has(index))
+      .slice(0, autoAssignedEdges.length);
+
+    for (const [edge, index] of autoAssignedEdges.flatMap((edge, edgeIndex) => {
+      const index = availableIndexes[edgeIndex];
+
+      return index === undefined ? [] : ([[edge, index]] as const);
+    })) {
+      assignments.set(edge.id, makeNodePortId(side, index));
+    }
+  }
+
+  return assignments;
+};
+
+export const decorateEdgesWithPortHandles = (
+  nodes: PipelineNode[],
+  edges: PipelineEdge[],
+  pendingConnection?: PendingNodePortConnection | null
+): PipelineEdge[] => {
+  const sourceHandleByEdgeId = makePortAssignments(nodes, edges, "right", pendingConnection);
+  const targetHandleByEdgeId = makePortAssignments(nodes, edges, "left", pendingConnection);
+
+  return edges.map((edge) => ({
+    ...edge,
+    sourceHandle:
+      sourceHandleByEdgeId.get(edge.id) ?? edge.sourceHandle ?? makeNodePortId("right", 0),
+    targetHandle:
+      targetHandleByEdgeId.get(edge.id) ?? edge.targetHandle ?? makeNodePortId("left", 0),
+  }));
+};

--- a/apps/app/src/pages/CanvasPage/NodeCard/nodePorts.unit.test.ts
+++ b/apps/app/src/pages/CanvasPage/NodeCard/nodePorts.unit.test.ts
@@ -3,6 +3,7 @@ import type { PipelineEdge, PipelineNode } from "../_store/canvasSlice";
 import {
   decorateEdgesWithPortHandles,
   getNodePortCount,
+  getNodePortCounts,
   getNodePortOffsets,
   makeNodePortId,
 } from "./nodePorts";
@@ -56,6 +57,21 @@ describe("node port helpers", () => {
         handleType: "source",
       })
     ).toBe(1);
+  });
+
+  it("counts both node sides in one helper", () => {
+    const edges = [
+      makeEdge("edge-in", "upstream", "node"),
+      makeEdge("edge-out", "node", "downstream"),
+    ];
+
+    expect(
+      getNodePortCounts(edges, "node", {
+        nodeId: "node",
+        handleId: "left-port-0",
+        handleType: "target",
+      })
+    ).toEqual({ leftPortCount: 2, rightPortCount: 1 });
   });
 
   it("creates predictable split offsets", () => {

--- a/apps/app/src/pages/CanvasPage/NodeCard/nodePorts.unit.test.ts
+++ b/apps/app/src/pages/CanvasPage/NodeCard/nodePorts.unit.test.ts
@@ -124,6 +124,19 @@ describe("node port helpers", () => {
     ]);
   });
 
+  it("keeps the original edge object when port handles are unchanged", () => {
+    const nodes = [makeNode("source", 100), makeNode("target", 240)];
+    const edge = {
+      ...makeEdge("edge-existing", "source", "target"),
+      sourceHandle: "right-port-0",
+      targetHandle: "left-port-0",
+    };
+
+    const decoratedEdges = decorateEdgesWithPortHandles(nodes, [edge]);
+
+    expect(decoratedEdges[0]).toBe(edge);
+  });
+
   it("reserves the dragged source handle while a new connection is pending", () => {
     const nodes = [makeNode("source", 100), makeNode("target", 240)];
     const edges = [

--- a/apps/app/src/pages/CanvasPage/NodeCard/nodePorts.unit.test.ts
+++ b/apps/app/src/pages/CanvasPage/NodeCard/nodePorts.unit.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import type { PipelineEdge, PipelineNode } from "../_store/canvasSlice";
+import {
+  decorateEdgesWithPortHandles,
+  getNodePortCount,
+  getNodePortOffsets,
+  makeNodePortId,
+} from "./nodePorts";
+
+const makeNode = (id: string, y: number): PipelineNode =>
+  ({
+    id,
+    type: "operation",
+    position: { x: 0, y },
+    measured: { width: 288, height: 120 },
+    data: { label: id },
+  }) as PipelineNode;
+
+const makeEdge = (id: string, source: string, target: string): PipelineEdge =>
+  ({
+    id,
+    source,
+    target,
+    type: "default",
+    animated: true,
+    data: {},
+  }) as PipelineEdge;
+
+describe("node port helpers", () => {
+  it("keeps a center slot for an unconnected side", () => {
+    expect(getNodePortCount([], "node-a", "right")).toBe(1);
+    expect(getNodePortOffsets(1)).toEqual([0]);
+  });
+
+  it("counts a pending connection as the next dynamic port", () => {
+    const edge = makeEdge("edge-existing", "source", "target");
+
+    expect(
+      getNodePortCount([], "source", "right", {
+        nodeId: "source",
+        handleId: "right-port-0",
+        handleType: "source",
+      })
+    ).toBe(1);
+    expect(
+      getNodePortCount([edge], "source", "right", {
+        nodeId: "source",
+        handleId: "right-port-0",
+        handleType: "source",
+      })
+    ).toBe(2);
+    expect(
+      getNodePortCount([edge], "source", "left", {
+        nodeId: "source",
+        handleId: "right-port-0",
+        handleType: "source",
+      })
+    ).toBe(1);
+  });
+
+  it("creates predictable split offsets", () => {
+    expect(getNodePortOffsets(2)).toEqual([-28, 28]);
+    expect(getNodePortOffsets(3)).toEqual([-36, 0, 36]);
+    expect(getNodePortOffsets(4)).toEqual([-42, -14, 14, 42]);
+    expect(makeNodePortId("left", 2)).toBe("left-port-2");
+  });
+
+  it("widens the port spread after four connections", () => {
+    expect(getNodePortOffsets(5)).toEqual([-56, -28, 0, 28, 56]);
+    expect(getNodePortOffsets(6)).toEqual([-70, -42, -14, 14, 42, 70]);
+  });
+
+  it("caps the port spread to the available card half-height", () => {
+    expect(getNodePortOffsets(6, 60)).toEqual([-60, -36, -12, 12, 36, 60]);
+    expect(getNodePortOffsets(8, 48)).toEqual([-48, -34, -21, -7, 7, 21, 34, 48]);
+  });
+
+  it("assigns source handles by target node vertical order", () => {
+    const nodes = [makeNode("source", 100), makeNode("low", 240), makeNode("high", 0)];
+    const edges = [makeEdge("edge-low", "source", "low"), makeEdge("edge-high", "source", "high")];
+
+    expect(decorateEdgesWithPortHandles(nodes, edges)).toEqual([
+      expect.objectContaining({ id: "edge-low", sourceHandle: "right-port-1" }),
+      expect.objectContaining({ id: "edge-high", sourceHandle: "right-port-0" }),
+    ]);
+  });
+
+  it("keeps an explicit source handle and routes automatic handles around it", () => {
+    const nodes = [
+      makeNode("source", 100),
+      makeNode("top", 0),
+      makeNode("bottom", 240),
+      makeNode("manual", 480),
+    ];
+    const edges = [
+      makeEdge("edge-bottom", "source", "bottom"),
+      {
+        ...makeEdge("edge-manual", "source", "manual"),
+        sourceHandle: "right-port-1",
+      },
+      makeEdge("edge-top", "source", "top"),
+    ];
+
+    expect(decorateEdgesWithPortHandles(nodes, edges)).toEqual([
+      expect.objectContaining({ id: "edge-bottom", sourceHandle: "right-port-2" }),
+      expect.objectContaining({ id: "edge-manual", sourceHandle: "right-port-1" }),
+      expect.objectContaining({ id: "edge-top", sourceHandle: "right-port-0" }),
+    ]);
+  });
+
+  it("reserves the dragged source handle while a new connection is pending", () => {
+    const nodes = [makeNode("source", 100), makeNode("target", 240)];
+    const edges = [
+      {
+        ...makeEdge("edge-existing", "source", "target"),
+        sourceHandle: "right-port-0",
+      },
+    ];
+
+    expect(
+      decorateEdgesWithPortHandles(nodes, edges, {
+        nodeId: "source",
+        handleId: "right-port-0",
+        handleType: "source",
+      })
+    ).toEqual([expect.objectContaining({ id: "edge-existing", sourceHandle: "right-port-1" })]);
+  });
+
+  it("assigns target handles by source node vertical order", () => {
+    const nodes = [makeNode("target", 100), makeNode("low", 240), makeNode("high", 0)];
+    const edges = [makeEdge("edge-low", "low", "target"), makeEdge("edge-high", "high", "target")];
+
+    expect(decorateEdgesWithPortHandles(nodes, edges)).toEqual([
+      expect.objectContaining({ id: "edge-low", targetHandle: "left-port-1" }),
+      expect.objectContaining({ id: "edge-high", targetHandle: "left-port-0" }),
+    ]);
+  });
+
+  it("keeps an explicit target handle and routes automatic handles around it", () => {
+    const nodes = [
+      makeNode("target", 100),
+      makeNode("top", 0),
+      makeNode("bottom", 240),
+      makeNode("manual", 480),
+    ];
+    const edges = [
+      makeEdge("edge-bottom", "bottom", "target"),
+      {
+        ...makeEdge("edge-manual", "manual", "target"),
+        targetHandle: "left-port-1",
+      },
+      makeEdge("edge-top", "top", "target"),
+    ];
+
+    expect(decorateEdgesWithPortHandles(nodes, edges)).toEqual([
+      expect.objectContaining({ id: "edge-bottom", targetHandle: "left-port-2" }),
+      expect.objectContaining({ id: "edge-manual", targetHandle: "left-port-1" }),
+      expect.objectContaining({ id: "edge-top", targetHandle: "left-port-0" }),
+    ]);
+  });
+
+  it("reserves the dragged target handle while a new upstream connection is pending", () => {
+    const nodes = [makeNode("target", 100), makeNode("source", 240)];
+    const edges = [
+      {
+        ...makeEdge("edge-existing", "source", "target"),
+        targetHandle: "left-port-0",
+      },
+    ];
+
+    expect(
+      decorateEdgesWithPortHandles(nodes, edges, {
+        nodeId: "target",
+        handleId: "left-port-0",
+        handleType: "target",
+      })
+    ).toEqual([expect.objectContaining({ id: "edge-existing", targetHandle: "left-port-1" })]);
+  });
+});

--- a/apps/app/src/pages/CanvasPage/NodeCard/useNodePortCounts.ts
+++ b/apps/app/src/pages/CanvasPage/NodeCard/useNodePortCounts.ts
@@ -1,0 +1,13 @@
+import { useStore } from "zustand";
+import { useShallow } from "zustand/shallow";
+import { useHarnessCanvasStore } from "../_store";
+import { getNodePortCounts } from "./nodePorts";
+
+export const useNodePortCounts = (nodeId: string) => {
+  const store = useHarnessCanvasStore();
+
+  return useStore(
+    store,
+    useShallow((state) => getNodePortCounts(state.edges, nodeId, state.connectStart))
+  );
+};

--- a/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
@@ -1,4 +1,3 @@
-import { Handle, Position } from "@xyflow/react";
 import { Zap, CheckCircle2, XCircle, Loader2, Circle, Brain, Repeat } from "lucide-react";
 import { useState } from "react";
 import { cn } from "@repo/ui/lib/utils";
@@ -18,7 +17,7 @@ import type { OperationNodeData, NodeRunStatus } from "@repo/pipeline-engine/sch
 import { useList } from "@refinedev/core";
 import { ResourceName } from "@/integrations/refine/dataProvider";
 import { type Operation, type BestPractice, AgentRuntimeSchema } from "@repo/schemas";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodePortCounts } from "../NodeCard";
 import { BestPracticeSelect } from "./BestPracticeSelect";
 
 export interface OperationNodeProps {
@@ -64,6 +63,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
   const isTestRunning = useStore(store, (s) => s.isTestRunning);
   const nodeLlmContent = useStore(store, (s) => s.nodeLlmContent);
   const setInspectingNodeId = useStore(store, (s) => s.setInspectingNodeId);
+  const { leftPortCount, rightPortCount } = useNodePortCounts(id);
 
   const { icon: StatusIcon, color, label: statusLabel } = statusConfig[data.status ?? "idle"];
 
@@ -117,6 +117,8 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
       onClick={handleCardClick}
     >
       <NodeCard
+        leftHandle
+        rightHandle
         bodyClassName="space-y-2"
         description={operation?.description || "自定义操作"}
         dimmed={dimmed}
@@ -138,6 +140,8 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
         }
         icon={Zap}
         label={data.operationName || data.label}
+        leftHandleCount={leftPortCount}
+        rightHandleCount={rightPortCount}
         runStatus={nodeRunStatus}
         selected={selected}
         theme="violet"
@@ -274,19 +278,6 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
           )}
         </div>
       </NodeCard>
-
-      {/* Target handle (input from object or previous operation) */}
-      <Handle
-        className="absolute h-3.5 w-3.5 rounded-full border-[3px] border-white shadow-sm transition-all hover:scale-110 -left-1.5 top-1/2 -mt-1.5 bg-violet-500"
-        position={Position.Left}
-        type="target"
-      />
-      {/* Source handle (output to next operation or object) */}
-      <Handle
-        className="absolute h-3.5 w-3.5 rounded-full border-[3px] border-white shadow-sm transition-all hover:scale-110 -right-1.5 top-1/2 -mt-1.5 bg-violet-500"
-        position={Position.Right}
-        type="source"
-      />
     </div>
   );
 };

--- a/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { Handle, Position } from "@xyflow/react";
+import { memo, useState } from "react";
 import { AlertTriangle, FolderOpen, HardDrive } from "lucide-react";
 import {
   OUTPUT_MODE_ENUM,
@@ -9,7 +8,7 @@ import {
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useHarnessCanvasStore, selectNodeRunState } from "../_store";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodePortCounts } from "../NodeCard";
 import { FolderBrowser } from "./FolderBrowser";
 
 export interface OutputLocalPathNodeProps {
@@ -30,6 +29,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
   const store = useHarnessCanvasStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
+  const { leftPortCount } = useNodePortCounts(id);
   const [browserOpen, setBrowserOpen] = useState(false);
 
   const handleLabelChange = (v: string) => updateNodeData(id, { label: v });
@@ -60,11 +60,13 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
   return (
     <div className="group relative" style={{ overflow: "visible" }}>
       <NodeCard
+        leftHandle
         bodyClassName="space-y-2"
         description="本地路径输出"
         dimmed={dimmed}
         icon={HardDrive}
         label={data.label}
+        leftHandleCount={leftPortCount}
         runStatus={runStatus}
         selected={selected}
         theme="teal"
@@ -143,13 +145,6 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
         onSelect={handleFolderSelect}
-      />
-
-      {/* Output nodes only receive connections — no source handle */}
-      <Handle
-        className="absolute h-3.5 w-3.5 rounded-full bg-teal-600 border-[3px] border-white shadow-sm transition-all hover:scale-110 -left-1.5 top-1/2 -mt-1.5"
-        position={Position.Left}
-        type="target"
       />
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { useState } from "react";
 import { AlertTriangle, FolderOpen, HardDrive } from "lucide-react";
 import {
   OUTPUT_MODE_ENUM,

--- a/apps/app/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.tsx
@@ -1,10 +1,9 @@
-import { Handle, Position } from "@xyflow/react";
 import { FolderOutput } from "lucide-react";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useHarnessCanvasStore, selectNodeRunState } from "../_store";
 import type { OutputProjectPathNodeData } from "@repo/pipeline-engine/schemas";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodePortCounts } from "../NodeCard";
 import { Input } from "@repo/ui/input";
 import { Textarea } from "@repo/ui/textarea";
 
@@ -20,6 +19,7 @@ export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathN
   const store = useHarnessCanvasStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
+  const { leftPortCount } = useNodePortCounts(id);
 
   const handleLabelChange = (v: string) => updateNodeData(id, { label: v });
   const handleProjectIdChange = (e: React.ChangeEvent<HTMLInputElement>) =>
@@ -32,11 +32,13 @@ export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathN
   return (
     <div className="group relative" style={{ overflow: "visible" }}>
       <NodeCard
+        leftHandle
         bodyClassName="space-y-2"
         description="项目路径输出"
         dimmed={dimmed}
         icon={FolderOutput}
         label={data.label}
+        leftHandleCount={leftPortCount}
         runStatus={runStatus}
         selected={selected}
         theme="teal"
@@ -73,13 +75,6 @@ export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathN
           onMouseDown={handleMouseDown}
         />
       </NodeCard>
-
-      {/* Output nodes only receive connections — no source handle */}
-      <Handle
-        className="absolute h-3.5 w-3.5 rounded-full bg-teal-500 border-[3px] border-white shadow-sm transition-all hover:scale-110 -left-1.5 top-1/2 -mt-1.5"
-        position={Position.Left}
-        type="target"
-      />
     </div>
   );
 };

--- a/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
@@ -236,11 +236,11 @@ export const createActionsSlice = (
   },
 
   handleFlowConnectStart: (_event, params) => {
-    if (!params.nodeId) return;
+    if (!params.nodeId || !params.handleType) return;
     get().handleConnectStart({
       nodeId: params.nodeId,
       handleId: params.handleId ?? null,
-      handleType: params.handleType ?? null,
+      handleType: params.handleType,
     });
   },
 
@@ -255,10 +255,17 @@ export const createActionsSlice = (
     const currentConnectStart = get().connectStart;
 
     if (fromNodeId) {
+      const handleType = getConnectStartHandleType(connectionState, currentConnectStart, fromNodeId);
+      if (!handleType) {
+        get().handleConnectStart(null);
+
+        return;
+      }
+
       get().handleConnectStart({
         nodeId: fromNodeId,
         handleId: getConnectStartHandleId(connectionState, currentConnectStart, fromNodeId),
-        handleType: getConnectStartHandleType(connectionState, currentConnectStart, fromNodeId),
+        handleType,
       });
 
       const { clientX, clientY } =

--- a/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
@@ -19,6 +19,23 @@ import {
   QUICK_ADD_NODE_ORIGIN,
   offsetPosition,
 } from "../utils/nodePosition";
+import type { ConnectStartState } from "./uiSlice";
+
+const getConnectStartHandleId = (
+  connectionState: FinalConnectionState,
+  currentConnectStart: ConnectStartState | null,
+  fromNodeId: string
+): string | null =>
+  connectionState.fromHandle?.id ??
+  (currentConnectStart?.nodeId === fromNodeId ? currentConnectStart.handleId : null);
+
+const getConnectStartHandleType = (
+  connectionState: FinalConnectionState,
+  currentConnectStart: ConnectStartState | null,
+  fromNodeId: string
+): ConnectStartState["handleType"] =>
+  connectionState.fromHandle?.type ??
+  (currentConnectStart?.nodeId === fromNodeId ? currentConnectStart.handleType : null);
 
 export interface ActionsSlice {
   exportCanvas: () => void;
@@ -235,12 +252,13 @@ export const createActionsSlice = (
     }
 
     const fromNodeId = connectionState.fromNode?.id ?? null;
+    const currentConnectStart = get().connectStart;
 
     if (fromNodeId) {
       get().handleConnectStart({
         nodeId: fromNodeId,
-        handleId: connectionState.fromHandle?.id ?? null,
-        handleType: connectionState.fromHandle?.type ?? null,
+        handleId: getConnectStartHandleId(connectionState, currentConnectStart, fromNodeId),
+        handleType: getConnectStartHandleType(connectionState, currentConnectStart, fromNodeId),
       });
 
       const { clientX, clientY } =
@@ -392,25 +410,26 @@ export const createActionsSlice = (
   },
 
   addNodeAndAutoConnect: (node) => {
-    const state = get();
-    state.addNode(node);
+    const connectStart = get().connectStart;
+    get().addNode(node);
 
-    if (state.connectStart) {
-      const sourceNode = state.nodes.find((n) => n.id === state.connectStart!.nodeId);
+    if (connectStart) {
+      const state = get();
+      const sourceNode = state.nodes.find((n) => n.id === connectStart.nodeId);
       if (sourceNode) {
-        if (state.connectStart.handleType === "source") {
+        if (connectStart.handleType === "source") {
           state.handleConnect({
-            source: state.connectStart.nodeId,
-            sourceHandle: state.connectStart.handleId,
+            source: connectStart.nodeId,
+            sourceHandle: connectStart.handleId,
             target: node.id,
             targetHandle: null,
           });
-        } else {
+        } else if (connectStart.handleType === "target") {
           state.handleConnect({
             source: node.id,
             sourceHandle: null,
-            target: state.connectStart.nodeId,
-            targetHandle: state.connectStart.handleId,
+            target: connectStart.nodeId,
+            targetHandle: connectStart.handleId,
           });
         }
       }

--- a/apps/app/src/pages/CanvasPage/_store/actionsSlice.unit.test.ts
+++ b/apps/app/src/pages/CanvasPage/_store/actionsSlice.unit.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { FinalConnectionState } from "@xyflow/system";
+import { createHarnessCanvasStore } from "./harnessCanvasStore";
+import type { PipelineNode } from "./canvasSlice";
+
+const makeNode = (id: string, type: PipelineNode["type"]): PipelineNode =>
+  ({
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data: { label: id, nodeType: type },
+  }) as PipelineNode;
+
+describe("canvas connection actions", () => {
+  it("keeps the dragged source handle when creating a connected node", () => {
+    const source = makeNode("source", "operation");
+    const target = makeNode("target", "output-local-path");
+    const store = createHarnessCanvasStore([source], [], null, "");
+
+    store.getState().handleConnectStart({
+      nodeId: source.id,
+      handleId: "right-port-2",
+      handleType: "source",
+    });
+
+    store.getState().addNodeAndAutoConnect(target);
+
+    expect(store.getState().edges).toEqual([
+      expect.objectContaining({
+        source: source.id,
+        sourceHandle: "right-port-2",
+        target: target.id,
+      }),
+    ]);
+    expect(store.getState().edges[0]?.targetHandle ?? null).toBeNull();
+    expect(store.getState().connectStart).toBeNull();
+  });
+
+  it("keeps the dragged target handle when creating a connected upstream node", () => {
+    const source = makeNode("source", "folder");
+    const target = makeNode("target", "operation");
+    const store = createHarnessCanvasStore([target], [], null, "");
+
+    store.getState().handleConnectStart({
+      nodeId: target.id,
+      handleId: "left-port-1",
+      handleType: "target",
+    });
+
+    store.getState().addNodeAndAutoConnect(source);
+
+    expect(store.getState().edges).toEqual([
+      expect.objectContaining({
+        source: source.id,
+        target: target.id,
+        targetHandle: "left-port-1",
+      }),
+    ]);
+    expect(store.getState().edges[0]?.sourceHandle ?? null).toBeNull();
+    expect(store.getState().connectStart).toBeNull();
+  });
+
+  it("falls back to the original connect start handle when connect end omits handle id", () => {
+    const source = makeNode("source", "operation");
+    const store = createHarnessCanvasStore([source], [], null, "");
+
+    store.getState().handleConnectStart({
+      nodeId: source.id,
+      handleId: "right-port-2",
+      handleType: "source",
+    });
+
+    store.getState().handleFlowConnectEnd(
+      { clientX: 100, clientY: 200 } as MouseEvent,
+      {
+        isValid: null,
+        fromNode: { id: source.id },
+        fromHandle: { id: null, type: "source" },
+      } as FinalConnectionState
+    );
+
+    expect(store.getState().connectStart).toEqual({
+      nodeId: source.id,
+      handleId: "right-port-2",
+      handleType: "source",
+    });
+    expect(store.getState().connectionMenu).toEqual({
+      screenX: 100,
+      screenY: 200,
+      flowX: 100,
+      flowY: 200,
+    });
+  });
+});

--- a/apps/app/src/pages/CanvasPage/_store/actionsSlice.unit.test.ts
+++ b/apps/app/src/pages/CanvasPage/_store/actionsSlice.unit.test.ts
@@ -91,4 +91,27 @@ describe("canvas connection actions", () => {
       flowY: 200,
     });
   });
+
+  it("clears connect start instead of opening the connection menu without a handle type", () => {
+    const source = makeNode("source", "operation");
+    const store = createHarnessCanvasStore([source], [], null, "");
+
+    store.getState().handleConnectStart({
+      nodeId: source.id,
+      handleId: "right-port-0",
+      handleType: null,
+    });
+
+    store.getState().handleFlowConnectEnd(
+      { clientX: 100, clientY: 200 } as MouseEvent,
+      {
+        isValid: null,
+        fromNode: { id: source.id },
+        fromHandle: { id: "right-port-0", type: null },
+      } as unknown as FinalConnectionState
+    );
+
+    expect(store.getState().connectStart).toBeNull();
+    expect(store.getState().connectionMenu).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

- 为 Canvas 节点接入动态左右端口数量，连接线根据节点两侧连接数分配稳定 handle
- 将 NodeCard 拆成展示层、端口层和主题配置，避免无端口场景依赖 React Flow hooks
- 补充节点端口、连接 repick、节点连接数等回归测试

## Verification

- `git diff --check upstream/main..HEAD`
- `bun run compile`
- `bun run lint`
- `bun run test src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx src/pages/CanvasPage/NodeCard/nodePorts.unit.test.ts src/pages/CanvasPage/_store/actionsSlice.unit.test.ts src/pages/CanvasPage/CodeFileNode/CodeFileNode.unit.test.tsx src/pages/CanvasPage/FolderNode/FolderNode.unit.test.tsx`
- `bun run build-storybook`