### PR TITLE
fix: localize canvas UI strings

### DIFF
--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -301,6 +301,7 @@
     "title": "Canvas",
     "pipelineTitle": "Pipeline title",
     "pipelineTitlePlaceholder": "Untitled Pipeline",
+    "nodeLabel": "Node label",
     "unsavedPipeline": "Unsaved Pipeline",
     "saveSuccess": "Pipeline saved",
     "saveFailed": "Save failed",
@@ -309,7 +310,9 @@
     "noPipelineId": "Pipeline has not been saved yet",
     "runFailed": "Pipeline validation failed, please retry",
     "runSaveFailed": "Failed to save pipeline validation result",
+    "runStartFailed": "Failed to start pipeline",
     "runCompleted": "Pipeline run completed",
+    "runSuccessDescription": "Job {{jobId}} completed pipeline validation",
     "runTest": "Run Test",
     "collapseSidebar": "Collapse sidebar",
     "expandSidebar": "Expand sidebar",
@@ -364,6 +367,7 @@
       "noSelection": "No node selected"
     },
     "contextMenu": {
+      "actions": "Actions",
       "addCodeFile": "Add Code File",
       "addFolder": "Add Folder",
       "addCondition": "Add Condition",
@@ -378,8 +382,92 @@
       "recipeNode": "Recipe",
       "outputEndpoint": "Output",
       "noOperationsForType": "No operations accept this type",
-      "newNode": "New Node"
+      "newNode": "New Node",
+      "group": "Group",
+      "newCompoundNode": "New compound node",
+      "groupSelected": "Group {{count}} selected nodes",
+      "ungroup": "Ungroup",
+      "detachFromGroup": "Remove from group",
+      "duplicate": "Duplicate",
+      "delete": "Delete"
     },
+    "floatingMenu": {
+      "menu": "Menu",
+      "backToWorkspace": "Back to workspace",
+      "save": "Save",
+      "export": "Export",
+      "import": "Import",
+      "settings": "Settings",
+      "importJson": "Import canvas JSON",
+      "saveSuccessDescription": "Pipeline \"{{name}}\" was saved",
+      "createSuccessDescription": "Pipeline \"{{name}}\" was created",
+      "saveFailedDescription": "Please try again later"
+    },
+    "nodeTypes": {
+      "operation": {
+        "label": "Operation",
+        "shortLabel": "OP"
+      },
+      "code-file": {
+        "label": "Code file",
+        "shortLabel": "File"
+      },
+      "folder": {
+        "label": "Folder",
+        "shortLabel": "Folder"
+      },
+      "github-projects": {
+        "label": "GitHub project",
+        "shortLabel": "GitHub"
+      },
+      "output-project-path": {
+        "label": "Project output",
+        "shortLabel": "Output"
+      },
+      "output-local-path": {
+        "label": "Local output",
+        "shortLabel": "Local"
+      },
+      "compound": {
+        "label": "Compound node",
+        "shortLabel": "Group"
+      }
+    },
+    "compoundNode": {
+      "childCount": "{{count}} nodes"
+    },
+    "llmContent": {
+      "title": "{{label}} - Thought content",
+      "running": "LLM is thinking...",
+      "empty": "No LLM output yet"
+    },
+    "runConsole": {
+      "title": "Console",
+      "logs": "{{count}} logs",
+      "loading": "Loading...",
+      "statusQueued": "Queued",
+      "statusRunning": "Running",
+      "statusDone": "Done",
+      "statusFailed": "Failed",
+      "statusCancelled": "Cancelled",
+      "statusExpired": "Expired"
+    },
+    "history": {
+      "addEdge": "Connect {{source}} -> {{target}}",
+      "addNode": "Add node {{label}}",
+      "addNodeWithEdge": "Add {{label}} and connect",
+      "removeNode": "Delete node {{label}}",
+      "updateNode": "Edit {{label}}",
+      "duplicateNode": "Duplicate node {{label}}",
+      "clearCanvas": "Clear canvas",
+      "addToCompound": "Add {{node}} to {{compound}}",
+      "removeFromCompound": "Remove {{node}} from {{compound}}",
+      "groupNodes": "Group {{count}} nodes",
+      "ungroupCompound": "Ungroup {{label}}"
+    },
+    "unknownNode": "Unknown node",
+    "folderTreeLoading": "Loading...",
+    "excludePath": "Exclude {{name}}",
     "folderDescPlaceholder": "Folder description...",
     "clickToSwitchRepo": "Click to switch repo",
     "pickFromLibrary": "Pick from library",
@@ -651,8 +739,32 @@
       "selectThisFolder": "Select this folder"
     },
     "codeFile": {
+      "pathLabel": "Code file path",
+      "languageLabel": "Code file language",
+      "descriptionLabel": "Code file description",
       "descriptionPlaceholder": "File description...",
       "browseFile": "Browse file"
+    },
+    "operation": {
+      "description": "Custom operation",
+      "statusIdle": "Pending",
+      "statusRunning": "Running",
+      "statusPass": "Success",
+      "statusFail": "Failed",
+      "config": "Config",
+      "acceptedObjectTypes": "Accepted object types",
+      "objectTypeFile": "File",
+      "objectTypeFolder": "Folder",
+      "objectTypeProject": "Project",
+      "agentRuntime": "Agent Runtime",
+      "runtime": "Runtime",
+      "defaultRuntime": "Default",
+      "viewLlmOutput": "View LLM output",
+      "loopEnabled": "Loop enabled",
+      "enableLoop": "Enable loop",
+      "maxLoopCount": "Max count",
+      "loopAcceptanceCondition": "Acceptance condition",
+      "loopAcceptancePlaceholder": "Describe what the output needs to satisfy..."
     },
     "condition": {
       "expressionPlaceholder": "Expression not set",
@@ -663,11 +775,13 @@
       "statusFail": "Fail"
     },
     "outputProjectPath": {
+      "description": "Project output",
       "descriptionPlaceholder": "Describe this output...",
       "projectIdLabel": "Project ID",
       "pathLabel": "Path"
     },
     "outputLocalPathNode": {
+      "description": "Local output",
       "pathLabel": "Path",
       "filenameLabel": "Filename",
       "writeModeLabel": "Write mode",
@@ -699,11 +813,28 @@
     "defaultBranch": "Default Branch",
     "connectRepo": "Connect Repository",
     "back": "Back",
+    "private": "Private",
+    "public": "Public",
     "tokenConfigured": "Token configured (can access private repos)",
     "tokenMissing": "Token not configured (public repos only)",
     "configure": "Configure",
     "modify": "Modify",
-    "urlParseError": "Unable to parse GitHub URL, please enter a valid repository link"
+    "urlParseError": "Unable to parse GitHub URL, please enter a valid repository link",
+    "tokenTitle": "GitHub Personal Access Token",
+    "tokenStatusConfigured": "Token configured",
+    "tokenPrivateAccess": "Can access private repos",
+    "tokenStatusMissing": "Token not configured",
+    "tokenPrivateRequiresPat": "Private repository access requires a Personal Access Token",
+    "personalAccessToken": "Personal Access Token",
+    "showToken": "Show token",
+    "hideToken": "Hide token",
+    "verify": "Verify",
+    "verifySuccess": "Verified as {{login}}",
+    "tokenLocalOnly": "Token is stored only in your local browser and is not uploaded to the server.",
+    "createTokenLink": "Create a GitHub token with repo permission",
+    "clearToken": "Clear token",
+    "projectListEmpty": "Project library is empty. Connect a GitHub repository from the Projects page first.",
+    "projectListNoResults": "No matching projects"
   },
   "skills": {
     "pageStructure": "Page Structure",

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -301,6 +301,7 @@
     "title": "画布",
     "pipelineTitle": "Pipeline 标题",
     "pipelineTitlePlaceholder": "无标题 Pipeline",
+    "nodeLabel": "节点标签",
     "unsavedPipeline": "未保存的 Pipeline",
     "saveSuccess": "Pipeline 已保存",
     "saveFailed": "保存失败",
@@ -309,7 +310,9 @@
     "noPipelineId": "Pipeline 尚未保存",
     "runFailed": "Pipeline 验证失败，请重试",
     "runSaveFailed": "Pipeline 验证结果保存失败",
+    "runStartFailed": "Pipeline 启动失败",
     "runCompleted": "Pipeline 运行完成提醒",
+    "runSuccessDescription": "Job {{jobId}} 已完成 Pipeline 验证",
     "runTest": "运行测试",
     "collapseSidebar": "收起侧栏",
     "expandSidebar": "展开侧栏",
@@ -364,6 +367,7 @@
       "noSelection": "未选中节点"
     },
     "contextMenu": {
+      "actions": "操作",
       "addCodeFile": "添加 Code File",
       "addFolder": "添加 Folder",
       "addCondition": "添加 Condition",
@@ -378,8 +382,92 @@
       "recipeNode": "快捷配方",
       "outputEndpoint": "输出终点",
       "noOperationsForType": "没有接受此类型的 Operation",
-      "newNode": "新建节点"
+      "newNode": "新建节点",
+      "group": "编组",
+      "newCompoundNode": "新建复合节点",
+      "groupSelected": "编组 {{count}} 个选中节点",
+      "ungroup": "解散编组",
+      "detachFromGroup": "从编组中移除",
+      "duplicate": "复制",
+      "delete": "删除"
     },
+    "floatingMenu": {
+      "menu": "菜单",
+      "backToWorkspace": "回到工作区",
+      "save": "保存",
+      "export": "导出",
+      "import": "导入",
+      "settings": "设置",
+      "importJson": "导入 Canvas JSON",
+      "saveSuccessDescription": "Pipeline「{{name}}」已保存",
+      "createSuccessDescription": "Pipeline「{{name}}」已创建",
+      "saveFailedDescription": "请稍后重试"
+    },
+    "nodeTypes": {
+      "operation": {
+        "label": "操作节点",
+        "shortLabel": "操作"
+      },
+      "code-file": {
+        "label": "代码文件",
+        "shortLabel": "文件"
+      },
+      "folder": {
+        "label": "文件夹",
+        "shortLabel": "文件夹"
+      },
+      "github-projects": {
+        "label": "GitHub 项目",
+        "shortLabel": "GitHub"
+      },
+      "output-project-path": {
+        "label": "项目输出",
+        "shortLabel": "输出"
+      },
+      "output-local-path": {
+        "label": "本地输出",
+        "shortLabel": "本地"
+      },
+      "compound": {
+        "label": "复合节点",
+        "shortLabel": "组"
+      }
+    },
+    "compoundNode": {
+      "childCount": "{{count}} 个节点"
+    },
+    "llmContent": {
+      "title": "{{label}} - 思考内容",
+      "running": "LLM 正在思考中...",
+      "empty": "暂无 LLM 输出内容"
+    },
+    "runConsole": {
+      "title": "控制台",
+      "logs": "{{count}} 条日志",
+      "loading": "加载中...",
+      "statusQueued": "排队中",
+      "statusRunning": "运行中",
+      "statusDone": "完成",
+      "statusFailed": "失败",
+      "statusCancelled": "已取消",
+      "statusExpired": "已过期"
+    },
+    "history": {
+      "addEdge": "连接 {{source}} -> {{target}}",
+      "addNode": "添加节点 {{label}}",
+      "addNodeWithEdge": "添加 {{label}} 并连接",
+      "removeNode": "删除节点 {{label}}",
+      "updateNode": "编辑 {{label}}",
+      "duplicateNode": "复制节点 {{label}}",
+      "clearCanvas": "清空画布",
+      "addToCompound": "添加 {{node}} 到 {{compound}}",
+      "removeFromCompound": "从 {{compound}} 移除 {{node}}",
+      "groupNodes": "编组 {{count}} 个节点",
+      "ungroupCompound": "解散编组 {{label}}"
+    },
+    "unknownNode": "未知节点",
+    "folderTreeLoading": "加载中...",
+    "excludePath": "排除 {{name}}",
     "folderDescPlaceholder": "文件夹描述...",
     "clickToSwitchRepo": "点击切换仓库",
     "pickFromLibrary": "从项目库选取",
@@ -651,8 +739,32 @@
       "selectThisFolder": "选择此文件夹"
     },
     "codeFile": {
+      "pathLabel": "代码文件路径",
+      "languageLabel": "代码文件语言",
+      "descriptionLabel": "代码文件描述",
       "descriptionPlaceholder": "文件描述...",
       "browseFile": "浏览文件"
+    },
+    "operation": {
+      "description": "自定义操作",
+      "statusIdle": "待运行",
+      "statusRunning": "运行中",
+      "statusPass": "成功",
+      "statusFail": "失败",
+      "config": "配置",
+      "acceptedObjectTypes": "接受的对象类型",
+      "objectTypeFile": "文件",
+      "objectTypeFolder": "文件夹",
+      "objectTypeProject": "项目",
+      "agentRuntime": "Agent Runtime",
+      "runtime": "Runtime",
+      "defaultRuntime": "默认",
+      "viewLlmOutput": "点击查看 LLM 输出",
+      "loopEnabled": "循环已开启",
+      "enableLoop": "开启循环",
+      "maxLoopCount": "最大次数",
+      "loopAcceptanceCondition": "验收条件",
+      "loopAcceptancePlaceholder": "描述输出需要满足的条件..."
     },
     "condition": {
       "expressionPlaceholder": "未设置表达式",
@@ -663,11 +775,13 @@
       "statusFail": "失败"
     },
     "outputProjectPath": {
+      "description": "项目输出",
       "descriptionPlaceholder": "描述此输出...",
       "projectIdLabel": "项目 ID",
       "pathLabel": "路径"
     },
     "outputLocalPathNode": {
+      "description": "本地输出",
       "pathLabel": "路径",
       "filenameLabel": "文件名",
       "writeModeLabel": "写入模式",
@@ -699,11 +813,28 @@
     "defaultBranch": "默认分支",
     "connectRepo": "连接仓库",
     "back": "返回",
+    "private": "Private",
+    "public": "Public",
     "tokenConfigured": "已配置 Token（可访问私有仓库）",
     "tokenMissing": "未配置 Token（仅可访问公开仓库）",
     "configure": "配置",
     "modify": "修改",
-    "urlParseError": "无法解析 GitHub URL，请输入完整的仓库链接"
+    "urlParseError": "无法解析 GitHub URL，请输入完整的仓库链接",
+    "tokenTitle": "GitHub Personal Access Token",
+    "tokenStatusConfigured": "Token 已配置",
+    "tokenPrivateAccess": "可访问私有仓库",
+    "tokenStatusMissing": "未配置 Token",
+    "tokenPrivateRequiresPat": "访问私有仓库需要填写 Personal Access Token",
+    "personalAccessToken": "Personal Access Token",
+    "showToken": "显示 Token",
+    "hideToken": "隐藏 Token",
+    "verify": "验证",
+    "verifySuccess": "验证成功，已登录为 {{login}}",
+    "tokenLocalOnly": "Token 仅保存在本地浏览器，不会上传至服务器。",
+    "createTokenLink": "在 GitHub 创建 Token（需勾选 repo 权限）",
+    "clearToken": "清除 Token",
+    "projectListEmpty": "项目库为空，请先在「项目」页面连接 GitHub 仓库",
+    "projectListNoResults": "未找到匹配的项目"
   },
   "skills": {
     "pageStructure": "页面结构",

--- a/apps/app/src/pages/CanvasPage/CanvasContextMenu/CanvasContextMenu.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasContextMenu/CanvasContextMenu.tsx
@@ -25,7 +25,7 @@ import { useList } from "@refinedev/core";
 import { ResourceName } from "@/integrations/refine/dataProvider";
 import type { Operation, Recipe } from "@repo/schemas";
 import { getAllowedConnections } from "../utils/getAllowedConnections";
-import { getNodeMeta } from "../utils/nodeTypeMeta";
+import { getNodeMeta, getNodeTypeLabel } from "../utils/nodeTypeMeta";
 import type { NodeType, BuiltinNodeType } from "@repo/pipeline-engine/schemas";
 import { cn } from "@repo/ui/lib/utils";
 
@@ -125,7 +125,7 @@ export const CanvasContextMenu = () => {
     if (!connectStart) return null;
     const node = nodes.find((n) => n.id === connectStart.nodeId);
 
-    return node ? { type: node.type, label: getNodeMeta(node.type)!.label } : null;
+    return node ? { type: node.type, label: getNodeTypeLabel(t, node.type) } : null;
   })();
 
   // Filter object types based on available connections
@@ -182,19 +182,24 @@ export const CanvasContextMenu = () => {
               })()}
             </span>
             <ArrowRight className="size-3 text-muted-foreground" />
-            <span className="text-xs font-medium text-muted-foreground">连接到...</span>
+            <span className="text-xs font-medium text-muted-foreground">
+              {t("canvas.contextMenu.connectTo")}
+            </span>
           </div>
         ) : (
-          <div className="px-1.5 py-1 text-xs font-medium text-muted-foreground">新建节点</div>
+          <div className="px-1.5 py-1 text-xs font-medium text-muted-foreground">
+            {t("canvas.contextMenu.newNode")}
+          </div>
         )}
 
         {/* Object types group */}
         {visibleObjectTypes.length > 0 && (
           <ContextMenuGroup>
-            <ContextMenuLabel>处理对象 (Object)</ContextMenuLabel>
+            <ContextMenuLabel>{t("canvas.contextMenu.objectTypes")}</ContextMenuLabel>
             {visibleObjectTypes.map((type) => {
               const Icon = TYPE_ICONS[type];
               const typeMeta = getNodeMeta(type)!;
+              const typeLabel = getNodeTypeLabel(t, type);
 
               return (
                 <ContextMenuItem
@@ -210,7 +215,7 @@ export const CanvasContextMenu = () => {
                   >
                     <Icon className="size-2.5 text-white" />
                   </span>
-                  <span className="text-xs font-medium">{typeMeta.label}</span>
+                  <span className="text-xs font-medium">{typeLabel}</span>
                 </ContextMenuItem>
               );
             })}
@@ -244,9 +249,9 @@ export const CanvasContextMenu = () => {
           <>
             <ContextMenuSeparator />
             <ContextMenuGroup>
-              <ContextMenuLabel>操作节点 (Operation)</ContextMenuLabel>
+              <ContextMenuLabel>{t("canvas.contextMenu.operationNodes")}</ContextMenuLabel>
               <p className="px-1.5 py-1 text-xs text-muted-foreground">
-                没有接受此类型的 Operation
+                {t("canvas.contextMenu.noOperationsForType")}
               </p>
             </ContextMenuGroup>
           </>
@@ -277,12 +282,12 @@ export const CanvasContextMenu = () => {
         {/* Compound / Group section */}
         <ContextMenuSeparator />
         <ContextMenuGroup>
-          <ContextMenuLabel>编组</ContextMenuLabel>
+          <ContextMenuLabel>{t("canvas.contextMenu.group")}</ContextMenuLabel>
           <ContextMenuItem closeOnClick={false} onClick={() => handleCreateObjectNode("compound")}>
             <span className="flex size-4 shrink-0 items-center justify-center rounded bg-indigo-500">
               <Group className="size-2.5 text-white" />
             </span>
-            <span className="text-xs font-medium">新建复合节点</span>
+            <span className="text-xs font-medium">{t("canvas.contextMenu.newCompoundNode")}</span>
           </ContextMenuItem>
           {(() => {
             if (selectedIds.length < 2) return null;
@@ -292,7 +297,9 @@ export const CanvasContextMenu = () => {
                 <span className="flex size-4 shrink-0 items-center justify-center rounded bg-indigo-500">
                   <Group className="size-2.5 text-white" />
                 </span>
-                <span className="text-xs font-medium">编组 {selectedIds.length} 个选中节点</span>
+                <span className="text-xs font-medium">
+                  {t("canvas.contextMenu.groupSelected", { count: selectedIds.length })}
+                </span>
               </ContextMenuItem>
             );
           })()}

--- a/apps/app/src/pages/CanvasPage/CanvasContextMenu/CanvasContextMenu.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasContextMenu/CanvasContextMenu.unit.test.tsx
@@ -32,6 +32,6 @@ describe("CanvasContextMenu", () => {
         <CanvasContextMenu />
       </HarnessCanvasStoreContext.Provider>
     );
-    expect(screen.getByText("新建节点")).toBeTruthy();
+    expect(screen.getByText("New Node")).toBeTruthy();
   });
 });

--- a/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { useHarnessCanvasStore } from "../_store";
 import { Menu, Home, Save, FileDown, FileUp, Settings, Undo, Redo } from "lucide-react";
@@ -9,6 +10,7 @@ import { ResourceName } from "@/integrations/refine/dataProvider";
 import type { PipelineNode, PipelineEdge } from "../_store/canvasSlice";
 
 export const CanvasFloatingMenu = () => {
+  const { t } = useTranslation();
   const store = useHarnessCanvasStore();
   const pipelineId = useStore(store, (state) => state.pipelineId);
   const pipelineName = useStore(store, (state) => state.pipelineName);
@@ -24,6 +26,7 @@ export const CanvasFloatingMenu = () => {
   const { mutate: createCanvas, mutation: createMutation } = useCreate();
 
   const [isOpen, setIsOpen] = useState(false);
+  const displayPipelineName = pipelineName || t("canvas.pipelineTitlePlaceholder");
 
   const handleSave = () => {
     if (pipelineId) {
@@ -33,13 +36,15 @@ export const CanvasFloatingMenu = () => {
         values: { nodes, edges },
         successNotification: {
           type: "success",
-          message: "保存成功",
-          description: `Pipeline「${pipelineName || "无标题"}」已保存`,
+          message: t("canvas.saveSuccess"),
+          description: t("canvas.floatingMenu.saveSuccessDescription", {
+            name: displayPipelineName,
+          }),
         },
         errorNotification: {
           type: "error",
-          message: "保存失败",
-          description: "请稍后重试",
+          message: t("canvas.saveFailed"),
+          description: t("canvas.floatingMenu.saveFailedDescription"),
         },
       });
     } else {
@@ -49,7 +54,7 @@ export const CanvasFloatingMenu = () => {
           resource: ResourceName.pipelines,
           values: {
             id: newId,
-            name: pipelineName || "无标题",
+            name: displayPipelineName,
             description: "",
             tags: [],
             createdAt: Date.now(),
@@ -59,13 +64,15 @@ export const CanvasFloatingMenu = () => {
           },
           successNotification: {
             type: "success",
-            message: "保存成功",
-            description: `Pipeline「${pipelineName || "无标题"}」已创建`,
+            message: t("canvas.saveSuccess"),
+            description: t("canvas.floatingMenu.createSuccessDescription", {
+              name: displayPipelineName,
+            }),
           },
           errorNotification: {
             type: "error",
-            message: "保存失败",
-            description: "请稍后重试",
+            message: t("canvas.saveFailed"),
+            description: t("canvas.floatingMenu.saveFailedDescription"),
           },
         },
         {
@@ -103,18 +110,18 @@ export const CanvasFloatingMenu = () => {
   };
 
   const menuItems = [
-    { icon: Home, label: "回到工作区", to: "/" },
+    { icon: Home, label: t("canvas.floatingMenu.backToWorkspace"), to: "/" },
     {
       icon: Save,
-      label: "保存",
+      label: t("canvas.floatingMenu.save"),
       onClick: handleSave,
       disabled: isPending,
     },
-    { icon: FileDown, label: "导出", onClick: exportCanvas },
-    { icon: FileUp, label: "导入", onClick: handleImport },
-    { icon: Undo, label: "撤销", onClick: handleUndo, divider: true },
-    { icon: Redo, label: "重做", onClick: handleRedo },
-    { icon: Settings, label: "设置", to: "/settings" },
+    { icon: FileDown, label: t("canvas.floatingMenu.export"), onClick: exportCanvas },
+    { icon: FileUp, label: t("canvas.floatingMenu.import"), onClick: handleImport },
+    { icon: Undo, label: t("canvas.undo"), onClick: handleUndo, divider: true },
+    { icon: Redo, label: t("canvas.redo"), onClick: handleRedo },
+    { icon: Settings, label: t("canvas.floatingMenu.settings"), to: "/settings" },
   ];
 
   const handleCloseMenu = () => setIsOpen(false);
@@ -129,7 +136,7 @@ export const CanvasFloatingMenu = () => {
       <Popover open={isOpen} onOpenChange={handleOpenChange}>
         <PopoverTrigger
           className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white shadow-md transition-all hover:bg-gray-50 hover:shadow-lg active:scale-95"
-          title="菜单"
+          title={t("canvas.floatingMenu.menu")}
         >
           <Menu className="h-5 w-5 text-gray-700" />
         </PopoverTrigger>
@@ -164,7 +171,7 @@ export const CanvasFloatingMenu = () => {
       <input
         ref={fileInputRef}
         accept=".json"
-        aria-label="Import canvas JSON"
+        aria-label={t("canvas.floatingMenu.importJson")}
         className="hidden"
         name="canvasImportFile"
         type="file"

--- a/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.unit.test.tsx
@@ -35,12 +35,12 @@ vi.mock("@tanstack/react-router", () => ({
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const openMenu = () => {
-  fireEvent.click(screen.getByTitle("菜单"));
+  fireEvent.click(screen.getByTitle("Menu"));
 };
 
 const clickSave = () => {
   openMenu();
-  fireEvent.click(screen.getByText("保存"));
+  fireEvent.click(screen.getByText("Save"));
 };
 
 const wrapperWithPipeline = ({ children }: React.PropsWithChildren) => (
@@ -103,7 +103,7 @@ describe("CanvasFloatingMenu - save behavior", () => {
           resource: "pipelines",
           values: expect.objectContaining({
             id: expect.any(String),
-            name: "无标题",
+            name: "Untitled Pipeline",
             nodes: [],
             edges: [],
           }),
@@ -137,7 +137,7 @@ describe("CanvasFloatingMenu - save behavior", () => {
       mockCreate.mockClear();
       mockUpdate.mockClear();
       openMenu();
-      fireEvent.click(screen.getByText("保存"));
+      fireEvent.click(screen.getByText("Save"));
 
       expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ id: generatedId }));
       expect(mockCreate).not.toHaveBeenCalled();
@@ -145,16 +145,16 @@ describe("CanvasFloatingMenu - save behavior", () => {
   });
 
   describe("menu items", () => {
-    it("renders 导入 item in the menu", () => {
+    it("renders Import item in the menu", () => {
       render(<CanvasFloatingMenu />, { wrapper: wrapperWithNullPipeline });
       openMenu();
-      expect(screen.getByText("导入")).toBeInTheDocument();
+      expect(screen.getByText("Import")).toBeInTheDocument();
     });
 
-    it("renders 导出 item in the menu", () => {
+    it("renders Export item in the menu", () => {
       render(<CanvasFloatingMenu />, { wrapper: wrapperWithNullPipeline });
       openMenu();
-      expect(screen.getByText("导出")).toBeInTheDocument();
+      expect(screen.getByText("Export")).toBeInTheDocument();
     });
   });
   it("save button is disabled while a mutation is pending", () => {
@@ -168,7 +168,7 @@ describe("CanvasFloatingMenu - save behavior", () => {
     // the disabled prop is wired to the button element.
     render(<CanvasFloatingMenu />, { wrapper: wrapperWithTestPipeline });
     openMenu();
-    const saveBtn = screen.getByText("保存").closest("button");
+    const saveBtn = screen.getByText("Save").closest("button");
     expect(saveBtn).not.toBeDisabled();
     isPendingUpdate.mockRestore?.();
   });

--- a/apps/app/src/pages/CanvasPage/CanvasNodeCreationPalette/CanvasNodeCreationPalette.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasNodeCreationPalette/CanvasNodeCreationPalette.tsx
@@ -11,7 +11,7 @@ import { cn } from "@repo/ui/lib/utils";
 import { SiGitHubIcon } from "@/components/icons/SiGitHubIcon";
 import { ResourceName } from "@/integrations/refine/dataProvider";
 import { useHarnessCanvasStore } from "../_store";
-import { getNodeMeta } from "../utils/nodeTypeMeta";
+import { getNodeMeta, getNodeTypeLabel, getNodeTypeShortLabel } from "../utils/nodeTypeMeta";
 import type { XYPosition } from "@xyflow/system";
 
 const QUICK_ADD_OBJECT_TYPES: BuiltinNodeType[] = ["code-file", "folder", "github-projects"];
@@ -57,8 +57,10 @@ export const CanvasNodeCreationPalette = ({
 
   const objectItems = QUICK_ADD_OBJECT_TYPES.filter((type) => {
     const meta = getNodeMeta(type);
+    const label = getNodeTypeLabel(t, type);
+    const shortLabel = getNodeTypeShortLabel(t, type);
 
-    return search === "" || includesSearch([meta?.label, meta?.shortLabel, type], search);
+    return search === "" || includesSearch([label, shortLabel, meta?.label, type], search);
   });
 
   const operationItems = operations.filter((operation) =>
@@ -124,6 +126,8 @@ export const CanvasNodeCreationPalette = ({
                 {objectItems.map((type) => {
                   const Icon = TYPE_ICONS[type];
                   const meta = getNodeMeta(type);
+                  const label = getNodeTypeLabel(t, type);
+                  const shortLabel = getNodeTypeShortLabel(t, type);
                   if (!meta) return null;
 
                   return (
@@ -141,8 +145,8 @@ export const CanvasNodeCreationPalette = ({
                       >
                         <Icon className="size-3.5 text-white" />
                       </span>
-                      <span className="min-w-0 flex-1 truncate font-medium">{meta.label}</span>
-                      <span className="text-xs text-muted-foreground">{meta.shortLabel}</span>
+                      <span className="min-w-0 flex-1 truncate font-medium">{label}</span>
+                      <span className="text-xs text-muted-foreground">{shortLabel}</span>
                     </button>
                   );
                 })}
@@ -169,7 +173,9 @@ export const CanvasNodeCreationPalette = ({
                       <Zap className="size-3.5 text-white" />
                     </span>
                     <span className="min-w-0 flex-1 truncate font-medium">{operation.name}</span>
-                    <span className="text-xs text-muted-foreground">OP</span>
+                    <span className="text-xs text-muted-foreground">
+                      {t("canvas.nodeTypes.operation.shortLabel")}
+                    </span>
                   </button>
                 ))}
               </div>

--- a/apps/app/src/pages/CanvasPage/CanvasNodeCreationPalette/CanvasNodeCreationPalette.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasNodeCreationPalette/CanvasNodeCreationPalette.unit.test.tsx
@@ -60,13 +60,13 @@ describe("CanvasNodeCreationPalette", () => {
     const user = userEvent.setup();
     renderQuickAdd();
 
-    expect(screen.getByText("代码文件")).toBeInTheDocument();
+    expect(screen.getByText("Code file")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Review Code\s*OP/ })).toBeInTheDocument();
     expect(screen.getByText("Strict Review")).toBeInTheDocument();
 
     await user.type(screen.getByPlaceholderText(/Search nodes|搜索节点/), "strict");
 
-    expect(screen.queryByText("代码文件")).not.toBeInTheDocument();
+    expect(screen.queryByText("Code file")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Review Code\s*OP/ })).not.toBeInTheDocument();
     expect(screen.getByText("Strict Review")).toBeInTheDocument();
   });

--- a/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx
@@ -161,7 +161,7 @@ export const CanvasToolbar = () => {
                 className="h-7 gap-1.5 px-2 text-xs text-green-600 hover:bg-green-50 hover:text-green-700 disabled:text-muted-foreground/30"
                 disabled={isRunning || !pipelineId}
                 size="sm"
-                title="运行测试"
+                title={t("canvas.runTest")}
                 variant="ghost"
                 onClick={handleRunTest}
               />

--- a/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.unit.test.tsx
@@ -63,11 +63,11 @@ const wrapperWithPipeline = ({ children }: React.PropsWithChildren) => (
 );
 
 describe("CanvasToolbar - export removed", () => {
-  it("does NOT render 导出 tooltip/button in the toolbar", () => {
+  it("does NOT render Export tooltip/button in the toolbar", () => {
     render(<CanvasToolbar />, { wrapper });
     const exportTooltips = screen
       .queryAllByTestId("tooltip")
-      .filter((el) => el.textContent === "导出");
+      .filter((el) => el.textContent === "Export");
     expect(exportTooltips).toHaveLength(0);
   });
 });
@@ -83,23 +83,23 @@ describe("CanvasToolbar - Run Test button", () => {
 
   it("renders the Run Test button", () => {
     render(<CanvasToolbar />, { wrapper });
-    expect(screen.getByTitle("运行测试")).toBeInTheDocument();
+    expect(screen.getByTitle("Run Test")).toBeInTheDocument();
   });
 
   it("Run Test button is disabled without pipelineId", () => {
     render(<CanvasToolbar />, { wrapper });
-    expect(screen.getByTitle("运行测试")).toBeDisabled();
+    expect(screen.getByTitle("Run Test")).toBeDisabled();
   });
 
   it("Run Test button is enabled when pipelineId exists", () => {
     render(<CanvasToolbar />, { wrapper: wrapperWithPipeline });
-    expect(screen.getByTitle("运行测试")).not.toBeDisabled();
+    expect(screen.getByTitle("Run Test")).not.toBeDisabled();
   });
 
   it("clicking Run saves pipeline then calls run API", async () => {
     const user = userEvent.setup();
     render(<CanvasToolbar />, { wrapper: wrapperWithPipeline });
-    await user.click(screen.getByTitle("运行测试"));
+    await user.click(screen.getByTitle("Run Test"));
 
     await waitFor(() => {
       expect(mockTrpcUpdate).toHaveBeenCalledWith(
@@ -117,7 +117,7 @@ describe("CanvasToolbar - Run Test button", () => {
   it("shows success toast after successful run", async () => {
     const user = userEvent.setup();
     render(<CanvasToolbar />, { wrapper: wrapperWithPipeline });
-    await user.click(screen.getByTitle("运行测试"));
+    await user.click(screen.getByTitle("Run Test"));
     await waitFor(() => {
       expect(toastStore.getState().toasts).toEqual(
         expect.arrayContaining([expect.objectContaining({ type: "success" })])
@@ -129,7 +129,7 @@ describe("CanvasToolbar - Run Test button", () => {
     mockTrpcUpdate.mockRejectedValue(new Error("save failed"));
     const user = userEvent.setup();
     render(<CanvasToolbar />, { wrapper: wrapperWithPipeline });
-    await user.click(screen.getByTitle("运行测试"));
+    await user.click(screen.getByTitle("Run Test"));
     await waitFor(() => {
       expect(toastStore.getState().toasts).toEqual(
         expect.arrayContaining([expect.objectContaining({ type: "error" })])
@@ -142,7 +142,7 @@ describe("CanvasToolbar - Run Test button", () => {
     mockTrpcRun.mockRejectedValue(new Error("Internal Server Error"));
     const user = userEvent.setup();
     render(<CanvasToolbar />, { wrapper: wrapperWithPipeline });
-    await user.click(screen.getByTitle("运行测试"));
+    await user.click(screen.getByTitle("Run Test"));
     await waitFor(() => {
       expect(toastStore.getState().toasts).toEqual(
         expect.arrayContaining([expect.objectContaining({ type: "error" })])

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { FileCode, FolderOpen } from "lucide-react";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
@@ -16,6 +17,7 @@ export interface CodeFileNodeProps {
 const handleStopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
 
 export const CodeFileNode = ({ id, data, selected }: CodeFileNodeProps) => {
+  const { t } = useTranslation();
   const store = useHarnessCanvasStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
@@ -48,7 +50,7 @@ export const CodeFileNode = ({ id, data, selected }: CodeFileNodeProps) => {
       <NodeCard
         rightHandle
         bodyClassName="space-y-2"
-        description="Code File"
+        description={t("canvas.nodeTypes.code-file.label")}
         dimmed={dimmed}
         icon={FileCode}
         label={data.label}
@@ -60,7 +62,7 @@ export const CodeFileNode = ({ id, data, selected }: CodeFileNodeProps) => {
       >
         <div className="flex items-center gap-1 rounded-md border border-slate-100 bg-slate-50 px-2 py-1">
           <input
-            aria-label="Code file path"
+            aria-label={t("nodes.codeFile.pathLabel")}
             className="nodrag nopan font-mono text-[11px] font-semibold text-slate-700 bg-transparent focus:outline-none flex-1 min-w-0"
             name={`${id}-filePath`}
             placeholder="src/file.tsx"
@@ -72,7 +74,7 @@ export const CodeFileNode = ({ id, data, selected }: CodeFileNodeProps) => {
           />
           <button
             className="nodrag nopan shrink-0 rounded p-0.5 text-orange-400 hover:bg-orange-100 hover:text-orange-700 transition-colors"
-            title="浏览文件"
+            title={t("nodes.codeFile.browseFile")}
             type="button"
             onClick={handleBrowseButtonClick}
             onMouseDown={handleStopPropagation}
@@ -80,7 +82,7 @@ export const CodeFileNode = ({ id, data, selected }: CodeFileNodeProps) => {
             <FolderOpen className="h-3.5 w-3.5" />
           </button>
           <input
-            aria-label="Code file language"
+            aria-label={t("nodes.codeFile.languageLabel")}
             className="nodrag nopan w-12 shrink-0 rounded bg-orange-100 px-1 py-0.5 font-mono text-[10px] font-medium text-orange-700 focus:outline-none focus:bg-orange-50 text-right"
             name={`${id}-language`}
             placeholder="ts"
@@ -92,10 +94,10 @@ export const CodeFileNode = ({ id, data, selected }: CodeFileNodeProps) => {
           />
         </div>
         <textarea
-          aria-label="Code file description"
+          aria-label={t("nodes.codeFile.descriptionLabel")}
           className="nodrag nopan text-[11px] text-slate-500 bg-transparent w-full resize-none focus:outline-none focus:bg-slate-50 focus:ring-1 focus:ring-slate-200 rounded px-1"
           name={`${id}-description`}
-          placeholder="文件描述..."
+          placeholder={t("nodes.codeFile.descriptionPlaceholder")}
           rows={2}
           value={data.description ?? ""}
           onChange={handleDescriptionChange}

--- a/apps/app/src/pages/CanvasPage/CompoundNode/CompoundNode.tsx
+++ b/apps/app/src/pages/CanvasPage/CompoundNode/CompoundNode.tsx
@@ -1,5 +1,6 @@
 import { Handle, Position } from "@xyflow/react";
 import { Group } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@repo/ui/lib/utils";
 import { useStore } from "zustand";
 import { useHarnessCanvasStore } from "../_store";
@@ -16,6 +17,7 @@ const handleMouseDown = (e: React.MouseEvent) => {
 };
 
 export const CompoundNode = ({ id, data, selected }: CompoundNodeProps) => {
+  const { t } = useTranslation();
   const store = useHarnessCanvasStore();
   const hoveredCompoundId = useStore(store, (s) => s.hoveredCompoundId);
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
@@ -49,7 +51,7 @@ export const CompoundNode = ({ id, data, selected }: CompoundNodeProps) => {
         />
         {data.childNodeIds.length > 0 && (
           <span className="text-[10px] text-indigo-400 whitespace-nowrap">
-            {data.childNodeIds.length} 节点
+            {t("canvas.compoundNode.childCount", { count: data.childNodeIds.length })}
           </span>
         )}
       </div>

--- a/apps/app/src/pages/CanvasPage/ConnectionMenu/ConnectionMenu.tsx
+++ b/apps/app/src/pages/CanvasPage/ConnectionMenu/ConnectionMenu.tsx
@@ -25,7 +25,7 @@ import { useList } from "@refinedev/core";
 import { ResourceName } from "@/integrations/refine/dataProvider";
 import type { Operation, Recipe } from "@repo/schemas";
 import { getAllowedConnections } from "../utils/getAllowedConnections";
-import { getNodeMeta } from "../utils/nodeTypeMeta";
+import { getNodeMeta, getNodeTypeLabel } from "../utils/nodeTypeMeta";
 import type { NodeType, BuiltinNodeType } from "@repo/pipeline-engine/schemas";
 import { cn } from "@repo/ui/lib/utils";
 
@@ -142,8 +142,12 @@ export const ConnectionMenu = () => {
           >
             <SourceIcon className="size-2.5 text-white" />
           </span>
-          <span className="text-xs font-medium text-foreground">{sourceMeta.label}</span>
-          <span className="ml-auto text-xs text-muted-foreground">连接到</span>
+          <span className="text-xs font-medium text-foreground">
+            {getNodeTypeLabel(t, sourceNode.type)}
+          </span>
+          <span className="ml-auto text-xs text-muted-foreground">
+            {t("canvas.contextMenu.connectTo")}
+          </span>
         </div>
 
         {/* Object types */}
@@ -151,7 +155,7 @@ export const ConnectionMenu = () => {
           availableTypes.includes(t as BuiltinNodeType)
         ) && (
           <ContextMenuGroup>
-            <ContextMenuLabel>处理对象</ContextMenuLabel>
+            <ContextMenuLabel>{t("canvas.contextMenu.processingObject")}</ContextMenuLabel>
             {["code-file", "folder", "github-projects"]
               .filter((t) => availableTypes.includes(t as BuiltinNodeType))
               .map((type) => {
@@ -172,7 +176,9 @@ export const ConnectionMenu = () => {
                     >
                       <Icon className="size-2.5 text-white" />
                     </span>
-                    <span className="text-xs font-medium text-foreground">{typeMeta.label}</span>
+                    <span className="text-xs font-medium text-foreground">
+                      {getNodeTypeLabel(t, type)}
+                    </span>
                     <Plus className="ml-auto size-3 text-muted-foreground" />
                   </ContextMenuItem>
                 );
@@ -210,7 +216,7 @@ export const ConnectionMenu = () => {
           <>
             <ContextMenuSeparator />
             <ContextMenuGroup>
-              <ContextMenuLabel>操作节点</ContextMenuLabel>
+              <ContextMenuLabel>{t("canvas.contextMenu.operationNode")}</ContextMenuLabel>
               <p className="px-1.5 py-1 text-xs text-muted-foreground">
                 {t("canvas.contextMenu.noOperationsForType")}
               </p>
@@ -223,7 +229,7 @@ export const ConnectionMenu = () => {
           <>
             <ContextMenuSeparator />
             <ContextMenuGroup>
-              <ContextMenuLabel>快捷配方</ContextMenuLabel>
+              <ContextMenuLabel>{t("canvas.contextMenu.recipeNode")}</ContextMenuLabel>
               {recipes.map((recipe) => (
                 <ContextMenuItem
                   key={recipe.id}
@@ -250,7 +256,7 @@ export const ConnectionMenu = () => {
           <>
             <ContextMenuSeparator />
             <ContextMenuGroup>
-              <ContextMenuLabel>输出终点</ContextMenuLabel>
+              <ContextMenuLabel>{t("canvas.contextMenu.outputEndpoint")}</ContextMenuLabel>
               {(["output-project-path", "output-local-path"] as BuiltinNodeType[])
                 .filter((t) => availableTypes.includes(t))
                 .map((type) => {
@@ -271,7 +277,9 @@ export const ConnectionMenu = () => {
                       >
                         <Icon className="size-2.5 text-white" />
                       </span>
-                      <span className="text-xs font-medium text-foreground">{typeMeta.label}</span>
+                      <span className="text-xs font-medium text-foreground">
+                        {getNodeTypeLabel(t, type)}
+                      </span>
                       <Plus className="ml-auto size-3 text-muted-foreground" />
                     </ContextMenuItem>
                   );

--- a/apps/app/src/pages/CanvasPage/ErrorNode/ErrorNode.tsx
+++ b/apps/app/src/pages/CanvasPage/ErrorNode/ErrorNode.tsx
@@ -1,5 +1,6 @@
 import { Handle, Position } from "@xyflow/react";
 import { AlertTriangle } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@repo/ui/lib/utils";
 
 export interface ErrorNodeProps {
@@ -10,6 +11,8 @@ export interface ErrorNodeProps {
 }
 
 export const ErrorNode = ({ id, type, selected }: ErrorNodeProps) => {
+  const { t } = useTranslation();
+
   return (
     <div
       className={cn(
@@ -25,7 +28,7 @@ export const ErrorNode = ({ id, type, selected }: ErrorNodeProps) => {
           <AlertTriangle className="h-4 w-4 text-red-600" />
         </div>
         <div className="flex flex-col min-w-0">
-          <span className="text-xs font-semibold text-red-700">未知节点</span>
+          <span className="text-xs font-semibold text-red-700">{t("canvas.unknownNode")}</span>
           <span className="text-[10px] text-red-400 truncate">
             type: {type ?? "undefined"} | id: {id}
           </span>

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
@@ -60,7 +60,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
       <NodeCard
         rightHandle
         bodyClassName="space-y-2"
-        description="Folder"
+        description={t("canvas.nodeTypes.folder.label")}
         dimmed={dimmed}
         icon={Folder}
         label={data.label}
@@ -82,7 +82,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
           />
           <Button
             className="nodrag nopan shrink-0 rounded p-0.5 text-orange-400 hover:bg-orange-100 hover:text-orange-700 transition-colors h-auto"
-            title="浏览文件夹"
+            title={t("canvas.browseFolder")}
             type="button"
             variant="ghost"
             onClick={handleFolderButtonClick}
@@ -101,7 +101,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
               >
                 {ep}
                 <Button
-                  aria-label={`移除排除 ${ep}`}
+                  aria-label={`${t("canvas.removeExclude")} ${ep}`}
                   className="nodrag nopan rounded-sm p-0 hover:bg-red-200 transition-colors h-auto"
                   size="icon-xs"
                   type="button"

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.unit.test.tsx
@@ -77,7 +77,7 @@ describe("FolderNode", () => {
       wrapper,
     });
 
-    const removeButtons = screen.getAllByRole("button", { name: /移除排除/ });
+    const removeButtons = screen.getAllByRole("button", { name: /Remove exclude/ });
     await user.click(removeButtons[0]);
 
     // Simulate re-render with updated data (store would trigger this in real app)

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderTreePreview.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderTreePreview.tsx
@@ -1,5 +1,6 @@
 import { Folder, File, Ban, RotateCw } from "lucide-react";
 import { useList } from "@refinedev/core";
+import { useTranslation } from "react-i18next";
 import { Button } from "@repo/ui/button";
 import { cn } from "@repo/ui/lib/utils";
 import { ResourceName } from "@/integrations/refine/dataProvider";
@@ -23,6 +24,7 @@ export const FolderTreePreview = ({
   excludedPaths,
   onExclude,
 }: FolderTreePreviewProps) => {
+  const { t } = useTranslation();
   const { query } = useList<DirectoryEntry>({
     resource: ResourceName.filesystem,
     filters: folderPath ? [{ field: "path", operator: "eq", value: folderPath }] : [],
@@ -38,7 +40,7 @@ export const FolderTreePreview = ({
     return (
       <div className="flex items-center gap-1 px-1 py-1 text-[10px] text-slate-400">
         <RotateCw className="h-3 w-3 animate-spin" />
-        加载中…
+        {t("canvas.folderTreeLoading")}
       </div>
     );
   }
@@ -75,7 +77,7 @@ export const FolderTreePreview = ({
             </span>
             {!isExcluded && entry.type === "directory" && (
               <Button
-                aria-label={`排除 ${entry.name}`}
+                aria-label={t("canvas.excludePath", { name: entry.name })}
                 className="nodrag nopan opacity-0 group-hover/entry:opacity-100 rounded p-0.5 text-red-400 hover:bg-red-100 hover:text-red-600 transition-all h-auto"
                 size="icon-xs"
                 type="button"

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubConnectDialog.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubConnectDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Link2, Loader2, AlertCircle, Lock, Globe, Key } from "lucide-react";
 import { cn } from "@repo/ui/lib/utils";
 import { Button } from "@repo/ui/button";
@@ -29,6 +30,7 @@ export const GitHubConnectDialog = ({
   onConnect,
   initialUrl = "",
 }: GitHubConnectDialogProps) => {
+  const { t } = useTranslation();
   const { token } = useGithubToken();
   const [url, setUrl] = useState(initialUrl);
   const [loading, setLoading] = useState(false);
@@ -44,7 +46,7 @@ export const GitHubConnectDialog = ({
 
     const parsed = parseGitHubUrl(url);
     if (!parsed) {
-      setError("无法解析 GitHub URL，请输入完整的仓库链接");
+      setError(t("github.urlParseError"));
       setLoading(false);
 
       return;
@@ -99,13 +101,13 @@ export const GitHubConnectDialog = ({
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Link2 className="h-4 w-4" />
-              连接 GitHub 仓库
+              {t("github.connectTitle")}
             </DialogTitle>
           </DialogHeader>
 
           {step === "input" && (
             <div className="space-y-4">
-              {/* Token 状态提示 */}
+              {/* Token state hint */}
               <div
                 className={cn(
                   "flex items-center justify-between rounded-md px-3 py-2 text-xs",
@@ -114,20 +116,20 @@ export const GitHubConnectDialog = ({
               >
                 <div className="flex items-center gap-1.5">
                   <Key className="h-3.5 w-3.5" />
-                  {token ? "已配置 Token（可访问私有仓库）" : "未配置 Token（仅可访问公开仓库）"}
+                  {token ? t("github.tokenConfigured") : t("github.tokenMissing")}
                 </div>
                 <button
                   className="font-medium underline underline-offset-2 hover:no-underline"
                   type="button"
                   onClick={handleOpenTokenDialog}
                 >
-                  {token ? "修改" : "配置"}
+                  {token ? t("github.modify") : t("github.configure")}
                 </button>
               </div>
 
-              {/* URL 输入 */}
+              {/* URL input */}
               <div className="space-y-1.5">
-                <label className="text-sm font-medium">GitHub 仓库 URL</label>
+                <label className="text-sm font-medium">{t("github.urlLabel")}</label>
                 <div className="flex gap-2">
                   <Input
                     className="font-mono text-sm"
@@ -144,10 +146,7 @@ export const GitHubConnectDialog = ({
                     )}
                   </Button>
                 </div>
-                <div className="text-xs text-muted-foreground">
-                  支持格式：https://github.com/owner/repo 或
-                  https://github.com/owner/repo/tree/branch
-                </div>
+                <div className="text-xs text-muted-foreground">{t("github.urlHint")}</div>
               </div>
 
               {error && (
@@ -161,7 +160,7 @@ export const GitHubConnectDialog = ({
 
           {step === "confirm" && repoInfo && (
             <div className="space-y-4">
-              {/* 仓库预览 */}
+              {/* Repository preview */}
               <div className="rounded-lg border bg-muted/30 p-4 space-y-2">
                 <div className="flex items-center gap-2">
                   {repoInfo.isPrivate ? (
@@ -171,17 +170,17 @@ export const GitHubConnectDialog = ({
                   )}
                   <span className="font-mono text-sm font-semibold">{repoInfo.fullName}</span>
                   <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-                    {repoInfo.isPrivate ? "Private" : "Public"}
+                    {repoInfo.isPrivate ? t("github.private") : t("github.public")}
                   </span>
                 </div>
 
                 <div className="grid grid-cols-2 gap-2 text-xs">
                   <div>
-                    <span className="text-muted-foreground">分支</span>
+                    <span className="text-muted-foreground">{t("github.branch")}</span>
                     <div className="font-mono font-medium">{repoInfo.branch}</div>
                   </div>
                   <div>
-                    <span className="text-muted-foreground">默认分支</span>
+                    <span className="text-muted-foreground">{t("github.defaultBranch")}</span>
                     <div className="font-mono font-medium">{repoInfo.defaultBranch}</div>
                   </div>
                 </div>
@@ -195,10 +194,10 @@ export const GitHubConnectDialog = ({
 
               <div className="flex gap-2 justify-end">
                 <Button size="sm" variant="outline" onClick={handleGoToInput}>
-                  返回
+                  {t("github.back")}
                 </Button>
                 <Button size="sm" onClick={handleConfirm}>
-                  连接仓库
+                  {t("github.connectRepo")}
                 </Button>
               </div>
             </div>

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx
@@ -78,7 +78,7 @@ export const GitHubProjectNode = ({ id, data, selected }: GitHubProjectNodeProps
       <NodeCard
         rightHandle
         bodyClassName="space-y-2"
-        description="GitHub Project"
+        description={t("canvas.nodeTypes.github-projects.label")}
         dimmed={dimmed}
         icon={SiGitHubIcon}
         label={data.label}

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubTokenDialog.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubTokenDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
 import { Key, Eye, EyeOff, ExternalLink, AlertCircle, CheckCircle, Loader2 } from "lucide-react";
 import { cn } from "@repo/ui/lib/utils";
 import { Button } from "@repo/ui/button";
@@ -38,6 +39,7 @@ const GitHubTokenDialogContent = ({
   handleClose: () => void;
   handleTokenSaved?: (token: string | null) => void;
 }) => {
+  const { t } = useTranslation();
   const { token: savedToken, setToken } = useGithubToken();
   const [inputValue, setInputValue] = useState(savedToken ?? "");
   const [showToken, setShowToken] = useState(false);
@@ -84,12 +86,12 @@ const GitHubTokenDialogContent = ({
       <DialogHeader>
         <DialogTitle className="flex items-center gap-2">
           <Key className="h-4 w-4 text-primary" />
-          GitHub Personal Access Token
+          {t("github.tokenTitle")}
         </DialogTitle>
       </DialogHeader>
 
       <div className="space-y-4">
-        {/* 当前状态 */}
+        {/* Current token state */}
         <div
           className={cn(
             "flex items-start gap-2 rounded-lg p-3 text-sm",
@@ -102,24 +104,24 @@ const GitHubTokenDialogContent = ({
             <>
               <CheckCircle className="mt-0.5 h-4 w-4 shrink-0" />
               <div>
-                <div className="font-medium">Token 已配置</div>
-                <div className="opacity-80">可访问私有仓库</div>
+                <div className="font-medium">{t("github.tokenStatusConfigured")}</div>
+                <div className="opacity-80">{t("github.tokenPrivateAccess")}</div>
               </div>
             </>
           ) : (
             <>
               <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
               <div>
-                <div className="font-medium">未配置 Token</div>
-                <div className="mt-0.5">访问私有仓库需要填写 Personal Access Token</div>
+                <div className="font-medium">{t("github.tokenStatusMissing")}</div>
+                <div className="mt-0.5">{t("github.tokenPrivateRequiresPat")}</div>
               </div>
             </>
           )}
         </div>
 
-        {/* Token 输入 */}
+        {/* Token input */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium">Personal Access Token</Label>
+          <Label className="text-sm font-medium">{t("github.personalAccessToken")}</Label>
           <div className="flex gap-2">
             <div className="relative flex-1">
               <Input
@@ -130,7 +132,8 @@ const GitHubTokenDialogContent = ({
                 onChange={handleInputChange}
               />
               <Button
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground h-auto p-0"
+                aria-label={showToken ? t("github.hideToken") : t("github.showToken")}
+                className="absolute right-2 top-1/2 h-auto -translate-y-1/2 p-0 text-muted-foreground hover:text-foreground"
                 type="button"
                 variant="ghost"
                 onClick={handleToggleShowToken}
@@ -144,15 +147,19 @@ const GitHubTokenDialogContent = ({
               variant="outline"
               onClick={handleVerify}
             >
-              {verifying ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "验证"}
+              {verifying ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : t("github.verify")}
             </Button>
           </div>
 
-          {/* 验证结果 */}
+          {/* Verification result */}
           {verifiedLogin && (
             <div className="flex items-center gap-1.5 text-xs text-green-600">
               <CheckCircle className="h-3.5 w-3.5" />
-              验证成功，已登录为 <strong>{verifiedLogin}</strong>
+              <Trans
+                components={{ strong: <strong /> }}
+                i18nKey="github.verifySuccess"
+                values={{ login: verifiedLogin }}
+              />
             </div>
           )}
           {verifyError && (
@@ -163,20 +170,21 @@ const GitHubTokenDialogContent = ({
           )}
         </div>
 
-        {/* 说明 */}
+        {/* Token storage note */}
         <div className="rounded-md bg-muted/50 p-3 text-xs text-muted-foreground space-y-1">
-          <div>Token 仅保存在本地浏览器，不会上传至服务器</div>
+          <div>{t("github.tokenLocalOnly")}</div>
           <a
             className="inline-flex items-center gap-1 text-primary hover:underline"
             href="https://github.com/settings/tokens/new?scopes=repo&description=Ordine"
             rel="noopener noreferrer"
             target="_blank"
           >
-            <ExternalLink className="h-3 w-3" />在 GitHub 创建 Token（需勾选 repo 权限）
+            <ExternalLink className="h-3 w-3" />
+            {t("github.createTokenLink")}
           </a>
         </div>
 
-        {/* 操作按钮 */}
+        {/* Actions */}
         <div className="flex justify-between">
           {savedToken && (
             <Button
@@ -185,15 +193,15 @@ const GitHubTokenDialogContent = ({
               variant="ghost"
               onClick={handleClear}
             >
-              清除 Token
+              {t("github.clearToken")}
             </Button>
           )}
           <div className="ml-auto flex gap-2">
             <Button size="sm" variant="outline" onClick={handleClose}>
-              取消
+              {t("common.cancel")}
             </Button>
             <Button disabled={!inputValue.trim()} size="sm" onClick={handleSave}>
-              保存
+              {t("common.save")}
             </Button>
           </div>
         </div>

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/PickProjectDialog.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/PickProjectDialog.tsx
@@ -67,7 +67,7 @@ export const PickProjectDialog = ({ open, onClose, onPick }: PickProjectDialogPr
         </DialogHeader>
 
         <div className="space-y-3">
-          {/* 搜索 */}
+          {/* Search */}
           <div className="relative">
             <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
             <input
@@ -79,20 +79,20 @@ export const PickProjectDialog = ({ open, onClose, onPick }: PickProjectDialogPr
             />
           </div>
 
-          {/* 项目列表 */}
+          {/* Project list */}
           <div className="max-h-72 overflow-y-auto space-y-1">
             {loading && (
               <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                加载中...
+                {t("common.loading")}
               </div>
             )}
 
             {!loading && filtered.length === 0 && (
               <div className="py-8 text-center text-sm text-muted-foreground">
                 {projects.length === 0
-                  ? "项目库为空，请先在「项目」页面连接 GitHub 仓库"
-                  : "未找到匹配的项目"}
+                  ? t("github.projectListEmpty")
+                  : t("github.projectListNoResults")}
               </div>
             )}
 

--- a/apps/app/src/pages/CanvasPage/LlmContentCard/LlmContentCard.tsx
+++ b/apps/app/src/pages/CanvasPage/LlmContentCard/LlmContentCard.tsx
@@ -1,11 +1,13 @@
 import { X, Brain, Loader2 } from "lucide-react";
 import Markdown from "react-markdown";
+import { useTranslation } from "react-i18next";
 import { Button } from "@repo/ui/button";
 import { ScrollArea } from "@repo/ui/scroll-area";
 import { useStore } from "zustand";
 import { useHarnessCanvasStore } from "../_store";
 
 export const LlmContentCard = () => {
+  const { t } = useTranslation();
   const store = useHarnessCanvasStore();
   const inspectingNodeId = useStore(store, (s) => s.inspectingNodeId);
   const handleDismissInspection = useStore(store, (s) => s.handleDismissInspection);
@@ -25,7 +27,9 @@ export const LlmContentCard = () => {
       <div className="flex shrink-0 items-center justify-between border-b px-4 py-2.5">
         <div className="flex items-center gap-2">
           <Brain className="h-4 w-4 text-violet-500" />
-          <span className="text-sm font-semibold truncate">{nodeLabel ?? "LLM"} — 思考内容</span>
+          <span className="text-sm font-semibold truncate">
+            {t("canvas.llmContent.title", { label: nodeLabel ?? "LLM" })}
+          </span>
           {status === "running" && <Loader2 className="h-3.5 w-3.5 animate-spin text-blue-500" />}
         </div>
         <Button
@@ -42,7 +46,7 @@ export const LlmContentCard = () => {
           {status === "running" && !content && (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
-              <span>LLM 正在思考中...</span>
+              <span>{t("canvas.llmContent.running")}</span>
             </div>
           )}
           {content ? (
@@ -51,7 +55,7 @@ export const LlmContentCard = () => {
             </div>
           ) : (
             status !== "running" && (
-              <p className="text-sm text-muted-foreground">暂无 LLM 输出内容</p>
+              <p className="text-sm text-muted-foreground">{t("canvas.llmContent.empty")}</p>
             )
           )}
         </div>

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
@@ -194,7 +194,7 @@ describe("NodeCard", () => {
       />
     );
 
-    const input = screen.getByLabelText("Node label");
+    const input = screen.getByLabelText(/Node label|节点标签/);
     expect(input).toHaveAttribute("readonly");
 
     fireEvent.click(input);
@@ -215,7 +215,7 @@ describe("NodeCard", () => {
       />
     );
 
-    const input = screen.getByLabelText("Node label");
+    const input = screen.getByLabelText(/Node label|节点标签/);
     expect(input).toHaveAttribute("readonly");
 
     fireEvent.focus(input);

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCardFrame.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCardFrame.tsx
@@ -9,6 +9,7 @@ import {
 import { cn } from "@repo/ui/lib/utils";
 import type { NodeRunStatus } from "@repo/pipeline-engine/schemas";
 import { memo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { themeMap, type NodeTheme } from "./nodeCardTheme";
 
 export interface NodeCardFrameProps {
@@ -41,6 +42,7 @@ export const NodeCardFrame = memo(
     runStatus,
     dimmed,
   }: NodeCardFrameProps) => {
+    const { t: translate } = useTranslation();
     const t = themeMap[theme] ?? themeMap.emerald;
     const [isLabelEditing, setIsLabelEditing] = useState(false);
     const handleChange = onLabelChange
@@ -76,7 +78,7 @@ export const NodeCardFrame = memo(
             <div className="flex min-h-8 flex-1 min-w-0 flex-col justify-center">
               {handleChange ? (
                 <input
-                  aria-label="Node label"
+                  aria-label={translate("canvas.nodeLabel")}
                   className={cn(
                     "nodrag nopan w-auto max-w-full bg-transparent text-xs font-semibold leading-tight [field-sizing:content] focus:outline-none",
                     isLabelEditing ? "select-text" : "cursor-default select-none"

--- a/apps/app/src/pages/CanvasPage/NodeContextMenu/NodeContextMenu.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeContextMenu/NodeContextMenu.tsx
@@ -31,7 +31,7 @@ import { useList } from "@refinedev/core";
 import { ResourceName } from "@/integrations/refine/dataProvider";
 import type { Operation, Recipe } from "@repo/schemas";
 import { getAllowedConnections } from "../utils/getAllowedConnections";
-import { getNodeMeta } from "../utils/nodeTypeMeta";
+import { getNodeMeta, getNodeTypeLabel, getNodeTypeShortLabel } from "../utils/nodeTypeMeta";
 import type { NodeType, BuiltinNodeType } from "@repo/pipeline-engine/schemas";
 import { cn } from "@repo/ui/lib/utils";
 
@@ -154,20 +154,22 @@ export const NodeContextMenu = () => {
               meta.iconBg
             )}
           >
-            {meta.shortLabel.charAt(0)}
+            {getNodeTypeShortLabel(t, node.type).charAt(0)}
           </span>
-          <span className="text-xs font-medium text-foreground">{meta.label}</span>
+          <span className="text-xs font-medium text-foreground">
+            {getNodeTypeLabel(t, node.type)}
+          </span>
         </div>
 
         {/* Actions submenu */}
         <ContextMenuSub>
           <ContextMenuSubTrigger>
             <Zap className="size-4 text-muted-foreground" />
-            Actions
+            {t("canvas.contextMenu.actions")}
           </ContextMenuSubTrigger>
           <ContextMenuSubContent className="min-w-52">
             <ContextMenuGroup>
-              <ContextMenuLabel>连接新节点</ContextMenuLabel>
+              <ContextMenuLabel>{t("canvas.contextMenu.connectNewNode")}</ContextMenuLabel>
             </ContextMenuGroup>
 
             {/* Object types */}
@@ -175,7 +177,7 @@ export const NodeContextMenu = () => {
               availableTypes.includes(t as BuiltinNodeType)
             ) && (
               <ContextMenuGroup>
-                <ContextMenuLabel>处理对象</ContextMenuLabel>
+                <ContextMenuLabel>{t("canvas.contextMenu.processingObject")}</ContextMenuLabel>
                 {["code-file", "folder", "github-projects"]
                   .filter((t) => availableTypes.includes(t as BuiltinNodeType))
                   .map((type) => {
@@ -196,7 +198,7 @@ export const NodeContextMenu = () => {
                         >
                           <Icon className="size-2.5 text-white" />
                         </span>
-                        {m.shortLabel}
+                        {getNodeTypeShortLabel(t, type)}
                       </ContextMenuItem>
                     );
                   })}
@@ -232,7 +234,7 @@ export const NodeContextMenu = () => {
                 <ContextMenuGroup>
                   <ContextMenuLabel>{t("canvas.contextMenu.operationNode")}</ContextMenuLabel>
                   <p className="px-1.5 py-1 text-xs text-muted-foreground">
-                    没有接受此类型的 Operation
+                    {t("canvas.contextMenu.noOperationsForType")}
                   </p>
                 </ContextMenuGroup>
               </>
@@ -243,7 +245,7 @@ export const NodeContextMenu = () => {
               <>
                 <ContextMenuSeparator />
                 <ContextMenuGroup>
-                  <ContextMenuLabel>快捷配方</ContextMenuLabel>
+                  <ContextMenuLabel>{t("canvas.contextMenu.recipeNode")}</ContextMenuLabel>
                   {recipes.map((recipe) => (
                     <ContextMenuItem
                       key={recipe.id}
@@ -267,7 +269,7 @@ export const NodeContextMenu = () => {
               <>
                 <ContextMenuSeparator />
                 <ContextMenuGroup>
-                  <ContextMenuLabel>输出终点</ContextMenuLabel>
+                  <ContextMenuLabel>{t("canvas.contextMenu.outputEndpoint")}</ContextMenuLabel>
                   {(["output-project-path", "output-local-path"] as BuiltinNodeType[])
                     .filter((t) => availableTypes.includes(t))
                     .map((type) => {
@@ -288,7 +290,7 @@ export const NodeContextMenu = () => {
                           >
                             <Icon className="size-2.5 text-white" />
                           </span>
-                          {m.label}
+                          {getNodeTypeLabel(t, type)}
                         </ContextMenuItem>
                       );
                     })}
@@ -301,7 +303,7 @@ export const NodeContextMenu = () => {
         {/* Duplicate */}
         <ContextMenuItem closeOnClick={false} onClick={handleNodeContextDuplicate}>
           <Copy className="size-4 text-muted-foreground" />
-          Duplicate
+          {t("canvas.contextMenu.duplicate")}
           <span className="ml-auto text-xs tracking-widest text-muted-foreground">⌘D</span>
         </ContextMenuItem>
 
@@ -309,7 +311,7 @@ export const NodeContextMenu = () => {
         {selectedIds.length >= 2 && (
           <ContextMenuItem closeOnClick={false} onClick={handleNodeContextGroupSelected}>
             <Group className="size-4 text-muted-foreground" />
-            编组 {selectedIds.length} 个选中节点
+            {t("canvas.contextMenu.groupSelected", { count: selectedIds.length })}
           </ContextMenuItem>
         )}
 
@@ -317,7 +319,7 @@ export const NodeContextMenu = () => {
         {node.type === "compound" && (
           <ContextMenuItem closeOnClick={false} onClick={handleNodeContextUngroup}>
             <Ungroup className="size-4 text-muted-foreground" />
-            解散编组
+            {t("canvas.contextMenu.ungroup")}
           </ContextMenuItem>
         )}
 
@@ -325,7 +327,7 @@ export const NodeContextMenu = () => {
         {node.parentId && (
           <ContextMenuItem closeOnClick={false} onClick={handleNodeContextDetach}>
             <Ungroup className="size-4 text-muted-foreground" />
-            从编组中移除
+            {t("canvas.contextMenu.detachFromGroup")}
           </ContextMenuItem>
         )}
 
@@ -338,7 +340,7 @@ export const NodeContextMenu = () => {
           onClick={handleNodeContextDelete}
         >
           <Trash2 className="size-4" />
-          Delete
+          {t("canvas.contextMenu.delete")}
           <span className="ml-auto text-xs tracking-widest text-destructive/40">⌫</span>
         </ContextMenuItem>
       </ContextMenuContent>

--- a/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
@@ -1,5 +1,6 @@
 import { Zap, CheckCircle2, XCircle, Loader2, Circle, Brain, Repeat } from "lucide-react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@repo/ui/lib/utils";
 import {
   Select,
@@ -27,16 +28,16 @@ export interface OperationNodeProps {
 
 const statusConfig: Record<
   NodeRunStatus,
-  { icon: React.ElementType; color: string; label: string }
+  { icon: React.ElementType; color: string; labelKey: string }
 > = {
-  idle: { icon: Circle, color: "text-gray-400", label: "待运行" },
+  idle: { icon: Circle, color: "text-gray-400", labelKey: "nodes.operation.statusIdle" },
   running: {
     icon: Loader2,
     color: "text-blue-500 animate-spin",
-    label: "运行中",
+    labelKey: "nodes.operation.statusRunning",
   },
-  pass: { icon: CheckCircle2, color: "text-green-500", label: "成功" },
-  fail: { icon: XCircle, color: "text-red-500", label: "失败" },
+  pass: { icon: CheckCircle2, color: "text-green-500", labelKey: "nodes.operation.statusPass" },
+  fail: { icon: XCircle, color: "text-red-500", labelKey: "nodes.operation.statusFail" },
 };
 
 const handleStopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
@@ -48,6 +49,7 @@ const RUNTIME_LABELS: Record<string, string> = {
 };
 
 export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
+  const { t } = useTranslation();
   const store = useHarnessCanvasStore();
   const { runStatus: nodeRunStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
   const { result: operationsResult } = useList<Operation>({
@@ -60,7 +62,8 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
   const setInspectingNodeId = useStore(store, (s) => s.setInspectingNodeId);
   const { leftPortCount, rightPortCount } = useNodePortCounts(id);
 
-  const { icon: StatusIcon, color, label: statusLabel } = statusConfig[data.status ?? "idle"];
+  const { icon: StatusIcon, color, labelKey } = statusConfig[data.status ?? "idle"];
+  const statusLabel = t(labelKey);
 
   const operation = operations.find((op: Operation) => op.id === data.operationId);
 
@@ -111,7 +114,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
         leftHandle
         rightHandle
         bodyClassName="space-y-2"
-        description={operation?.description || "自定义操作"}
+        description={operation?.description || t("nodes.operation.description")}
         dimmed={dimmed}
         headerRight={
           <div
@@ -142,7 +145,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
         {data.config && Object.keys(data.config).length > 0 && (
           <div className="space-y-1">
             <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
-              配置
+              {t("nodes.operation.config")}
             </p>
             <div className="rounded bg-slate-50 px-2 py-1.5">
               <pre className="text-[9px] text-slate-500 overflow-hidden text-ellipsis">
@@ -157,7 +160,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
         {operation?.acceptedObjectTypes && (
           <div className="space-y-1">
             <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
-              接受的对象类型
+              {t("nodes.operation.acceptedObjectTypes")}
             </p>
             <div className="flex flex-wrap gap-1">
               {operation.acceptedObjectTypes.map((type) => (
@@ -165,9 +168,9 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
                   key={type}
                   className="rounded bg-violet-50 px-1.5 py-0.5 text-[9px] font-medium text-violet-600"
                 >
-                  {type === "file" && "文件"}
-                  {type === "folder" && "文件夹"}
-                  {type === "project" && "项目"}
+                  {type === "file" && t("nodes.operation.objectTypeFile")}
+                  {type === "folder" && t("nodes.operation.objectTypeFolder")}
+                  {type === "project" && t("nodes.operation.objectTypeProject")}
                 </span>
               ))}
             </div>
@@ -178,7 +181,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
         <div className="space-y-1" onMouseDown={handleStopPropagation}>
           <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
             <Brain className="mr-1 inline-block h-3 w-3" />
-            Agent Runtime
+            {t("nodes.operation.agentRuntime")}
           </p>
           <Select
             open={runtimeOpen}
@@ -194,8 +197,8 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
             </SelectTrigger>
             <SelectContent>
               <SelectGroup>
-                <SelectLabel>Runtime</SelectLabel>
-                <SelectItem value="__default__">默认</SelectItem>
+                <SelectLabel>{t("nodes.operation.runtime")}</SelectLabel>
+                <SelectItem value="__default__">{t("nodes.operation.defaultRuntime")}</SelectItem>
                 {AgentRuntimeSchema.options.map((p) => (
                   <SelectItem key={p} value={p}>
                     {RUNTIME_LABELS[p] ?? p}
@@ -209,7 +212,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
         {hasLlmContent && (
           <div className="flex items-center gap-1 rounded-md border border-violet-200 bg-violet-50 px-2 py-1 text-[10px] text-violet-600">
             <Brain className="h-3 w-3 shrink-0" />
-            <span>点击查看 LLM 输出</span>
+            <span>{t("nodes.operation.viewLlmOutput")}</span>
           </div>
         )}
 
@@ -226,17 +229,17 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
             onClick={handleLoopToggle}
           >
             <Repeat className="h-3 w-3 shrink-0" />
-            {data.loopEnabled ? "循环已开启" : "开启循环"}
+            {data.loopEnabled ? t("nodes.operation.loopEnabled") : t("nodes.operation.enableLoop")}
           </button>
 
           {data.loopEnabled && (
             <div className="space-y-1.5 rounded-md border border-amber-100 bg-amber-50/50 p-2">
               <div className="flex items-center gap-2">
                 <span className="text-[10px] font-medium text-amber-700 whitespace-nowrap">
-                  最大次数
+                  {t("nodes.operation.maxLoopCount")}
                 </span>
                 <input
-                  aria-label="Maximum loop count"
+                  aria-label={t("nodes.operation.maxLoopCount")}
                   className="nodrag nopan h-5 w-14 rounded border border-amber-200 bg-white px-1.5 text-[10px] text-amber-800 focus:outline-none focus:ring-1 focus:ring-amber-300"
                   max={20}
                   min={1}
@@ -247,12 +250,14 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
                 />
               </div>
               <div className="space-y-0.5">
-                <span className="text-[10px] font-medium text-amber-700">验收条件</span>
+                <span className="text-[10px] font-medium text-amber-700">
+                  {t("nodes.operation.loopAcceptanceCondition")}
+                </span>
                 <textarea
-                  aria-label="Loop acceptance condition"
+                  aria-label={t("nodes.operation.loopAcceptanceCondition")}
                   className="nodrag nopan w-full rounded border border-amber-200 bg-white px-1.5 py-1 text-[10px] text-amber-800 placeholder:text-amber-300 focus:outline-none focus:ring-1 focus:ring-amber-300"
                   name={`${id}-loopCondition`}
-                  placeholder="描述输出需要满足的条件..."
+                  placeholder={t("nodes.operation.loopAcceptancePlaceholder")}
                   rows={2}
                   value={data.loopConditionPrompt ?? ""}
                   onChange={handleConditionChange}

--- a/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { AlertTriangle, FolderOpen, HardDrive } from "lucide-react";
 import {
   OUTPUT_MODE_ENUM,
@@ -19,13 +20,14 @@ export interface OutputLocalPathNodeProps {
 
 const handleStopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
 
-const MODE_LABELS: Record<OutputMode, string> = {
-  overwrite: "覆写",
-  error_if_exists: "已存在则中断",
-  auto_rename: "自动重命名",
+const MODE_LABEL_KEYS: Record<OutputMode, string> = {
+  overwrite: "nodes.outputLocalPathNode.modeOverwrite",
+  error_if_exists: "nodes.outputLocalPathNode.modeErrorIfExists",
+  auto_rename: "nodes.outputLocalPathNode.modeAutoRename",
 };
 
 export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeProps) => {
+  const { t } = useTranslation();
   const store = useHarnessCanvasStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
@@ -62,7 +64,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
       <NodeCard
         leftHandle
         bodyClassName="space-y-2"
-        description="本地路径输出"
+        description={t("nodes.outputLocalPathNode.description")}
         dimmed={dimmed}
         icon={HardDrive}
         label={data.label}
@@ -73,7 +75,9 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
         onLabelChange={handleLabelChange}
       >
         <div className="flex items-center gap-1 rounded-md border border-teal-100 bg-teal-50 px-2 py-1">
-          <span className="shrink-0 text-[10px] font-medium text-teal-500">路径</span>
+          <span className="shrink-0 text-[10px] font-medium text-teal-500">
+            {t("nodes.outputLocalPathNode.pathLabel")}
+          </span>
           <input
             className="nodrag nopan flex-1 min-w-0 bg-transparent font-mono text-[11px] font-semibold text-teal-800 focus:outline-none"
             placeholder="/Users/you/Desktop/output"
@@ -85,7 +89,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
           />
           <button
             className="nodrag nopan shrink-0 rounded p-0.5 text-teal-400 hover:bg-teal-100 hover:text-teal-700 transition-colors"
-            title="浏览文件夹"
+            title={t("nodes.outputLocalPathNode.browseFolder")}
             type="button"
             onClick={handleFolderButtonClick}
             onMouseDown={handleStopPropagation}
@@ -95,7 +99,9 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
         </div>
 
         <div className="flex items-center gap-1 rounded-md border border-teal-100 bg-teal-50 px-2 py-1">
-          <span className="shrink-0 text-[10px] font-medium text-teal-500">文件名</span>
+          <span className="shrink-0 text-[10px] font-medium text-teal-500">
+            {t("nodes.outputLocalPathNode.filenameLabel")}
+          </span>
           <input
             className="nodrag nopan flex-1 min-w-0 bg-transparent font-mono text-[11px] font-semibold text-teal-800 focus:outline-none"
             placeholder="output.md"
@@ -108,7 +114,9 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
         </div>
 
         <div className="flex items-center gap-1 rounded-md border border-teal-100 bg-teal-50 px-2 py-1">
-          <span className="shrink-0 text-[10px] font-medium text-teal-500">写入模式</span>
+          <span className="shrink-0 text-[10px] font-medium text-teal-500">
+            {t("nodes.outputLocalPathNode.writeModeLabel")}
+          </span>
           <select
             className="nodrag nopan flex-1 min-w-0 bg-transparent text-[11px] font-semibold text-teal-800 focus:outline-none cursor-pointer"
             value={currentMode}
@@ -118,7 +126,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
           >
             {Object.values(OUTPUT_MODE_ENUM).map((mode) => (
               <option key={mode} value={mode}>
-                {MODE_LABELS[mode]}
+                {t(MODE_LABEL_KEYS[mode])}
               </option>
             ))}
           </select>
@@ -127,13 +135,13 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
         {currentMode === "error_if_exists" && (
           <div className="flex items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-[10px] text-amber-700">
             <AlertTriangle className="h-3 w-3 shrink-0" />
-            <span>如果输出文件已存在，管线将会中断</span>
+            <span>{t("nodes.outputLocalPathNode.errorIfExistsWarning")}</span>
           </div>
         )}
 
         <textarea
           className="nodrag nopan text-[11px] text-slate-500 bg-transparent w-full resize-none focus:outline-none focus:bg-slate-50 focus:ring-1 focus:ring-slate-200 rounded px-1"
-          placeholder="描述此输出..."
+          placeholder={t("nodes.outputLocalPathNode.descriptionPlaceholder")}
           rows={2}
           value={data.description ?? ""}
           onChange={handleDescriptionChange}

--- a/apps/app/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.tsx
@@ -1,4 +1,5 @@
 import { FolderOutput } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useHarnessCanvasStore, selectNodeRunState } from "../_store";
@@ -16,6 +17,7 @@ export interface OutputProjectPathNodeProps {
 const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
 
 export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathNodeProps) => {
+  const { t } = useTranslation();
   const store = useHarnessCanvasStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
@@ -34,7 +36,7 @@ export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathN
       <NodeCard
         leftHandle
         bodyClassName="space-y-2"
-        description="项目路径输出"
+        description={t("nodes.outputProjectPath.description")}
         dimmed={dimmed}
         icon={FolderOutput}
         label={data.label}
@@ -46,7 +48,9 @@ export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathN
       >
         <div className="space-y-1.5">
           <div className="flex items-center gap-1 rounded-md border border-slate-100 bg-slate-50 px-2.5 py-1">
-            <span className="shrink-0 text-[10px] font-medium text-slate-400">项目 ID</span>
+            <span className="shrink-0 text-[10px] font-medium text-slate-400">
+              {t("nodes.outputProjectPath.projectIdLabel")}
+            </span>
             <Input
               className="nodrag nopan flex-1 min-w-0 bg-transparent font-mono text-[11px] text-slate-700 focus:outline-none border-none shadow-none p-0 h-auto"
               placeholder="project-id"
@@ -56,7 +60,9 @@ export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathN
             />
           </div>
           <div className="flex items-center gap-1 rounded-md border border-teal-100 bg-teal-50 px-2.5 py-1">
-            <span className="shrink-0 text-[10px] font-medium text-teal-500">路径</span>
+            <span className="shrink-0 text-[10px] font-medium text-teal-500">
+              {t("nodes.outputProjectPath.pathLabel")}
+            </span>
             <Input
               className="nodrag nopan flex-1 min-w-0 bg-transparent font-mono text-[11px] font-semibold text-teal-800 focus:outline-none border-none shadow-none p-0 h-auto"
               placeholder="src/output/"
@@ -68,7 +74,7 @@ export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathN
         </div>
         <Textarea
           className="nodrag nopan text-[11px] text-slate-500 bg-transparent w-full resize-none focus:outline-none focus:bg-slate-50 focus:ring-1 focus:ring-slate-200 rounded px-1 border-none shadow-none min-h-0 p-0"
-          placeholder="描述此输出..."
+          placeholder={t("nodes.outputProjectPath.descriptionPlaceholder")}
           rows={2}
           value={data.description ?? ""}
           onChange={handleDescriptionChange}

--- a/apps/app/src/pages/CanvasPage/RunConsole/RunConsole.tsx
+++ b/apps/app/src/pages/CanvasPage/RunConsole/RunConsole.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { Terminal, X, ChevronUp, ChevronDown, Loader2 } from "lucide-react";
 import { Button } from "@repo/ui/button";
 import { ScrollArea } from "@repo/ui/scroll-area";
@@ -12,13 +13,13 @@ import type { JobData, JobStatus } from "./types";
 
 const POLL_INTERVAL = 1500;
 
-const statusLabel: Record<JobStatus, string> = {
-  queued: "Queued",
-  running: "Running",
-  done: "Done",
-  failed: "Failed",
-  cancelled: "Cancelled",
-  expired: "Expired",
+const statusLabelKeys: Record<JobStatus, string> = {
+  queued: "canvas.runConsole.statusQueued",
+  running: "canvas.runConsole.statusRunning",
+  done: "canvas.runConsole.statusDone",
+  failed: "canvas.runConsole.statusFailed",
+  cancelled: "canvas.runConsole.statusCancelled",
+  expired: "canvas.runConsole.statusExpired",
 };
 
 const parseTimestamp = (log: string): string => {
@@ -76,6 +77,7 @@ const isTerminalStatus = (s: JobStatus) =>
   s === "done" || s === "failed" || s === "cancelled" || s === "expired";
 
 export const RunConsole = () => {
+  const { t } = useTranslation();
   const store = useHarnessCanvasStore();
   const jobId = useStore(store, (s) => s.activeJobId);
   const handleCloseConsole = useStore(store, (s) => s.handleCloseConsole);
@@ -190,7 +192,7 @@ export const RunConsole = () => {
       <div className="flex h-9 items-center justify-between border-b bg-muted/50 px-3">
         <div className="flex items-center gap-2 text-xs">
           <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="font-medium">Console</span>
+          <span className="font-medium">{t("canvas.runConsole.title")}</span>
           {job && (
             <>
               <span className="text-muted-foreground">|</span>
@@ -204,10 +206,12 @@ export const RunConsole = () => {
                   job.status === "expired" && "text-slate-600"
                 )}
               >
-                {statusLabel[job.status]}
+                {t(statusLabelKeys[job.status])}
               </span>
               {job.status === "running" && (
-                <span className="text-muted-foreground">({traceLogs.length} logs)</span>
+                <span className="text-muted-foreground">
+                  ({t("canvas.runConsole.logs", { count: traceLogs.length })})
+                </span>
               )}
             </>
           )}
@@ -239,7 +243,7 @@ export const RunConsole = () => {
             {!job && (
               <div className="flex items-center gap-2 text-muted-foreground">
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Loading...
+                {t("canvas.runConsole.loading")}
               </div>
             )}
             {traceLogs

--- a/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
@@ -37,6 +37,14 @@ const getConnectStartHandleType = (
   connectionState.fromHandle?.type ??
   (currentConnectStart?.nodeId === fromNodeId ? currentConnectStart.handleType : null);
 
+const makeLocalizedDefaultNodeData = (type: BuiltinNodeType) => {
+  const fallback = makeDefaultNodeData(type);
+
+  return makeDefaultNodeData(type, {
+    label: i18n.t(`canvas.nodeTypes.${type}.label`, { defaultValue: fallback.label }),
+  });
+};
+
 export interface ActionsSlice {
   exportCanvas: () => void;
   importCanvas: (data: { nodes: PipelineNode[]; edges: PipelineEdge[] }) => void;
@@ -395,7 +403,7 @@ export const createActionsSlice = (
         method: "post",
         payload: { id: pipelineId },
       }),
-      () => "Failed to start pipeline"
+      () => t("canvas.runStartFailed")
     );
 
     runResult.match(
@@ -405,7 +413,7 @@ export const createActionsSlice = (
         toastStore.getState().addToast({
           type: "success",
           title: t("canvas.runCompleted"),
-          description: `Job ${result.jobId} ${t("canvas.runSuccess")}`,
+          description: t("canvas.runSuccessDescription", { jobId: result.jobId }),
         });
       },
       (error) => {
@@ -456,7 +464,7 @@ export const createActionsSlice = (
       id: `${type}-${Date.now()}`,
       type,
       position: { x: contextMenu.flowX, y: contextMenu.flowY },
-      data: makeDefaultNodeData(type as BuiltinNodeType),
+      data: makeLocalizedDefaultNodeData(type as BuiltinNodeType),
     });
   },
 
@@ -494,7 +502,7 @@ export const createActionsSlice = (
       type,
       origin: QUICK_ADD_NODE_ORIGIN,
       position,
-      data: makeDefaultNodeData(type as BuiltinNodeType),
+      data: makeLocalizedDefaultNodeData(type as BuiltinNodeType),
     });
     set({ isQuickAddOpen: false, quickAddQuery: "" });
   },
@@ -549,7 +557,7 @@ export const createActionsSlice = (
         { x: connectionMenu.flowX, y: connectionMenu.flowY },
         CONNECTION_MENU_NODE_OFFSET
       ),
-      data: makeDefaultNodeData(type as BuiltinNodeType),
+      data: makeLocalizedDefaultNodeData(type as BuiltinNodeType),
     });
   },
 
@@ -655,7 +663,7 @@ export const createActionsSlice = (
       id: newId,
       type,
       position: offsetPosition(node.position, NODE_CONTEXT_CONNECT_OFFSET),
-      data: makeDefaultNodeData(type as BuiltinNodeType),
+      data: makeLocalizedDefaultNodeData(type as BuiltinNodeType),
     });
     get().handleConnect({
       source: nodeContextMenu.nodeId,

--- a/apps/app/src/pages/CanvasPage/_store/canvasSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/canvasSlice.ts
@@ -21,6 +21,7 @@ import {
 
 import { computeAutoLayout } from "./autoLayout";
 import { DUPLICATE_NODE_OFFSET, offsetPosition } from "../utils/nodePosition";
+import i18n from "@/lib/i18n";
 
 /**
  * Sort nodes so that parents (compound nodes) appear before their children.
@@ -71,6 +72,14 @@ const initialNodes: PipelineNode[] = [];
 
 const initialEdges: PipelineEdge[] = [];
 
+const makeLocalizedDefaultNodeData = (type: BuiltinNodeType) => {
+  const fallback = makeDefaultNodeData(type);
+
+  return makeDefaultNodeData(type, {
+    label: i18n.t(`canvas.nodeTypes.${type}.label`, { defaultValue: fallback.label }),
+  });
+};
+
 export const createCanvasSlice = (
   set: Parameters<HarnessCanvasStoreSlice>[0],
   get: Parameters<HarnessCanvasStoreSlice>[1],
@@ -117,7 +126,10 @@ export const createCanvasSlice = (
       recordCommand(
         {
           type: "ADD_EDGE",
-          label: `连接 ${sourceNode.data.label} → ${targetNode.data.label}`,
+          label: i18n.t("canvas.history.addEdge", {
+            source: sourceNode.data.label,
+            target: targetNode.data.label,
+          }),
           payload: { source: connection.source, target: connection.target },
         },
         (draft) => {
@@ -135,7 +147,7 @@ export const createCanvasSlice = (
       recordCommand(
         {
           type: "ADD_NODE",
-          label: `添加节点 ${node.data.label}`,
+          label: i18n.t("canvas.history.addNode", { label: node.data.label }),
           payload: { id: node.id, nodeType: node.type },
         },
         (draft) => {
@@ -156,7 +168,7 @@ export const createCanvasSlice = (
         id: newId,
         type: targetType,
         position: { x: source.position.x + 300, y: source.position.y },
-        data: makeDefaultNodeData(targetType as BuiltinNodeType),
+        data: makeLocalizedDefaultNodeData(targetType as BuiltinNodeType),
       };
       const newEdge: PipelineEdge = {
         id: `e-${sourceId}-${newId}`,
@@ -170,7 +182,7 @@ export const createCanvasSlice = (
       recordCommand(
         {
           type: "ADD_NODE_WITH_EDGE",
-          label: `添加 ${newNode.data.label} 并连接`,
+          label: i18n.t("canvas.history.addNodeWithEdge", { label: newNode.data.label }),
           payload: { sourceId, targetType, newId },
         },
         (draft) => {
@@ -190,7 +202,7 @@ export const createCanvasSlice = (
       recordCommand(
         {
           type: "REMOVE_NODE",
-          label: `删除节点 ${node.data.label}`,
+          label: i18n.t("canvas.history.removeNode", { label: node.data.label }),
           payload: { id: nodeId },
         },
         (draft) => {
@@ -214,7 +226,7 @@ export const createCanvasSlice = (
       recordCommand(
         {
           type: "UPDATE_NODE_DATA",
-          label: `编辑 ${node.data.label}`,
+          label: i18n.t("canvas.history.updateNode", { label: node.data.label }),
           payload: { id: nodeId, fields: Object.keys(data) },
         },
         (draft) => {
@@ -256,7 +268,7 @@ export const createCanvasSlice = (
       recordCommand(
         {
           type: "DUPLICATE_NODE",
-          label: `复制节点 ${source.data.label}`,
+          label: i18n.t("canvas.history.duplicateNode", { label: source.data.label }),
           payload: { sourceId: nodeId, newId },
         },
         (draft) => {
@@ -267,10 +279,13 @@ export const createCanvasSlice = (
 
     clearCanvas: () => {
       const { recordCommand } = get();
-      recordCommand({ type: "CLEAR_CANVAS", label: "清空画布" }, (draft) => {
-        draft.nodes = [];
-        draft.edges = [];
-      });
+      recordCommand(
+        { type: "CLEAR_CANVAS", label: i18n.t("canvas.history.clearCanvas") },
+        (draft) => {
+          draft.nodes = [];
+          draft.edges = [];
+        }
+      );
       set({ selectedNodeId: null, selectedEdgeId: null });
     },
 
@@ -297,7 +312,10 @@ export const createCanvasSlice = (
       state.recordCommand(
         {
           type: "ADD_TO_COMPOUND",
-          label: `添加 ${node.data.label} 到 ${compound.data.label}`,
+          label: i18n.t("canvas.history.addToCompound", {
+            node: node.data.label,
+            compound: compound.data.label,
+          }),
           payload: { nodeId, compoundId },
         },
         (draft) => {
@@ -347,7 +365,10 @@ export const createCanvasSlice = (
       state.recordCommand(
         {
           type: "REMOVE_FROM_COMPOUND",
-          label: `从 ${compound.data.label} 移除 ${node.data.label}`,
+          label: i18n.t("canvas.history.removeFromCompound", {
+            node: node.data.label,
+            compound: compound.data.label,
+          }),
           payload: { nodeId, compoundId },
         },
         (draft) => {
@@ -385,7 +406,7 @@ export const createCanvasSlice = (
       const childW = 240;
       const childH = 120;
       const compoundId = `compound-${Date.now()}`;
-      const compoundData = makeDefaultNodeData("compound") as CompoundNodeData;
+      const compoundData = makeLocalizedDefaultNodeData("compound") as CompoundNodeData;
       compoundData.childNodeIds = [...nodeIds];
 
       const minX = Math.min(...selectedNodes.map((n) => n.position.x));
@@ -408,7 +429,7 @@ export const createCanvasSlice = (
       state.recordCommand(
         {
           type: "GROUP_NODES",
-          label: `编组 ${nodeIds.length} 个节点`,
+          label: i18n.t("canvas.history.groupNodes", { count: nodeIds.length }),
           payload: { compoundId, nodeIds },
         },
         (draft) => {
@@ -441,7 +462,7 @@ export const createCanvasSlice = (
       state.recordCommand(
         {
           type: "UNGROUP_COMPOUND",
-          label: `解散编组 ${compound.data.label}`,
+          label: i18n.t("canvas.history.ungroupCompound", { label: compound.data.label }),
           payload: { compoundId, childIds },
         },
         (draft) => {

--- a/apps/app/src/pages/CanvasPage/utils/makeDefaultNodeData.ts
+++ b/apps/app/src/pages/CanvasPage/utils/makeDefaultNodeData.ts
@@ -1,11 +1,14 @@
 import type { BuiltinNodeType } from "@repo/pipeline-engine/schemas";
 import type { PipelineNodeData } from "../schemas/PipelineNodeDataSchema";
 
-export const makeDefaultNodeData = (type: BuiltinNodeType): PipelineNodeData => {
+export const makeDefaultNodeData = (
+  type: BuiltinNodeType,
+  options?: { label?: string }
+): PipelineNodeData => {
   switch (type) {
     case "operation": {
       return {
-        label: "Operation",
+        label: options?.label ?? "Operation",
         nodeType: "operation",
         operationId: "",
         operationName: "",
@@ -15,7 +18,7 @@ export const makeDefaultNodeData = (type: BuiltinNodeType): PipelineNodeData => 
     }
     case "code-file": {
       return {
-        label: "代码文件",
+        label: options?.label ?? "Code file",
         nodeType: "code-file",
         filePath: "",
         language: "typescript",
@@ -24,7 +27,7 @@ export const makeDefaultNodeData = (type: BuiltinNodeType): PipelineNodeData => 
     }
     case "folder": {
       return {
-        label: "文件夹",
+        label: options?.label ?? "Folder",
         nodeType: "folder",
         folderPath: "",
         description: "",
@@ -32,7 +35,7 @@ export const makeDefaultNodeData = (type: BuiltinNodeType): PipelineNodeData => 
     }
     case "github-projects": {
       return {
-        label: "GitHub 项目",
+        label: options?.label ?? "GitHub project",
         nodeType: "github-projects",
         owner: "",
         repo: "",
@@ -42,7 +45,7 @@ export const makeDefaultNodeData = (type: BuiltinNodeType): PipelineNodeData => 
     }
     case "output-project-path": {
       return {
-        label: "项目路径输出",
+        label: options?.label ?? "Project output",
         nodeType: "output-project-path",
         projectId: "",
         path: "",
@@ -51,7 +54,7 @@ export const makeDefaultNodeData = (type: BuiltinNodeType): PipelineNodeData => 
     }
     case "output-local-path": {
       return {
-        label: "本地路径输出",
+        label: options?.label ?? "Local output",
         nodeType: "output-local-path",
         localPath: "",
         description: "",
@@ -59,7 +62,7 @@ export const makeDefaultNodeData = (type: BuiltinNodeType): PipelineNodeData => 
     }
     case "compound": {
       return {
-        label: "复合节点",
+        label: options?.label ?? "Compound node",
         nodeType: "compound",
         childNodeIds: [],
         description: "",

--- a/apps/app/src/pages/CanvasPage/utils/nodeTypeMeta.ts
+++ b/apps/app/src/pages/CanvasPage/utils/nodeTypeMeta.ts
@@ -1,4 +1,36 @@
 import type { BuiltinNodeType } from "@repo/pipeline-engine/schemas";
+import type { TFunction } from "i18next";
+
+const nodeTypeI18nKeys = {
+  operation: {
+    label: "canvas.nodeTypes.operation.label",
+    shortLabel: "canvas.nodeTypes.operation.shortLabel",
+  },
+  "code-file": {
+    label: "canvas.nodeTypes.code-file.label",
+    shortLabel: "canvas.nodeTypes.code-file.shortLabel",
+  },
+  folder: {
+    label: "canvas.nodeTypes.folder.label",
+    shortLabel: "canvas.nodeTypes.folder.shortLabel",
+  },
+  "github-projects": {
+    label: "canvas.nodeTypes.github-projects.label",
+    shortLabel: "canvas.nodeTypes.github-projects.shortLabel",
+  },
+  "output-project-path": {
+    label: "canvas.nodeTypes.output-project-path.label",
+    shortLabel: "canvas.nodeTypes.output-project-path.shortLabel",
+  },
+  "output-local-path": {
+    label: "canvas.nodeTypes.output-local-path.label",
+    shortLabel: "canvas.nodeTypes.output-local-path.shortLabel",
+  },
+  compound: {
+    label: "canvas.nodeTypes.compound.label",
+    shortLabel: "canvas.nodeTypes.compound.shortLabel",
+  },
+} as const satisfies Record<BuiltinNodeType, { label: string; shortLabel: string }>;
 
 export const nodeTypeMeta = {
   operation: {
@@ -13,8 +45,8 @@ export const nodeTypeMeta = {
     plusBg: "bg-violet-100 text-violet-700 hover:bg-violet-200",
   },
   "code-file": {
-    label: "代码文件",
-    shortLabel: "文件",
+    label: "Code file",
+    shortLabel: "File",
     border: "border-orange-200",
     selectedBorder: "border-orange-500",
     header: "bg-orange-50",
@@ -24,8 +56,8 @@ export const nodeTypeMeta = {
     plusBg: "bg-orange-100 text-orange-700 hover:bg-orange-200",
   },
   folder: {
-    label: "文件夹",
-    shortLabel: "文件夹",
+    label: "Folder",
+    shortLabel: "Folder",
     border: "border-orange-200",
     selectedBorder: "border-orange-500",
     header: "bg-orange-50",
@@ -35,7 +67,7 @@ export const nodeTypeMeta = {
     plusBg: "bg-orange-100 text-orange-700 hover:bg-orange-200",
   },
   "github-projects": {
-    label: "GitHub 项目",
+    label: "GitHub project",
     shortLabel: "GitHub",
     border: "border-orange-200",
     selectedBorder: "border-orange-500",
@@ -46,8 +78,8 @@ export const nodeTypeMeta = {
     plusBg: "bg-orange-100 text-orange-700 hover:bg-orange-200",
   },
   "output-project-path": {
-    label: "项目路径输出",
-    shortLabel: "输出",
+    label: "Project output",
+    shortLabel: "Output",
     border: "border-teal-200",
     selectedBorder: "border-teal-500",
     header: "bg-teal-50",
@@ -57,8 +89,8 @@ export const nodeTypeMeta = {
     plusBg: "bg-teal-100 text-teal-700 hover:bg-teal-200",
   },
   "output-local-path": {
-    label: "本地路径输出",
-    shortLabel: "本地",
+    label: "Local output",
+    shortLabel: "Local",
     border: "border-teal-200",
     selectedBorder: "border-teal-500",
     header: "bg-teal-50",
@@ -68,8 +100,8 @@ export const nodeTypeMeta = {
     plusBg: "bg-teal-100 text-teal-700 hover:bg-teal-200",
   },
   compound: {
-    label: "复合节点",
-    shortLabel: "组",
+    label: "Compound node",
+    shortLabel: "Group",
     border: "border-indigo-200",
     selectedBorder: "border-indigo-500",
     header: "bg-indigo-50",
@@ -85,3 +117,19 @@ type NodeMetaEntry = (typeof nodeTypeMeta)[BuiltinNodeType];
 /** Safe lookup — returns meta for known types, undefined for plugin types */
 export const getNodeMeta = (type: string): NodeMetaEntry | undefined =>
   nodeTypeMeta[type as BuiltinNodeType] as NodeMetaEntry | undefined;
+
+export const getNodeTypeLabel = (t: TFunction, type: string): string => {
+  const meta = getNodeMeta(type);
+  const keys = nodeTypeI18nKeys[type as BuiltinNodeType];
+
+  return keys ? t(keys.label, { defaultValue: meta?.label ?? type }) : (meta?.label ?? type);
+};
+
+export const getNodeTypeShortLabel = (t: TFunction, type: string): string => {
+  const meta = getNodeMeta(type);
+  const keys = nodeTypeI18nKeys[type as BuiltinNodeType];
+
+  return keys
+    ? t(keys.shortLabel, { defaultValue: meta?.shortLabel ?? type })
+    : (meta?.shortLabel ?? type);
+};


### PR DESCRIPTION
Closes https://github.com/forge-town/ordine/issues/24

## Problem
Canvas UI copy was still split across hard-coded Chinese/English strings in menus, node cards, dialogs, toasts, labels, placeholders, and tooltips. Switching locales could leave mixed-language Canvas surfaces.

## Changes
- Added Canvas, Canvas node, GitHub dialog, output node, run console, history, and toast locale keys in `apps/app/src/locales/en.json` and `apps/app/src/locales/zh.json`.
- Replaced hard-coded Canvas UI copy with existing `react-i18next` patterns across Canvas menus, toolbar, quick add, node cards, GitHub dialogs, output nodes, and empty/run states.
- Added localized default node labels for newly created built-in nodes while preserving existing/user-provided node labels, operation names, recipe names, repo names, and paths as data.
- Updated Canvas unit tests that asserted old hard-coded labels.

## Main files
- `apps/app/src/locales/en.json`
- `apps/app/src/locales/zh.json`
- `apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.tsx`
- `apps/app/src/pages/CanvasPage/CanvasContextMenu/CanvasContextMenu.tsx`
- `apps/app/src/pages/CanvasPage/ConnectionMenu/ConnectionMenu.tsx`
- `apps/app/src/pages/CanvasPage/NodeContextMenu/NodeContextMenu.tsx`
- `apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx`
- `apps/app/src/pages/CanvasPage/GitHubProjectNode/*Dialog.tsx`
- `apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx`
- `apps/app/src/pages/CanvasPage/_store/actionsSlice.ts`
- `apps/app/src/pages/CanvasPage/_store/canvasSlice.ts`
- `apps/app/src/pages/CanvasPage/utils/nodeTypeMeta.ts`

## Verification
- `bun run --cwd apps/app compile` - passed
- `bun run --cwd apps/app lint` - passed
- `bun run --cwd apps/app test src/pages/CanvasPage` - passed, 24 files / 117 tests
- `bun run --cwd apps/app test` - passed, 70 files / 271 passed / 2 skipped
- `git diff --cached --check` - passed
- Forbidden error-handling scan: `rg --line-number '\btry\b\s*\{|\btry\b\s*finally|\.catch\s*\(' apps/app/src/locales/en.json apps/app/src/locales/zh.json apps/app/src/pages/CanvasPage` - no matches
- Canvas source Chinese hard-code scan excluding tests/stories - no matches

## Browser verification
Using Chrome DevTools CLI against local app at `http://localhost:9430` with a temporary local Postgres container and `BETTER_AUTH_SECRET` env:
- Registered a local test account and opened `/canvas`.
- Verified Chinese locale: floating menu, empty state, quick add palette, default code-file node label, node form labels, status bar, and toolbar labels render in Chinese.
- Switched `i18nextLng` to `en`, reloaded `/canvas`, and verified English floating menu, empty state, quick add palette, context menu, toolbar labels, and status bar.
- Checked desktop and narrow viewport top Canvas controls via bounding-box overlap script: no overlaps detected.
- Captured screenshots locally at `.omx/logs/issue-24-canvas-desktop.png` and `.omx/logs/issue-24-canvas-narrow.png`.

Closest existing Playwright e2e note: `bun run --cwd apps/app test:e2e e2e/crud.e2e.spec.ts --project=chromium` is not Canvas-specific. It was attempted and timed out in the existing `navigateAndWait(... networkidle)` fixture on authenticated routes; Canvas behavior was instead verified directly through Chrome DevTools CLI.

## Sub-agent reviews
- `code-reviewer`: APPROVE, 0 findings. Reviewed staged diff, spec compliance, diagnostics, locale key coverage, and forbidden-pattern scans.
- `security-reviewer`: LOW risk, 0 findings. Reviewed staged diff for secrets, unsafe rendering, token handling, dependency changes, and forbidden error-handling patterns. `bun audit` could not reach the audit service, but no dependency files changed.

## Copilot / reviewer comments
Before starting #24, PR #33 was checked. Copilot comments there concerned AgentPanel scroll behavior, REST JSON/body validation, and service snapshot validation; they were already replied to as fixed on that PR and are outside this localization diff. Vercel's comment was a deployment authorization notice, not a code issue.

## Remaining risk
- Import/export JSON shape validation remains an existing issue and is explicitly covered by follow-up issue #26.
- React Flow built-in control tooltips remain a known follow-up for issue #29.
