### PR TITLE
fix: normalize canvas top bar layout

### DIFF
--- a/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.tsx
@@ -125,7 +125,7 @@ export const CanvasFloatingMenu = () => {
   };
 
   return (
-    <div className="fixed left-4 top-4 z-50">
+    <div className="pointer-events-auto" data-testid="canvas-floating-menu">
       <Popover open={isOpen} onOpenChange={handleOpenChange}>
         <PopoverTrigger
           className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white shadow-md transition-all hover:bg-gray-50 hover:shadow-lg active:scale-95"

--- a/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
@@ -1,34 +1,28 @@
 import { useCallback, useRef } from "react";
-import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { useHarnessCanvasStore } from "../_store";
-import { Input } from "@repo/ui/input";
-import { CanvasToolbar } from "../CanvasToolbar";
 import { CanvasFlow } from "../CanvasFlow";
 import { CanvasContextMenu } from "../CanvasContextMenu";
 import { ConnectionMenu } from "../ConnectionMenu";
 import { NodeContextMenu } from "../NodeContextMenu";
-import { CanvasFloatingMenu } from "../CanvasFloatingMenu";
 import { RunConsole } from "../RunConsole";
 import { LlmContentCard } from "../LlmContentCard/LlmContentCard";
 import { CanvasEmptyState } from "../CanvasEmptyState";
 import { CanvasNodeCreationPalette } from "../CanvasNodeCreationPalette";
 import { CanvasStatusBar } from "../CanvasStatusBar";
+import { CanvasTopChrome } from "../CanvasTopChrome/CanvasTopChrome";
 import { getScreenViewportCenter, getViewportRectCenter } from "../utils/nodePosition";
 
 export const CanvasInner = () => {
-  const { t } = useTranslation();
   const store = useHarnessCanvasStore();
   const flowViewportRef = useRef<HTMLDivElement>(null);
 
-  const pipelineName = useStore(store, (state) => state.pipelineName);
   const contextMenu = useStore(store, (state) => state.contextMenu);
   const connectionMenu = useStore(store, (state) => state.connectionMenu);
   const nodeContextMenu = useStore(store, (state) => state.nodeContextMenu);
   const isConsoleOpen = useStore(store, (state) => state.isConsoleOpen);
   const isQuickAddOpen = useStore(store, (state) => state.isQuickAddOpen);
   const nodes = useStore(store, (state) => state.nodes);
-  const handlePipelineNameChange = useStore(store, (state) => state.handlePipelineNameChange);
 
   const getFlowViewportScreenCenter = useCallback(() => {
     const rect = flowViewportRef.current?.getBoundingClientRect();
@@ -38,22 +32,7 @@ export const CanvasInner = () => {
 
   return (
     <div className="relative h-full w-full">
-      <CanvasFloatingMenu />
-
-      <div className="pointer-events-none absolute left-16 top-4 z-40 flex w-[clamp(6rem,calc(50vw-16rem),14rem)] items-center max-[700px]:left-3 max-[700px]:top-[3.25rem] max-[700px]:w-[min(16rem,calc(100vw-1.5rem))]">
-        <div className="pointer-events-auto flex w-full min-w-0 items-center gap-2 rounded-full border border-gray-200 bg-white/90 px-3 py-1.5 shadow-sm backdrop-blur-sm">
-          <Input
-            aria-label={t("canvas.pipelineTitle")}
-            className="h-7 min-w-0 w-full border-none bg-transparent text-sm font-medium text-gray-700 shadow-none outline-none placeholder:text-gray-400"
-            name="pipelineName"
-            placeholder={t("canvas.pipelineTitlePlaceholder")}
-            value={pipelineName}
-            onChange={(e) => handlePipelineNameChange(e.target.value)}
-          />
-        </div>
-      </div>
-
-      <CanvasToolbar />
+      <CanvasTopChrome />
 
       <CanvasFlow viewportRef={flowViewportRef} />
 

--- a/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
@@ -10,7 +10,7 @@ import { LlmContentCard } from "../LlmContentCard/LlmContentCard";
 import { CanvasEmptyState } from "../CanvasEmptyState";
 import { CanvasNodeCreationPalette } from "../CanvasNodeCreationPalette";
 import { CanvasStatusBar } from "../CanvasStatusBar";
-import { CanvasTopChrome } from "../CanvasTopChrome/CanvasTopChrome";
+import { CanvasTopChrome } from "../CanvasTopChrome";
 import { getScreenViewportCenter, getViewportRectCenter } from "../utils/nodePosition";
 
 export const CanvasInner = () => {

--- a/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx
@@ -36,8 +36,8 @@ export const CanvasToolbar = () => {
   const handleRunTest = useStore(store, (state) => state.handleRunTest);
 
   return (
-    <div className="absolute left-1/2 top-3 z-10 -translate-x-1/2">
-      <div className="flex items-center gap-0.5 rounded-xl border bg-background px-1.5 py-1 shadow-md">
+    <div className="pointer-events-auto w-max max-w-full" data-testid="canvas-toolbar">
+      <div className="flex h-10 w-max items-center gap-0.5 rounded-full border bg-background px-1.5 py-1 shadow-md max-[420px]:gap-0 max-[420px]:px-1">
         {/* Zoom controls */}
         <Tooltip>
           <TooltipTrigger
@@ -158,7 +158,7 @@ export const CanvasToolbar = () => {
           <TooltipTrigger
             render={
               <Button
-                className="h-7 gap-1.5 px-2 text-xs text-green-600 hover:bg-green-50 hover:text-green-700 disabled:text-muted-foreground/30"
+                className="h-7 gap-1.5 px-2 text-xs text-green-600 hover:bg-green-50 hover:text-green-700 disabled:text-muted-foreground/30 max-[420px]:w-7 max-[420px]:gap-0 max-[420px]:px-0"
                 disabled={isRunning || !pipelineId}
                 size="sm"
                 title="运行测试"
@@ -168,7 +168,7 @@ export const CanvasToolbar = () => {
             }
           >
             <Play className="h-3.5 w-3.5" />
-            <span>{t("canvas.run")}</span>
+            <span className="max-[420px]:hidden">{t("canvas.run")}</span>
           </TooltipTrigger>
           <TooltipContent>{t("canvas.run")}</TooltipContent>
         </Tooltip>

--- a/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { HarnessCanvasStoreProvider } from "../_store";
+import { CanvasTopChrome } from "./CanvasTopChrome";
+
+const meta: Meta<typeof CanvasTopChrome> = {
+  title: "CanvasPage/CanvasTopChrome",
+  component: CanvasTopChrome,
+  decorators: [
+    (Story) => (
+      <HarnessCanvasStoreProvider
+        pipeline={{
+          id: "story-pipeline",
+          name: "Aligned canvas pipeline",
+          nodes: [],
+          edges: [],
+        }}
+      >
+        <div className="relative h-40 w-full bg-slate-50">
+          <Story />
+        </div>
+      </HarnessCanvasStoreProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CanvasTopChrome>;
+
+export const Default: Story = {};

--- a/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Meta, StoryObj } from "@storybook/react";
 import { HarnessCanvasStoreProvider } from "../_store";
 import { CanvasTopChrome } from "./CanvasTopChrome";
 

--- a/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import { Input } from "@repo/ui/input";
+import { CanvasFloatingMenu } from "../CanvasFloatingMenu";
+import { CanvasToolbar } from "../CanvasToolbar";
+import { useHarnessCanvasStore } from "../_store";
+
+export const CanvasTopChrome = () => {
+  const { t } = useTranslation();
+  const store = useHarnessCanvasStore();
+  const pipelineName = useStore(store, (state) => state.pipelineName);
+  const handlePipelineNameChange = useStore(store, (state) => state.handlePipelineNameChange);
+
+  const renderPipelineTitle = (className: string, testId: string) => (
+    <div className={className} data-testid={testId}>
+      <div className="pointer-events-auto flex h-10 w-full min-w-0 items-center rounded-full border border-gray-200 bg-white/90 px-3 shadow-sm backdrop-blur-sm">
+        <Input
+          aria-label={t("canvas.pipelineTitle")}
+          className="h-7 min-w-0 w-full border-none bg-transparent text-sm font-medium text-gray-700 shadow-none outline-none placeholder:text-gray-400"
+          name="pipelineName"
+          placeholder={t("canvas.pipelineTitlePlaceholder")}
+          value={pipelineName}
+          onChange={(e) => handlePipelineNameChange(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-3 top-3 z-50 sm:inset-x-4"
+      data-testid="canvas-top-chrome"
+    >
+      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-2 max-[420px]:grid-cols-1 min-[700px]:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] min-[700px]:gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <CanvasFloatingMenu />
+          {renderPipelineTitle(
+            "hidden min-w-0 min-[700px]:flex min-[700px]:w-[clamp(10rem,calc(50vw-17rem),18rem)]",
+            "canvas-title-desktop"
+          )}
+        </div>
+
+        <div className="pointer-events-auto max-w-full justify-self-end overflow-x-auto max-[420px]:justify-self-start max-[420px]:[scrollbar-width:none] min-[700px]:justify-self-center">
+          <CanvasToolbar />
+        </div>
+
+        <div className="hidden min-[700px]:block" />
+      </div>
+
+      {renderPipelineTitle(
+        "mt-2 flex w-full min-w-0 min-[700px]:hidden",
+        "canvas-title-narrow"
+      )}
+    </div>
+  );
+};

--- a/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
@@ -1,4 +1,5 @@
 import { render } from "@/test/test-wrapper";
+import i18n from "@/lib/i18n";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
@@ -59,7 +60,7 @@ describe("CanvasTopChrome", () => {
   it("preserves pipeline title editing", async () => {
     const user = userEvent.setup();
     const store = renderTopChrome();
-    const [desktopTitleInput] = screen.getAllByRole("textbox", { name: "Pipeline title" });
+    const [desktopTitleInput] = screen.getAllByRole("textbox", { name: i18n.t("canvas.pipelineTitle") });
 
     await user.clear(desktopTitleInput);
     await user.type(desktopTitleInput, "Aligned pipeline");

--- a/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
@@ -1,0 +1,69 @@
+import { render } from "@/test/test-wrapper";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { createHarnessCanvasStore, HarnessCanvasStoreContext } from "../_store";
+import { CanvasTopChrome } from "./CanvasTopChrome";
+
+vi.mock("../CanvasFloatingMenu", () => ({
+  CanvasFloatingMenu: () => (
+    <button className="pointer-events-auto h-10 w-10" title="菜单" type="button">
+      Menu
+    </button>
+  ),
+}));
+
+vi.mock("../CanvasToolbar", () => ({
+  CanvasToolbar: () => <div data-testid="canvas-toolbar">Toolbar</div>,
+}));
+
+const renderTopChrome = () => {
+  const store = createHarnessCanvasStore([], []);
+
+  render(
+    <HarnessCanvasStoreContext.Provider value={store}>
+      <CanvasTopChrome />
+    </HarnessCanvasStoreContext.Provider>
+  );
+
+  return store;
+};
+
+describe("CanvasTopChrome", () => {
+  it("uses one top chrome coordinate system for menu, title, and toolbar", () => {
+    renderTopChrome();
+
+    expect(screen.getByTestId("canvas-top-chrome")).toHaveClass(
+      "absolute",
+      "top-3",
+      "z-50",
+      "pointer-events-none"
+    );
+    const toolbarSlot = screen.getByTestId("canvas-toolbar").parentElement;
+    expect(toolbarSlot).not.toBeNull();
+    expect(toolbarSlot as HTMLElement).toHaveClass(
+      "max-w-full",
+      "overflow-x-auto",
+      "max-[420px]:justify-self-start"
+    );
+    expect(screen.getByTestId("canvas-title-desktop")).toHaveClass(
+      "hidden",
+      "min-[700px]:flex"
+    );
+    expect(screen.getByTestId("canvas-title-narrow")).toHaveClass(
+      "mt-2",
+      "min-[700px]:hidden"
+    );
+  });
+
+  it("preserves pipeline title editing", async () => {
+    const user = userEvent.setup();
+    const store = renderTopChrome();
+    const [desktopTitleInput] = screen.getAllByRole("textbox", { name: "Pipeline title" });
+
+    await user.clear(desktopTitleInput);
+    await user.type(desktopTitleInput, "Aligned pipeline");
+
+    expect(store.getState().pipelineName).toBe("Aligned pipeline");
+  });
+});

--- a/apps/app/src/pages/CanvasPage/CanvasTopChrome/index.ts
+++ b/apps/app/src/pages/CanvasPage/CanvasTopChrome/index.ts
@@ -1,0 +1,1 @@
+export * from "./CanvasTopChrome";


### PR DESCRIPTION
Refs https://github.com/forge-town/ordine/issues/28

## 问题

Canvas 汉堡菜单、pipeline 标题和居中工具栏各自独立定位。高度、顶部偏移、z-index 和窄屏行为可能逐渐发散。

## 变更

- 新增 `CanvasTopChrome` 组合层，统一管理菜单、pipeline 标题和工具栏的定位。
- 规范化 Canvas 顶部 chrome 的 top offset、高度、间距和 z-index。
- 将菜单和工具栏从独立的 fixed/absolute 定位中移出。
- 保留 pipeline 标题编辑和现有工具栏操作行为。
- 新增 Storybook story 和单元测试覆盖顶部 chrome 布局和标题编辑。
- 新增 `<=420px` 堆叠布局，防止极窄 CSS 视口下菜单和工具栏重叠。

## 主要文件

- `apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.tsx`
- `apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx`
- `apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.stories.tsx`
- `apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx`
- `apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.tsx`
- `apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx`

## 验证

- `bun run --cwd apps/app compile` — 通过
- `bun run --cwd apps/app lint` — 通过
- `bun run --cwd apps/app test src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.unit.test.tsx src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.unit.test.tsx` — 18 测试通过
- `bun run --cwd apps/app test src/pages/CanvasPage` — 25 文件 / 119 测试通过
- `bun run --cwd apps/app test` — 71 文件 / 273 通过 / 2 跳过
- LSP 诊断：0 错误
- 禁止模式扫描：无新增 `try-catch`、`try-finally`、`.catch()`

## 浏览器验证

Chrome DevTools CLI 验证本地 `http://localhost:9430/canvas`：
- 桌面 1440x900：菜单、标题和工具栏共享一致的顶行；无重叠；`pageOverflowX` 0。
- 窄屏 390x844：菜单、工具栏和标题堆叠不重叠；`pageOverflowX` 0。
- 极窄 360x800：菜单 rect `12,12-52,52`、工具栏 rect `12,60-309,100`、标题 rect `12,108-348,148`；所有重叠检查 false；`pageOverflowX` 0。
- Pipeline 标题编辑正常工作。
- 工具栏缩放按钮和 quick-add 操作保持可点击。

## 截图

Desktop before:
![Desktop before](https://raw.githubusercontent.com/woodfishhhh/ordine/pr-assets/issue-28/pr-screenshots/issue28/before-desktop.png)

Desktop after:
![Desktop after](https://raw.githubusercontent.com/woodfishhhh/ordine/pr-assets/issue-28/pr-screenshots/issue28/after-desktop.png)

Narrow before:
![Narrow before](https://raw.githubusercontent.com/woodfishhhh/ordine/pr-assets/issue-28/pr-screenshots/issue28/before-narrow.png)

Narrow after:
![Narrow after](https://raw.githubusercontent.com/woodfishhhh/ordine/pr-assets/issue-28/pr-screenshots/issue28/after-narrow.png)

## 评审

- **code-reviewer**：初始 MEDIUM 发现（`<370px` 重叠风险），已通过 `max-[420px]` 堆叠布局 + 工具栏 containment 修复；复评 APPROVE，0 发现项。
- **security-reviewer**：LOW 风险，0 阻塞发现项。

## Copilot 修复记录

- CanvasTopChrome.unit.test.tsx：使用 `i18n.t("canvas.pipelineTitle")` 查询 aria-label，消除 locale 依赖
- 新增 `CanvasTopChrome/index.ts` barrel export，匹配组件目录既有约定
- CanvasInner.tsx：导入路径从 `../CanvasTopChrome/CanvasTopChrome` 简化为 `../CanvasTopChrome`
