### PR TITLE
Add Hermes agent runtime

### DIFF
--- a/apps/app/src/integrations/trpc/routers/settings.ts
+++ b/apps/app/src/integrations/trpc/routers/settings.ts
@@ -1,10 +1,10 @@
 import { z } from "zod/v4";
 import { publicProcedure, router } from "../init";
 import { settingsService } from "../services";
-import { AgentRuntimeSchema } from "@repo/schemas";
+import { DefaultAgentRuntimeSchema } from "@repo/schemas";
 
 const UpdateSettingsSchema = z.object({
-  defaultAgentRuntime: AgentRuntimeSchema.optional(),
+  defaultAgentRuntime: DefaultAgentRuntimeSchema.optional(),
   defaultApiKey: z.string().optional(),
   defaultModel: z.string().optional(),
   defaultOutputPath: z.string().optional(),

--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -825,6 +825,7 @@
       "runtimeSelectLabel": "Select Agent Runtime",
       "defaultRuntime": "Default",
       "defaultAgent": "Default",
+      "agentIncompatible": "incompatible",
       "inspectLlmOutput": "View LLM output",
       "loopEnabled": "Loop enabled",
       "enableLoop": "Enable loop",

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -825,6 +825,7 @@
       "runtimeSelectLabel": "选择 Agent Runtime",
       "defaultRuntime": "默认",
       "defaultAgent": "默认",
+      "agentIncompatible": "不兼容",
       "inspectLlmOutput": "点击查看 LLM 输出",
       "loopEnabled": "循环已开启",
       "enableLoop": "开启循环",

--- a/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
@@ -1,5 +1,5 @@
 import { Zap, CheckCircle2, XCircle, Loader2, Circle, Brain, Repeat } from "lucide-react";
-import { type SyntheticEvent } from "react";
+import { type ElementType, type SyntheticEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@repo/ui/lib/utils";
 import {
@@ -24,10 +24,7 @@ export interface OperationNodeProps {
   selected?: boolean;
 }
 
-const statusConfig: Record<
-  NodeRunStatus,
-  { icon: React.ElementType; color: string; labelKey: string }
-> = {
+const statusConfig: Record<NodeRunStatus, { icon: ElementType; color: string; labelKey: string }> = {
   idle: {
     icon: Circle,
     color: "text-gray-400",
@@ -110,11 +107,21 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
   const statusLabel = t(labelKey);
 
   const operation = operations.find((op: Operation) => op.id === data.operationId);
+  const executor = operation?.config.executor;
+  const effectiveAgentMode =
+    executor?.type === "agent" ? (executor.agentMode ?? "prompt") : undefined;
+  const isSkillOperation = effectiveAgentMode === "skill";
+  const selectableAgents = isSkillOperation
+    ? agents.filter((agent) => agent.defaultRuntime !== "hermes")
+    : agents;
 
   const selectedAgentId = data.agentId ?? "";
-  const selectedAgentLabel = selectedAgentId
-    ? (agents.find((a) => a.id === selectedAgentId)?.name ?? selectedAgentId)
-    : t("nodes.operation.defaultAgent");
+  const selectedAgent = agents.find((agent) => agent.id === selectedAgentId);
+  const isAgentIncompatible =
+    isSkillOperation && !!selectedAgent && selectedAgent.defaultRuntime === "hermes";
+  const selectedAgentLabel = isAgentIncompatible
+    ? `${selectedAgent.name} (${t("nodes.operation.agentIncompatible")})`
+    : (selectedAgentId ? (selectedAgent?.name ?? selectedAgentId) : t("nodes.operation.defaultAgent"));
 
   const hasLlmContent = !!nodeLlmContent[id];
   const canInspect = isTestRunning || hasLlmContent;
@@ -132,6 +139,9 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
   const handleAgentTriggerClick = (event: SyntheticEvent) => {
     stopCanvasInteraction(event);
     handleOperationAgentDropdownToggle(id);
+  };
+  const handleAgentChange = (agentId: string | null) => {
+    handleOperationAgentChange(id, agentId);
   };
   const handleLoopButtonClick = (event: SyntheticEvent) => {
     stopCanvasInteraction(event);
@@ -182,7 +192,6 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
         theme="violet"
         onLabelChange={handleOperationLabelChange.bind(null, id)}
       >
-        {/* Config display (read-only summary) */}
         {data.config && Object.keys(data.config).length > 0 && (
           <div className="space-y-1">
             <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
@@ -197,7 +206,6 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
           </div>
         )}
 
-        {/* Accepted object types */}
         {operation?.acceptedObjectTypes && (
           <div className="space-y-1">
             <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
@@ -216,7 +224,6 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
           </div>
         )}
 
-        {/* Agent selector */}
         <div className="nodrag nopan space-y-1.5" {...canvasInteractionHandlers}>
           <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
             <Brain className="mr-1 inline-block h-3 w-3" />
@@ -226,7 +233,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
             open={agentOpen}
             value={selectedAgentId || "__default__"}
             onOpenChange={handleOperationAgentDropdownOpenChange.bind(null, id)}
-            onValueChange={handleOperationAgentChange.bind(null, id)}
+            onValueChange={handleAgentChange}
           >
             <SelectTrigger
               aria-label={t("nodes.operation.agent")}
@@ -244,7 +251,12 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
               <SelectGroup>
                 <SelectLabel>{t("nodes.operation.agent")}</SelectLabel>
                 <SelectItem value="__default__">{t("nodes.operation.defaultAgent")}</SelectItem>
-                {agents.map((agent) => (
+                {isAgentIncompatible && (
+                  <SelectItem disabled value={selectedAgentId}>
+                    {selectedAgent.name} ({t("nodes.operation.agentIncompatible")})
+                  </SelectItem>
+                )}
+                {selectableAgents.map((agent) => (
                   <SelectItem key={agent.id} value={agent.id}>
                     {agent.name}
                   </SelectItem>
@@ -261,7 +273,6 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
           </div>
         )}
 
-        {/* Loop / Retry settings */}
         <div className="nodrag nopan space-y-1.5" {...canvasInteractionHandlers}>
           <button
             className={cn(

--- a/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.unit.test.tsx
@@ -20,7 +20,10 @@ vi.mock("@refinedev/core", () => ({
     if (resource === "agents") {
       return {
         result: {
-          data: [{ id: "agent-claude", name: "Claude" }],
+          data: [
+            { id: "agent-claude", name: "Claude", defaultRuntime: "claude-code" },
+            { id: "agent-hermes", name: "Hermes", defaultRuntime: "hermes" },
+          ],
         },
       };
     }
@@ -33,6 +36,7 @@ vi.mock("@refinedev/core", () => ({
             name: "Review Code",
             description: "Review code with an agent",
             acceptedObjectTypes: ["file", "project"],
+            config: { executor: { type: "agent", agentMode: "skill", skillId: "review-code" } },
           },
         ],
       },
@@ -128,6 +132,36 @@ describe("OperationNode", () => {
       });
     });
     expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it("shows stale Hermes selection as incompatible rather than hiding it", async () => {
+    const user = userEvent.setup();
+    const staleData: OperationNodeData = { ...baseData, agentId: "agent-hermes" };
+    const store = renderOperationNode(staleData);
+
+    const trigger = screen.getByRole("combobox", { name: "Agent" });
+    expect(trigger).toHaveTextContent(/Hermes/);
+
+    await user.click(trigger);
+
+    const hermesOption = await screen.findByRole("option", { name: /Hermes/ });
+    expect(hermesOption).toHaveAttribute("aria-disabled", "true");
+
+    await user.click(await screen.findByRole("option", { name: "默认" }));
+
+    await waitFor(() => {
+      expect(store.getState().nodes[0]?.data).toMatchObject({ agentId: undefined });
+    });
+  });
+
+  it("hides Hermes-backed agents for skill operations", async () => {
+    const user = userEvent.setup();
+    renderOperationNode();
+
+    await user.click(screen.getByRole("combobox", { name: "Agent" }));
+
+    expect(await screen.findByRole("option", { name: "Claude" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Hermes" })).not.toBeInTheDocument();
   });
 
   it("updates loop settings without bubbling canvas interactions", async () => {

--- a/apps/app/src/pages/DistillationStudioPage/DistillationForm.tsx
+++ b/apps/app/src/pages/DistillationStudioPage/DistillationForm.tsx
@@ -382,9 +382,11 @@ export const DistillationForm = () => {
                       </FormControl>
                       <SelectContent>
                         <SelectGroup>
-                          <SelectItem value="mastra">mastra</SelectItem>
-                          <SelectItem value="codex">codex</SelectItem>
-                          <SelectItem value="claude-code">claude-code</SelectItem>
+                          {AgentRuntimeSchema.options.map((agent) => (
+                            <SelectItem key={agent} value={agent}>
+                              {agent}
+                            </SelectItem>
+                          ))}
                         </SelectGroup>
                       </SelectContent>
                     </Select>

--- a/apps/app/src/pages/RuntimesPage/RuntimeIcon/RuntimeIcon.tsx
+++ b/apps/app/src/pages/RuntimesPage/RuntimeIcon/RuntimeIcon.tsx
@@ -1,9 +1,10 @@
-import { Bot, Flame, Globe, Cpu, Server } from "lucide-react";
+import { Bot, Flame, Globe, Cpu, Server, Sparkles } from "lucide-react";
 import { cn } from "@repo/ui/lib/utils";
 
 const ICON_MAP: Record<string, { icon: typeof Bot; color: string }> = {
   "claude-code": { icon: Flame, color: "text-orange-500" },
   codex: { icon: Globe, color: "text-emerald-500" },
+  hermes: { icon: Sparkles, color: "text-cyan-500" },
   openclaw: { icon: Bot, color: "text-rose-500" },
   mastra: { icon: Cpu, color: "text-violet-500" },
 };

--- a/apps/app/src/pages/SettingsPage/sections/DeveloperSection/DeveloperSection.tsx
+++ b/apps/app/src/pages/SettingsPage/sections/DeveloperSection/DeveloperSection.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useOne, useUpdate } from "@refinedev/core";
 import { Input } from "@repo/ui/input";
-import { AgentRuntimeSchema, type AgentRuntime, type Settings } from "@repo/schemas";
+import { DefaultAgentRuntimeSchema, type DefaultAgentRuntime, type Settings } from "@repo/schemas";
 import {
   Select,
   SelectContent,
@@ -15,7 +15,7 @@ import { Field } from "../../Field";
 import { SaveButton } from "../../SaveButton";
 import { SectionHeader } from "../../SectionHeader";
 
-const AGENT_RUNTIME_OPTIONS = AgentRuntimeSchema.options;
+const AGENT_RUNTIME_OPTIONS = DefaultAgentRuntimeSchema.options;
 
 export const DeveloperSection = () => {
   const { t } = useTranslation();
@@ -24,7 +24,7 @@ export const DeveloperSection = () => {
     id: "default",
   });
   const { mutateAsync: updateSettings } = useUpdate();
-  const [defaultAgentRuntime, setDefaultAgentRuntime] = useState<AgentRuntime | null>(null);
+  const [defaultAgentRuntime, setDefaultAgentRuntime] = useState<DefaultAgentRuntime | null>(null);
   const [defaultOutputPath, setDefaultOutputPath] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
@@ -32,7 +32,7 @@ export const DeveloperSection = () => {
     defaultAgentRuntime ?? settingsResult?.defaultAgentRuntime ?? AGENT_RUNTIME_OPTIONS[0];
   const currentPath = defaultOutputPath ?? settingsResult?.defaultOutputPath ?? "";
 
-  const handleAgentRuntimeChange = useCallback((value: AgentRuntime | null) => {
+  const handleAgentRuntimeChange = useCallback((value: DefaultAgentRuntime | null) => {
     if (!value) return;
 
     setDefaultAgentRuntime(value);

--- a/apps/cli/src/daemon.ts
+++ b/apps/cli/src/daemon.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { ResultAsync } from "neverthrow";
 import { api } from "./api";
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
@@ -16,8 +17,24 @@ interface DetectedRuntime {
 const RUNTIME_BINARIES: Record<string, string> = {
   "claude-code": "claude",
   codex: "codex",
+  hermes: "hermes",
   mastra: "mastra",
   openclaw: "openclaw",
+};
+
+const LOCATE_BINARY_COMMAND = process.platform === "win32" ? "where.exe" : "which";
+
+const firstPath = (stdout: string): string | undefined => {
+  const paths = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (process.platform === "win32") {
+    return paths.find((line) => line.toLowerCase().endsWith(".exe")) ?? paths[0];
+  }
+
+  return paths[0];
 };
 
 const execFileAsync = (bin: string, args: string[]): Promise<{ stdout: string; stderr: string }> =>
@@ -36,14 +53,20 @@ const detectBinary = async (
   type: string,
   binaryName: string,
 ): Promise<DetectedRuntime | undefined> => {
-  const whichResult = await execFileAsync("which", [binaryName]).catch(() => undefined);
-  if (!whichResult) return undefined;
+  const whichResult = await ResultAsync.fromPromise(
+    execFileAsync(LOCATE_BINARY_COMMAND, [binaryName]),
+    () => undefined as never,
+  );
+  if (whichResult.isErr()) return undefined;
 
-  const path = whichResult.stdout.trim();
+  const path = firstPath(whichResult.value.stdout);
   if (!path) return undefined;
 
-  const versionResult = await execFileAsync(path, ["--version"]).catch(() => undefined);
-  const version = versionResult?.stdout.trim() || undefined;
+  const versionResult = await ResultAsync.fromPromise(
+    execFileAsync(path, ["--version"]),
+    () => undefined as never,
+  );
+  const version = versionResult.isOk() ? versionResult.value.stdout.trim() || undefined : undefined;
 
   return {
     id: `local-${type}`,

--- a/packages/agent-engine/src/agentEngine.ts
+++ b/packages/agent-engine/src/agentEngine.ts
@@ -1,6 +1,7 @@
 import {
   runClaude,
   runCodex,
+  runHermes,
   runMastra,
   runOpenclaw,
   type ClaudeStreamEvent,
@@ -87,6 +88,23 @@ const runMastraDirect = async (opts: AgentRunOptions): Promise<AgentRunResult> =
 
 type DriverFn = (opts: AgentRunOptions) => Promise<AgentRunResult>;
 
+const runHermesDirect = async (opts: AgentRunOptions): Promise<AgentRunResult> => {
+  const result = await runHermes({
+    systemPrompt: opts.systemPrompt,
+    userPrompt: opts.userPrompt,
+    cwd: opts.cwd,
+    model: opts.model,
+    allowedTools: opts.allowedTools,
+    onProgress: toAsyncProgress(opts.onProgress),
+  });
+
+  if (result.isErr()) {
+    return Promise.reject(result.error);
+  }
+
+  return { text: result.value, events: [] };
+};
+
 const runOpenclawDirect = async (opts: AgentRunOptions): Promise<AgentRunResult> => {
   const result = await runOpenclaw({
     systemPrompt: opts.systemPrompt,
@@ -101,6 +119,7 @@ const runOpenclawDirect = async (opts: AgentRunOptions): Promise<AgentRunResult>
 const DRIVERS: Record<AgentRuntime, DriverFn> = {
   "claude-code": runLocalClaudeDirect,
   codex: runCodexDirect,
+  hermes: runHermesDirect,
   mastra: runMastraDirect,
   openclaw: runOpenclawDirect,
 };

--- a/packages/agent-engine/src/agentEngine.unit.test.ts
+++ b/packages/agent-engine/src/agentEngine.unit.test.ts
@@ -20,6 +20,21 @@ vi.mock("@repo/agent", () => ({
     await opts.onProgress?.("progress");
     return "fake codex output";
   }),
+  runHermes: vi.fn(async (opts: { onProgress?: (s: string) => Promise<void> }) => {
+    await opts.onProgress?.("progress");
+    return {
+      isErr: () => false,
+      value: "fake hermes output",
+    };
+  }),
+  runMastra: vi.fn(async (opts: { onProgress?: (s: string) => Promise<void> }) => {
+    await opts.onProgress?.("progress");
+    return { text: "fake mastra output", events: [] };
+  }),
+  runOpenclaw: vi.fn(async (opts: { onProgress?: (s: string) => Promise<void> }) => {
+    await opts.onProgress?.("progress");
+    return { text: "fake openclaw output" };
+  }),
 }));
 
 vi.mock("@repo/obs", () => ({
@@ -31,6 +46,7 @@ vi.mock("@repo/logger", () => ({
 }));
 
 import { agentEngine } from "./agentEngine";
+import { runHermes } from "@repo/agent";
 import { recordAgentRunWithSpans } from "@repo/obs";
 
 describe("agentEngine", () => {
@@ -63,6 +79,30 @@ describe("agentEngine", () => {
 
     expect(result.text).toBe("fake codex output");
     expect(result.events).toEqual([]);
+  });
+
+  it("dispatches to runHermes for hermes", async () => {
+    const result = await agentEngine.run({
+      agent: "hermes",
+      mode: "direct",
+      systemPrompt: "Analyze this",
+      userPrompt: "Hello",
+      cwd: "/tmp/test",
+      model: "nous-hermes-4",
+      allowedTools: ["WebSearch"],
+    });
+
+    expect(result.text).toBe("fake hermes output");
+    expect(result.events).toEqual([]);
+    expect(runHermes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: "/tmp/test",
+        model: "nous-hermes-4",
+        allowedTools: ["WebSearch"],
+        systemPrompt: "Analyze this",
+        userPrompt: "Hello",
+      }),
+    );
   });
 
   it("throws for unsupported agent backend", async () => {
@@ -118,6 +158,44 @@ describe("agentEngine", () => {
       }),
       expect.any(Function),
     );
+  });
+
+  it("records hermes observability with empty event spans", async () => {
+    await agentEngine.run({
+      agent: "hermes",
+      mode: "direct",
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+      jobId: "job-1",
+      agentId: "hermes-agent",
+    });
+
+    expect(recordAgentRunWithSpans).toHaveBeenCalledOnce();
+    expect(recordAgentRunWithSpans).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-1",
+        agentRuntime: "hermes",
+        agentId: "hermes-agent",
+        rawPayload: expect.objectContaining({
+          system: "sys",
+          prompt: "user",
+          output: "fake hermes output",
+        }),
+      }),
+      expect.any(Function),
+    );
+
+    const buildSpans = vi.mocked(recordAgentRunWithSpans).mock.calls[0]![1];
+    expect(buildSpans(123)).toEqual([
+      expect.objectContaining({
+        rawExportId: 123,
+        spanType: "agent_run",
+        name: "hermes-agent",
+        output: "fake hermes output",
+        status: "completed",
+      }),
+    ]);
   });
 
   it("skips observability when jobId or agentId is missing", async () => {

--- a/packages/agent/src/hermes/index.ts
+++ b/packages/agent/src/hermes/index.ts
@@ -1,0 +1,1 @@
+export * from "./runHermes";

--- a/packages/agent/src/hermes/runHermes.ts
+++ b/packages/agent/src/hermes/runHermes.ts
@@ -1,0 +1,145 @@
+import { execFile } from "node:child_process";
+import { logger } from "@repo/logger";
+import { err, errAsync, ok, ResultAsync, type Result } from "neverthrow";
+
+export interface RunHermesOptions {
+  systemPrompt: string;
+  userPrompt: string;
+  cwd: string;
+  model?: string;
+  allowedTools?: readonly string[];
+  timeoutMs?: number;
+  onProgress?: (line: string) => Promise<void> | void;
+}
+
+const HERMES_BIN = "hermes";
+export const MAX_HERMES_PROMPT_ARG_CHARS = 20_000;
+const HERMES_SAFE_TOOLSETS = ["safe"] as const;
+const HERMES_SAFE_TOOL_NAMES = ["WebSearch", "WebFetch"] as const;
+const HERMES_SAFE_TOOL_NAME_SET = new Set<string>(HERMES_SAFE_TOOL_NAMES);
+
+const buildPrompt = (systemPrompt: string, userPrompt: string): string => {
+  if (!systemPrompt) {
+    return userPrompt;
+  }
+
+  return `${systemPrompt}\n\n${userPrompt}`;
+};
+
+const buildToolsetArgs = (allowedTools: readonly string[] = []): Result<string[], Error> => {
+  if (allowedTools.length === 0) {
+    return ok([]);
+  }
+
+  const unsupportedTools = allowedTools.filter((tool) => !HERMES_SAFE_TOOL_NAME_SET.has(tool));
+  if (unsupportedTools.length > 0) {
+    return err(
+      new Error(
+        `Hermes cannot safely honor local tool permissions: ${unsupportedTools.join(", ")}`,
+      ),
+    );
+  }
+
+  const missingSafeTools = HERMES_SAFE_TOOL_NAMES.filter((tool) => !allowedTools.includes(tool));
+  if (missingSafeTools.length > 0) {
+    return err(
+      new Error(
+        `Hermes cannot safely enable a partial safe toolset; missing permissions: ${missingSafeTools.join(", ")}`,
+      ),
+    );
+  }
+
+  return ok(["--toolsets", HERMES_SAFE_TOOLSETS.join(",")]);
+};
+
+const execHermes = ({
+  args,
+  cwd,
+  timeoutMs,
+  onProgress,
+}: {
+  args: string[];
+  cwd: string;
+  timeoutMs: number;
+  onProgress?: RunHermesOptions["onProgress"];
+}): Promise<Result<string, Error>> =>
+  new Promise((resolve) => {
+    execFile(
+      HERMES_BIN,
+      args,
+      {
+        cwd,
+        timeout: timeoutMs,
+        maxBuffer: 10 * 1024 * 1024,
+        env: { ...process.env },
+      },
+      (error, stdout, stderr) => {
+        const text = String(stdout);
+        const stderrText = String(stderr).trim();
+
+        if (error) {
+          const code = error.code ?? "UNKNOWN";
+          const diagnostic = stderrText || error.message;
+          const errMsg = `hermes exited with code ${code}: ${diagnostic}`;
+          logger.error({ code, stderr: stderrText.slice(0, 500) }, "runHermes: non-zero exit");
+          void onProgress?.(`[Hermes] Error: ${errMsg.slice(0, 200)}`);
+          resolve(err(new Error(errMsg)));
+
+          return;
+        }
+
+        if (text.trim().length === 0) {
+          logger.error({ stderr: stderrText.slice(0, 500) }, "runHermes: empty output");
+          void onProgress?.("[Hermes] Empty output");
+          resolve(err(new Error("hermes returned empty output")));
+
+          return;
+        }
+
+        logger.info({ len: text.length }, "runHermes: complete");
+        void onProgress?.(`[Hermes] Complete (${text.length} chars)`);
+        resolve(ok(text));
+      },
+    );
+  });
+
+export const runHermes = ({
+  systemPrompt,
+  userPrompt,
+  cwd,
+  model,
+  allowedTools,
+  timeoutMs = 10 * 60 * 1000,
+  onProgress,
+}: RunHermesOptions): ResultAsync<string, Error> => {
+  const prompt = buildPrompt(systemPrompt, userPrompt);
+  if (prompt.length > MAX_HERMES_PROMPT_ARG_CHARS) {
+    return errAsync(
+      new Error(
+        `Hermes prompt is too large for CLI argument mode: ${prompt.length} chars (max ${MAX_HERMES_PROMPT_ARG_CHARS})`,
+      ),
+    );
+  }
+
+  const toolsetArgs = buildToolsetArgs(allowedTools);
+  if (toolsetArgs.isErr()) {
+    return errAsync(toolsetArgs.error);
+  }
+
+  const args = ["-z", prompt, ...toolsetArgs.value];
+
+  if (model) {
+    args.push("--model", model);
+  }
+
+  logger.info({ cwd, model }, "runHermes: starting");
+  const startProgress = ResultAsync.fromSafePromise(
+    Promise.resolve(onProgress?.(`[Hermes] Starting hermes -z (cwd=${cwd})...`)),
+  );
+
+  return startProgress.andThen(() =>
+    ResultAsync.fromSafePromise(execHermes({ args, cwd, timeoutMs, onProgress })).andThen(
+      (result) => result,
+    ),
+  );
+};

--- a/packages/agent/src/hermes/runHermes.unit.test.ts
+++ b/packages/agent/src/hermes/runHermes.unit.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@repo/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+type ExecFileCallback = (
+  error: { code?: string | number; message: string } | null,
+  stdout: string,
+  stderr: string,
+) => void;
+
+const execFileMock =
+  vi.fn<
+    (bin: string, args: string[], opts: Record<string, unknown>, cb: ExecFileCallback) => void
+  >();
+
+vi.mock("node:child_process", () => ({
+  execFile: (bin: string, args: string[], opts: Record<string, unknown>, cb: ExecFileCallback) =>
+    execFileMock(bin, args, opts, cb),
+}));
+
+import { MAX_HERMES_PROMPT_ARG_CHARS, runHermes, type RunHermesOptions } from "./runHermes";
+
+describe("runHermes", () => {
+  beforeEach(() => {
+    execFileMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls hermes -z with combined prompt, cwd, timeout, and model", async () => {
+    execFileMock.mockImplementation((_bin, _args, _opts, cb) => {
+      cb(null, "Hermes output", "");
+    });
+
+    const opts: RunHermesOptions = {
+      systemPrompt: "You are precise",
+      userPrompt: "Analyze this",
+      cwd: "/tmp/test",
+      model: "nous-hermes-4",
+      allowedTools: ["WebSearch", "WebFetch"],
+      timeoutMs: 1234,
+    };
+
+    const result = await runHermes(opts);
+
+    expect(result.isOk()).toBe(true);
+    expect(execFileMock).toHaveBeenCalledOnce();
+    const [bin, args, execOpts] = execFileMock.mock.calls[0]!;
+    expect(bin).toBe("hermes");
+    expect(args[0]).toBe("-z");
+    expect(args[1]).toContain("You are precise");
+    expect(args[1]).toContain("Analyze this");
+    expect(args).toContain("--toolsets");
+    expect(args).toContain("safe");
+    expect(args).toContain("--model");
+    expect(args).toContain("nous-hermes-4");
+    expect(execOpts.cwd).toBe("/tmp/test");
+    expect(execOpts.timeout).toBe(1234);
+  });
+
+  it("does not enable Hermes toolsets when no tools are allowed", async () => {
+    execFileMock.mockImplementation((_bin, _args, _opts, cb) => {
+      cb(null, "Hermes output", "");
+    });
+
+    const result = await runHermes({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+      allowedTools: [],
+    });
+
+    expect(result.isOk()).toBe(true);
+    const [, args] = execFileMock.mock.calls[0]!;
+    expect(args).not.toContain("--toolsets");
+    expect(args).not.toContain("safe");
+  });
+
+  it("returns an error when prompts exceed the Hermes CLI argument limit", async () => {
+    const result = await runHermes({
+      systemPrompt: "",
+      userPrompt: "x".repeat(MAX_HERMES_PROMPT_ARG_CHARS + 1),
+      cwd: "/tmp",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toMatch(/too large/);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an error for local tool allowlists because Hermes cannot enforce them safely", async () => {
+    const result = await runHermes({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+      allowedTools: ["Read"],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(/cannot safely honor local tool permissions/);
+    }
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an error for partial safe tool allowlists because Hermes only exposes the full safe toolset", async () => {
+    const result = await runHermes({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+      allowedTools: ["WebSearch"],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toMatch(/partial safe toolset/);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("returns stdout text on success", async () => {
+    execFileMock.mockImplementation((_bin, _args, _opts, cb) => {
+      cb(null, "final stdout", "");
+    });
+
+    const result = await runHermes({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBe("final stdout");
+  });
+
+  it("reports progress", async () => {
+    execFileMock.mockImplementation((_bin, _args, _opts, cb) => {
+      cb(null, "done", "");
+    });
+
+    const progress: string[] = [];
+    const result = await runHermes({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+      onProgress: async (line) => {
+        progress.push(line);
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(progress).toEqual([
+      "[Hermes] Starting hermes -z (cwd=/tmp)...",
+      "[Hermes] Complete (4 chars)",
+    ]);
+  });
+
+  it("rejects on non-zero exit code", async () => {
+    execFileMock.mockImplementation((_bin, _args, _opts, cb) => {
+      cb({ code: 2, message: "exit code 2" }, "", "bad config");
+    });
+
+    const result = await runHermes({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toMatch(/hermes exited with code 2/);
+  });
+
+  it("falls back to error message when stderr is empty", async () => {
+    execFileMock.mockImplementation((_bin, _args, _opts, cb) => {
+      cb({ code: 2, message: "spawn failed" }, "", "");
+    });
+
+    const result = await runHermes({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("hermes exited with code 2: spawn failed");
+    }
+  });
+
+  it("returns an error for empty stdout", async () => {
+    execFileMock.mockImplementation((_bin, _args, _opts, cb) => {
+      cb(null, "   ", "");
+    });
+
+    const result = await runHermes({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toMatch(/empty output/);
+  });
+});

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./schemas";
 export * from "./claude";
 export * from "./codex";
+export * from "./hermes";
 export * from "./mastra";
 export * from "./openclaw";
 export * from "./providers";

--- a/packages/agent/src/scan/scanRuntimes.ts
+++ b/packages/agent/src/scan/scanRuntimes.ts
@@ -12,8 +12,30 @@ export interface DetectedRuntime {
 const RUNTIME_BINARIES: Record<string, string> = {
   "claude-code": "claude",
   codex: "codex",
+  hermes: "hermes",
   mastra: "mastra",
   openclaw: "openclaw",
+};
+
+type RuntimeScanPlatform = typeof process.platform;
+
+export const locateBinaryCommand = (platform: RuntimeScanPlatform = process.platform): string =>
+  platform === "win32" ? "where.exe" : "which";
+
+export const firstPath = (
+  stdout: string,
+  platform: RuntimeScanPlatform = process.platform,
+): string | undefined => {
+  const paths = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (platform === "win32") {
+    return paths.find((line) => line.toLowerCase().endsWith(".exe")) ?? paths[0];
+  }
+
+  return paths[0];
 };
 
 const execFileAsync = (bin: string, args: string[]): Promise<{ stdout: string; stderr: string }> =>
@@ -33,7 +55,7 @@ const detectBinary = async (
   binaryName: string,
 ): Promise<DetectedRuntime | undefined> => {
   const whichResult = await ResultAsync.fromPromise(
-    execFileAsync("which", [binaryName]),
+    execFileAsync(locateBinaryCommand(), [binaryName]),
     () => undefined as never,
   );
 
@@ -41,7 +63,11 @@ const detectBinary = async (
     return undefined;
   }
 
-  const path = whichResult.value.stdout.trim();
+  const path = firstPath(whichResult.value.stdout);
+  if (!path) {
+    return undefined;
+  }
+
   logger.info(`Found runtime ${type} at ${path}`);
 
   const versionResult = await ResultAsync.fromPromise(

--- a/packages/agent/src/scan/scanRuntimes.unit.test.ts
+++ b/packages/agent/src/scan/scanRuntimes.unit.test.ts
@@ -20,7 +20,9 @@ vi.mock("node:child_process", () => ({
     execFileMock(bin, args, opts, cb),
 }));
 
-import { scanRuntimes, type DetectedRuntime } from "./scanRuntimes";
+import { firstPath, locateBinaryCommand, scanRuntimes, type DetectedRuntime } from "./scanRuntimes";
+
+const LOCATE_BIN = locateBinaryCommand();
 
 describe("scanRuntimes", () => {
   beforeEach(() => {
@@ -33,7 +35,7 @@ describe("scanRuntimes", () => {
 
   it("detects a runtime when which succeeds and version succeeds", async () => {
     execFileMock.mockImplementation((bin, args, _opts, cb) => {
-      if (bin === "which") {
+      if (bin === LOCATE_BIN) {
         cb(null, "/usr/local/bin/claude\n", "");
       } else if (args[0] === "--version") {
         cb(null, "claude 1.2.3\n", "");
@@ -52,7 +54,7 @@ describe("scanRuntimes", () => {
 
   it("detects a runtime when which succeeds but version fails", async () => {
     execFileMock.mockImplementation((bin, _args, _opts, cb) => {
-      if (bin === "which") {
+      if (bin === LOCATE_BIN) {
         cb(null, "/usr/local/bin/codex\n", "");
       } else {
         cb({ message: "version failed", code: 1 }, "", "");
@@ -79,7 +81,7 @@ describe("scanRuntimes", () => {
 
   it("returns all detected runtimes", async () => {
     execFileMock.mockImplementation((bin, args, _opts, cb) => {
-      if (bin === "which") {
+      if (bin === LOCATE_BIN) {
         cb(null, `/usr/local/bin/${args[0]}\n`, "");
       } else {
         cb(null, "v1.0.0\n", "");
@@ -88,18 +90,59 @@ describe("scanRuntimes", () => {
 
     const results = await scanRuntimes();
 
-    expect(results.length).toBeGreaterThanOrEqual(4);
+    expect(results.length).toBeGreaterThanOrEqual(5);
     const types = results.map((r) => r.type);
 
     expect(types).toContain("claude-code");
     expect(types).toContain("codex");
     expect(types).toContain("mastra");
     expect(types).toContain("openclaw");
+    expect(types).toContain("hermes");
+  });
+
+  it("detects hermes when the binary exists", async () => {
+    execFileMock.mockImplementation((bin, args, _opts, cb) => {
+      if (bin === LOCATE_BIN && args[0] === "hermes") {
+        cb(null, "/usr/local/bin/hermes\n", "");
+
+        return;
+      }
+
+      if (bin === "/usr/local/bin/hermes") {
+        cb(null, "hermes 0.1.0\n", "");
+
+        return;
+      }
+
+      cb({ message: "not found", code: 1 }, "", "");
+    });
+
+    const results = await scanRuntimes();
+    const hermes = results.find((r) => r.type === "hermes");
+
+    expect(hermes).toEqual({
+      type: "hermes",
+      binaryName: "hermes",
+      path: "/usr/local/bin/hermes",
+      version: "hermes 0.1.0",
+    } satisfies DetectedRuntime);
+  });
+
+  it("prefers exe paths when Windows where returns multiple matches", () => {
+    const path = firstPath("C:\\bin\\hermes.cmd\r\nC:\\bin\\hermes.exe\r\n", "win32");
+
+    expect(path).toBe("C:\\bin\\hermes.exe");
+  });
+
+  it("uses the first locate result on non-Windows platforms", () => {
+    const path = firstPath("C:\\bin\\hermes.cmd\r\nC:\\bin\\hermes.exe\r\n", "linux");
+
+    expect(path).toBe("C:\\bin\\hermes.cmd");
   });
 
   it("each detected runtime has correct shape", async () => {
     execFileMock.mockImplementation((bin, args, _opts, cb) => {
-      if (bin === "which") {
+      if (bin === LOCATE_BIN) {
         cb(null, `/usr/bin/${args[0]}\n`, "");
       } else {
         cb(null, "2.0.0\n", "");

--- a/packages/db-schema/src/tables/agent_raw_exports_table.ts
+++ b/packages/db-schema/src/tables/agent_raw_exports_table.ts
@@ -1,6 +1,6 @@
 import { sql } from "drizzle-orm";
 import { text, timestamp, pgTable, index, serial, integer, jsonb } from "drizzle-orm/pg-core";
-import type { AgentRuntime, AgentRunStatus } from "@repo/schemas";
+import type { AgentRunStatus, AgentRuntime } from "@repo/schemas";
 import { jobsTable } from "./jobs_table";
 
 export const agentRawExportsTable = pgTable(

--- a/packages/db-schema/src/tables/settings_table.ts
+++ b/packages/db-schema/src/tables/settings_table.ts
@@ -1,10 +1,10 @@
 import { text, pgTable, timestamp } from "drizzle-orm/pg-core";
-import type { AgentRuntime } from "@repo/schemas";
+import type { DefaultAgentRuntime } from "@repo/schemas";
 
 export const settingsTable = pgTable("settings", {
   id: text("id").primaryKey().default("default"),
   defaultAgentRuntime: text("default_agent_runtime")
-    .$type<AgentRuntime>()
+    .$type<DefaultAgentRuntime>()
     .notNull()
     .default("mastra"),
   defaultApiKey: text("default_api_key").notNull().default(""),

--- a/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.test.ts
+++ b/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.test.ts
@@ -306,6 +306,52 @@ describe("executeOperationNode — agent override", () => {
     expect(deps.runSkill).toHaveBeenCalledWith(expect.objectContaining({ agent: "claude-code" }));
   });
 
+  it("blocks Hermes for skill operations because local tool permissions cannot be preserved", async () => {
+    const deps = makeDeps();
+    const op = makeOperation({
+      type: "agent",
+      agentMode: "skill",
+      skillId: "sk-1",
+      agent: "claude-code",
+    });
+    const ops = new Map([["op-id", op]]);
+    const node = makeNode({ operationId: "op-id", agentRuntime: "hermes" });
+    const ctx = makeCtx(deps, ops);
+
+    const result = await executeOperationNode(node, makeInput(), ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error?.message).toContain("Hermes is not available");
+    expect(deps.runSkill).not.toHaveBeenCalled();
+    expect(trace).toHaveBeenCalledWith(
+      "job-1",
+      expect.stringContaining("Hermes is not available for skill operation"),
+    );
+  });
+
+  it("propagates Hermes skill failures instead of marking the node done", async () => {
+    const deps = makeDeps();
+    const op = makeOperation({
+      type: "agent",
+      agentMode: "skill",
+      skillId: "sk-1",
+      agent: "claude-code",
+    });
+    const ops = new Map([["op-id", op]]);
+    const node = makeNode({ operationId: "op-id", agentRuntime: "hermes" });
+    const ctx = makeCtx(deps, ops, { node });
+
+    const result = await processOperationNode(node, makeInput(), ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).not.toBeNull();
+      expect(result.error?.message).toContain("Hermes is not available");
+    }
+    expect(ctx.nodeOutputs.has("op-1")).toBe(false);
+    expect(trace).not.toHaveBeenCalledWith("job-1", "@@NODE_DONE::op-1");
+  });
+
   it("falls back to executor.agent when agentRuntime is not set", async () => {
     const deps = makeDeps();
     const op = makeOperation({

--- a/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.ts
+++ b/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.ts
@@ -163,6 +163,18 @@ export const executeOperationNode = async (
     const skillDescription = skill
       ? `${skill.label}: ${skill.description}`
       : `Skill "${skillId}" (no description available)`;
+    const agent = agentOverride ?? executor.agent;
+
+    if (agent === "hermes") {
+      const message = `Hermes is not available for skill operation "${operation.name}" because skills require local tool permissions`;
+      await trace(
+        jobId,
+        `WARNING: ${message}`,
+      );
+      await trace(jobId, `@@NODE_FAIL::${node.id}`);
+
+      return { ok: false, error: new ScriptExecutionError(message) };
+    }
 
     await trace(jobId, `Running skill "${skillId}"${skill ? ` (${skill.label})` : ""}...`);
     const skillResult = await deps.runSkill({
@@ -171,7 +183,7 @@ export const executeOperationNode = async (
       systemPrompt: executor.systemPrompt,
       inputContent: effectiveInput,
       inputPath: input.inputPath,
-      agent: agentOverride ?? executor.agent,
+      agent,
       allowedTools: executor.allowedTools,
       onChunk: handleChunk,
       onProgress,

--- a/packages/schemas/src/agent-runtime/AgentRuntimeSchema.ts
+++ b/packages/schemas/src/agent-runtime/AgentRuntimeSchema.ts
@@ -3,8 +3,18 @@ import { z } from "zod/v4";
 export const AGENT_RUNTIME_ENUM = {
   CLAUDE_CODE: "claude-code",
   CODEX: "codex",
+  HERMES: "hermes",
   MASTRA: "mastra",
   OPENCLAW: "openclaw",
 } as const;
 export const AgentRuntimeSchema = z.enum(AGENT_RUNTIME_ENUM);
 export type AgentRuntime = z.infer<typeof AgentRuntimeSchema>;
+
+export const DEFAULT_AGENT_RUNTIME_ENUM = {
+  CLAUDE_CODE: AGENT_RUNTIME_ENUM.CLAUDE_CODE,
+  CODEX: AGENT_RUNTIME_ENUM.CODEX,
+  MASTRA: AGENT_RUNTIME_ENUM.MASTRA,
+  OPENCLAW: AGENT_RUNTIME_ENUM.OPENCLAW,
+} as const;
+export const DefaultAgentRuntimeSchema = z.enum(DEFAULT_AGENT_RUNTIME_ENUM);
+export type DefaultAgentRuntime = z.infer<typeof DefaultAgentRuntimeSchema>;

--- a/packages/schemas/src/settings/SettingsSchema.ts
+++ b/packages/schemas/src/settings/SettingsSchema.ts
@@ -1,10 +1,10 @@
 import { z } from "zod/v4";
-import { AgentRuntimeSchema } from "../agent-runtime/AgentRuntimeSchema";
+import { DefaultAgentRuntimeSchema } from "../agent-runtime/AgentRuntimeSchema";
 import { MetaSchema } from "../meta";
 
 export const SettingsSchema = z.object({
   id: z.string(),
-  defaultAgentRuntime: AgentRuntimeSchema,
+  defaultAgentRuntime: DefaultAgentRuntimeSchema,
   defaultApiKey: z.string(),
   defaultModel: z.string(),
   defaultOutputPath: z.string(),

--- a/packages/services/src/settingsService/createSettingsService.unit.test.ts
+++ b/packages/services/src/settingsService/createSettingsService.unit.test.ts
@@ -60,4 +60,19 @@ describe("createSettingsService", () => {
 
     expect(result.defaultAgentRuntime).toBe("mastra");
   });
+
+  it("normalizes Hermes out of workspace default runtime", async () => {
+    mockDao.get.mockResolvedValueOnce({
+      defaultAgentRuntime: "hermes",
+      defaultApiKey: "key",
+      defaultModel: "kimi-for-coding/k2p6",
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    });
+
+    const svc = createSettingsService({} as never);
+    const result = await svc.get();
+
+    expect(result.defaultAgentRuntime).toBe("mastra");
+  });
 });

--- a/packages/services/src/settingsService/normalizeSettingsRecord.ts
+++ b/packages/services/src/settingsService/normalizeSettingsRecord.ts
@@ -1,13 +1,17 @@
-import { AgentRuntimeSchema } from "@repo/schemas";
+import { DefaultAgentRuntimeSchema } from "@repo/schemas";
 
 const DEFAULT_AGENT_RUNTIME = "mastra";
 
-export const normalizeSettingsRecord = <T extends { defaultAgentRuntime: unknown }>(
-  record: T
+export const normalizeSettingsRecord = <
+  T extends { defaultAgentRuntime: unknown },
+>(
+  record: T,
 ): Omit<T, "defaultAgentRuntime"> & {
-  defaultAgentRuntime: (typeof AgentRuntimeSchema.options)[number];
+  defaultAgentRuntime: (typeof DefaultAgentRuntimeSchema.options)[number];
 } => {
-  const parsedAgentRuntime = AgentRuntimeSchema.safeParse(record.defaultAgentRuntime);
+  const parsedAgentRuntime = DefaultAgentRuntimeSchema.safeParse(
+    record.defaultAgentRuntime,
+  );
 
   return {
     ...record,


### PR DESCRIPTION
## Summary
- Add Hermes as a first-class agent runtime using `hermes -z`
- Wire runtime scanning, agent-engine dispatch, observability, and UI labels/icons
- Add Windows runtime discovery fallback via `where.exe` and prefer `.exe` paths

Closes #47

## Verification
- `bunx vitest run src/scan/scanRuntimes.unit.test.ts src/hermes/runHermes.unit.test.ts` in `packages/agent`
- `bun run test src/agentEngine.unit.test.ts` in `packages/agent-engine`
- `bun --filter=@repo/agent run check-types`
- `bun --filter=@repo/agent-engine run check-types`
- `bun --filter=@ordine/cli run check-types`
- `bun --filter=@repo/schemas run check-types`
- `bun --filter=@repo/db-schema run check-types`

## Known unrelated local failure
- `bun run compile` in `apps/app` currently fails on existing Vite 7.3.2 vs 6.4.2 plugin type mismatch in `vitest.config.ts`.