### PR TITLE
feat(canvas): add Langflow-style workspace layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,10 @@ output
 
 # Local agent/context files
 AGENTS.md
+MEMORY.md
+Start-Ordine.cmd
+scripts/windows/
+.worktrees/
 
 # Local browser/test artifacts
 .playwright-cli/

--- a/apps/app/.storybook/preview.tsx
+++ b/apps/app/.storybook/preview.tsx
@@ -7,7 +7,8 @@ import {
   RouterContextProvider,
 } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ToastStoreProvider } from "../src/store/toastProvider";
+import { ToastStoreProvider } from "../src/store/toastStore/toastProvider";
+import "@xyflow/react/dist/style.css";
 import "../src/lib/i18n";
 import "../src/styles.css";
 

--- a/apps/app/e2e/canvas.e2e.spec.ts
+++ b/apps/app/e2e/canvas.e2e.spec.ts
@@ -1,0 +1,65 @@
+import { expect, type Page } from "@playwright/test";
+import { test, navigateAndWait, expectNoJSErrors } from "./fixtures";
+
+const openCanvasPage = async (page: Page) => {
+  await navigateAndWait(page, "/pipelines");
+
+  const firstCanvasLink = page.locator("a[href*='/canvas?id=']").first();
+  if ((await firstCanvasLink.count()) > 0) {
+    await firstCanvasLink.click();
+    await page.waitForURL(/\/canvas\?id=/);
+    await page.waitForLoadState("networkidle");
+
+    return;
+  }
+
+  const createButton = page.locator("button:has(svg.lucide-plus)").first();
+  if ((await createButton.count()) === 0) {
+    test.skip(true, "No saved pipeline link or create button found");
+
+    return;
+  }
+
+  await createButton.click();
+  await page.waitForURL(/\/canvas\?id=/);
+  await page.waitForLoadState("networkidle");
+};
+
+test.describe("Canvas editor", () => {
+  test("supports the LangFlow shell workflow", async ({ page, pageErrors }) => {
+    await openCanvasPage(page);
+
+    await expect(page.getByTestId("canvas-mini-sidebar")).toBeVisible();
+    await expect(page.getByTestId("canvas-component-panel")).toBeVisible();
+    await expect(page.getByTestId("canvas-flow-viewport")).toBeVisible();
+    await expect(page.getByTestId("canvas-status-bar")).toContainText(/\d+/);
+
+    await page.keyboard.press("/");
+    const searchInput = page.getByRole("textbox", { name: /Search components/i });
+    await expect(searchInput).toBeFocused();
+    await searchInput.fill("file");
+
+    const fileButton = page
+      .getByTestId("canvas-component-panel")
+      .getByRole("button", { name: /File/i })
+      .first();
+    if ((await fileButton.count()) === 0) {
+      test.skip(true, "File component entry not found");
+
+      return;
+    }
+
+    await fileButton.click();
+    const firstNode = page.locator(".react-flow__node").first();
+    await expect(firstNode).toBeVisible();
+    await expect(page.locator("[data-card-mode='compact']").first()).toBeVisible();
+
+    await firstNode.click();
+    await expect(page.getByTestId("canvas-properties-panel")).toBeVisible();
+
+    await page.getByRole("button", { name: /Workspace/i }).click();
+    await expect(page.getByTestId("canvas-workspace-sidebar-overlay")).toBeVisible();
+
+    expectNoJSErrors(pageErrors);
+  });
+});

--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -1016,7 +1016,7 @@
     "barrelExport": "Barrel Export",
     "barrelExportDesc": "Generate and check index.ts barrel export files, ensuring all index files only do re-export.",
     "errorHandling": "Error Handling",
-    "errorHandlingDesc": "Standardize try-catch usage, ensuring catch blocks have substantive handling logic, not empty or just logging.",
+    "errorHandlingDesc": "Standardize neverthrow-based error handling, keeping errors explicit and eliminating try-catch from application code.",
     "dbNaming": "Database Table Naming",
     "dbNamingDesc": "Verify and correct database table definition naming standards, including table names, column names and indexes.",
     "svgIcon": "SVG Icon Standards",
@@ -1079,3 +1079,4 @@
     }
   }
 }
+

--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -389,6 +389,60 @@
         "description": "Align dragged nodes to the canvas grid."
       }
     },
+    "workspaceSidebar": {
+      "title": "Workspace"
+    },
+    "nodeCardMode": {
+      "compact": "Compact cards",
+      "expanded": "Expanded cards"
+    },
+    "componentPanel": {
+      "searchLabel": "Search components",
+      "searchPlaceholder": "Search components...",
+      "categoryAriaLabel": "{{label}} category",
+      "skillFallbackLabel": "Skill",
+      "newCustomOperation": "New Custom Operation",
+      "categories": {
+        "input": "Input Objects",
+        "operations": "Operations",
+        "skills": "Skills",
+        "output": "Output"
+      }
+    },
+    "propertiesPanel": {
+      "empty": "Select a canvas node to configure it.",
+      "backToComponents": "Back to components",
+      "fields": {
+        "label": "Label",
+        "filePath": "File path",
+        "language": "Language",
+        "description": "Description",
+        "folderPath": "Folder path",
+        "owner": "Owner",
+        "repository": "Repository",
+        "branch": "Branch",
+        "localPath": "Local path",
+        "prompt": "Prompt",
+        "operationName": "Operation name",
+        "agentId": "Agent ID",
+        "maxLoopCount": "Max loop count",
+        "loopCondition": "Loop condition",
+        "projectId": "Project ID",
+        "outputPath": "Output path",
+        "outputFileName": "Output file name",
+        "writeMode": "Write mode"
+      },
+      "placeholders": {
+        "filePath": "src/file.tsx",
+        "language": "typescript",
+        "folderPath": "src/components"
+      },
+      "outputMode": {
+        "overwrite": "Overwrite",
+        "errorIfExists": "Error if exists",
+        "autoRename": "Auto rename"
+      }
+    },
     "collapseSidebar": "Collapse sidebar",
     "expandSidebar": "Expand sidebar",
     "nodeLibrary": "Node Library",

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -1016,7 +1016,7 @@
     "barrelExport": "桶导出规范",
     "barrelExportDesc": "生成和检查 index.ts 桶导出文件，确保所有 index 文件仅做 re-export。",
     "errorHandling": "错误处理",
-    "errorHandlingDesc": "规范化 try-catch 写法，确保 catch 块有实质处理逻辑，不为空或仅记录日志。",
+    "errorHandlingDesc": "规范 neverthrow 式错误处理，保持错误显式传递，并在应用代码中消除 try-catch。",
     "dbNaming": "数据库表命名",
     "dbNamingDesc": "验证和修正数据库表定义的命名规范，包括表名、列名和索引。",
     "svgIcon": "SVG 图标规范",
@@ -1074,3 +1074,4 @@
     }
   }
 }
+

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -389,6 +389,60 @@
         "description": "拖动节点时对齐到画布网格。"
       }
     },
+    "workspaceSidebar": {
+      "title": "工作区"
+    },
+    "nodeCardMode": {
+      "compact": "紧凑卡片",
+      "expanded": "展开卡片"
+    },
+    "componentPanel": {
+      "searchLabel": "搜索组件",
+      "searchPlaceholder": "搜索组件...",
+      "categoryAriaLabel": "{{label}} 分类",
+      "skillFallbackLabel": "技能",
+      "newCustomOperation": "新建自定义 Operation",
+      "categories": {
+        "input": "输入对象",
+        "operations": "Operation",
+        "skills": "技能",
+        "output": "输出"
+      }
+    },
+    "propertiesPanel": {
+      "empty": "选择一个画布节点来配置它。",
+      "backToComponents": "返回组件列表",
+      "fields": {
+        "label": "标题",
+        "filePath": "文件路径",
+        "language": "语言",
+        "description": "描述",
+        "folderPath": "文件夹路径",
+        "owner": "所有者",
+        "repository": "仓库",
+        "branch": "分支",
+        "localPath": "本地路径",
+        "prompt": "提示词",
+        "operationName": "Operation 名称",
+        "agentId": "Agent ID",
+        "maxLoopCount": "最大循环次数",
+        "loopCondition": "循环条件",
+        "projectId": "Project ID",
+        "outputPath": "输出路径",
+        "outputFileName": "输出文件名",
+        "writeMode": "写入模式"
+      },
+      "placeholders": {
+        "filePath": "src/file.tsx",
+        "language": "typescript",
+        "folderPath": "src/components"
+      },
+      "outputMode": {
+        "overwrite": "覆盖",
+        "errorIfExists": "存在时报错",
+        "autoRename": "自动重命名"
+      }
+    },
     "collapseSidebar": "收起侧栏",
     "expandSidebar": "展开侧栏",
     "nodeLibrary": "节点库",

--- a/apps/app/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type DragEvent, type ElementType } from "react";
+import { useRef, useState, type DragEvent, type ElementType } from "react";
 import { Link } from "@tanstack/react-router";
 import { useList } from "@refinedev/core";
 import type { BuiltinNodeType, Operation, Skill } from "@repo/schemas";
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
+import { useHotkeys } from "react-hotkeys-hook";
 import type { XYPosition } from "@xyflow/system";
 import { Badge } from "@repo/ui/badge";
 import { Button } from "@repo/ui/button";
@@ -30,14 +31,26 @@ import {
   encodeCanvasComponentDragPayload,
   type CanvasComponentDragPayload,
 } from "../utils/canvasComponentDragPayload";
-import { getNodeMeta, getNodeTypeLabel, getNodeTypeShortLabel } from "../utils/nodeTypeMeta";
+import {
+  getNodeMeta,
+  getNodeTypeLabel,
+  getNodeTypeShortLabel,
+} from "../utils/nodeTypeMeta";
 
 interface CanvasComponentPanelProps {
   getCreateNodeScreenPosition: () => XYPosition;
 }
 
-const INPUT_NODE_TYPES: BuiltinNodeType[] = ["folder", "file", "github-project", "prompt"];
-const OUTPUT_NODE_TYPES: BuiltinNodeType[] = ["output-local-path", "output-project-path"];
+const INPUT_NODE_TYPES: BuiltinNodeType[] = [
+  "folder",
+  "file",
+  "github-project",
+  "prompt",
+];
+const OUTPUT_NODE_TYPES: BuiltinNodeType[] = [
+  "output-local-path",
+  "output-project-path",
+];
 
 const TYPE_ICONS: Record<string, ElementType> = {
   file: FileCode,
@@ -50,14 +63,10 @@ const TYPE_ICONS: Record<string, ElementType> = {
 
 const normalizeSearch = (value: string) => value.trim().toLowerCase();
 
-const includesSearch = (values: Array<string | null | undefined>, query: string) =>
-  values.some((value) => value?.toLowerCase().includes(query));
-
-const shouldHandleSlashShortcut = (target: EventTarget | null) => {
-  if (!(target instanceof HTMLElement)) return true;
-
-  return !["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName) && !target.isContentEditable;
-};
+const includesSearch = (
+  values: Array<string | null | undefined>,
+  query: string,
+) => values.some((value) => value?.toLowerCase().includes(query));
 
 const createDragImage = ({
   iconBg,
@@ -93,38 +102,65 @@ export const CanvasComponentPanel = ({
 }: CanvasComponentPanelProps) => {
   const { t } = useTranslation();
   const searchInputRef = useRef<HTMLInputElement | null>(null);
-  const [draggingComponentId, setDraggingComponentId] = useState<string | null>(null);
+  const [draggingComponentId, setDraggingComponentId] = useState<string | null>(
+    null,
+  );
   const store = useCanvasPageStore();
-  const componentSearchQuery = useStore(store, (state) => state.componentSearchQuery);
+  const componentSearchQuery = useStore(
+    store,
+    (state) => state.componentSearchQuery,
+  );
   const collapsedComponentCategories = useStore(
     store,
     (state) => state.collapsedComponentCategories,
   );
-  const handleComponentSearchChange = useStore(store, (state) => state.handleComponentSearchChange);
-  const toggleComponentCategory = useStore(store, (state) => state.toggleComponentCategory);
-  const handleCreateObjectNode = useStore(store, (state) => state.handleCreateObjectNode);
-  const handleCreateOperationNode = useStore(store, (state) => state.handleCreateOperationNode);
+  const handleComponentSearchChange = useStore(
+    store,
+    (state) => state.handleComponentSearchChange,
+  );
+  const toggleComponentCategory = useStore(
+    store,
+    (state) => state.toggleComponentCategory,
+  );
+  const handleCreateObjectNode = useStore(
+    store,
+    (state) => state.handleCreateObjectNode,
+  );
+  const handleCreateOperationNode = useStore(
+    store,
+    (state) => state.handleCreateOperationNode,
+  );
   const handleCreateSkillOperationNode = useStore(
     store,
     (state) => state.handleCreateSkillOperationNode,
   );
-  const { result: operationsResult } = useList<Operation>({ resource: ResourceName.operations });
-  const { result: skillsResult } = useList<Skill>({ resource: ResourceName.skills });
+  const { result: operationsResult } = useList<Operation>({
+    resource: ResourceName.operations,
+  });
+  const { result: skillsResult } = useList<Skill>({
+    resource: ResourceName.skills,
+  });
   const operations = operationsResult.data;
   const skills = skillsResult.data;
   const search = normalizeSearch(componentSearchQuery);
   const componentSearchLabel = t("canvas.componentPanel.searchLabel", {
     defaultValue: "Search components",
   });
-  const componentSearchPlaceholder = t("canvas.componentPanel.searchPlaceholder", {
-    defaultValue: "Search components...",
-  });
+  const componentSearchPlaceholder = t(
+    "canvas.componentPanel.searchPlaceholder",
+    {
+      defaultValue: "Search components...",
+    },
+  );
   const inputCategoryLabel = t("canvas.componentPanel.categories.input", {
     defaultValue: "Input Objects",
   });
-  const operationsCategoryLabel = t("canvas.componentPanel.categories.operations", {
-    defaultValue: "Operations",
-  });
+  const operationsCategoryLabel = t(
+    "canvas.componentPanel.categories.operations",
+    {
+      defaultValue: "Operations",
+    },
+  );
   const skillsCategoryLabel = t("canvas.componentPanel.categories.skills", {
     defaultValue: "Skills",
   });
@@ -135,25 +171,25 @@ export const CanvasComponentPanel = ({
   const skillFallbackLabel = t("canvas.componentPanel.skillFallbackLabel", {
     defaultValue: "Skill",
   });
-  const newCustomOperationLabel = t("canvas.componentPanel.newCustomOperation", {
-    defaultValue: "New Custom Operation",
-  });
+  const newCustomOperationLabel = t(
+    "canvas.componentPanel.newCustomOperation",
+    {
+      defaultValue: "New Custom Operation",
+    },
+  );
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "/" || !shouldHandleSlashShortcut(event.target)) return;
-      event.preventDefault();
+  useHotkeys(
+    "/",
+    () => {
       searchInputRef.current?.focus();
+    },
+    { preventDefault: true },
+  );
+
+  const handleCategoryHeaderClick =
+    (category: CanvasComponentCategory) => () => {
+      toggleComponentCategory(category);
     };
-
-    globalThis.addEventListener("keydown", handleKeyDown);
-
-    return () => globalThis.removeEventListener("keydown", handleKeyDown);
-  }, []);
-
-  const handleCategoryHeaderClick = (category: CanvasComponentCategory) => () => {
-    toggleComponentCategory(category);
-  };
 
   const handleNodeTypeItemClick = (type: BuiltinNodeType) => () => {
     handleCreateObjectNode(type, getCreateNodeScreenPosition());
@@ -204,7 +240,10 @@ export const CanvasComponentPanel = ({
     const label = getNodeTypeLabel(t, type);
     const shortLabel = getNodeTypeShortLabel(t, type);
 
-    return search === "" || includesSearch([label, shortLabel, meta?.label, type], search);
+    return (
+      search === "" ||
+      includesSearch([label, shortLabel, meta?.label, type], search)
+    );
   });
 
   const outputItems = OUTPUT_NODE_TYPES.filter((type) => {
@@ -212,19 +251,28 @@ export const CanvasComponentPanel = ({
     const label = getNodeTypeLabel(t, type);
     const shortLabel = getNodeTypeShortLabel(t, type);
 
-    return search === "" || includesSearch([label, shortLabel, meta?.label, type], search);
+    return (
+      search === "" ||
+      includesSearch([label, shortLabel, meta?.label, type], search)
+    );
   });
 
   const operationItems = operations.filter((operation) =>
     search === ""
       ? true
-      : includesSearch([operation.name, operation.description, "operation"], search),
+      : includesSearch(
+          [operation.name, operation.description, "operation"],
+          search,
+        ),
   );
 
   const skillItems = skills.filter((skill) =>
     search === ""
       ? true
-      : includesSearch([skill.name, skill.label, skill.description, ...skill.tags], search),
+      : includesSearch(
+          [skill.name, skill.label, skill.description, ...skill.tags],
+          search,
+        ),
   );
 
   const renderCategoryHeader = (
@@ -245,8 +293,7 @@ export const CanvasComponentPanel = ({
         className="h-9 w-full justify-start gap-2 rounded-none border-t px-5 text-sm font-semibold"
         type="button"
         variant="ghost"
-        onClick={handleCategoryHeaderClick(category)}
-      >
+        onClick={handleCategoryHeaderClick(category)}>
         <ChevronIcon className="size-3.5" />
         <span className="flex-1 text-left">{label}</span>
         <span className="text-xs text-muted-foreground">{count}</span>
@@ -279,14 +326,17 @@ export const CanvasComponentPanel = ({
           label,
           payload: { kind: "object", type },
           shortLabel,
-        })}
-      >
+        })}>
         <span
-          className={cn("flex size-6 shrink-0 items-center justify-center rounded", meta.iconBg)}
-        >
+          className={cn(
+            "flex size-6 shrink-0 items-center justify-center rounded",
+            meta.iconBg,
+          )}>
           <Icon className="size-3.5 text-white" />
         </span>
-        <span className="min-w-0 flex-1 truncate text-sm font-medium">{label}</span>
+        <span className="min-w-0 flex-1 truncate text-sm font-medium">
+          {label}
+        </span>
         <span className="text-xs text-muted-foreground">{shortLabel}</span>
         <Plus className="size-3 text-muted-foreground" />
       </Button>
@@ -296,8 +346,7 @@ export const CanvasComponentPanel = ({
   return (
     <div
       className="flex h-full min-h-0 flex-col bg-background"
-      data-testid="canvas-component-panel"
-    >
+      data-testid="canvas-component-panel">
       <div className="border-b p-4">
         <div className="flex h-10 items-center gap-2 rounded-md border bg-muted/30 px-3">
           <Search className="size-4 text-muted-foreground" />
@@ -319,10 +368,16 @@ export const CanvasComponentPanel = ({
       <div className="min-h-0 flex-1 overflow-y-auto">
         {renderCategoryHeader("input", inputCategoryLabel, objectItems.length)}
         {!collapsedComponentCategories.input && (
-          <div className="space-y-1 p-3">{objectItems.map(renderNodeTypeItem)}</div>
+          <div className="space-y-1 p-3">
+            {objectItems.map(renderNodeTypeItem)}
+          </div>
         )}
 
-        {renderCategoryHeader("operations", operationsCategoryLabel, operationItems.length)}
+        {renderCategoryHeader(
+          "operations",
+          operationsCategoryLabel,
+          operationItems.length,
+        )}
         {!collapsedComponentCategories.operations && (
           <div className="space-y-1 p-3">
             {operationItems.map((operation) => (
@@ -331,7 +386,8 @@ export const CanvasComponentPanel = ({
                 draggable
                 className={cn(
                   "h-10 w-full cursor-grab justify-start gap-2 rounded-md px-2 text-left transition-[opacity,transform,background-color] active:cursor-grabbing",
-                  draggingComponentId === operation.id && "scale-[0.98] opacity-60",
+                  draggingComponentId === operation.id &&
+                    "scale-[0.98] opacity-60",
                 )}
                 type="button"
                 variant="ghost"
@@ -343,8 +399,7 @@ export const CanvasComponentPanel = ({
                   label: operation.name,
                   payload: { kind: "operation", operation },
                   shortLabel: operationShortLabel,
-                })}
-              >
+                })}>
                 <span className="flex size-6 shrink-0 items-center justify-center rounded bg-violet-500">
                   <Zap className="size-3.5 text-white" />
                 </span>
@@ -378,14 +433,18 @@ export const CanvasComponentPanel = ({
                   label: skill.label,
                   payload: { kind: "skill", skill },
                   shortLabel: skill.tags[0] ?? skillFallbackLabel,
-                })}
-              >
+                })}>
                 <span className="flex size-6 shrink-0 items-center justify-center rounded bg-amber-500">
                   <Sparkles className="size-3.5 text-white" />
                 </span>
-                <span className="min-w-0 flex-1 truncate text-sm font-medium">{skill.label}</span>
+                <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                  {skill.label}
+                </span>
                 {skill.tags.slice(0, 1).map((tag) => (
-                  <Badge key={tag} className="shrink-0 text-[10px]" variant="secondary">
+                  <Badge
+                    key={tag}
+                    className="shrink-0 text-[10px]"
+                    variant="secondary">
                     {tag}
                   </Badge>
                 ))}
@@ -394,17 +453,22 @@ export const CanvasComponentPanel = ({
           </div>
         )}
 
-        {renderCategoryHeader("output", outputCategoryLabel, outputItems.length)}
+        {renderCategoryHeader(
+          "output",
+          outputCategoryLabel,
+          outputItems.length,
+        )}
         {!collapsedComponentCategories.output && (
-          <div className="space-y-1 p-3">{outputItems.map(renderNodeTypeItem)}</div>
+          <div className="space-y-1 p-3">
+            {outputItems.map(renderNodeTypeItem)}
+          </div>
         )}
       </div>
 
       <div className="border-t p-3">
         <Link
           className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted"
-          to="/pipelines/operations/new"
-        >
+          to="/pipelines/operations/new">
           <Plus className="size-4" />
           {newCustomOperationLabel}
         </Link>
@@ -412,3 +476,4 @@ export const CanvasComponentPanel = ({
     </div>
   );
 };
+

--- a/apps/app/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.tsx
@@ -113,6 +113,31 @@ export const CanvasComponentPanel = ({
   const operations = operationsResult.data;
   const skills = skillsResult.data;
   const search = normalizeSearch(componentSearchQuery);
+  const componentSearchLabel = t("canvas.componentPanel.searchLabel", {
+    defaultValue: "Search components",
+  });
+  const componentSearchPlaceholder = t("canvas.componentPanel.searchPlaceholder", {
+    defaultValue: "Search components...",
+  });
+  const inputCategoryLabel = t("canvas.componentPanel.categories.input", {
+    defaultValue: "Input Objects",
+  });
+  const operationsCategoryLabel = t("canvas.componentPanel.categories.operations", {
+    defaultValue: "Operations",
+  });
+  const skillsCategoryLabel = t("canvas.componentPanel.categories.skills", {
+    defaultValue: "Skills",
+  });
+  const outputCategoryLabel = t("canvas.componentPanel.categories.output", {
+    defaultValue: "Output",
+  });
+  const operationShortLabel = t("canvas.nodeTypes.operation.shortLabel");
+  const skillFallbackLabel = t("canvas.componentPanel.skillFallbackLabel", {
+    defaultValue: "Skill",
+  });
+  const newCustomOperationLabel = t("canvas.componentPanel.newCustomOperation", {
+    defaultValue: "New Custom Operation",
+  });
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -213,7 +238,10 @@ export const CanvasComponentPanel = ({
     return (
       <Button
         aria-expanded={!collapsed}
-        aria-label={`${label} category`}
+        aria-label={t("canvas.componentPanel.categoryAriaLabel", {
+          label,
+          defaultValue: "{{label}} category",
+        })}
         className="h-9 w-full justify-start gap-2 rounded-none border-t px-5 text-sm font-semibold"
         type="button"
         variant="ghost"
@@ -275,10 +303,10 @@ export const CanvasComponentPanel = ({
           <Search className="size-4 text-muted-foreground" />
           <Input
             ref={searchInputRef}
-            aria-label="Search components"
+            aria-label={componentSearchLabel}
             className="h-8 border-none bg-transparent px-0 shadow-none focus-visible:ring-0"
             name="canvasComponentSearch"
-            placeholder="Search components..."
+            placeholder={componentSearchPlaceholder}
             value={componentSearchQuery}
             onChange={handleComponentSearchChange}
           />
@@ -289,12 +317,12 @@ export const CanvasComponentPanel = ({
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {renderCategoryHeader("input", "Input Objects", objectItems.length)}
+        {renderCategoryHeader("input", inputCategoryLabel, objectItems.length)}
         {!collapsedComponentCategories.input && (
           <div className="space-y-1 p-3">{objectItems.map(renderNodeTypeItem)}</div>
         )}
 
-        {renderCategoryHeader("operations", "Operations", operationItems.length)}
+        {renderCategoryHeader("operations", operationsCategoryLabel, operationItems.length)}
         {!collapsedComponentCategories.operations && (
           <div className="space-y-1 p-3">
             {operationItems.map((operation) => (
@@ -314,7 +342,7 @@ export const CanvasComponentPanel = ({
                   iconBg: "bg-violet-500",
                   label: operation.name,
                   payload: { kind: "operation", operation },
-                  shortLabel: "Operation",
+                  shortLabel: operationShortLabel,
                 })}
               >
                 <span className="flex size-6 shrink-0 items-center justify-center rounded bg-violet-500">
@@ -329,7 +357,7 @@ export const CanvasComponentPanel = ({
           </div>
         )}
 
-        {renderCategoryHeader("skills", "Skills", skillItems.length)}
+        {renderCategoryHeader("skills", skillsCategoryLabel, skillItems.length)}
         {!collapsedComponentCategories.skills && (
           <div className="space-y-1 p-3">
             {skillItems.map((skill) => (
@@ -349,7 +377,7 @@ export const CanvasComponentPanel = ({
                   iconBg: "bg-amber-500",
                   label: skill.label,
                   payload: { kind: "skill", skill },
-                  shortLabel: skill.tags[0] ?? "Skill",
+                  shortLabel: skill.tags[0] ?? skillFallbackLabel,
                 })}
               >
                 <span className="flex size-6 shrink-0 items-center justify-center rounded bg-amber-500">
@@ -366,7 +394,7 @@ export const CanvasComponentPanel = ({
           </div>
         )}
 
-        {renderCategoryHeader("output", "Output", outputItems.length)}
+        {renderCategoryHeader("output", outputCategoryLabel, outputItems.length)}
         {!collapsedComponentCategories.output && (
           <div className="space-y-1 p-3">{outputItems.map(renderNodeTypeItem)}</div>
         )}
@@ -378,7 +406,7 @@ export const CanvasComponentPanel = ({
           to="/pipelines/operations/new"
         >
           <Plus className="size-4" />
-          New Custom Operation
+          {newCustomOperationLabel}
         </Link>
       </div>
     </div>

--- a/apps/app/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ElementType } from "react";
+import { useEffect, useRef, useState, type DragEvent, type ElementType } from "react";
 import { Link } from "@tanstack/react-router";
 import { useList } from "@refinedev/core";
 import type { BuiltinNodeType, Operation, Skill } from "@repo/schemas";
@@ -25,6 +25,11 @@ import { cn } from "@repo/ui/lib/utils";
 import { SiGitHubIcon } from "@/components/icons/SiGitHubIcon";
 import { ResourceName } from "@/integrations/refine/dataProvider";
 import { useCanvasPageStore, type CanvasComponentCategory } from "../_store";
+import {
+  CANVAS_COMPONENT_DRAG_MIME,
+  encodeCanvasComponentDragPayload,
+  type CanvasComponentDragPayload,
+} from "../utils/canvasComponentDragPayload";
 import { getNodeMeta, getNodeTypeLabel, getNodeTypeShortLabel } from "../utils/nodeTypeMeta";
 
 interface CanvasComponentPanelProps {
@@ -54,11 +59,41 @@ const shouldHandleSlashShortcut = (target: EventTarget | null) => {
   return !["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName) && !target.isContentEditable;
 };
 
+const createDragImage = ({
+  iconBg,
+  label,
+  shortLabel,
+}: {
+  iconBg: string;
+  label: string;
+  shortLabel: string;
+}) => {
+  const image = document.createElement("div");
+  image.className = "canvas-component-drag-image";
+
+  const icon = document.createElement("span");
+  icon.className = `canvas-component-drag-image__icon ${iconBg}`;
+
+  const text = document.createElement("span");
+  text.className = "canvas-component-drag-image__text";
+  text.textContent = label;
+
+  const meta = document.createElement("span");
+  meta.className = "canvas-component-drag-image__meta";
+  meta.textContent = shortLabel;
+
+  image.append(icon, text, meta);
+  document.body.append(image);
+
+  return image;
+};
+
 export const CanvasComponentPanel = ({
   getCreateNodeScreenPosition,
 }: CanvasComponentPanelProps) => {
   const { t } = useTranslation();
   const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const [draggingComponentId, setDraggingComponentId] = useState<string | null>(null);
   const store = useCanvasPageStore();
   const componentSearchQuery = useStore(store, (state) => state.componentSearchQuery);
   const collapsedComponentCategories = useStore(
@@ -105,6 +140,38 @@ export const CanvasComponentPanel = ({
 
   const handleSkillItemClick = (skill: Skill) => () => {
     void handleCreateSkillOperationNode(skill, getCreateNodeScreenPosition());
+  };
+
+  const handleComponentDragStart =
+    ({
+      dragId,
+      iconBg,
+      label,
+      payload,
+      shortLabel,
+    }: {
+      dragId: string;
+      iconBg: string;
+      label: string;
+      payload: CanvasComponentDragPayload;
+      shortLabel: string;
+    }) =>
+    (event: DragEvent<HTMLButtonElement>) => {
+      event.dataTransfer.effectAllowed = "copy";
+      event.dataTransfer.setData(
+        CANVAS_COMPONENT_DRAG_MIME,
+        encodeCanvasComponentDragPayload(payload),
+      );
+      event.dataTransfer.setData("text/plain", label);
+
+      const dragImage = createDragImage({ iconBg, label, shortLabel });
+      event.dataTransfer.setDragImage(dragImage, 24, 24);
+      setTimeout(() => dragImage.remove(), 0);
+      setDraggingComponentId(dragId);
+    };
+
+  const handleComponentDragEnd = () => {
+    setDraggingComponentId(null);
   };
 
   const objectItems = INPUT_NODE_TYPES.filter((type) => {
@@ -169,10 +236,22 @@ export const CanvasComponentPanel = ({
     return (
       <Button
         key={type}
-        className="h-10 w-full justify-start gap-2 rounded-md px-2 text-left"
+        draggable
+        className={cn(
+          "h-10 w-full cursor-grab justify-start gap-2 rounded-md px-2 text-left transition-[opacity,transform,background-color] active:cursor-grabbing",
+          draggingComponentId === type && "scale-[0.98] opacity-60",
+        )}
         type="button"
         variant="ghost"
         onClick={handleNodeTypeItemClick(type)}
+        onDragEnd={handleComponentDragEnd}
+        onDragStart={handleComponentDragStart({
+          dragId: type,
+          iconBg: meta.iconBg,
+          label,
+          payload: { kind: "object", type },
+          shortLabel,
+        })}
       >
         <span
           className={cn("flex size-6 shrink-0 items-center justify-center rounded", meta.iconBg)}
@@ -221,10 +300,22 @@ export const CanvasComponentPanel = ({
             {operationItems.map((operation) => (
               <Button
                 key={operation.id}
-                className="h-10 w-full justify-start gap-2 rounded-md px-2 text-left"
+                draggable
+                className={cn(
+                  "h-10 w-full cursor-grab justify-start gap-2 rounded-md px-2 text-left transition-[opacity,transform,background-color] active:cursor-grabbing",
+                  draggingComponentId === operation.id && "scale-[0.98] opacity-60",
+                )}
                 type="button"
                 variant="ghost"
                 onClick={handleOperationItemClick(operation)}
+                onDragEnd={handleComponentDragEnd}
+                onDragStart={handleComponentDragStart({
+                  dragId: operation.id,
+                  iconBg: "bg-violet-500",
+                  label: operation.name,
+                  payload: { kind: "operation", operation },
+                  shortLabel: "Operation",
+                })}
               >
                 <span className="flex size-6 shrink-0 items-center justify-center rounded bg-violet-500">
                   <Zap className="size-3.5 text-white" />
@@ -244,10 +335,22 @@ export const CanvasComponentPanel = ({
             {skillItems.map((skill) => (
               <Button
                 key={skill.id}
-                className="h-auto min-h-10 w-full justify-start gap-2 rounded-md px-2 py-2 text-left"
+                draggable
+                className={cn(
+                  "h-auto min-h-10 w-full cursor-grab justify-start gap-2 rounded-md px-2 py-2 text-left transition-[opacity,transform,background-color] active:cursor-grabbing",
+                  draggingComponentId === skill.id && "scale-[0.98] opacity-60",
+                )}
                 type="button"
                 variant="ghost"
                 onClick={handleSkillItemClick(skill)}
+                onDragEnd={handleComponentDragEnd}
+                onDragStart={handleComponentDragStart({
+                  dragId: skill.id,
+                  iconBg: "bg-amber-500",
+                  label: skill.label,
+                  payload: { kind: "skill", skill },
+                  shortLabel: skill.tags[0] ?? "Skill",
+                })}
               >
                 <span className="flex size-6 shrink-0 items-center justify-center rounded bg-amber-500">
                   <Sparkles className="size-3.5 text-white" />

--- a/apps/app/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.tsx
@@ -1,0 +1,283 @@
+import { useEffect, useRef, type ElementType } from "react";
+import { Link } from "@tanstack/react-router";
+import { useList } from "@refinedev/core";
+import type { BuiltinNodeType, Operation, Skill } from "@repo/schemas";
+import {
+  ChevronDown,
+  ChevronRight,
+  FileCode,
+  Folder,
+  FolderOutput,
+  HardDrive,
+  MessageSquareText,
+  Plus,
+  Search,
+  Sparkles,
+  Zap,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import type { XYPosition } from "@xyflow/system";
+import { Badge } from "@repo/ui/badge";
+import { Button } from "@repo/ui/button";
+import { Input } from "@repo/ui/input";
+import { cn } from "@repo/ui/lib/utils";
+import { SiGitHubIcon } from "@/components/icons/SiGitHubIcon";
+import { ResourceName } from "@/integrations/refine/dataProvider";
+import { useCanvasPageStore, type CanvasComponentCategory } from "../_store";
+import { getNodeMeta, getNodeTypeLabel, getNodeTypeShortLabel } from "../utils/nodeTypeMeta";
+
+interface CanvasComponentPanelProps {
+  getCreateNodeScreenPosition: () => XYPosition;
+}
+
+const INPUT_NODE_TYPES: BuiltinNodeType[] = ["folder", "file", "github-project", "prompt"];
+const OUTPUT_NODE_TYPES: BuiltinNodeType[] = ["output-local-path", "output-project-path"];
+
+const TYPE_ICONS: Record<string, ElementType> = {
+  file: FileCode,
+  folder: Folder,
+  "github-project": SiGitHubIcon,
+  prompt: MessageSquareText,
+  "output-project-path": FolderOutput,
+  "output-local-path": HardDrive,
+};
+
+const normalizeSearch = (value: string) => value.trim().toLowerCase();
+
+const includesSearch = (values: Array<string | null | undefined>, query: string) =>
+  values.some((value) => value?.toLowerCase().includes(query));
+
+const shouldHandleSlashShortcut = (target: EventTarget | null) => {
+  if (!(target instanceof HTMLElement)) return true;
+
+  return !["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName) && !target.isContentEditable;
+};
+
+export const CanvasComponentPanel = ({
+  getCreateNodeScreenPosition,
+}: CanvasComponentPanelProps) => {
+  const { t } = useTranslation();
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const store = useCanvasPageStore();
+  const componentSearchQuery = useStore(store, (state) => state.componentSearchQuery);
+  const collapsedComponentCategories = useStore(
+    store,
+    (state) => state.collapsedComponentCategories,
+  );
+  const handleComponentSearchChange = useStore(store, (state) => state.handleComponentSearchChange);
+  const toggleComponentCategory = useStore(store, (state) => state.toggleComponentCategory);
+  const handleCreateObjectNode = useStore(store, (state) => state.handleCreateObjectNode);
+  const handleCreateOperationNode = useStore(store, (state) => state.handleCreateOperationNode);
+  const handleCreateSkillOperationNode = useStore(
+    store,
+    (state) => state.handleCreateSkillOperationNode,
+  );
+  const { result: operationsResult } = useList<Operation>({ resource: ResourceName.operations });
+  const { result: skillsResult } = useList<Skill>({ resource: ResourceName.skills });
+  const operations = operationsResult.data;
+  const skills = skillsResult.data;
+  const search = normalizeSearch(componentSearchQuery);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "/" || !shouldHandleSlashShortcut(event.target)) return;
+      event.preventDefault();
+      searchInputRef.current?.focus();
+    };
+
+    globalThis.addEventListener("keydown", handleKeyDown);
+
+    return () => globalThis.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  const handleCategoryHeaderClick = (category: CanvasComponentCategory) => () => {
+    toggleComponentCategory(category);
+  };
+
+  const handleNodeTypeItemClick = (type: BuiltinNodeType) => () => {
+    handleCreateObjectNode(type, getCreateNodeScreenPosition());
+  };
+
+  const handleOperationItemClick = (operation: Operation) => () => {
+    handleCreateOperationNode(operation, getCreateNodeScreenPosition());
+  };
+
+  const handleSkillItemClick = (skill: Skill) => () => {
+    void handleCreateSkillOperationNode(skill, getCreateNodeScreenPosition());
+  };
+
+  const objectItems = INPUT_NODE_TYPES.filter((type) => {
+    const meta = getNodeMeta(type);
+    const label = getNodeTypeLabel(t, type);
+    const shortLabel = getNodeTypeShortLabel(t, type);
+
+    return search === "" || includesSearch([label, shortLabel, meta?.label, type], search);
+  });
+
+  const outputItems = OUTPUT_NODE_TYPES.filter((type) => {
+    const meta = getNodeMeta(type);
+    const label = getNodeTypeLabel(t, type);
+    const shortLabel = getNodeTypeShortLabel(t, type);
+
+    return search === "" || includesSearch([label, shortLabel, meta?.label, type], search);
+  });
+
+  const operationItems = operations.filter((operation) =>
+    search === ""
+      ? true
+      : includesSearch([operation.name, operation.description, "operation"], search),
+  );
+
+  const skillItems = skills.filter((skill) =>
+    search === ""
+      ? true
+      : includesSearch([skill.name, skill.label, skill.description, ...skill.tags], search),
+  );
+
+  const renderCategoryHeader = (
+    category: CanvasComponentCategory,
+    label: string,
+    count: number,
+  ) => {
+    const collapsed = collapsedComponentCategories[category];
+    const ChevronIcon = collapsed ? ChevronRight : ChevronDown;
+
+    return (
+      <Button
+        aria-expanded={!collapsed}
+        aria-label={`${label} category`}
+        className="h-9 w-full justify-start gap-2 rounded-none border-t px-5 text-sm font-semibold"
+        type="button"
+        variant="ghost"
+        onClick={handleCategoryHeaderClick(category)}
+      >
+        <ChevronIcon className="size-3.5" />
+        <span className="flex-1 text-left">{label}</span>
+        <span className="text-xs text-muted-foreground">{count}</span>
+      </Button>
+    );
+  };
+
+  const renderNodeTypeItem = (type: BuiltinNodeType) => {
+    const Icon = TYPE_ICONS[type];
+    const meta = getNodeMeta(type);
+    const label = getNodeTypeLabel(t, type);
+    const shortLabel = getNodeTypeShortLabel(t, type);
+    if (!meta) return null;
+
+    return (
+      <Button
+        key={type}
+        className="h-10 w-full justify-start gap-2 rounded-md px-2 text-left"
+        type="button"
+        variant="ghost"
+        onClick={handleNodeTypeItemClick(type)}
+      >
+        <span
+          className={cn("flex size-6 shrink-0 items-center justify-center rounded", meta.iconBg)}
+        >
+          <Icon className="size-3.5 text-white" />
+        </span>
+        <span className="min-w-0 flex-1 truncate text-sm font-medium">{label}</span>
+        <span className="text-xs text-muted-foreground">{shortLabel}</span>
+        <Plus className="size-3 text-muted-foreground" />
+      </Button>
+    );
+  };
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col bg-background"
+      data-testid="canvas-component-panel"
+    >
+      <div className="border-b p-4">
+        <div className="flex h-10 items-center gap-2 rounded-md border bg-muted/30 px-3">
+          <Search className="size-4 text-muted-foreground" />
+          <Input
+            ref={searchInputRef}
+            aria-label="Search components"
+            className="h-8 border-none bg-transparent px-0 shadow-none focus-visible:ring-0"
+            name="canvasComponentSearch"
+            placeholder="Search components..."
+            value={componentSearchQuery}
+            onChange={handleComponentSearchChange}
+          />
+          <kbd className="rounded border bg-background px-1.5 py-0.5 text-[10px] text-muted-foreground">
+            /
+          </kbd>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {renderCategoryHeader("input", "Input Objects", objectItems.length)}
+        {!collapsedComponentCategories.input && (
+          <div className="space-y-1 p-3">{objectItems.map(renderNodeTypeItem)}</div>
+        )}
+
+        {renderCategoryHeader("operations", "Operations", operationItems.length)}
+        {!collapsedComponentCategories.operations && (
+          <div className="space-y-1 p-3">
+            {operationItems.map((operation) => (
+              <Button
+                key={operation.id}
+                className="h-10 w-full justify-start gap-2 rounded-md px-2 text-left"
+                type="button"
+                variant="ghost"
+                onClick={handleOperationItemClick(operation)}
+              >
+                <span className="flex size-6 shrink-0 items-center justify-center rounded bg-violet-500">
+                  <Zap className="size-3.5 text-white" />
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                  {operation.name}
+                </span>
+                <Plus className="size-3 text-muted-foreground" />
+              </Button>
+            ))}
+          </div>
+        )}
+
+        {renderCategoryHeader("skills", "Skills", skillItems.length)}
+        {!collapsedComponentCategories.skills && (
+          <div className="space-y-1 p-3">
+            {skillItems.map((skill) => (
+              <Button
+                key={skill.id}
+                className="h-auto min-h-10 w-full justify-start gap-2 rounded-md px-2 py-2 text-left"
+                type="button"
+                variant="ghost"
+                onClick={handleSkillItemClick(skill)}
+              >
+                <span className="flex size-6 shrink-0 items-center justify-center rounded bg-amber-500">
+                  <Sparkles className="size-3.5 text-white" />
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm font-medium">{skill.label}</span>
+                {skill.tags.slice(0, 1).map((tag) => (
+                  <Badge key={tag} className="shrink-0 text-[10px]" variant="secondary">
+                    {tag}
+                  </Badge>
+                ))}
+              </Button>
+            ))}
+          </div>
+        )}
+
+        {renderCategoryHeader("output", "Output", outputItems.length)}
+        {!collapsedComponentCategories.output && (
+          <div className="space-y-1 p-3">{outputItems.map(renderNodeTypeItem)}</div>
+        )}
+      </div>
+
+      <div className="border-t p-3">
+        <Link
+          className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted"
+          to="/pipelines/operations/new"
+        >
+          <Plus className="size-4" />
+          New Custom Operation
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/apps/app/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.unit.test.tsx
@@ -1,9 +1,10 @@
 import { render } from "@/test/test-wrapper";
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Operation, Skill } from "@repo/schemas";
 import { describe, expect, it, vi } from "vitest";
 import { createCanvasPageStore, CanvasPageStoreContext } from "../_store";
+import { CANVAS_COMPONENT_DRAG_MIME } from "../utils/canvasComponentDragPayload";
 import { CanvasComponentPanel } from "./CanvasComponentPanel";
 
 const operations = [
@@ -86,5 +87,31 @@ describe("CanvasComponentPanel", () => {
 
     expect(screen.queryByRole("button", { name: /Review Code/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Error Handling/i })).toBeInTheDocument();
+  });
+
+  it("serializes palette items for drag creation", () => {
+    renderPanel();
+
+    const data = new Map<string, string>();
+    const dataTransfer = {
+      effectAllowed: "none",
+      setData: vi.fn((type: string, value: string) => data.set(type, value)),
+      setDragImage: vi.fn(),
+    };
+
+    fireEvent.dragStart(screen.getByRole("button", { name: /Review Code/i }), {
+      dataTransfer,
+    });
+
+    expect(dataTransfer.effectAllowed).toBe("copy");
+    expect(dataTransfer.setData).toHaveBeenCalledWith(
+      CANVAS_COMPONENT_DRAG_MIME,
+      expect.any(String),
+    );
+    expect(JSON.parse(data.get(CANVAS_COMPONENT_DRAG_MIME) ?? "{}")).toMatchObject({
+      kind: "operation",
+      operation: { id: "review-code" },
+    });
+    expect(dataTransfer.setDragImage).toHaveBeenCalled();
   });
 });

--- a/apps/app/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.unit.test.tsx
@@ -1,0 +1,90 @@
+import { render } from "@/test/test-wrapper";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Operation, Skill } from "@repo/schemas";
+import { describe, expect, it, vi } from "vitest";
+import { createCanvasPageStore, CanvasPageStoreContext } from "../_store";
+import { CanvasComponentPanel } from "./CanvasComponentPanel";
+
+const operations = [
+  {
+    id: "review-code",
+    name: "Review Code",
+    description: "Find correctness issues",
+    config: {},
+    acceptedObjectTypes: ["file"],
+  },
+] as Operation[];
+
+const skills = [
+  {
+    id: "skill-error-handling",
+    name: "error-handling",
+    label: "Error Handling",
+    description: "Use neverthrow",
+    category: "code-quality",
+    tags: ["Neverthrow"],
+  },
+] as Skill[];
+
+vi.mock("@refinedev/core", () => ({
+  useList: ({ resource }: { resource: string }) => ({
+    result: {
+      data: resource === "skills" ? skills : operations,
+    },
+  }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to, ...props }: React.PropsWithChildren<{ to: string }>) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const renderPanel = () => {
+  const store = createCanvasPageStore();
+  store.setState({ screenToFlowPosition: (pos) => ({ x: pos.x, y: pos.y }) });
+
+  render(
+    <CanvasPageStoreContext.Provider value={store}>
+      <CanvasComponentPanel getCreateNodeScreenPosition={() => ({ x: 400, y: 300 })} />
+    </CanvasPageStoreContext.Provider>,
+  );
+
+  return store;
+};
+
+describe("CanvasComponentPanel", () => {
+  it("renders collapsible component categories", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    expect(screen.getByRole("button", { name: /Input Objects category/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Operations category/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Skills category/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Output category/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Review Code/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Error Handling/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Operations category/i }));
+
+    expect(screen.queryByRole("button", { name: /Review Code/i })).not.toBeInTheDocument();
+  });
+
+  it("filters across categories and focuses search with slash", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.keyboard("/");
+
+    const searchInput = screen.getByRole("textbox", { name: /Search components/i });
+    expect(searchInput).toHaveFocus();
+
+    await user.type(searchInput, "never");
+
+    expect(screen.queryByRole("button", { name: /Review Code/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Error Handling/i })).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/pages/CanvasPage/CanvasComponentPanel/index.ts
+++ b/apps/app/src/pages/CanvasPage/CanvasComponentPanel/index.ts
@@ -1,0 +1,1 @@
+export * from "./CanvasComponentPanel";

--- a/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.tsx
@@ -1,138 +1,28 @@
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { useCanvasPageStore } from "../_store";
 import { Menu, Home, Save, FileDown, FileUp, Settings, Undo, Redo } from "lucide-react";
 import { Link } from "@tanstack/react-router";
-import { useCreate, useUpdate } from "@refinedev/core";
 import { Popover, PopoverContent, PopoverTrigger } from "@repo/ui/popover";
 import { Button } from "@repo/ui/button";
 import { Input } from "@repo/ui/input";
-import { ResourceName } from "@/integrations/refine/dataProvider";
-import { toastStore } from "@/store/toastStore";
-import { ResultAsync } from "neverthrow";
-import {
-  isCanvasImportFileTooLarge,
-  parseCanvasImportJson,
-  type CanvasImportError,
-} from "../utils/canvasImportJson";
+import { useCanvasWorkspacePersistence } from "../useCanvasWorkspacePersistence";
 
 export const CanvasFloatingMenu = () => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
-  const pipelineId = useStore(store, (state) => state.pipelineId);
-  const pipelineName = useStore(store, (state) => state.pipelineName);
-  const nodes = useStore(store, (state) => state.nodes);
-  const edges = useStore(store, (state) => state.edges);
   const exportCanvas = useStore(store, (state) => state.exportCanvas);
-  const importCanvas = useStore(store, (state) => state.importCanvas);
   const handleUndo = useStore(store, (state) => state.handleUndo);
   const handleRedo = useStore(store, (state) => state.handleRedo);
   const openCanvasSettings = useStore(store, (state) => state.openCanvasSettings);
-  const handlePipelineIdChange = useStore(store, (state) => state.handlePipelineIdChange);
-
-  const { mutate: updateCanvas, mutation: updateMutation } = useUpdate();
-  const { mutate: createCanvas, mutation: createMutation } = useCreate();
 
   const [isOpen, setIsOpen] = useState(false);
-  const displayPipelineName = pipelineName || t("canvas.pipelineTitlePlaceholder");
-
-  const handleSave = () => {
-    if (pipelineId) {
-      updateCanvas({
-        resource: ResourceName.pipelines,
-        id: pipelineId,
-        values: { nodes, edges },
-        successNotification: {
-          type: "success",
-          message: t("canvas.saveSuccess"),
-          description: t("canvas.floatingMenu.saveSuccessDescription", {
-            name: displayPipelineName,
-          }),
-        },
-        errorNotification: {
-          type: "error",
-          message: t("canvas.saveFailed"),
-          description: t("canvas.floatingMenu.saveFailedDescription"),
-        },
-      });
-    } else {
-      const newId = crypto.randomUUID();
-      createCanvas(
-        {
-          resource: ResourceName.pipelines,
-          values: {
-            id: newId,
-            name: displayPipelineName,
-            description: "",
-            tags: [],
-            timeoutMs: null,
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
-            nodes,
-            edges,
-          },
-          successNotification: {
-            type: "success",
-            message: t("canvas.saveSuccess"),
-            description: t("canvas.floatingMenu.createSuccessDescription", {
-              name: displayPipelineName,
-            }),
-          },
-          errorNotification: {
-            type: "error",
-            message: t("canvas.saveFailed"),
-            description: t("canvas.floatingMenu.saveFailedDescription"),
-          },
-        },
-        {
-          onSuccess: () => {
-            handlePipelineIdChange(newId);
-          },
-        },
-      );
-    }
-  };
-
-  const isPending = updateMutation.isPending || createMutation.isPending;
-
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const handleImport = () => {
-    fileInputRef.current?.click();
-  };
-
-  const showImportError = (error: CanvasImportError) => {
-    const description =
-      error === "invalid-json"
-        ? t("canvas.importInvalidJson")
-        : error === "file-too-large"
-          ? t("canvas.importFileTooLarge")
-          : t("canvas.importInvalidPipelineJson");
-
-    toastStore.getState().addToast({
-      type: "error",
-      title: t("canvas.importFailed"),
-      description,
+  const { fileInputRef, handleImport, handleImportFileChange, handleSave, isPending } =
+    useCanvasWorkspacePersistence({
+      onAfterImportFileSelect: () => setIsOpen(false),
+      onAfterSave: () => setIsOpen(false),
     });
-  };
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    e.target.value = "";
-    setIsOpen(false);
-
-    if (isCanvasImportFileTooLarge(file)) {
-      showImportError("file-too-large");
-
-      return;
-    }
-
-    void ResultAsync.fromPromise(file.text(), () => "invalid-json" as const)
-      .andThen((text) => parseCanvasImportJson(text))
-      .match(importCanvas, showImportError);
-  };
 
   const menuItems = [
     { icon: Home, label: t("canvas.floatingMenu.backToWorkspace"), to: "/" },
@@ -201,7 +91,7 @@ export const CanvasFloatingMenu = () => {
         className="hidden"
         name="canvasImportFile"
         type="file"
-        onChange={handleFileChange}
+        onChange={handleImportFileChange}
       />
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.tsx
@@ -2,7 +2,16 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { useCanvasPageStore } from "../_store";
-import { Menu, Home, Save, FileDown, FileUp, Settings, Undo, Redo } from "lucide-react";
+import {
+  Menu,
+  Home,
+  Save,
+  FileDown,
+  FileUp,
+  Settings,
+  Undo,
+  Redo,
+} from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { Popover, PopoverContent, PopoverTrigger } from "@repo/ui/popover";
 import { Button } from "@repo/ui/button";
@@ -15,14 +24,22 @@ export const CanvasFloatingMenu = () => {
   const exportCanvas = useStore(store, (state) => state.exportCanvas);
   const handleUndo = useStore(store, (state) => state.handleUndo);
   const handleRedo = useStore(store, (state) => state.handleRedo);
-  const openCanvasSettings = useStore(store, (state) => state.openCanvasSettings);
+  const openCanvasSettings = useStore(
+    store,
+    (state) => state.openCanvasSettings,
+  );
 
   const [isOpen, setIsOpen] = useState(false);
-  const { fileInputRef, handleImport, handleImportFileChange, handleSave, isPending } =
-    useCanvasWorkspacePersistence({
-      onAfterImportFileSelect: () => setIsOpen(false),
-      onAfterSave: () => setIsOpen(false),
-    });
+  const {
+    fileInputRef,
+    handleImport,
+    handleImportFileChange,
+    handleSave,
+    isPending,
+  } = useCanvasWorkspacePersistence({
+    onAfterImportFileSelect: () => setIsOpen(false),
+    onAfterSave: () => setIsOpen(false),
+  });
 
   const menuItems = [
     { icon: Home, label: t("canvas.floatingMenu.backToWorkspace"), to: "/" },
@@ -32,11 +49,23 @@ export const CanvasFloatingMenu = () => {
       onClick: handleSave,
       disabled: isPending,
     },
-    { icon: FileDown, label: t("canvas.floatingMenu.export"), onClick: exportCanvas },
-    { icon: FileUp, label: t("canvas.floatingMenu.import"), onClick: handleImport },
+    {
+      icon: FileDown,
+      label: t("canvas.floatingMenu.export"),
+      onClick: exportCanvas,
+    },
+    {
+      icon: FileUp,
+      label: t("canvas.floatingMenu.import"),
+      onClick: handleImport,
+    },
     { icon: Undo, label: t("canvas.undo"), onClick: handleUndo, divider: true },
     { icon: Redo, label: t("canvas.redo"), onClick: handleRedo },
-    { icon: Settings, label: t("canvas.settingsDrawer.menuLabel"), onClick: openCanvasSettings },
+    {
+      icon: Settings,
+      label: t("canvas.settingsDrawer.menuLabel"),
+      onClick: openCanvasSettings,
+    },
   ];
 
   const handleCloseMenu = () => setIsOpen(false);
@@ -51,21 +80,25 @@ export const CanvasFloatingMenu = () => {
       <Popover open={isOpen} onOpenChange={handleOpenChange}>
         <PopoverTrigger
           className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white shadow-md transition-all hover:bg-gray-50 hover:shadow-lg active:scale-95"
-          title={t("canvas.floatingMenu.menu")}
-        >
+          title={t("canvas.floatingMenu.menu")}>
           <Menu className="h-5 w-5 text-gray-700" />
         </PopoverTrigger>
 
-        <PopoverContent align="start" className="w-48 p-2" side="bottom" sideOffset={8}>
+        <PopoverContent
+          align="start"
+          className="w-48 p-2"
+          side="bottom"
+          sideOffset={8}>
           {menuItems.map((item, index) => (
             <div key={item.label}>
-              {item.divider && index > 0 && <div className="my-1 border-t border-gray-100" />}
+              {item.divider && index > 0 && (
+                <div className="my-1 border-t border-gray-100" />
+              )}
               {item.to ? (
                 <Link
                   className="flex w-full items-center gap-3 px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50"
                   to={item.to}
-                  onClick={handleCloseMenu}
-                >
+                  onClick={handleCloseMenu}>
                   <item.icon className="h-4 w-4" />
                   {item.label}
                 </Link>
@@ -74,8 +107,7 @@ export const CanvasFloatingMenu = () => {
                   className="flex h-auto w-full items-center justify-start gap-3 px-4 py-2 text-sm text-gray-700"
                   disabled={item.disabled}
                   variant="ghost"
-                  onClick={handleItemClick(item.onClick)}
-                >
+                  onClick={handleItemClick(item.onClick)}>
                   <item.icon className="h-4 w-4" />
                   {item.label}
                 </Button>
@@ -96,3 +128,4 @@ export const CanvasFloatingMenu = () => {
     </div>
   );
 };
+

--- a/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.unit.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { act, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { CanvasFloatingMenu } from "./CanvasFloatingMenu";
 import { createCanvasPageStore, CanvasPageStoreContext, CanvasPageStoreProvider } from "../_store";
@@ -180,7 +180,9 @@ describe("CanvasFloatingMenu - save behavior", () => {
       expect(generatedId).toBeTruthy();
 
       // Simulate refine calling onSuccess
-      onSuccess();
+      act(() => {
+        onSuccess();
+      });
 
       // Re-click save — now it should route to UPDATE path since pipelineId was set
       mockCreate.mockClear();

--- a/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFloatingMenu/CanvasFloatingMenu.unit.test.tsx
@@ -1,10 +1,23 @@
-import { act, render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { CanvasFloatingMenu } from "./CanvasFloatingMenu";
-import { createCanvasPageStore, CanvasPageStoreContext, CanvasPageStoreProvider } from "../_store";
+import {
+  createCanvasPageStore,
+  CanvasPageStoreContext,
+  CanvasPageStoreProvider,
+} from "../_store";
 import { toastStore } from "@/store/toastStore";
 import type { PipelineEdge, PipelineNode } from "../_store/canvasSlice";
-import { MAX_CANVAS_IMPORT_BYTES, MAX_CANVAS_IMPORT_NODES } from "../utils/canvasImportJson";
+import {
+  MAX_CANVAS_IMPORT_BYTES,
+  MAX_CANVAS_IMPORT_NODES,
+} from "../utils/canvasImportJson";
 
 // ─── Mock @refinedev/core ─────────────────────────────────────────────────────
 
@@ -47,7 +60,8 @@ const clickSave = () => {
 };
 
 const wrapperWithPipeline = ({ children }: React.PropsWithChildren) => (
-  <CanvasPageStoreProvider pipeline={{ id: "pipe-001", name: "My Pipeline", nodes: [], edges: [] }}>
+  <CanvasPageStoreProvider
+    pipeline={{ id: "pipe-001", name: "My Pipeline", nodes: [], edges: [] }}>
     {children}
   </CanvasPageStoreProvider>
 );
@@ -57,7 +71,8 @@ const wrapperWithNullPipeline = ({ children }: React.PropsWithChildren) => (
 );
 
 const wrapperWithTestPipeline = ({ children }: React.PropsWithChildren) => (
-  <CanvasPageStoreProvider pipeline={{ id: "pipe-001", name: "Test", nodes: [], edges: [] }}>
+  <CanvasPageStoreProvider
+    pipeline={{ id: "pipe-001", name: "Test", nodes: [], edges: [] }}>
     {children}
   </CanvasPageStoreProvider>
 );
@@ -86,12 +101,16 @@ const makeEdge = (id: string): PipelineEdge => ({
 });
 
 const uploadJsonFile = (content: string) => {
-  const input = document.querySelector<HTMLInputElement>("input[name='canvasImportFile']");
+  const input = document.querySelector<HTMLInputElement>(
+    "input[name='canvasImportFile']",
+  );
   expect(input).toBeTruthy();
 
   fireEvent.change(input!, {
     target: {
-      files: [new File([content], "pipeline.json", { type: "application/json" })],
+      files: [
+        new File([content], "pipeline.json", { type: "application/json" }),
+      ],
     },
   });
 };
@@ -102,7 +121,9 @@ const expectImportFailedToast = async () => {
       toastStore
         .getState()
         .toasts.some(
-          (toast) => toast.type === "error" && /^(Import failed|导入失败)$/.test(toast.title),
+          (toast) =>
+            toast.type === "error" &&
+            /^(Import failed|导入失败)$/.test(toast.title),
         ),
     ).toBe(true),
   );
@@ -190,7 +211,9 @@ describe("CanvasFloatingMenu - save behavior", () => {
       openMenu();
       fireEvent.click(screen.getByText("Save"));
 
-      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ id: generatedId }));
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: generatedId }),
+      );
       expect(mockCreate).not.toHaveBeenCalled();
     });
   });
@@ -236,7 +259,10 @@ describe("CanvasFloatingMenu - save behavior", () => {
         height: 120,
         backgroundImage: "url(https://example.invalid/tracker)",
       },
-      data: { ...baseNode.data, importMetadata: { shouldSurviveValidation: true } },
+      data: {
+        ...baseNode.data,
+        importMetadata: { shouldSurviveValidation: true },
+      },
     };
     const sanitizedNode = {
       ...baseNode,
@@ -256,14 +282,30 @@ describe("CanvasFloatingMenu - save behavior", () => {
       JSON.stringify({
         name: "Imported Pipeline",
         nodes: [node],
-        edges: [{ id: "edge-1", source: "n1", target: "n2", type: "default", animated: true }],
+        edges: [
+          {
+            id: "edge-1",
+            source: "n1",
+            target: "n2",
+            type: "default",
+            animated: true,
+          },
+        ],
       }),
     );
 
-    await waitFor(() => expect(store.getState().pipelineName).toBe("Imported Pipeline"));
+    await waitFor(() =>
+      expect(store.getState().pipelineName).toBe("Imported Pipeline"),
+    );
     expect(store.getState().nodes).toEqual([sanitizedNode]);
     expect(store.getState().edges).toEqual([
-      { id: "edge-1", source: "n1", target: "n2", type: "default", animated: true },
+      {
+        id: "edge-1",
+        source: "n1",
+        target: "n2",
+        type: "default",
+        animated: true,
+      },
     ]);
   });
 
@@ -285,7 +327,9 @@ describe("CanvasFloatingMenu - save behavior", () => {
       }),
     );
 
-    await waitFor(() => expect(store.getState().pipelineName).toBe("Legacy Pipeline Title"));
+    await waitFor(() =>
+      expect(store.getState().pipelineName).toBe("Legacy Pipeline Title"),
+    );
     expect(store.getState().nodes).toEqual([node]);
     expect(store.getState().edges).toEqual([]);
   });
@@ -293,7 +337,12 @@ describe("CanvasFloatingMenu - save behavior", () => {
   it("shows a toast and preserves canvas state for invalid pipeline JSON", async () => {
     const initialNode = makeNode("existing");
     const initialEdge = makeEdge("existing-edge");
-    const store = createCanvasPageStore([initialNode], [initialEdge], null, "Existing Pipeline");
+    const store = createCanvasPageStore(
+      [initialNode],
+      [initialEdge],
+      null,
+      "Existing Pipeline",
+    );
 
     render(
       <CanvasPageStoreContext.Provider value={store}>
@@ -301,7 +350,13 @@ describe("CanvasFloatingMenu - save behavior", () => {
       </CanvasPageStoreContext.Provider>,
     );
 
-    uploadJsonFile(JSON.stringify({ name: "Invalid Pipeline", nodes: "not-array", edges: [] }));
+    uploadJsonFile(
+      JSON.stringify({
+        name: "Invalid Pipeline",
+        nodes: "not-array",
+        edges: [],
+      }),
+    );
 
     await expectImportFailedToast();
     expect(store.getState().pipelineName).toBe("Existing Pipeline");
@@ -312,7 +367,12 @@ describe("CanvasFloatingMenu - save behavior", () => {
   it("shows a toast and preserves canvas state for unsupported node types", async () => {
     const initialNode = makeNode("existing");
     const initialEdge = makeEdge("existing-edge");
-    const store = createCanvasPageStore([initialNode], [initialEdge], null, "Existing Pipeline");
+    const store = createCanvasPageStore(
+      [initialNode],
+      [initialEdge],
+      null,
+      "Existing Pipeline",
+    );
 
     render(
       <CanvasPageStoreContext.Provider value={store}>
@@ -337,7 +397,12 @@ describe("CanvasFloatingMenu - save behavior", () => {
   it("shows a toast and preserves canvas state for invalid operation runtime", async () => {
     const initialNode = makeNode("existing");
     const initialEdge = makeEdge("existing-edge");
-    const store = createCanvasPageStore([initialNode], [initialEdge], null, "Existing Pipeline");
+    const store = createCanvasPageStore(
+      [initialNode],
+      [initialEdge],
+      null,
+      "Existing Pipeline",
+    );
 
     render(
       <CanvasPageStoreContext.Provider value={store}>
@@ -376,7 +441,12 @@ describe("CanvasFloatingMenu - save behavior", () => {
   it("shows a toast and preserves canvas state for bad JSON", async () => {
     const initialNode = makeNode("existing");
     const initialEdge = makeEdge("existing-edge");
-    const store = createCanvasPageStore([initialNode], [initialEdge], null, "Existing Pipeline");
+    const store = createCanvasPageStore(
+      [initialNode],
+      [initialEdge],
+      null,
+      "Existing Pipeline",
+    );
 
     render(
       <CanvasPageStoreContext.Provider value={store}>
@@ -395,7 +465,12 @@ describe("CanvasFloatingMenu - save behavior", () => {
   it("shows a toast and preserves canvas state when the import file is too large", async () => {
     const initialNode = makeNode("existing");
     const initialEdge = makeEdge("existing-edge");
-    const store = createCanvasPageStore([initialNode], [initialEdge], null, "Existing Pipeline");
+    const store = createCanvasPageStore(
+      [initialNode],
+      [initialEdge],
+      null,
+      "Existing Pipeline",
+    );
 
     render(
       <CanvasPageStoreContext.Provider value={store}>
@@ -414,9 +489,15 @@ describe("CanvasFloatingMenu - save behavior", () => {
   it("shows a toast and preserves canvas state when the import graph is too large", async () => {
     const initialNode = makeNode("existing");
     const initialEdge = makeEdge("existing-edge");
-    const store = createCanvasPageStore([initialNode], [initialEdge], null, "Existing Pipeline");
-    const importedNodes = Array.from({ length: MAX_CANVAS_IMPORT_NODES + 1 }, (_, index) =>
-      makeNode(`oversized-${index}`),
+    const store = createCanvasPageStore(
+      [initialNode],
+      [initialEdge],
+      null,
+      "Existing Pipeline",
+    );
+    const importedNodes = Array.from(
+      { length: MAX_CANVAS_IMPORT_NODES + 1 },
+      (_, index) => makeNode(`oversized-${index}`),
     );
 
     render(
@@ -454,3 +535,4 @@ describe("CanvasFloatingMenu - save behavior", () => {
     expect(store.getState().isCanvasSettingsOpen).toBe(true);
   });
 });
+

--- a/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.stories.tsx
@@ -1,19 +1,64 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Refine } from "@refinedev/core";
 import { ReactFlowProvider } from "@xyflow/react";
+import type { PipelineData } from "@repo/schemas";
 import { CanvasPageStoreProvider } from "../_store";
+import { canvasStoryDataProvider } from "../storybookData";
 import { CanvasFlow } from "./CanvasFlow";
+
+const portAlignmentPipeline: PipelineData = {
+  id: "story-port-alignment",
+  name: "Port Alignment Debug",
+  description: "Debug fixture for React Flow handle alignment.",
+  tags: ["storybook", "debug"],
+  timeoutMs: null,
+  createdAt: new Date("2026-04-08T16:00:00.000Z"),
+  updatedAt: new Date("2026-04-08T16:00:00.000Z"),
+  nodes: [
+    {
+      id: "story-file-source",
+      type: "file",
+      position: { x: 80, y: 140 },
+      data: {
+        nodeType: "file",
+        label: "README.md",
+        filePath: "README.md",
+        language: "markdown",
+        description: "Source file for the debug connection.",
+      },
+    },
+    {
+      id: "story-review-target",
+      type: "operation",
+      position: { x: 460, y: 140 },
+      data: {
+        nodeType: "operation",
+        label: "Review Code",
+        operationId: "review-code",
+        operationName: "Review Code",
+        status: "idle",
+        config: {},
+      },
+    },
+  ],
+  edges: [],
+};
 
 const meta: Meta<typeof CanvasFlow> = {
   title: "CanvasPage/CanvasFlow",
   component: CanvasFlow,
   tags: ["autodocs"],
   decorators: [
-    (Story) => (
-      <CanvasPageStoreProvider pipeline={null}>
-        <ReactFlowProvider>
-          <Story />
-        </ReactFlowProvider>
-      </CanvasPageStoreProvider>
+    (Story, context) => (
+      <Refine dataProvider={canvasStoryDataProvider}>
+        <CanvasPageStoreProvider pipeline={context.parameters.canvasPipeline ?? null}>
+          <ReactFlowProvider>
+            <div className="h-[640px] w-full">
+              <Story />
+            </div>
+          </ReactFlowProvider>
+        </CanvasPageStoreProvider>
+      </Refine>
     ),
   ],
   parameters: {
@@ -33,6 +78,19 @@ export const Default: Story = {
     docs: {
       description: {
         story: "Empty flow surface using the shared default viewport configuration.",
+      },
+    },
+  },
+};
+
+export const PortAlignmentDebug: Story = {
+  args: {},
+  parameters: {
+    canvasPipeline: portAlignmentPipeline,
+    docs: {
+      description: {
+        story:
+          "Two-node React Flow fixture for checking that draggable connection previews start and end on the visible NodeCard ports.",
       },
     },
   },

--- a/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
@@ -1,8 +1,15 @@
-import { useMemo, type DragEvent, type Ref } from "react";
+import { useEffect, useMemo, type DragEvent, type Ref } from "react";
 import { useStore } from "zustand";
 import { useCanvasPageStore } from "../_store";
 import { useHotkeys } from "react-hotkeys-hook";
-import { ReactFlow, Background, BackgroundVariant, Controls, MiniMap } from "@xyflow/react";
+import {
+  ReactFlow,
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  useUpdateNodeInternals,
+} from "@xyflow/react";
 import { CompoundNode } from "../CompoundNode";
 import { FileNode } from "../FileNode";
 import { ErrorNode } from "../ErrorNode";
@@ -41,6 +48,7 @@ const defaultEdgeOptions = {
 
 const proOpts = { hideAttribution: false };
 const snapGrid: [number, number] = [24, 24];
+const nodePortRemeasureDelayMs = 220;
 
 interface CanvasFlowProps {
   viewportRef?: Ref<HTMLDivElement>;
@@ -57,6 +65,7 @@ const handleComponentDragOver = (event: DragEvent<HTMLDivElement>) => {
 
 export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
   const store = useCanvasPageStore();
+  const updateNodeInternals = useUpdateNodeInternals();
 
   const nodes = useStore(store, (s) => s.nodes);
   const edges = useStore(store, (s) => s.edges);
@@ -101,6 +110,25 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
         onPaneContextMenu: handleFlowPaneContextMenu,
       }
     : {};
+  const nodeIds = useMemo(() => nodes.map((node) => node.id), [nodes]);
+
+  useEffect(() => {
+    if (nodeIds.length === 0) {
+      return;
+    }
+
+    const frameId = requestAnimationFrame(() => updateNodeInternals(nodeIds));
+    // Node cards pop in with scale; remeasure after that animation settles.
+    const timeoutId = globalThis.setTimeout(
+      () => updateNodeInternals(nodeIds),
+      nodePortRemeasureDelayMs,
+    );
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      globalThis.clearTimeout(timeoutId);
+    };
+  }, [connectStart, edges, nodeIds, updateNodeInternals]);
 
   useHotkeys(
     "mod+z",

--- a/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type Ref } from "react";
+import { useMemo, type DragEvent, type Ref } from "react";
 import { useStore } from "zustand";
 import { useCanvasPageStore } from "../_store";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -12,6 +12,11 @@ import { OperationNode } from "../OperationNode";
 import { PromptNode } from "../PromptNode";
 import { OutputProjectPathNode } from "../OutputProjectPathNode";
 import { OutputLocalPathNode } from "../OutputLocalPathNode";
+import {
+  CANVAS_COMPONENT_DRAG_MIME,
+  decodeCanvasComponentDragPayload,
+  hasCanvasComponentDragPayload,
+} from "../utils/canvasComponentDragPayload";
 import { DEFAULT_CANVAS_VIEWPORT } from "../utils/canvasViewport";
 import { decorateEdgesWithPortHandles } from "../NodeCard";
 
@@ -41,6 +46,15 @@ interface CanvasFlowProps {
   viewportRef?: Ref<HTMLDivElement>;
 }
 
+const handleComponentDragOver = (event: DragEvent<HTMLDivElement>) => {
+  if (!hasCanvasComponentDragPayload(event.dataTransfer.types)) {
+    return;
+  }
+
+  event.preventDefault();
+  event.dataTransfer.dropEffect = "copy";
+};
+
 export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
   const store = useCanvasPageStore();
 
@@ -67,6 +81,9 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
   const handleFlowEdgeClick = useStore(store, (s) => s.handleFlowEdgeClick);
   const handleFlowPaneClick = useStore(store, (s) => s.handleFlowPaneClick);
   const handleFlowPaneContextMenu = useStore(store, (s) => s.handleFlowPaneContextMenu);
+  const handleCreateObjectNode = useStore(store, (s) => s.handleCreateObjectNode);
+  const handleCreateOperationNode = useStore(store, (s) => s.handleCreateOperationNode);
+  const handleCreateSkillOperationNode = useStore(store, (s) => s.handleCreateSkillOperationNode);
   const handleFlowNodeDrag = useStore(store, (s) => s.handleFlowNodeDrag);
   const handleFlowNodeDragStop = useStore(store, (s) => s.handleFlowNodeDragStop);
   const handleFlowMove = useStore(store, (s) => s.handleFlowMove);
@@ -102,8 +119,41 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
     { preventDefault: false },
   );
 
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    const payload = decodeCanvasComponentDragPayload(
+      event.dataTransfer.getData(CANVAS_COMPONENT_DRAG_MIME),
+    );
+    if (!payload) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const screenPosition = { x: event.clientX, y: event.clientY };
+    if (payload.kind === "object") {
+      handleCreateObjectNode(payload.type, screenPosition);
+
+      return;
+    }
+
+    if (payload.kind === "operation") {
+      handleCreateOperationNode(payload.operation, screenPosition);
+
+      return;
+    }
+
+    void handleCreateSkillOperationNode(payload.skill, screenPosition);
+  };
+
   return (
-    <div ref={viewportRef} className="h-full w-full" data-testid="canvas-flow-viewport">
+    <div
+      ref={viewportRef}
+      className="h-full w-full"
+      data-testid="canvas-flow-viewport"
+      onDragOver={handleComponentDragOver}
+      onDrop={handleDrop}
+    >
       <ReactFlow
         className="bg-slate-50/50"
         defaultEdgeOptions={defaultEdgeOptions}

--- a/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type DragEvent, type Ref } from "react";
+import { useEffect, useMemo, useRef, type DragEvent, type Ref } from "react";
 import { useStore } from "zustand";
 import { useCanvasPageStore } from "../_store";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -116,17 +116,74 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
   );
   const handleFlowMove = useStore(store, (s) => s.handleFlowMove);
   const updateNodeInternals = useUpdateNodeInternals();
+  const nodeIds = useMemo(() => nodes.map((node) => node.id), [nodes]);
+  const latestNodeIdsRef = useRef(nodeIds);
+  const pendingRemeasureRef = useRef<{
+    frameId: number | null;
+    timeoutId: ReturnType<typeof globalThis.setTimeout> | null;
+  }>({
+    frameId: null,
+    timeoutId: null,
+  });
+
+  latestNodeIdsRef.current = nodeIds;
+
+  const clearScheduledNodeInternalsUpdate = () => {
+    const { frameId, timeoutId } = pendingRemeasureRef.current;
+
+    if (frameId !== null && typeof cancelAnimationFrame !== "undefined") {
+      cancelAnimationFrame(frameId);
+    }
+
+    if (timeoutId !== null) {
+      globalThis.clearTimeout(timeoutId);
+    }
+
+    pendingRemeasureRef.current = {
+      frameId: null,
+      timeoutId: null,
+    };
+  };
 
   const scheduleUpdateAllNodeInternals = () => {
-    const ids = nodes.map((n) => n.id);
-    if (ids.length === 0) return;
-    requestAnimationFrame(() => {
-      updateNodeInternals(ids);
-    });
-    globalThis.setTimeout(() => {
-      updateNodeInternals(ids);
+    clearScheduledNodeInternalsUpdate();
+
+    if (latestNodeIdsRef.current.length === 0) {
+      return;
+    }
+
+    const runUpdate = () => {
+      if (latestNodeIdsRef.current.length === 0) {
+        return;
+      }
+
+      updateNodeInternals(latestNodeIdsRef.current);
+    };
+
+    const timeoutId = globalThis.setTimeout(() => {
+      pendingRemeasureRef.current.timeoutId = null;
+      runUpdate();
     }, nodePortRemeasureDelayMs);
+    const frameId =
+      typeof requestAnimationFrame === "undefined"
+        ? null
+        : requestAnimationFrame(() => {
+            pendingRemeasureRef.current.frameId = null;
+            runUpdate();
+          });
+
+    pendingRemeasureRef.current = {
+      frameId,
+      timeoutId,
+    };
   };
+
+  useEffect(
+    () => () => {
+      clearScheduledNodeInternalsUpdate();
+    },
+    [],
+  );
 
   const interactiveHandlers = isCanvasInteractive
     ? {

--- a/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, type DragEvent, type Ref } from "react";
+import { useMemo, type DragEvent, type Ref } from "react";
 import { useStore } from "zustand";
 import { useCanvasPageStore } from "../_store";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -65,8 +65,6 @@ const handleComponentDragOver = (event: DragEvent<HTMLDivElement>) => {
 
 export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
   const store = useCanvasPageStore();
-  const updateNodeInternals = useUpdateNodeInternals();
-
   const nodes = useStore(store, (s) => s.nodes);
   const edges = useStore(store, (s) => s.edges);
   const connectStart = useStore(store, (s) => s.connectStart);
@@ -83,24 +81,69 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
   const handleUndo = useStore(store, (s) => s.handleUndo);
   const handleRedo = useStore(store, (s) => s.handleRedo);
   const handleFlowInit = useStore(store, (s) => s.handleFlowInit);
-  const handleFlowConnectStart = useStore(store, (s) => s.handleFlowConnectStart);
+  const handleFlowConnectStart = useStore(
+    store,
+    (s) => s.handleFlowConnectStart,
+  );
   const handleFlowConnectEnd = useStore(store, (s) => s.handleFlowConnectEnd);
   const handleFlowNodeClick = useStore(store, (s) => s.handleFlowNodeClick);
-  const handleFlowNodeContextMenu = useStore(store, (s) => s.handleFlowNodeContextMenu);
+  const handleFlowNodeContextMenu = useStore(
+    store,
+    (s) => s.handleFlowNodeContextMenu,
+  );
   const handleFlowEdgeClick = useStore(store, (s) => s.handleFlowEdgeClick);
   const handleFlowPaneClick = useStore(store, (s) => s.handleFlowPaneClick);
-  const handleFlowPaneContextMenu = useStore(store, (s) => s.handleFlowPaneContextMenu);
-  const handleCreateObjectNode = useStore(store, (s) => s.handleCreateObjectNode);
-  const handleCreateOperationNode = useStore(store, (s) => s.handleCreateOperationNode);
-  const handleCreateSkillOperationNode = useStore(store, (s) => s.handleCreateSkillOperationNode);
+  const handleFlowPaneContextMenu = useStore(
+    store,
+    (s) => s.handleFlowPaneContextMenu,
+  );
+  const handleCreateObjectNode = useStore(
+    store,
+    (s) => s.handleCreateObjectNode,
+  );
+  const handleCreateOperationNode = useStore(
+    store,
+    (s) => s.handleCreateOperationNode,
+  );
+  const handleCreateSkillOperationNode = useStore(
+    store,
+    (s) => s.handleCreateSkillOperationNode,
+  );
   const handleFlowNodeDrag = useStore(store, (s) => s.handleFlowNodeDrag);
-  const handleFlowNodeDragStop = useStore(store, (s) => s.handleFlowNodeDragStop);
+  const handleFlowNodeDragStop = useStore(
+    store,
+    (s) => s.handleFlowNodeDragStop,
+  );
   const handleFlowMove = useStore(store, (s) => s.handleFlowMove);
+  const updateNodeInternals = useUpdateNodeInternals();
+
+  const scheduleUpdateAllNodeInternals = () => {
+    const ids = nodes.map((n) => n.id);
+    if (ids.length === 0) return;
+    requestAnimationFrame(() => {
+      updateNodeInternals(ids);
+    });
+    globalThis.setTimeout(() => {
+      updateNodeInternals(ids);
+    }, nodePortRemeasureDelayMs);
+  };
+
   const interactiveHandlers = isCanvasInteractive
     ? {
-        onConnect: handleConnect,
-        onConnectEnd: handleFlowConnectEnd,
-        onConnectStart: handleFlowConnectStart,
+        onConnect: (...args: Parameters<typeof handleConnect>) => {
+          handleConnect(...args);
+          scheduleUpdateAllNodeInternals();
+        },
+        onConnectEnd: (...args: Parameters<typeof handleFlowConnectEnd>) => {
+          handleFlowConnectEnd(...args);
+          scheduleUpdateAllNodeInternals();
+        },
+        onConnectStart: (
+          ...args: Parameters<typeof handleFlowConnectStart>
+        ) => {
+          handleFlowConnectStart(...args);
+          scheduleUpdateAllNodeInternals();
+        },
         onEdgeClick: handleFlowEdgeClick,
         onNodeClick: handleFlowNodeClick,
         onNodeContextMenu: handleFlowNodeContextMenu,
@@ -110,26 +153,6 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
         onPaneContextMenu: handleFlowPaneContextMenu,
       }
     : {};
-  const nodeIds = useMemo(() => nodes.map((node) => node.id), [nodes]);
-
-  useEffect(() => {
-    if (nodeIds.length === 0) {
-      return;
-    }
-
-    const frameId = requestAnimationFrame(() => updateNodeInternals(nodeIds));
-    // Node cards pop in with scale; remeasure after that animation settles.
-    const timeoutId = globalThis.setTimeout(
-      () => updateNodeInternals(nodeIds),
-      nodePortRemeasureDelayMs,
-    );
-
-    return () => {
-      cancelAnimationFrame(frameId);
-      globalThis.clearTimeout(timeoutId);
-    };
-  }, [connectStart, edges, nodeIds, updateNodeInternals]);
-
   useHotkeys(
     "mod+z",
     (e) => {
@@ -180,8 +203,7 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
       className="h-full w-full"
       data-testid="canvas-flow-viewport"
       onDragOver={handleComponentDragOver}
-      onDrop={handleDrop}
-    >
+      onDrop={handleDrop}>
       <ReactFlow
         className="bg-slate-50/50"
         defaultEdgeOptions={defaultEdgeOptions}
@@ -203,9 +225,11 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
         onEdgesChange={handleEdgesChange}
         onInit={handleFlowInit}
         onMove={(_event, viewport) => handleFlowMove(viewport.zoom)}
-        onNodesChange={handleNodesChange}
-        {...interactiveHandlers}
-      >
+        onNodesChange={(changes) => {
+          handleNodesChange(changes);
+          scheduleUpdateAllNodeInternals();
+        }}
+        {...interactiveHandlers}>
         {canvasSettings.showBackground && (
           <Background
             color="#cbd5e1"
@@ -235,3 +259,4 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
     </div>
   );
 };
+

--- a/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.unit.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ReactFlowProvider } from "@xyflow/react";
 import type * as XyFlowReact from "@xyflow/react";
 import type { PipelineNode } from "../_store/canvasSlice";
@@ -9,6 +9,16 @@ import {
   encodeCanvasComponentDragPayload,
 } from "../utils/canvasComponentDragPayload";
 import { CanvasFlow } from "./CanvasFlow";
+
+const xyflowMocks = vi.hoisted(() => {
+  const updateNodeInternals = vi.fn();
+
+  return {
+    onNodesChange: undefined as ((changes: unknown[]) => void) | undefined,
+    updateNodeInternals,
+    useUpdateNodeInternals: vi.fn(() => updateNodeInternals),
+  };
+});
 
 vi.mock("@xyflow/react", async (importOriginal) => {
   const actual = await importOriginal<typeof XyFlowReact>();
@@ -38,6 +48,7 @@ vi.mock("@xyflow/react", async (importOriginal) => {
       onNodeDragStop,
       onPaneClick,
       onPaneContextMenu,
+      onNodesChange,
       snapToGrid,
     }: React.PropsWithChildren<{
       defaultViewport?: { zoom: number };
@@ -61,8 +72,12 @@ vi.mock("@xyflow/react", async (importOriginal) => {
       onNodeDragStop?: unknown;
       onPaneClick?: unknown;
       onPaneContextMenu?: unknown;
+      onNodesChange?: unknown;
       snapToGrid?: boolean;
     }>) => {
+      xyflowMocks.onNodesChange = onNodesChange as
+        | ((changes: unknown[]) => void)
+        | undefined;
       const handleMouseMove = () => onMove?.(null, { x: 0, y: 0, zoom: 0.6 });
 
       return (
@@ -98,6 +113,7 @@ vi.mock("@xyflow/react", async (importOriginal) => {
     Background: () => <div data-testid="flow-background" />,
     Controls: () => <div data-testid="flow-controls" />,
     MiniMap: () => <div data-testid="mini-map" />,
+    useUpdateNodeInternals: xyflowMocks.useUpdateNodeInternals,
   };
 });
 
@@ -148,6 +164,16 @@ const makeDragEvent = (
 };
 
 describe("CanvasFlow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    xyflowMocks.onNodesChange = undefined;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
   it("renders without crashing", () => {
     const { container } = render(<CanvasFlow />, { wrapper });
     expect(container.firstChild).toBeTruthy();
@@ -289,5 +315,86 @@ describe("CanvasFlow", () => {
         position: { x: 240, y: 180 },
       }),
     ]);
+  });
+
+  it("coalesces repeated node-internals remeasurements", () => {
+    vi.useFakeTimers();
+
+    const scheduledFrames = new Map<number, ReturnType<typeof setTimeout>>();
+    let nextFrameId = 1;
+
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        const frameId = nextFrameId++;
+        const timeoutId = globalThis.setTimeout(() => callback(16), 0);
+
+        scheduledFrames.set(frameId, timeoutId);
+
+        return frameId;
+      }),
+    );
+    vi.stubGlobal(
+      "cancelAnimationFrame",
+      vi.fn((frameId: number) => {
+        const timeoutId = scheduledFrames.get(frameId);
+
+        if (timeoutId !== undefined) {
+          globalThis.clearTimeout(timeoutId);
+          scheduledFrames.delete(frameId);
+        }
+      }),
+    );
+
+    const store = createCanvasPageStore([makeNode("a")], []);
+
+    render(
+      <CanvasPageStoreContext.Provider value={store}>
+        <ReactFlowProvider>
+          <CanvasFlow />
+        </ReactFlowProvider>
+      </CanvasPageStoreContext.Provider>,
+    );
+
+    act(() => {
+      xyflowMocks.onNodesChange?.([
+        { id: "a", type: "position", position: { x: 12, y: 18 }, dragging: false },
+      ]);
+      xyflowMocks.onNodesChange?.([
+        { id: "a", type: "position", position: { x: 24, y: 36 }, dragging: false },
+      ]);
+      vi.runAllTimers();
+    });
+
+    expect(xyflowMocks.updateNodeInternals).toHaveBeenCalledTimes(2);
+    expect(xyflowMocks.updateNodeInternals).toHaveBeenNthCalledWith(1, ["a"]);
+    expect(xyflowMocks.updateNodeInternals).toHaveBeenNthCalledWith(2, ["a"]);
+  });
+
+  it("falls back to timeout when requestAnimationFrame is unavailable", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", undefined);
+    vi.stubGlobal("cancelAnimationFrame", undefined);
+
+    const store = createCanvasPageStore([makeNode("a")], []);
+
+    render(
+      <CanvasPageStoreContext.Provider value={store}>
+        <ReactFlowProvider>
+          <CanvasFlow />
+        </ReactFlowProvider>
+      </CanvasPageStoreContext.Provider>,
+    );
+
+    expect(() => {
+      act(() => {
+        xyflowMocks.onNodesChange?.([
+          { id: "a", type: "position", position: { x: 12, y: 18 }, dragging: false },
+        ]);
+        vi.runAllTimers();
+      });
+    }).not.toThrow();
+    expect(xyflowMocks.updateNodeInternals).toHaveBeenCalledTimes(1);
+    expect(xyflowMocks.updateNodeInternals).toHaveBeenCalledWith(["a"]);
   });
 });

--- a/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.unit.test.tsx
@@ -3,7 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ReactFlowProvider } from "@xyflow/react";
 import type * as XyFlowReact from "@xyflow/react";
 import type { PipelineNode } from "../_store/canvasSlice";
-import { createCanvasPageStore, CanvasPageStoreContext, CanvasPageStoreProvider } from "../_store";
+import {
+  createCanvasPageStore,
+  CanvasPageStoreContext,
+  CanvasPageStoreProvider,
+} from "../_store";
 import {
   CANVAS_COMPONENT_DRAG_MIME,
   encodeCanvasComponentDragPayload,
@@ -87,14 +91,22 @@ vi.mock("@xyflow/react", async (importOriginal) => {
           data-elements-selectable={String(elementsSelectable ?? true)}
           data-has-on-connect={String(typeof onConnect === "function")}
           data-has-on-connect-end={String(typeof onConnectEnd === "function")}
-          data-has-on-connect-start={String(typeof onConnectStart === "function")}
+          data-has-on-connect-start={String(
+            typeof onConnectStart === "function",
+          )}
           data-has-on-edge-click={String(typeof onEdgeClick === "function")}
           data-has-on-node-click={String(typeof onNodeClick === "function")}
-          data-has-on-node-context-menu={String(typeof onNodeContextMenu === "function")}
+          data-has-on-node-context-menu={String(
+            typeof onNodeContextMenu === "function",
+          )}
           data-has-on-node-drag={String(typeof onNodeDrag === "function")}
-          data-has-on-node-drag-stop={String(typeof onNodeDragStop === "function")}
+          data-has-on-node-drag-stop={String(
+            typeof onNodeDragStop === "function",
+          )}
           data-has-on-pane-click={String(typeof onPaneClick === "function")}
-          data-has-on-pane-context-menu={String(typeof onPaneContextMenu === "function")}
+          data-has-on-pane-context-menu={String(
+            typeof onPaneContextMenu === "function",
+          )}
           data-nodes-connectable={String(nodesConnectable ?? true)}
           data-nodes-draggable={String(nodesDraggable ?? true)}
           data-pan-on-drag={String(panOnDrag ?? true)}
@@ -104,8 +116,7 @@ vi.mock("@xyflow/react", async (importOriginal) => {
           data-zoom-on-double-click={String(zoomOnDoubleClick ?? true)}
           data-zoom-on-pinch={String(zoomOnPinch ?? true)}
           data-zoom-on-scroll={String(zoomOnScroll ?? true)}
-          onMouseMove={handleMouseMove}
-        >
+          onMouseMove={handleMouseMove}>
           {children}
         </div>
       );
@@ -177,7 +188,10 @@ describe("CanvasFlow", () => {
   it("renders without crashing", () => {
     const { container } = render(<CanvasFlow />, { wrapper });
     expect(container.firstChild).toBeTruthy();
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-zoom", "1.25");
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-zoom",
+      "1.25",
+    );
     expect(screen.queryByTestId("flow-controls")).not.toBeInTheDocument();
   });
 
@@ -193,16 +207,46 @@ describe("CanvasFlow", () => {
       </CanvasPageStoreContext.Provider>,
     );
 
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-nodes-draggable", "false");
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-nodes-connectable", "false");
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-elements-selectable", "false");
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-pan-on-drag", "false");
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-zoom-on-scroll", "false");
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-has-on-node-click", "false");
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-has-on-edge-click", "false");
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-has-on-pane-click", "false");
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-has-on-connect", "false");
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-delete-key-code", "null");
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-nodes-draggable",
+      "false",
+    );
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-nodes-connectable",
+      "false",
+    );
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-elements-selectable",
+      "false",
+    );
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-pan-on-drag",
+      "false",
+    );
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-zoom-on-scroll",
+      "false",
+    );
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-has-on-node-click",
+      "false",
+    );
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-has-on-edge-click",
+      "false",
+    );
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-has-on-pane-click",
+      "false",
+    );
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-has-on-connect",
+      "false",
+    );
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-delete-key-code",
+      "null",
+    );
   });
 
   it("shows MiniMap when multiple nodes exist and the console is closed", () => {
@@ -211,7 +255,10 @@ describe("CanvasFlow", () => {
     expect(screen.getByTestId("mini-map")).toBeInTheDocument();
     expect(screen.getByTestId("flow-background")).toBeInTheDocument();
     expect(screen.queryByTestId("flow-controls")).not.toBeInTheDocument();
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-auto-fit", "false");
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-auto-fit",
+      "false",
+    );
   });
 
   it("hides MiniMap for a single node", () => {
@@ -242,7 +289,10 @@ describe("CanvasFlow", () => {
     expect(screen.queryByTestId("mini-map")).not.toBeInTheDocument();
     expect(screen.queryByTestId("flow-background")).not.toBeInTheDocument();
     expect(screen.queryByTestId("flow-controls")).not.toBeInTheDocument();
-    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-snap-to-grid", "true");
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-snap-to-grid",
+      "true",
+    );
   });
 
   it("hides MiniMap while the console is open", () => {
@@ -262,7 +312,9 @@ describe("CanvasFlow", () => {
       </CanvasPageStoreContext.Provider>,
     );
 
-    screen.getByTestId("react-flow").dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+    screen
+      .getByTestId("react-flow")
+      .dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
 
     expect(store.getState().viewportZoom).toBe(0.6);
   });
@@ -279,7 +331,9 @@ describe("CanvasFlow", () => {
       </CanvasPageStoreContext.Provider>,
     );
 
-    expect(viewportRef.current).toBe(screen.getByTestId("canvas-flow-viewport"));
+    expect(viewportRef.current).toBe(
+      screen.getByTestId("canvas-flow-viewport"),
+    );
   });
 
   it("drops dragged palette items onto the flow viewport", () => {
@@ -305,7 +359,10 @@ describe("CanvasFlow", () => {
 
     const viewport = screen.getByTestId("canvas-flow-viewport");
     fireEvent(viewport, makeDragEvent("dragover", dataTransfer));
-    fireEvent(viewport, makeDragEvent("drop", dataTransfer, { clientX: 240, clientY: 180 }));
+    fireEvent(
+      viewport,
+      makeDragEvent("drop", dataTransfer, { clientX: 240, clientY: 180 }),
+    );
 
     expect(dataTransfer.dropEffect).toBe("copy");
     expect(store.getState().nodes).toEqual([
@@ -358,10 +415,20 @@ describe("CanvasFlow", () => {
 
     act(() => {
       xyflowMocks.onNodesChange?.([
-        { id: "a", type: "position", position: { x: 12, y: 18 }, dragging: false },
+        {
+          id: "a",
+          type: "position",
+          position: { x: 12, y: 18 },
+          dragging: false,
+        },
       ]);
       xyflowMocks.onNodesChange?.([
-        { id: "a", type: "position", position: { x: 24, y: 36 }, dragging: false },
+        {
+          id: "a",
+          type: "position",
+          position: { x: 24, y: 36 },
+          dragging: false,
+        },
       ]);
       vi.runAllTimers();
     });
@@ -389,7 +456,12 @@ describe("CanvasFlow", () => {
     expect(() => {
       act(() => {
         xyflowMocks.onNodesChange?.([
-          { id: "a", type: "position", position: { x: 12, y: 18 }, dragging: false },
+          {
+            id: "a",
+            type: "position",
+            position: { x: 12, y: 18 },
+            dragging: false,
+          },
         ]);
         vi.runAllTimers();
       });
@@ -398,3 +470,4 @@ describe("CanvasFlow", () => {
     expect(xyflowMocks.updateNodeInternals).toHaveBeenCalledWith(["a"]);
   });
 });
+

--- a/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasFlow/CanvasFlow.unit.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ReactFlowProvider } from "@xyflow/react";
 import type * as XyFlowReact from "@xyflow/react";
 import type { PipelineNode } from "../_store/canvasSlice";
 import { createCanvasPageStore, CanvasPageStoreContext, CanvasPageStoreProvider } from "../_store";
+import {
+  CANVAS_COMPONENT_DRAG_MIME,
+  encodeCanvasComponentDragPayload,
+} from "../utils/canvasComponentDragPayload";
 import { CanvasFlow } from "./CanvasFlow";
 
 vi.mock("@xyflow/react", async (importOriginal) => {
@@ -130,6 +134,19 @@ const renderWithStore = (nodes: PipelineNode[], isConsoleOpen = false) => {
   );
 };
 
+const makeDragEvent = (
+  type: "dragover" | "drop",
+  dataTransfer: object,
+  position?: { clientX: number; clientY: number },
+) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+  Object.defineProperty(event, "clientX", { value: position?.clientX ?? 0 });
+  Object.defineProperty(event, "clientY", { value: position?.clientY ?? 0 });
+
+  return event;
+};
+
 describe("CanvasFlow", () => {
   it("renders without crashing", () => {
     const { container } = render(<CanvasFlow />, { wrapper });
@@ -237,5 +254,40 @@ describe("CanvasFlow", () => {
     );
 
     expect(viewportRef.current).toBe(screen.getByTestId("canvas-flow-viewport"));
+  });
+
+  it("drops dragged palette items onto the flow viewport", () => {
+    const store = createCanvasPageStore([], []);
+    const dataTransfer = {
+      dropEffect: "none",
+      types: [CANVAS_COMPONENT_DRAG_MIME],
+      getData: vi.fn(() =>
+        encodeCanvasComponentDragPayload({
+          kind: "object",
+          type: "file",
+        }),
+      ),
+    };
+
+    render(
+      <CanvasPageStoreContext.Provider value={store}>
+        <ReactFlowProvider>
+          <CanvasFlow />
+        </ReactFlowProvider>
+      </CanvasPageStoreContext.Provider>,
+    );
+
+    const viewport = screen.getByTestId("canvas-flow-viewport");
+    fireEvent(viewport, makeDragEvent("dragover", dataTransfer));
+    fireEvent(viewport, makeDragEvent("drop", dataTransfer, { clientX: 240, clientY: 180 }));
+
+    expect(dataTransfer.dropEffect).toBe("copy");
+    expect(store.getState().nodes).toEqual([
+      expect.objectContaining({
+        type: "file",
+        origin: [0.5, 0.5],
+        position: { x: 240, y: 180 },
+      }),
+    ]);
   });
 });

--- a/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from "react";
 import { useStore } from "zustand";
-import { useCanvasPageStore } from "../_store";
+import { selectSelectedNode, useCanvasPageStore } from "../_store";
 import { CanvasFlow } from "../CanvasFlow";
 import { CanvasContextMenu } from "../CanvasContextMenu";
 import { ConnectionMenu } from "../ConnectionMenu";
@@ -13,6 +13,10 @@ import { CanvasNodeCreationPalette } from "../CanvasNodeCreationPalette";
 import { CanvasStatusBar } from "../CanvasStatusBar";
 import { CanvasSettingsDrawer } from "../CanvasSettingsDrawer";
 import { CanvasTopChrome } from "../CanvasTopChrome";
+import { CanvasMiniSidebar } from "../CanvasMiniSidebar";
+import { CanvasComponentPanel } from "../CanvasComponentPanel";
+import { CanvasNodePropertiesPanel } from "../CanvasNodePropertiesPanel";
+import { CanvasWorkspaceSidebarOverlay } from "../CanvasWorkspaceSidebarOverlay";
 import { getScreenViewportCenter, getViewportRectCenter } from "../utils/nodePosition";
 
 export const CanvasInner = () => {
@@ -26,6 +30,9 @@ export const CanvasInner = () => {
   const isQuickAddOpen = useStore(store, (state) => state.isQuickAddOpen);
   const agentPanelIsOpen = useStore(store, (state) => state.agentPanel.isOpen);
   const nodes = useStore(store, (state) => state.nodes);
+  const sidebarPanel = useStore(store, (state) => state.sidebarPanel);
+  const selectedNode = useStore(store, selectSelectedNode);
+  const showPropertiesPanel = sidebarPanel === "properties" && !!selectedNode;
 
   const getFlowViewportScreenCenter = useCallback(() => {
     const rect = flowViewportRef.current?.getBoundingClientRect();
@@ -34,32 +41,57 @@ export const CanvasInner = () => {
   }, []);
 
   return (
-    <div className="relative h-full w-full">
-      <CanvasTopChrome />
+    <div
+      className="flex h-full min-h-0 w-full overflow-hidden bg-background"
+      data-testid="canvas-langflow-shell"
+    >
+      <CanvasMiniSidebar />
 
-      <CanvasFlow viewportRef={flowViewportRef} />
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <CanvasTopChrome />
 
-      {nodes.length === 0 && <CanvasEmptyState />}
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <aside
+            className="h-full w-[min(22rem,28vw)] min-w-72 shrink-0 border-r bg-background"
+            data-testid="canvas-work-panel"
+          >
+            {showPropertiesPanel ? (
+              <CanvasNodePropertiesPanel />
+            ) : (
+              <CanvasComponentPanel getCreateNodeScreenPosition={getFlowViewportScreenCenter} />
+            )}
+          </aside>
 
-      {isQuickAddOpen && (
-        <CanvasNodeCreationPalette getCreateNodeScreenPosition={getFlowViewportScreenCenter} />
-      )}
+          <main className="relative min-w-0 flex-1 overflow-hidden">
+            <CanvasFlow viewportRef={flowViewportRef} />
 
-      <CanvasStatusBar />
+            {nodes.length === 0 && <CanvasEmptyState />}
+
+            {isQuickAddOpen && (
+              <CanvasNodeCreationPalette
+                getCreateNodeScreenPosition={getFlowViewportScreenCenter}
+              />
+            )}
+
+            <CanvasStatusBar />
+
+            {contextMenu && <CanvasContextMenu />}
+
+            {connectionMenu && <ConnectionMenu />}
+
+            {nodeContextMenu && <NodeContextMenu />}
+
+            <LlmContentCard />
+
+            {isConsoleOpen && <RunConsole />}
+
+            {agentPanelIsOpen && <AgentPanel />}
+          </main>
+        </div>
+      </div>
 
       <CanvasSettingsDrawer />
-
-      {contextMenu && <CanvasContextMenu />}
-
-      {connectionMenu && <ConnectionMenu />}
-
-      {nodeContextMenu && <NodeContextMenu />}
-
-      <LlmContentCard />
-
-      {isConsoleOpen && <RunConsole />}
-
-      {agentPanelIsOpen && <AgentPanel />}
+      <CanvasWorkspaceSidebarOverlay />
     </div>
   );
 };

--- a/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ReactFlowProvider } from "@xyflow/react";
 import type * as XyFlowReact from "@xyflow/react";
@@ -23,9 +24,32 @@ vi.mock("@/services/pipelinesService", () => ({
 }));
 
 vi.mock("@refinedev/core", () => ({
-  useList: () => ({ result: { data: [] } }),
+  useList: ({ resource }: { resource: string }) => ({
+    result: {
+      data:
+        resource === "operations"
+          ? [
+              {
+                id: "review-code",
+                name: "Review Code",
+                description: "",
+                config: {},
+                acceptedObjectTypes: ["file"],
+              },
+            ]
+          : [],
+    },
+  }),
   useUpdate: () => ({ mutate: vi.fn(), mutation: { isPending: false } }),
   useCreate: () => ({ mutate: vi.fn(), mutation: { isPending: false } }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to, ...props }: React.PropsWithChildren<{ to: string }>) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
 }));
 
 const queryClient = new QueryClient({
@@ -71,6 +95,25 @@ describe("CanvasInner", () => {
   it("renders without crashing", () => {
     const { container } = render(<CanvasInner />, { wrapper: wrapperWithoutPipeline });
     expect(container.firstChild).toBeTruthy();
+  });
+
+  it("renders the LangFlow shell with mini sidebar and component panel", () => {
+    render(<CanvasInner />, { wrapper });
+
+    expect(screen.getByTestId("canvas-langflow-shell")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-mini-sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-component-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-flow-viewport")).toBeInTheDocument();
+  });
+
+  it("opens the workspace sidebar overlay from the mini sidebar", async () => {
+    const user = userEvent.setup();
+    render(<CanvasInner />, { wrapper });
+
+    await user.click(screen.getByRole("button", { name: /Workspace/i }));
+
+    expect(screen.getByTestId("canvas-workspace-sidebar-overlay")).toBeInTheDocument();
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
   });
 
   it("shows the canvas empty state when there are no nodes", () => {

--- a/apps/app/src/pages/CanvasPage/CanvasMiniSidebar/CanvasMiniSidebar.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasMiniSidebar/CanvasMiniSidebar.tsx
@@ -1,0 +1,102 @@
+import { Menu, PanelLeft, PanelRight, Settings2, Workflow } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import { Button } from "@repo/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@repo/ui/tooltip";
+import { useCanvasPageStore } from "../_store";
+
+export const CanvasMiniSidebar = () => {
+  const { t } = useTranslation();
+  const store = useCanvasPageStore();
+  const isWorkspaceSidebarOpen = useStore(store, (state) => state.isWorkspaceSidebarOpen);
+  const nodeCardMode = useStore(store, (state) => state.nodeCardMode);
+  const openWorkspaceSidebar = useStore(store, (state) => state.openWorkspaceSidebar);
+  const openCanvasSettings = useStore(store, (state) => state.openCanvasSettings);
+  const toggleNodeCardMode = useStore(store, (state) => state.toggleNodeCardMode);
+
+  const workspaceLabel = t("canvas.workspaceSidebar.title", { defaultValue: "Workspace" });
+  const settingsLabel = t("canvas.settingsDrawer.menuLabel");
+  const nodeCardLabel =
+    nodeCardMode === "compact"
+      ? t("canvas.nodeCardMode.compact", { defaultValue: "Compact cards" })
+      : t("canvas.nodeCardMode.expanded", { defaultValue: "Expanded cards" });
+  const handleOpenWorkspaceSidebar = () => {
+    openWorkspaceSidebar();
+  };
+  const handleToggleNodeCardMode = () => {
+    toggleNodeCardMode();
+  };
+  const handleOpenCanvasSettings = () => {
+    openCanvasSettings();
+  };
+
+  return (
+    <aside
+      className="flex w-14 shrink-0 flex-col items-center gap-2 border-r bg-background/95 px-2 py-3 backdrop-blur"
+      data-testid="canvas-mini-sidebar"
+    >
+      <div className="flex size-9 items-center justify-center rounded-md border bg-muted/40 text-primary">
+        <Workflow className="size-4" />
+      </div>
+
+      <div className="flex flex-1 flex-col items-center gap-1">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label={workspaceLabel}
+                aria-pressed={isWorkspaceSidebarOpen}
+                className="size-9 rounded-md"
+                size="icon"
+                variant={isWorkspaceSidebarOpen ? "secondary" : "ghost"}
+                onClick={handleOpenWorkspaceSidebar}
+              />
+            }
+          >
+            <Menu className="size-4" />
+          </TooltipTrigger>
+          <TooltipContent>{workspaceLabel}</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label={nodeCardLabel}
+                aria-pressed={nodeCardMode === "expanded"}
+                className="size-9 rounded-md"
+                size="icon"
+                variant={nodeCardMode === "expanded" ? "secondary" : "ghost"}
+                onClick={handleToggleNodeCardMode}
+              />
+            }
+          >
+            {nodeCardMode === "compact" ? (
+              <PanelLeft className="size-4" />
+            ) : (
+              <PanelRight className="size-4" />
+            )}
+          </TooltipTrigger>
+          <TooltipContent>{nodeCardLabel}</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label={settingsLabel}
+                className="size-9 rounded-md"
+                size="icon"
+                variant="ghost"
+                onClick={handleOpenCanvasSettings}
+              />
+            }
+          >
+            <Settings2 className="size-4" />
+          </TooltipTrigger>
+          <TooltipContent>{settingsLabel}</TooltipContent>
+        </Tooltip>
+      </div>
+    </aside>
+  );
+};

--- a/apps/app/src/pages/CanvasPage/CanvasMiniSidebar/CanvasMiniSidebar.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasMiniSidebar/CanvasMiniSidebar.tsx
@@ -5,6 +5,8 @@ import { Button } from "@repo/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@repo/ui/tooltip";
 import { useCanvasPageStore } from "../_store";
 
+export const CANVAS_WORKSPACE_SIDEBAR_ID = "canvas-workspace-sidebar-overlay";
+
 export const CanvasMiniSidebar = () => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
@@ -16,9 +18,10 @@ export const CanvasMiniSidebar = () => {
 
   const workspaceLabel = t("canvas.workspaceSidebar.title", { defaultValue: "Workspace" });
   const settingsLabel = t("canvas.settingsDrawer.menuLabel");
-  const nodeCardLabel =
+  const compactCardsLabel = t("canvas.nodeCardMode.compact", { defaultValue: "Compact cards" });
+  const nodeCardModeLabel =
     nodeCardMode === "compact"
-      ? t("canvas.nodeCardMode.compact", { defaultValue: "Compact cards" })
+      ? compactCardsLabel
       : t("canvas.nodeCardMode.expanded", { defaultValue: "Expanded cards" });
   const handleOpenWorkspaceSidebar = () => {
     openWorkspaceSidebar();
@@ -44,8 +47,9 @@ export const CanvasMiniSidebar = () => {
           <TooltipTrigger
             render={
               <Button
+                aria-controls={CANVAS_WORKSPACE_SIDEBAR_ID}
+                aria-expanded={isWorkspaceSidebarOpen}
                 aria-label={workspaceLabel}
-                aria-pressed={isWorkspaceSidebarOpen}
                 className="size-9 rounded-md"
                 size="icon"
                 variant={isWorkspaceSidebarOpen ? "secondary" : "ghost"}
@@ -62,11 +66,11 @@ export const CanvasMiniSidebar = () => {
           <TooltipTrigger
             render={
               <Button
-                aria-label={nodeCardLabel}
-                aria-pressed={nodeCardMode === "expanded"}
+                aria-label={compactCardsLabel}
+                aria-pressed={nodeCardMode === "compact"}
                 className="size-9 rounded-md"
                 size="icon"
-                variant={nodeCardMode === "expanded" ? "secondary" : "ghost"}
+                variant={nodeCardMode === "compact" ? "secondary" : "ghost"}
                 onClick={handleToggleNodeCardMode}
               />
             }
@@ -77,7 +81,7 @@ export const CanvasMiniSidebar = () => {
               <PanelRight className="size-4" />
             )}
           </TooltipTrigger>
-          <TooltipContent>{nodeCardLabel}</TooltipContent>
+          <TooltipContent>{nodeCardModeLabel}</TooltipContent>
         </Tooltip>
 
         <Tooltip>

--- a/apps/app/src/pages/CanvasPage/CanvasMiniSidebar/CanvasMiniSidebar.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasMiniSidebar/CanvasMiniSidebar.tsx
@@ -10,34 +10,39 @@ export const CANVAS_WORKSPACE_SIDEBAR_ID = "canvas-workspace-sidebar-overlay";
 export const CanvasMiniSidebar = () => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
-  const isWorkspaceSidebarOpen = useStore(store, (state) => state.isWorkspaceSidebarOpen);
+  const isWorkspaceSidebarOpen = useStore(
+    store,
+    (state) => state.isWorkspaceSidebarOpen,
+  );
   const nodeCardMode = useStore(store, (state) => state.nodeCardMode);
-  const openWorkspaceSidebar = useStore(store, (state) => state.openWorkspaceSidebar);
-  const openCanvasSettings = useStore(store, (state) => state.openCanvasSettings);
-  const toggleNodeCardMode = useStore(store, (state) => state.toggleNodeCardMode);
+  const openWorkspaceSidebar = useStore(
+    store,
+    (state) => state.openWorkspaceSidebar,
+  );
+  const openCanvasSettings = useStore(
+    store,
+    (state) => state.openCanvasSettings,
+  );
+  const toggleNodeCardMode = useStore(
+    store,
+    (state) => state.toggleNodeCardMode,
+  );
 
-  const workspaceLabel = t("canvas.workspaceSidebar.title", { defaultValue: "Workspace" });
+  const workspaceLabel = t("canvas.workspaceSidebar.title", {
+    defaultValue: "Workspace",
+  });
   const settingsLabel = t("canvas.settingsDrawer.menuLabel");
-  const compactCardsLabel = t("canvas.nodeCardMode.compact", { defaultValue: "Compact cards" });
+  const compactCardsLabel = t("canvas.nodeCardMode.compact", {
+    defaultValue: "Compact cards",
+  });
   const nodeCardModeLabel =
     nodeCardMode === "compact"
       ? compactCardsLabel
       : t("canvas.nodeCardMode.expanded", { defaultValue: "Expanded cards" });
-  const handleOpenWorkspaceSidebar = () => {
-    openWorkspaceSidebar();
-  };
-  const handleToggleNodeCardMode = () => {
-    toggleNodeCardMode();
-  };
-  const handleOpenCanvasSettings = () => {
-    openCanvasSettings();
-  };
-
   return (
     <aside
       className="flex w-14 shrink-0 flex-col items-center gap-2 border-r bg-background/95 px-2 py-3 backdrop-blur"
-      data-testid="canvas-mini-sidebar"
-    >
+      data-testid="canvas-mini-sidebar">
       <div className="flex size-9 items-center justify-center rounded-md border bg-muted/40 text-primary">
         <Workflow className="size-4" />
       </div>
@@ -53,10 +58,9 @@ export const CanvasMiniSidebar = () => {
                 className="size-9 rounded-md"
                 size="icon"
                 variant={isWorkspaceSidebarOpen ? "secondary" : "ghost"}
-                onClick={handleOpenWorkspaceSidebar}
+                onClick={openWorkspaceSidebar}
               />
-            }
-          >
+            }>
             <Menu className="size-4" />
           </TooltipTrigger>
           <TooltipContent>{workspaceLabel}</TooltipContent>
@@ -71,10 +75,9 @@ export const CanvasMiniSidebar = () => {
                 className="size-9 rounded-md"
                 size="icon"
                 variant={nodeCardMode === "compact" ? "secondary" : "ghost"}
-                onClick={handleToggleNodeCardMode}
+                onClick={toggleNodeCardMode}
               />
-            }
-          >
+            }>
             {nodeCardMode === "compact" ? (
               <PanelLeft className="size-4" />
             ) : (
@@ -92,10 +95,9 @@ export const CanvasMiniSidebar = () => {
                 className="size-9 rounded-md"
                 size="icon"
                 variant="ghost"
-                onClick={handleOpenCanvasSettings}
+                onClick={openCanvasSettings}
               />
-            }
-          >
+            }>
             <Settings2 className="size-4" />
           </TooltipTrigger>
           <TooltipContent>{settingsLabel}</TooltipContent>
@@ -104,3 +106,4 @@ export const CanvasMiniSidebar = () => {
     </aside>
   );
 };
+

--- a/apps/app/src/pages/CanvasPage/CanvasMiniSidebar/CanvasMiniSidebar.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasMiniSidebar/CanvasMiniSidebar.unit.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { CanvasPageStoreContext, createCanvasPageStore } from "../_store";
+import { CanvasMiniSidebar } from "./CanvasMiniSidebar";
+
+const renderMiniSidebar = () => {
+  const store = createCanvasPageStore();
+
+  render(
+    <CanvasPageStoreContext.Provider value={store}>
+      <CanvasMiniSidebar />
+    </CanvasPageStoreContext.Provider>,
+  );
+
+  return store;
+};
+
+describe("CanvasMiniSidebar", () => {
+  it("opens workspace, toggles node cards, and opens settings", async () => {
+    const user = userEvent.setup();
+    const store = renderMiniSidebar();
+
+    await user.click(screen.getByRole("button", { name: /Workspace/i }));
+    expect(store.getState().isWorkspaceSidebarOpen).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: /Compact cards/i }));
+    expect(store.getState().nodeCardMode).toBe("expanded");
+
+    await user.click(screen.getByRole("button", { name: /Expanded cards/i }));
+    expect(store.getState().nodeCardMode).toBe("compact");
+
+    await user.click(screen.getByRole("button", { name: /Settings|设置/i }));
+    expect(store.getState().isCanvasSettingsOpen).toBe(true);
+  });
+});

--- a/apps/app/src/pages/CanvasPage/CanvasMiniSidebar/CanvasMiniSidebar.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasMiniSidebar/CanvasMiniSidebar.unit.test.tsx
@@ -21,14 +21,23 @@ describe("CanvasMiniSidebar", () => {
     const user = userEvent.setup();
     const store = renderMiniSidebar();
 
-    await user.click(screen.getByRole("button", { name: /Workspace/i }));
+    const workspaceButton = screen.getByRole("button", { name: /Workspace/i });
+    expect(workspaceButton).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(workspaceButton);
     expect(store.getState().isWorkspaceSidebarOpen).toBe(true);
+    expect(workspaceButton).toHaveAttribute("aria-expanded", "true");
 
-    await user.click(screen.getByRole("button", { name: /Compact cards/i }));
+    const compactCardsButton = screen.getByRole("button", { name: /Compact cards/i });
+    expect(compactCardsButton).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(compactCardsButton);
     expect(store.getState().nodeCardMode).toBe("expanded");
+    expect(compactCardsButton).toHaveAttribute("aria-pressed", "false");
 
-    await user.click(screen.getByRole("button", { name: /Expanded cards/i }));
+    await user.click(compactCardsButton);
     expect(store.getState().nodeCardMode).toBe("compact");
+    expect(compactCardsButton).toHaveAttribute("aria-pressed", "true");
 
     await user.click(screen.getByRole("button", { name: /Settings|设置/i }));
     expect(store.getState().isCanvasSettingsOpen).toBe(true);

--- a/apps/app/src/pages/CanvasPage/CanvasMiniSidebar/index.ts
+++ b/apps/app/src/pages/CanvasPage/CanvasMiniSidebar/index.ts
@@ -1,0 +1,1 @@
+export * from "./CanvasMiniSidebar";

--- a/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.tsx
@@ -8,6 +8,7 @@ import {
   MessageSquareText,
   Zap,
 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { OUTPUT_MODE_ENUM, type OutputMode } from "@repo/schemas";
 import { Button } from "@repo/ui/button";
@@ -19,15 +20,16 @@ import { SiGitHubIcon } from "@/components/icons/SiGitHubIcon";
 import { selectSelectedNode, useCanvasPageStore } from "../_store";
 import { getNodeMeta } from "../utils/nodeTypeMeta";
 
-const outputModeLabels: Record<OutputMode, string> = {
-  overwrite: "Overwrite",
-  error_if_exists: "Error if exists",
-  auto_rename: "Auto rename",
-};
+const outputModeLabelKeys = {
+  overwrite: "canvas.propertiesPanel.outputMode.overwrite",
+  error_if_exists: "canvas.propertiesPanel.outputMode.errorIfExists",
+  auto_rename: "canvas.propertiesPanel.outputMode.autoRename",
+} as const satisfies Record<OutputMode, string>;
 
 const fieldId = (nodeId: string, field: string) => `canvas-properties-${nodeId}-${field}`;
 
 export const CanvasNodePropertiesPanel = () => {
+  const { t } = useTranslation();
   const store = useCanvasPageStore();
   const selectedNode = useStore(store, selectSelectedNode);
   const updateNodeData = useStore(store, (state) => state.updateNodeData);
@@ -43,7 +45,7 @@ export const CanvasNodePropertiesPanel = () => {
   if (!selectedNode) {
     return (
       <div className="flex h-full flex-col bg-background p-4">
-        <p className="text-sm text-muted-foreground">Select a canvas node to configure it.</p>
+        <p className="text-sm text-muted-foreground">{t("canvas.propertiesPanel.empty")}</p>
       </div>
     );
   }
@@ -142,10 +144,12 @@ export const CanvasNodePropertiesPanel = () => {
   }) => {
     const id = fieldId(selectedNode.id, field);
     const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      const nextValue = Number.parseInt(event.target.value, 10);
+      const nextValue = event.currentTarget.valueAsNumber;
 
-      if (!Number.isNaN(nextValue)) {
-        handleValueChange(nextValue);
+      if (Number.isFinite(nextValue) && Number.isInteger(nextValue)) {
+        const lowerBound = min ?? Number.NEGATIVE_INFINITY;
+        const upperBound = max ?? Number.POSITIVE_INFINITY;
+        handleValueChange(Math.min(Math.max(nextValue, lowerBound), upperBound));
       }
     };
 
@@ -180,7 +184,7 @@ export const CanvasNodePropertiesPanel = () => {
           onClick={handleBackToComponentsClick}
         >
           <ArrowLeft className="size-4" />
-          Back to components
+          {t("canvas.propertiesPanel.backToComponents")}
         </Button>
         <div className="flex items-center gap-3">
           <span
@@ -198,7 +202,7 @@ export const CanvasNodePropertiesPanel = () => {
       <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
         {renderTextField({
           field: "label",
-          label: "Label",
+          label: t("canvas.propertiesPanel.fields.label"),
           value: String(data.label ?? ""),
         })}
 
@@ -206,19 +210,19 @@ export const CanvasNodePropertiesPanel = () => {
           <>
             {renderTextField({
               field: "filePath",
-              label: "File path",
-              placeholder: "src/file.tsx",
+              label: t("canvas.propertiesPanel.fields.filePath"),
+              placeholder: t("canvas.propertiesPanel.placeholders.filePath"),
               value: data.filePath,
             })}
             {renderTextField({
               field: "language",
-              label: "Language",
-              placeholder: "typescript",
+              label: t("canvas.propertiesPanel.fields.language"),
+              placeholder: t("canvas.propertiesPanel.placeholders.language"),
               value: data.language ?? "",
             })}
             {renderTextareaField({
               field: "description",
-              label: "Description",
+              label: t("canvas.propertiesPanel.fields.description"),
               value: data.description ?? "",
             })}
           </>
@@ -228,13 +232,13 @@ export const CanvasNodePropertiesPanel = () => {
           <>
             {renderTextField({
               field: "folderPath",
-              label: "Folder path",
-              placeholder: "src/components",
+              label: t("canvas.propertiesPanel.fields.folderPath"),
+              placeholder: t("canvas.propertiesPanel.placeholders.folderPath"),
               value: data.folderPath,
             })}
             {renderTextareaField({
               field: "description",
-              label: "Description",
+              label: t("canvas.propertiesPanel.fields.description"),
               value: data.description ?? "",
             })}
           </>
@@ -244,27 +248,27 @@ export const CanvasNodePropertiesPanel = () => {
           <>
             {renderTextField({
               field: "owner",
-              label: "Owner",
+              label: t("canvas.propertiesPanel.fields.owner"),
               value: data.owner,
             })}
             {renderTextField({
               field: "repo",
-              label: "Repository",
+              label: t("canvas.propertiesPanel.fields.repository"),
               value: data.repo,
             })}
             {renderTextField({
               field: "branch",
-              label: "Branch",
+              label: t("canvas.propertiesPanel.fields.branch"),
               value: data.branch ?? "",
             })}
             {renderTextField({
               field: "localPath",
-              label: "Local path",
+              label: t("canvas.propertiesPanel.fields.localPath"),
               value: data.localPath ?? "",
             })}
             {renderTextareaField({
               field: "description",
-              label: "Description",
+              label: t("canvas.propertiesPanel.fields.description"),
               value: data.description ?? "",
             })}
           </>
@@ -274,12 +278,12 @@ export const CanvasNodePropertiesPanel = () => {
           <>
             {renderTextareaField({
               field: "prompt",
-              label: "Prompt",
+              label: t("canvas.propertiesPanel.fields.prompt"),
               value: data.prompt,
             })}
             {renderTextareaField({
               field: "description",
-              label: "Description",
+              label: t("canvas.propertiesPanel.fields.description"),
               value: data.description ?? "",
             })}
           </>
@@ -289,17 +293,17 @@ export const CanvasNodePropertiesPanel = () => {
           <>
             {renderTextField({
               field: "operationName",
-              label: "Operation name",
+              label: t("canvas.propertiesPanel.fields.operationName"),
               value: data.operationName,
             })}
             {renderTextField({
               field: "agentId",
-              label: "Agent ID",
+              label: t("canvas.propertiesPanel.fields.agentId"),
               value: data.agentId ?? "",
             })}
             {renderIntegerField({
               field: "maxLoopCount",
-              label: "Max loop count",
+              label: t("canvas.propertiesPanel.fields.maxLoopCount"),
               max: 20,
               min: 1,
               value: data.maxLoopCount ?? 3,
@@ -307,7 +311,7 @@ export const CanvasNodePropertiesPanel = () => {
             })}
             {renderTextareaField({
               field: "loopConditionPrompt",
-              label: "Loop condition",
+              label: t("canvas.propertiesPanel.fields.loopCondition"),
               value: data.loopConditionPrompt ?? "",
             })}
           </>
@@ -317,17 +321,17 @@ export const CanvasNodePropertiesPanel = () => {
           <>
             {renderTextField({
               field: "projectId",
-              label: "Project ID",
+              label: t("canvas.propertiesPanel.fields.projectId"),
               value: data.projectId ?? "",
             })}
             {renderTextField({
               field: "path",
-              label: "Output path",
+              label: t("canvas.propertiesPanel.fields.outputPath"),
               value: data.path,
             })}
             {renderTextareaField({
               field: "description",
-              label: "Description",
+              label: t("canvas.propertiesPanel.fields.description"),
               value: data.description ?? "",
             })}
           </>
@@ -337,16 +341,16 @@ export const CanvasNodePropertiesPanel = () => {
           <>
             {renderTextField({
               field: "localPath",
-              label: "Local path",
+              label: t("canvas.propertiesPanel.fields.localPath"),
               value: data.localPath,
             })}
             {renderTextField({
               field: "outputFileName",
-              label: "Output file name",
+              label: t("canvas.propertiesPanel.fields.outputFileName"),
               value: data.outputFileName ?? "",
             })}
             <div className="space-y-1.5">
-              <Label>Write mode</Label>
+              <Label>{t("canvas.propertiesPanel.fields.writeMode")}</Label>
               <Select
                 value={data.outputMode ?? "overwrite"}
                 onValueChange={(value) => handleUpdateNodeData({ outputMode: value as OutputMode })}
@@ -357,7 +361,7 @@ export const CanvasNodePropertiesPanel = () => {
                 <SelectContent>
                   {Object.values(OUTPUT_MODE_ENUM).map((mode) => (
                     <SelectItem key={mode} value={mode}>
-                      {outputModeLabels[mode]}
+                      {t(outputModeLabelKeys[mode])}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -365,7 +369,7 @@ export const CanvasNodePropertiesPanel = () => {
             </div>
             {renderTextareaField({
               field: "description",
-              label: "Description",
+              label: t("canvas.propertiesPanel.fields.description"),
               value: data.description ?? "",
             })}
           </>
@@ -374,7 +378,7 @@ export const CanvasNodePropertiesPanel = () => {
         {data.nodeType === "compound" &&
           renderTextareaField({
             field: "description",
-            label: "Description",
+            label: t("canvas.propertiesPanel.fields.description"),
             value: data.description ?? "",
           })}
       </div>

--- a/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.tsx
@@ -14,7 +14,13 @@ import { OUTPUT_MODE_ENUM, type OutputMode } from "@repo/schemas";
 import { Button } from "@repo/ui/button";
 import { Input } from "@repo/ui/input";
 import { Label } from "@repo/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/select";
 import { Textarea } from "@repo/ui/textarea";
 import { SiGitHubIcon } from "@/components/icons/SiGitHubIcon";
 import { selectSelectedNode, useCanvasPageStore } from "../_store";
@@ -26,7 +32,8 @@ const outputModeLabelKeys = {
   auto_rename: "canvas.propertiesPanel.outputMode.autoRename",
 } as const satisfies Record<OutputMode, string>;
 
-const fieldId = (nodeId: string, field: string) => `canvas-properties-${nodeId}-${field}`;
+const fieldId = (nodeId: string, field: string) =>
+  `canvas-properties-${nodeId}-${field}`;
 
 export const CanvasNodePropertiesPanel = () => {
   const { t } = useTranslation();
@@ -38,14 +45,13 @@ export const CanvasNodePropertiesPanel = () => {
     (state) => state.handleOperationMaxLoopChange,
   );
   const clearSelection = useStore(store, (state) => state.clearSelection);
-  const handleBackToComponentsClick = () => {
-    clearSelection();
-  };
 
   if (!selectedNode) {
     return (
       <div className="flex h-full flex-col bg-background p-4">
-        <p className="text-sm text-muted-foreground">{t("canvas.propertiesPanel.empty")}</p>
+        <p className="text-sm text-muted-foreground">
+          {t("canvas.propertiesPanel.empty")}
+        </p>
       </div>
     );
   }
@@ -93,7 +99,9 @@ export const CanvasNodePropertiesPanel = () => {
           name={id}
           placeholder={placeholder}
           value={value}
-          onChange={(event) => handleUpdateNodeData({ [field]: event.target.value })}
+          onChange={(event) =>
+            handleUpdateNodeData({ [field]: event.target.value })
+          }
         />
       </div>
     );
@@ -121,7 +129,9 @@ export const CanvasNodePropertiesPanel = () => {
           placeholder={placeholder}
           rows={4}
           value={value}
-          onChange={(event) => handleUpdateNodeData({ [field]: event.target.value })}
+          onChange={(event) =>
+            handleUpdateNodeData({ [field]: event.target.value })
+          }
         />
       </div>
     );
@@ -149,7 +159,9 @@ export const CanvasNodePropertiesPanel = () => {
       if (Number.isFinite(nextValue) && Number.isInteger(nextValue)) {
         const lowerBound = min ?? Number.NEGATIVE_INFINITY;
         const upperBound = max ?? Number.POSITIVE_INFINITY;
-        handleValueChange(Math.min(Math.max(nextValue, lowerBound), upperBound));
+        handleValueChange(
+          Math.min(Math.max(nextValue, lowerBound), upperBound),
+        );
       }
     };
 
@@ -174,22 +186,19 @@ export const CanvasNodePropertiesPanel = () => {
   return (
     <div
       className="flex h-full min-h-0 flex-col bg-background"
-      data-testid="canvas-properties-panel"
-    >
+      data-testid="canvas-properties-panel">
       <div className="border-b p-4">
         <Button
           className="mb-3 h-8 gap-2 px-2 text-muted-foreground"
           type="button"
           variant="ghost"
-          onClick={handleBackToComponentsClick}
-        >
+          onClick={clearSelection}>
           <ArrowLeft className="size-4" />
           {t("canvas.propertiesPanel.backToComponents")}
         </Button>
         <div className="flex items-center gap-3">
           <span
-            className={`flex size-9 items-center justify-center rounded-md ${meta?.iconBg ?? "bg-slate-500"}`}
-          >
+            className={`flex size-9 items-center justify-center rounded-md ${meta?.iconBg ?? "bg-slate-500"}`}>
             <Icon className="size-4 text-white" />
           </span>
           <div className="min-w-0">
@@ -307,7 +316,8 @@ export const CanvasNodePropertiesPanel = () => {
               max: 20,
               min: 1,
               value: data.maxLoopCount ?? 3,
-              handleValueChange: (value) => handleOperationMaxLoopChange(selectedNode.id, value),
+              handleValueChange: (value) =>
+                handleOperationMaxLoopChange(selectedNode.id, value),
             })}
             {renderTextareaField({
               field: "loopConditionPrompt",
@@ -353,8 +363,9 @@ export const CanvasNodePropertiesPanel = () => {
               <Label>{t("canvas.propertiesPanel.fields.writeMode")}</Label>
               <Select
                 value={data.outputMode ?? "overwrite"}
-                onValueChange={(value) => handleUpdateNodeData({ outputMode: value as OutputMode })}
-              >
+                onValueChange={(value) =>
+                  handleUpdateNodeData({ outputMode: value as OutputMode })
+                }>
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
@@ -385,3 +396,4 @@ export const CanvasNodePropertiesPanel = () => {
     </div>
   );
 };
+

--- a/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.tsx
@@ -31,6 +31,10 @@ export const CanvasNodePropertiesPanel = () => {
   const store = useCanvasPageStore();
   const selectedNode = useStore(store, selectSelectedNode);
   const updateNodeData = useStore(store, (state) => state.updateNodeData);
+  const handleOperationMaxLoopChange = useStore(
+    store,
+    (state) => state.handleOperationMaxLoopChange,
+  );
   const clearSelection = useStore(store, (state) => state.clearSelection);
   const handleBackToComponentsClick = () => {
     clearSelection();
@@ -116,6 +120,48 @@ export const CanvasNodePropertiesPanel = () => {
           rows={4}
           value={value}
           onChange={(event) => handleUpdateNodeData({ [field]: event.target.value })}
+        />
+      </div>
+    );
+  };
+
+  const renderIntegerField = ({
+    field,
+    label,
+    max,
+    min,
+    value,
+    handleValueChange,
+  }: {
+    field: string;
+    label: string;
+    max?: number;
+    min?: number;
+    value: number;
+    handleValueChange: (value: number) => void;
+  }) => {
+    const id = fieldId(selectedNode.id, field);
+    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const nextValue = Number.parseInt(event.target.value, 10);
+
+      if (!Number.isNaN(nextValue)) {
+        handleValueChange(nextValue);
+      }
+    };
+
+    return (
+      <div className="space-y-1.5">
+        <Label htmlFor={id}>{label}</Label>
+        <Input
+          id={id}
+          inputMode="numeric"
+          max={max}
+          min={min}
+          name={id}
+          step={1}
+          type="number"
+          value={value}
+          onChange={handleInputChange}
         />
       </div>
     );
@@ -251,10 +297,13 @@ export const CanvasNodePropertiesPanel = () => {
               label: "Agent ID",
               value: data.agentId ?? "",
             })}
-            {renderTextField({
+            {renderIntegerField({
               field: "maxLoopCount",
               label: "Max loop count",
-              value: String(data.maxLoopCount ?? 3),
+              max: 20,
+              min: 1,
+              value: data.maxLoopCount ?? 3,
+              handleValueChange: (value) => handleOperationMaxLoopChange(selectedNode.id, value),
             })}
             {renderTextareaField({
               field: "loopConditionPrompt",

--- a/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.tsx
@@ -1,0 +1,334 @@
+import {
+  ArrowLeft,
+  Box,
+  FileCode,
+  Folder,
+  FolderOutput,
+  HardDrive,
+  MessageSquareText,
+  Zap,
+} from "lucide-react";
+import { useStore } from "zustand";
+import { OUTPUT_MODE_ENUM, type OutputMode } from "@repo/schemas";
+import { Button } from "@repo/ui/button";
+import { Input } from "@repo/ui/input";
+import { Label } from "@repo/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui/select";
+import { Textarea } from "@repo/ui/textarea";
+import { SiGitHubIcon } from "@/components/icons/SiGitHubIcon";
+import { selectSelectedNode, useCanvasPageStore } from "../_store";
+import { getNodeMeta } from "../utils/nodeTypeMeta";
+
+const outputModeLabels: Record<OutputMode, string> = {
+  overwrite: "Overwrite",
+  error_if_exists: "Error if exists",
+  auto_rename: "Auto rename",
+};
+
+const fieldId = (nodeId: string, field: string) => `canvas-properties-${nodeId}-${field}`;
+
+export const CanvasNodePropertiesPanel = () => {
+  const store = useCanvasPageStore();
+  const selectedNode = useStore(store, selectSelectedNode);
+  const updateNodeData = useStore(store, (state) => state.updateNodeData);
+  const clearSelection = useStore(store, (state) => state.clearSelection);
+  const handleBackToComponentsClick = () => {
+    clearSelection();
+  };
+
+  if (!selectedNode) {
+    return (
+      <div className="flex h-full flex-col bg-background p-4">
+        <p className="text-sm text-muted-foreground">Select a canvas node to configure it.</p>
+      </div>
+    );
+  }
+
+  const data = selectedNode.data;
+  const meta = getNodeMeta(selectedNode.type);
+  const Icon =
+    selectedNode.type === "file"
+      ? FileCode
+      : selectedNode.type === "folder"
+        ? Folder
+        : selectedNode.type === "github-project"
+          ? SiGitHubIcon
+          : selectedNode.type === "prompt"
+            ? MessageSquareText
+            : selectedNode.type === "operation"
+              ? Zap
+              : selectedNode.type === "output-project-path"
+                ? FolderOutput
+                : selectedNode.type === "output-local-path"
+                  ? HardDrive
+                  : Box;
+  const handleUpdateNodeData = (patch: Record<string, unknown>) => {
+    updateNodeData(selectedNode.id, patch);
+  };
+
+  const renderTextField = ({
+    field,
+    label,
+    placeholder,
+    value,
+  }: {
+    field: string;
+    label: string;
+    placeholder?: string;
+    value: string;
+  }) => {
+    const id = fieldId(selectedNode.id, field);
+
+    return (
+      <div className="space-y-1.5">
+        <Label htmlFor={id}>{label}</Label>
+        <Input
+          id={id}
+          name={id}
+          placeholder={placeholder}
+          value={value}
+          onChange={(event) => handleUpdateNodeData({ [field]: event.target.value })}
+        />
+      </div>
+    );
+  };
+
+  const renderTextareaField = ({
+    field,
+    label,
+    placeholder,
+    value,
+  }: {
+    field: string;
+    label: string;
+    placeholder?: string;
+    value: string;
+  }) => {
+    const id = fieldId(selectedNode.id, field);
+
+    return (
+      <div className="space-y-1.5">
+        <Label htmlFor={id}>{label}</Label>
+        <Textarea
+          id={id}
+          name={id}
+          placeholder={placeholder}
+          rows={4}
+          value={value}
+          onChange={(event) => handleUpdateNodeData({ [field]: event.target.value })}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col bg-background"
+      data-testid="canvas-properties-panel"
+    >
+      <div className="border-b p-4">
+        <Button
+          className="mb-3 h-8 gap-2 px-2 text-muted-foreground"
+          type="button"
+          variant="ghost"
+          onClick={handleBackToComponentsClick}
+        >
+          <ArrowLeft className="size-4" />
+          Back to components
+        </Button>
+        <div className="flex items-center gap-3">
+          <span
+            className={`flex size-9 items-center justify-center rounded-md ${meta?.iconBg ?? "bg-slate-500"}`}
+          >
+            <Icon className="size-4 text-white" />
+          </span>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold">{data.label}</p>
+            <p className="text-xs text-muted-foreground">{selectedNode.type}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
+        {renderTextField({
+          field: "label",
+          label: "Label",
+          value: String(data.label ?? ""),
+        })}
+
+        {data.nodeType === "file" && (
+          <>
+            {renderTextField({
+              field: "filePath",
+              label: "File path",
+              placeholder: "src/file.tsx",
+              value: data.filePath,
+            })}
+            {renderTextField({
+              field: "language",
+              label: "Language",
+              placeholder: "typescript",
+              value: data.language ?? "",
+            })}
+            {renderTextareaField({
+              field: "description",
+              label: "Description",
+              value: data.description ?? "",
+            })}
+          </>
+        )}
+
+        {data.nodeType === "folder" && (
+          <>
+            {renderTextField({
+              field: "folderPath",
+              label: "Folder path",
+              placeholder: "src/components",
+              value: data.folderPath,
+            })}
+            {renderTextareaField({
+              field: "description",
+              label: "Description",
+              value: data.description ?? "",
+            })}
+          </>
+        )}
+
+        {data.nodeType === "github-project" && (
+          <>
+            {renderTextField({
+              field: "owner",
+              label: "Owner",
+              value: data.owner,
+            })}
+            {renderTextField({
+              field: "repo",
+              label: "Repository",
+              value: data.repo,
+            })}
+            {renderTextField({
+              field: "branch",
+              label: "Branch",
+              value: data.branch ?? "",
+            })}
+            {renderTextField({
+              field: "localPath",
+              label: "Local path",
+              value: data.localPath ?? "",
+            })}
+            {renderTextareaField({
+              field: "description",
+              label: "Description",
+              value: data.description ?? "",
+            })}
+          </>
+        )}
+
+        {data.nodeType === "prompt" && (
+          <>
+            {renderTextareaField({
+              field: "prompt",
+              label: "Prompt",
+              value: data.prompt,
+            })}
+            {renderTextareaField({
+              field: "description",
+              label: "Description",
+              value: data.description ?? "",
+            })}
+          </>
+        )}
+
+        {data.nodeType === "operation" && (
+          <>
+            {renderTextField({
+              field: "operationName",
+              label: "Operation name",
+              value: data.operationName,
+            })}
+            {renderTextField({
+              field: "agentId",
+              label: "Agent ID",
+              value: data.agentId ?? "",
+            })}
+            {renderTextField({
+              field: "maxLoopCount",
+              label: "Max loop count",
+              value: String(data.maxLoopCount ?? 3),
+            })}
+            {renderTextareaField({
+              field: "loopConditionPrompt",
+              label: "Loop condition",
+              value: data.loopConditionPrompt ?? "",
+            })}
+          </>
+        )}
+
+        {data.nodeType === "output-project-path" && (
+          <>
+            {renderTextField({
+              field: "projectId",
+              label: "Project ID",
+              value: data.projectId ?? "",
+            })}
+            {renderTextField({
+              field: "path",
+              label: "Output path",
+              value: data.path,
+            })}
+            {renderTextareaField({
+              field: "description",
+              label: "Description",
+              value: data.description ?? "",
+            })}
+          </>
+        )}
+
+        {data.nodeType === "output-local-path" && (
+          <>
+            {renderTextField({
+              field: "localPath",
+              label: "Local path",
+              value: data.localPath,
+            })}
+            {renderTextField({
+              field: "outputFileName",
+              label: "Output file name",
+              value: data.outputFileName ?? "",
+            })}
+            <div className="space-y-1.5">
+              <Label>Write mode</Label>
+              <Select
+                value={data.outputMode ?? "overwrite"}
+                onValueChange={(value) => handleUpdateNodeData({ outputMode: value as OutputMode })}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.values(OUTPUT_MODE_ENUM).map((mode) => (
+                    <SelectItem key={mode} value={mode}>
+                      {outputModeLabels[mode]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {renderTextareaField({
+              field: "description",
+              label: "Description",
+              value: data.description ?? "",
+            })}
+          </>
+        )}
+
+        {data.nodeType === "compound" &&
+          renderTextareaField({
+            field: "description",
+            label: "Description",
+            value: data.description ?? "",
+          })}
+      </div>
+    </div>
+  );
+};

--- a/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.unit.test.tsx
@@ -88,4 +88,17 @@ describe("CanvasNodePropertiesPanel", () => {
     expect(data.maxLoopCount).toBe(8);
     expect(typeof data.maxLoopCount).toBe("number");
   });
+
+  it("uses number input semantics for max loop count edits", () => {
+    const store = renderPanel(operationNode);
+    const input = screen.getByRole("spinbutton", { name: /Max loop count/i });
+    const readMaxLoopCount = () =>
+      (store.getState().nodes[0]?.data as { maxLoopCount?: unknown } | undefined)?.maxLoopCount;
+
+    fireEvent.change(input, { target: { value: "1e2" } });
+    expect(readMaxLoopCount()).toBe(20);
+
+    fireEvent.change(input, { target: { value: "7.5" } });
+    expect(readMaxLoopCount()).toBe(20);
+  });
 });

--- a/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.unit.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@/test/test-wrapper";
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { createCanvasPageStore, CanvasPageStoreContext } from "../_store";
@@ -19,9 +19,26 @@ const fileNode = {
   },
 } as PipelineNode;
 
-const renderPanel = () => {
-  const store = createCanvasPageStore([fileNode]);
-  store.setState({ selectedNodeId: fileNode.id, sidebarPanel: "properties" });
+const operationNode = {
+  id: "operation-1",
+  type: "operation",
+  position: { x: 0, y: 0 },
+  data: {
+    label: "Review Code",
+    nodeType: "operation",
+    operationId: "review-code",
+    operationName: "Review Code",
+    status: "idle",
+    config: {},
+    loopEnabled: true,
+    maxLoopCount: 3,
+    loopConditionPrompt: "",
+  },
+} as PipelineNode;
+
+const renderPanel = (node: PipelineNode = fileNode) => {
+  const store = createCanvasPageStore([node]);
+  store.setState({ selectedNodeId: node.id, sidebarPanel: "properties" });
 
   render(
     <CanvasPageStoreContext.Provider value={store}>
@@ -57,5 +74,18 @@ describe("CanvasNodePropertiesPanel", () => {
 
     expect(store.getState().sidebarPanel).toBe("components");
     expect(store.getState().selectedNodeId).toBeNull();
+  });
+
+  it("stores operation max loop count edits as a number", () => {
+    const store = renderPanel(operationNode);
+
+    fireEvent.change(screen.getByRole("spinbutton", { name: /Max loop count/i }), {
+      target: { value: "8" },
+    });
+
+    const data = store.getState().nodes[0]?.data as { maxLoopCount?: unknown };
+
+    expect(data.maxLoopCount).toBe(8);
+    expect(typeof data.maxLoopCount).toBe("number");
   });
 });

--- a/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.unit.test.tsx
@@ -1,0 +1,61 @@
+import { render } from "@/test/test-wrapper";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { createCanvasPageStore, CanvasPageStoreContext } from "../_store";
+import type { PipelineNode } from "../_store/canvasSlice";
+import { CanvasNodePropertiesPanel } from "./CanvasNodePropertiesPanel";
+
+const fileNode = {
+  id: "file-1",
+  type: "file",
+  position: { x: 0, y: 0 },
+  data: {
+    label: "Source File",
+    nodeType: "file",
+    filePath: "src/index.ts",
+    language: "typescript",
+    description: "",
+  },
+} as PipelineNode;
+
+const renderPanel = () => {
+  const store = createCanvasPageStore([fileNode]);
+  store.setState({ selectedNodeId: fileNode.id, sidebarPanel: "properties" });
+
+  render(
+    <CanvasPageStoreContext.Provider value={store}>
+      <CanvasNodePropertiesPanel />
+    </CanvasPageStoreContext.Provider>,
+  );
+
+  return store;
+};
+
+describe("CanvasNodePropertiesPanel", () => {
+  it("edits selected file node data from the left panel", async () => {
+    const user = userEvent.setup();
+    const store = renderPanel();
+
+    const pathInput = screen.getByRole("textbox", { name: /File path/i });
+
+    await user.clear(pathInput);
+    await user.type(pathInput, "src/app.tsx");
+
+    expect(store.getState().nodes[0]?.data).toEqual(
+      expect.objectContaining({
+        filePath: "src/app.tsx",
+      }),
+    );
+  });
+
+  it("returns to the component panel from properties", async () => {
+    const user = userEvent.setup();
+    const store = renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /Back to components/i }));
+
+    expect(store.getState().sidebarPanel).toBe("components");
+    expect(store.getState().selectedNodeId).toBeNull();
+  });
+});

--- a/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/index.ts
+++ b/apps/app/src/pages/CanvasPage/CanvasNodePropertiesPanel/index.ts
@@ -1,0 +1,1 @@
+export * from "./CanvasNodePropertiesPanel";

--- a/apps/app/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.tsx
@@ -26,7 +26,6 @@ import { cn } from "@repo/ui/lib/utils";
 import {
   useCanvasPageStore,
   type CanvasSettingsState,
-  type NodeCardMode,
 } from "../_store";
 
 const settingEntries = [

--- a/apps/app/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.tsx
@@ -1,4 +1,13 @@
-import { Grid3X3, Map, MousePointer2, Settings2, X, Magnet } from "lucide-react";
+import {
+  Grid3X3,
+  Map,
+  MousePointer2,
+  PanelLeft,
+  PanelRight,
+  Settings2,
+  X,
+  Magnet,
+} from "lucide-react";
 import type { ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
@@ -14,7 +23,7 @@ import {
   SheetTitle,
 } from "@repo/ui/sheet";
 import { cn } from "@repo/ui/lib/utils";
-import { useCanvasPageStore, type CanvasSettingsState } from "../_store";
+import { useCanvasPageStore, type CanvasSettingsState, type NodeCardMode } from "../_store";
 
 const settingEntries = [
   { id: "showMiniMap" as const, icon: Map },
@@ -23,14 +32,21 @@ const settingEntries = [
   { id: "snapToGrid" as const, icon: Magnet },
 ];
 
+const nodeCardModeOptions = [
+  { id: "compact" as const, icon: PanelLeft },
+  { id: "expanded" as const, icon: PanelRight },
+];
+
 export const CanvasSettingsDrawer = () => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const isOpen = useStore(store, (s) => s.isCanvasSettingsOpen);
   const settings = useStore(store, (s) => s.canvasSettings);
+  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const openCanvasSettings = useStore(store, (s) => s.openCanvasSettings);
   const closeCanvasSettings = useStore(store, (s) => s.closeCanvasSettings);
   const updateCanvasSettings = useStore(store, (s) => s.updateCanvasSettings);
+  const setNodeCardMode = useStore(store, (s) => s.setNodeCardMode);
 
   const handleOpenChange = (open: boolean) => {
     if (open) {
@@ -51,6 +67,10 @@ export const CanvasSettingsDrawer = () => {
 
   const handleGlobalSettingsClick = () => {
     closeCanvasSettings();
+  };
+
+  const handleNodeCardModeClick = (mode: NodeCardMode) => {
+    setNodeCardMode(mode);
   };
 
   return (
@@ -121,6 +141,39 @@ export const CanvasSettingsDrawer = () => {
               </div>
             );
           })}
+
+          <div className="rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+            <div className="flex items-start gap-3">
+              <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md bg-slate-100 text-slate-600">
+                <PanelLeft className="size-4" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <Label className="text-slate-800">
+                  {t("canvas.settingsDrawer.nodeCardMode.label", {
+                    defaultValue: "Node card mode",
+                  })}
+                </Label>
+                <div className="mt-3 grid grid-cols-2 overflow-hidden rounded-md border border-slate-200 bg-slate-50 p-1">
+                  {nodeCardModeOptions.map(({ id, icon: Icon }) => (
+                    <Button
+                      key={id}
+                      aria-pressed={nodeCardMode === id}
+                      className="h-8 gap-1.5"
+                      size="sm"
+                      type="button"
+                      variant={nodeCardMode === id ? "secondary" : "ghost"}
+                      onClick={() => handleNodeCardModeClick(id)}
+                    >
+                      <Icon className="size-3.5" />
+                      {t(`canvas.settingsDrawer.nodeCardMode.${id}`, {
+                        defaultValue: id === "compact" ? "Compact" : "Expanded",
+                      })}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
 
         <div className="border-t bg-slate-50 p-4">

--- a/apps/app/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.tsx
@@ -23,7 +23,11 @@ import {
   SheetTitle,
 } from "@repo/ui/sheet";
 import { cn } from "@repo/ui/lib/utils";
-import { useCanvasPageStore, type CanvasSettingsState, type NodeCardMode } from "../_store";
+import {
+  useCanvasPageStore,
+  type CanvasSettingsState,
+  type NodeCardMode,
+} from "../_store";
 
 const settingEntries = [
   { id: "showMiniMap" as const, icon: Map },
@@ -62,15 +66,9 @@ export const CanvasSettingsDrawer = () => {
     id: keyof CanvasSettingsState,
     event: ChangeEvent<HTMLInputElement>,
   ) => {
-    updateCanvasSettings({ [id]: event.target.checked } as Partial<CanvasSettingsState>);
-  };
-
-  const handleGlobalSettingsClick = () => {
-    closeCanvasSettings();
-  };
-
-  const handleNodeCardModeClick = (mode: NodeCardMode) => {
-    setNodeCardMode(mode);
+    updateCanvasSettings({
+      [id]: event.target.checked,
+    } as Partial<CanvasSettingsState>);
   };
 
   return (
@@ -78,8 +76,7 @@ export const CanvasSettingsDrawer = () => {
       <SheetContent
         className="w-[min(24rem,calc(100vw-1rem))] max-w-sm gap-0 border-l bg-white/95 p-0 backdrop-blur"
         showCloseButton={false}
-        side="right"
-      >
+        side="right">
         <SheetHeader className="border-b pr-12">
           <div className="flex items-center gap-2">
             <span className="flex size-8 items-center justify-center rounded-md bg-slate-100 text-slate-700">
@@ -87,7 +84,9 @@ export const CanvasSettingsDrawer = () => {
             </span>
             <SheetTitle>{t("canvas.settingsDrawer.title")}</SheetTitle>
           </div>
-          <SheetDescription>{t("canvas.settingsDrawer.description")}</SheetDescription>
+          <SheetDescription>
+            {t("canvas.settingsDrawer.description")}
+          </SheetDescription>
           <SheetClose
             render={
               <Button
@@ -96,8 +95,7 @@ export const CanvasSettingsDrawer = () => {
                 size="icon-sm"
                 variant="ghost"
               />
-            }
-          >
+            }>
             <X className="size-4" />
           </SheetClose>
         </SheetHeader>
@@ -105,8 +103,7 @@ export const CanvasSettingsDrawer = () => {
         <div
           aria-label={t("canvas.settingsDrawer.title")}
           className="flex-1 space-y-3 overflow-y-auto p-4"
-          role="group"
-        >
+          role="group">
           {settingEntries.map(({ id, icon: Icon }) => {
             const inputId = `canvas-setting-${id}`;
             const descriptionId = `${inputId}-description`;
@@ -114,8 +111,7 @@ export const CanvasSettingsDrawer = () => {
             return (
               <div
                 key={id}
-                className="flex items-start gap-3 rounded-md border border-slate-200 bg-white p-3 shadow-sm"
-              >
+                className="flex items-start gap-3 rounded-md border border-slate-200 bg-white p-3 shadow-sm">
                 <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md bg-slate-100 text-slate-600">
                   <Icon className="size-4" />
                 </span>
@@ -123,7 +119,9 @@ export const CanvasSettingsDrawer = () => {
                   <Label className="text-slate-800" htmlFor={inputId}>
                     {t(`canvas.settingsDrawer.${id}.label`)}
                   </Label>
-                  <p className="mt-0.5 text-xs leading-5 text-slate-500" id={descriptionId}>
+                  <p
+                    className="mt-0.5 text-xs leading-5 text-slate-500"
+                    id={descriptionId}>
                     {t(`canvas.settingsDrawer.${id}.description`)}
                   </p>
                 </div>
@@ -162,8 +160,7 @@ export const CanvasSettingsDrawer = () => {
                       size="sm"
                       type="button"
                       variant={nodeCardMode === id ? "secondary" : "ghost"}
-                      onClick={() => handleNodeCardModeClick(id)}
-                    >
+                      onClick={() => setNodeCardMode(id)}>
                       <Icon className="size-3.5" />
                       {t(`canvas.settingsDrawer.nodeCardMode.${id}`, {
                         defaultValue: id === "compact" ? "Compact" : "Expanded",
@@ -180,8 +177,7 @@ export const CanvasSettingsDrawer = () => {
           <Link
             className="inline-flex h-8 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100"
             to="/settings"
-            onClick={handleGlobalSettingsClick}
-          >
+            onClick={closeCanvasSettings}>
             {t("canvas.settingsDrawer.globalSettings")}
           </Link>
         </div>
@@ -189,3 +185,4 @@ export const CanvasSettingsDrawer = () => {
     </Sheet>
   );
 };
+

--- a/apps/app/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.tsx
@@ -23,10 +23,7 @@ import {
   SheetTitle,
 } from "@repo/ui/sheet";
 import { cn } from "@repo/ui/lib/utils";
-import {
-  useCanvasPageStore,
-  type CanvasSettingsState,
-} from "../_store";
+import { useCanvasPageStore, type CanvasSettingsState } from "../_store";
 
 const settingEntries = [
   { id: "showMiniMap" as const, icon: Map },

--- a/apps/app/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.unit.test.tsx
@@ -81,4 +81,19 @@ describe("CanvasSettingsDrawer", () => {
     expect(store.getState().nodes).toHaveLength(1);
     expect(store.getState().nodes[0]?.data.label).toBe("User Label");
   });
+
+  it("updates node card mode from the settings drawer", async () => {
+    const user = userEvent.setup();
+    const store = renderOpenDrawer();
+
+    expect(store.getState().nodeCardMode).toBe("compact");
+
+    await user.click(screen.getByRole("button", { name: /Expanded/i }));
+
+    expect(store.getState().nodeCardMode).toBe("expanded");
+
+    await user.click(screen.getByRole("button", { name: /Compact/i }));
+
+    expect(store.getState().nodeCardMode).toBe("compact");
+  });
 });

--- a/apps/app/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.tsx
@@ -13,7 +13,10 @@ export const CanvasStatusBar = () => {
 
   return (
     <div className="pointer-events-none absolute bottom-3 left-1/2 z-20 -translate-x-1/2">
-      <div className="flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-full border border-border bg-background/90 px-3 py-1 text-xs text-muted-foreground shadow-sm backdrop-blur-sm">
+      <div
+        className="flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-full border border-border bg-background/90 px-3 py-1 text-xs text-muted-foreground shadow-sm backdrop-blur-sm"
+        data-testid="canvas-status-bar"
+      >
         <span className="whitespace-nowrap">
           {t("canvas.status.nodeCount", { count: nodes.length })}
         </span>

--- a/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx
@@ -51,7 +51,7 @@ export const CanvasToolbar = () => {
 
   return (
     <div className="pointer-events-auto w-max max-w-full" data-testid="canvas-toolbar">
-      <div className="flex h-10 w-max items-center gap-0.5 rounded-full border bg-background px-1.5 py-1 shadow-md max-[420px]:gap-0 max-[420px]:px-1">
+      <div className="flex h-10 w-max items-center gap-0.5 rounded-md border bg-background px-1.5 py-1 shadow-md max-[420px]:gap-0 max-[420px]:px-1">
         {/* Zoom controls */}
         <Tooltip>
           <TooltipTrigger
@@ -140,7 +140,7 @@ export const CanvasToolbar = () => {
           <TooltipContent>{t("canvas.formatLayout")}</TooltipContent>
         </Tooltip>
 
-        <Separator className="mx-1 h-5" orientation="vertical" />
+        <Separator className="mx-1 h-7" orientation="vertical" />
 
         {/* History controls */}
         <Button
@@ -164,7 +164,7 @@ export const CanvasToolbar = () => {
           <Redo2 className="h-4 w-4" />
         </Button>
 
-        <Separator className="mx-1 h-5" orientation="vertical" />
+        <Separator className="mx-1 h-7" orientation="vertical" />
 
         {/* Quick add */}
         <Tooltip>
@@ -206,7 +206,7 @@ export const CanvasToolbar = () => {
           <TooltipContent>{t("canvas.agentPanel.toggle")}</TooltipContent>
         </Tooltip>
 
-        <Separator className="mx-1 h-5" orientation="vertical" />
+        <Separator className="mx-1 h-7" orientation="vertical" />
 
         {/* Delete */}
         <Tooltip>
@@ -228,7 +228,7 @@ export const CanvasToolbar = () => {
           <TooltipContent>{t("canvas.deleteNode")}</TooltipContent>
         </Tooltip>
 
-        <Separator className="mx-1 h-5" orientation="vertical" />
+        <Separator className="mx-1 h-7" orientation="vertical" />
 
         {/* Run Test */}
         <Tooltip>

--- a/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.unit.test.tsx
@@ -38,7 +38,14 @@ vi.mock("@repo/ui/button", () => ({
     </button>
   ),
 }));
-vi.mock("@repo/ui/separator", () => ({ Separator: () => <hr /> }));
+vi.mock("@repo/ui/separator", () => ({
+  Separator: ({
+    orientation,
+    ...props
+  }: React.ComponentProps<"hr"> & { orientation?: "horizontal" | "vertical" }) => (
+    <hr data-orientation={orientation} {...props} />
+  ),
+}));
 vi.mock("@repo/ui/tooltip", () => ({
   Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
   TooltipTrigger: ({
@@ -83,6 +90,18 @@ describe("CanvasToolbar - export removed", () => {
 });
 
 describe("CanvasToolbar - viewport controls", () => {
+  it("uses the same medium radius as the title input and full-height separators", () => {
+    render(<CanvasToolbar />, { wrapper });
+
+    const toolbarShell = screen.getByTestId("canvas-toolbar").firstElementChild;
+    expect(toolbarShell).toHaveClass("rounded-md");
+    expect(toolbarShell).not.toHaveClass("rounded-full");
+    expect(screen.getAllByRole("separator")).toHaveLength(4);
+    for (const separator of screen.getAllByRole("separator")) {
+      expect(separator).toHaveClass("h-7");
+    }
+  });
+
   it("keeps zoom and fit view available through accessible custom controls", () => {
     render(<CanvasToolbar />, { wrapper });
 

--- a/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { Input } from "@repo/ui/input";
-import { CanvasFloatingMenu } from "../CanvasFloatingMenu";
 import { CanvasToolbar } from "../CanvasToolbar";
 import { useCanvasPageStore } from "../_store";
 
@@ -11,43 +10,27 @@ export const CanvasTopChrome = () => {
   const pipelineName = useStore(store, (state) => state.pipelineName);
   const handlePipelineNameChange = useStore(store, (state) => state.handlePipelineNameChange);
 
-  const renderPipelineTitle = (className: string, testId: string) => (
-    <div className={className} data-testid={testId}>
-      <div className="pointer-events-auto flex h-10 w-full min-w-0 items-center rounded-full border border-gray-200 bg-white/90 px-3 shadow-sm backdrop-blur-sm">
-        <Input
-          aria-label={t("canvas.pipelineTitle")}
-          className="h-7 min-w-0 w-full border-none bg-transparent text-sm font-medium text-gray-700 shadow-none outline-none placeholder:text-gray-400"
-          name="pipelineName"
-          placeholder={t("canvas.pipelineTitlePlaceholder")}
-          value={pipelineName}
-          onChange={handlePipelineNameChange}
-        />
-      </div>
-    </div>
-  );
-
   return (
     <div
-      className="pointer-events-none absolute inset-x-3 top-3 z-50 sm:inset-x-4"
+      className="flex min-h-16 items-center gap-3 border-b bg-background/95 px-3 py-3 backdrop-blur"
       data-testid="canvas-top-chrome"
     >
-      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-2 max-[420px]:grid-cols-1 min-[700px]:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] min-[700px]:gap-3">
-        <div className="flex min-w-0 items-center gap-3">
-          <CanvasFloatingMenu />
-          {renderPipelineTitle(
-            "hidden min-w-0 min-[700px]:flex min-[700px]:w-[clamp(10rem,calc(50vw-17rem),18rem)]",
-            "canvas-title-desktop",
-          )}
+      <div className="min-w-0 flex-1" data-testid="canvas-title-desktop">
+        <div className="flex h-10 w-full min-w-0 items-center rounded-md border bg-background px-3 shadow-sm">
+          <Input
+            aria-label={t("canvas.pipelineTitle")}
+            className="h-7 min-w-0 w-full border-none bg-transparent px-0 text-sm font-medium text-foreground shadow-none outline-none placeholder:text-muted-foreground focus-visible:ring-0"
+            name="pipelineName"
+            placeholder={t("canvas.pipelineTitlePlaceholder")}
+            value={pipelineName}
+            onChange={handlePipelineNameChange}
+          />
         </div>
-
-        <div className="pointer-events-auto max-w-full justify-self-end overflow-x-auto max-[420px]:justify-self-start max-[420px]:[scrollbar-width:none] min-[700px]:justify-self-center">
-          <CanvasToolbar />
-        </div>
-
-        <div className="hidden min-[700px]:block" />
       </div>
 
-      {renderPipelineTitle("mt-2 flex w-full min-w-0 min-[700px]:hidden", "canvas-title-narrow")}
+      <div className="min-w-0 max-w-full overflow-x-auto [scrollbar-width:none]">
+        <CanvasToolbar />
+      </div>
     </div>
   );
 };

--- a/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
@@ -6,14 +6,6 @@ import { describe, expect, it, vi } from "vitest";
 import { createCanvasPageStore, CanvasPageStoreContext } from "../_store";
 import { CanvasTopChrome } from "./CanvasTopChrome";
 
-vi.mock("../CanvasFloatingMenu", () => ({
-  CanvasFloatingMenu: () => (
-    <button className="pointer-events-auto h-10 w-10" title="菜单" type="button">
-      Menu
-    </button>
-  ),
-}));
-
 vi.mock("../CanvasToolbar", () => ({
   CanvasToolbar: () => <div data-testid="canvas-toolbar">Toolbar</div>,
 }));
@@ -31,30 +23,24 @@ const renderTopChrome = () => {
 };
 
 describe("CanvasTopChrome", () => {
-  it("uses one top chrome coordinate system for menu, title, and toolbar", () => {
+  it("renders the shell top bar with title and toolbar", () => {
     renderTopChrome();
 
     expect(screen.getByTestId("canvas-top-chrome")).toHaveClass(
-      "absolute",
-      "top-3",
-      "z-50",
-      "pointer-events-none",
+      "border-b",
+      "bg-background/95",
+      "backdrop-blur",
     );
     const toolbarSlot = screen.getByTestId("canvas-toolbar").parentElement;
     expect(toolbarSlot).not.toBeNull();
-    expect(toolbarSlot as HTMLElement).toHaveClass(
-      "max-w-full",
-      "overflow-x-auto",
-      "max-[420px]:justify-self-start",
-    );
-    expect(screen.getByTestId("canvas-title-desktop")).toHaveClass("hidden", "min-[700px]:flex");
-    expect(screen.getByTestId("canvas-title-narrow")).toHaveClass("mt-2", "min-[700px]:hidden");
+    expect(toolbarSlot as HTMLElement).toHaveClass("min-w-0", "max-w-full", "overflow-x-auto");
+    expect(screen.getByTestId("canvas-title-desktop")).toHaveClass("min-w-0", "flex-1");
   });
 
   it("preserves pipeline title editing", async () => {
     const user = userEvent.setup();
     const store = renderTopChrome();
-    const [desktopTitleInput] = screen.getAllByRole("textbox", {
+    const desktopTitleInput = screen.getByRole("textbox", {
       name: i18n.t("canvas.pipelineTitle"),
     });
 

--- a/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
@@ -65,11 +65,16 @@ export const CanvasWorkspaceSidebarOverlay = () => {
   );
   const displayPipelineName =
     pipelineName || t("canvas.pipelineTitlePlaceholder");
-  const { fileInputRef, handleImport, handleImportFileChange, handleSave, isPending } =
-    useCanvasWorkspacePersistence({
-      onAfterImportFileSelect: closeWorkspaceSidebar,
-      onAfterSave: closeWorkspaceSidebar,
-    });
+  const {
+    fileInputRef,
+    handleImport,
+    handleImportFileChange,
+    handleSave,
+    isPending,
+  } = useCanvasWorkspacePersistence({
+    onAfterImportFileSelect: closeWorkspaceSidebar,
+    onAfterSave: closeWorkspaceSidebar,
+  });
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {

--- a/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
@@ -195,6 +195,7 @@ export const CanvasWorkspaceSidebarOverlay = () => {
       <SheetContent
         className="flex w-[min(22rem,calc(100vw-1rem))] flex-col gap-0 border-r bg-background/95 p-0 backdrop-blur"
         data-testid="canvas-workspace-sidebar-overlay"
+        showCloseButton={false}
         side="left"
       >
         <SheetHeader className="border-b px-4 py-4 pr-12">

--- a/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
@@ -1,4 +1,3 @@
-import { useRef } from "react";
 import {
   Activity,
   Bot,
@@ -19,10 +18,8 @@ import {
   Zap,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
-import { useCreate, useUpdate } from "@refinedev/core";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
-import { ResultAsync } from "neverthrow";
 import { Button } from "@repo/ui/button";
 import { Input } from "@repo/ui/input";
 import { Separator } from "@repo/ui/separator";
@@ -34,15 +31,9 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@repo/ui/sheet";
-import { ResourceName } from "@/integrations/refine/dataProvider";
-import { toastStore } from "@/store/toastStore";
 import { useCanvasPageStore } from "../_store";
 import { CANVAS_WORKSPACE_SIDEBAR_ID } from "../CanvasMiniSidebar";
-import {
-  isCanvasImportFileTooLarge,
-  parseCanvasImportJson,
-  type CanvasImportError,
-} from "../utils/canvasImportJson";
+import { useCanvasWorkspacePersistence } from "../useCanvasWorkspacePersistence";
 
 const workspaceLinks = [
   { icon: LayoutDashboard, labelKey: "nav.dashboard", to: "/" },
@@ -58,35 +49,27 @@ const workspaceLinks = [
 
 export const CanvasWorkspaceSidebarOverlay = () => {
   const { t } = useTranslation();
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const store = useCanvasPageStore();
   const isOpen = useStore(store, (state) => state.isWorkspaceSidebarOpen);
   const closeWorkspaceSidebar = useStore(
     store,
     (state) => state.closeWorkspaceSidebar,
   );
-  const pipelineId = useStore(store, (state) => state.pipelineId);
   const pipelineName = useStore(store, (state) => state.pipelineName);
-  const nodes = useStore(store, (state) => state.nodes);
-  const edges = useStore(store, (state) => state.edges);
   const exportCanvas = useStore(store, (state) => state.exportCanvas);
-  const importCanvas = useStore(store, (state) => state.importCanvas);
   const handleUndo = useStore(store, (state) => state.handleUndo);
   const handleRedo = useStore(store, (state) => state.handleRedo);
-  const handlePipelineIdChange = useStore(
-    store,
-    (state) => state.handlePipelineIdChange,
-  );
   const openCanvasSettings = useStore(
     store,
     (state) => state.openCanvasSettings,
   );
-
-  const { mutate: updateCanvas, mutation: updateMutation } = useUpdate();
-  const { mutate: createCanvas, mutation: createMutation } = useCreate();
   const displayPipelineName =
     pipelineName || t("canvas.pipelineTitlePlaceholder");
-  const isPending = updateMutation.isPending || createMutation.isPending;
+  const { fileInputRef, handleImport, handleImportFileChange, handleSave, isPending } =
+    useCanvasWorkspacePersistence({
+      onAfterImportFileSelect: closeWorkspaceSidebar,
+      onAfterSave: closeWorkspaceSidebar,
+    });
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
@@ -96,104 +79,6 @@ export const CanvasWorkspaceSidebarOverlay = () => {
 
   const handleCloseDrawer = () => {
     closeWorkspaceSidebar();
-  };
-
-  const showImportError = (error: CanvasImportError) => {
-    const description =
-      error === "invalid-json"
-        ? t("canvas.importInvalidJson")
-        : error === "file-too-large"
-          ? t("canvas.importFileTooLarge")
-          : t("canvas.importInvalidPipelineJson");
-
-    toastStore.getState().addToast({
-      type: "error",
-      title: t("canvas.importFailed"),
-      description,
-    });
-  };
-
-  const handleSave = () => {
-    if (pipelineId) {
-      updateCanvas({
-        resource: ResourceName.pipelines,
-        id: pipelineId,
-        values: { nodes, edges },
-        successNotification: {
-          type: "success",
-          message: t("canvas.saveSuccess"),
-          description: t("canvas.floatingMenu.saveSuccessDescription", {
-            name: displayPipelineName,
-          }),
-        },
-        errorNotification: {
-          type: "error",
-          message: t("canvas.saveFailed"),
-          description: t("canvas.floatingMenu.saveFailedDescription"),
-        },
-      });
-      handleCloseDrawer();
-
-      return;
-    }
-
-    const newId = crypto.randomUUID();
-    createCanvas(
-      {
-        resource: ResourceName.pipelines,
-        values: {
-          id: newId,
-          name: displayPipelineName,
-          description: "",
-          tags: [],
-          timeoutMs: null,
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-          nodes,
-          edges,
-        },
-        successNotification: {
-          type: "success",
-          message: t("canvas.saveSuccess"),
-          description: t("canvas.floatingMenu.createSuccessDescription", {
-            name: displayPipelineName,
-          }),
-        },
-        errorNotification: {
-          type: "error",
-          message: t("canvas.saveFailed"),
-          description: t("canvas.floatingMenu.saveFailedDescription"),
-        },
-      },
-      {
-        onSuccess: () => {
-          handlePipelineIdChange(newId);
-        },
-      },
-    );
-    handleCloseDrawer();
-  };
-
-  const handleImport = () => {
-    fileInputRef.current?.click();
-  };
-
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
-
-    event.target.value = "";
-    handleCloseDrawer();
-
-    if (isCanvasImportFileTooLarge(file)) {
-      showImportError("file-too-large");
-
-      return;
-    }
-
-    void ResultAsync.fromPromise(file.text(), () => "invalid-json" as const)
-      .andThen((text) => parseCanvasImportJson(text))
-      .match(importCanvas, showImportError);
   };
 
   const handleActionClick = (action: () => void) => () => {
@@ -331,7 +216,7 @@ export const CanvasWorkspaceSidebarOverlay = () => {
           className="hidden"
           name="canvasImportFile"
           type="file"
-          onChange={handleFileChange}
+          onChange={handleImportFileChange}
         />
       </SheetContent>
     </Sheet>

--- a/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
@@ -37,6 +37,7 @@ import {
 import { ResourceName } from "@/integrations/refine/dataProvider";
 import { toastStore } from "@/store/toastStore";
 import { useCanvasPageStore } from "../_store";
+import { CANVAS_WORKSPACE_SIDEBAR_ID } from "../CanvasMiniSidebar";
 import {
   isCanvasImportFileTooLarge,
   parseCanvasImportJson,
@@ -195,6 +196,7 @@ export const CanvasWorkspaceSidebarOverlay = () => {
       <SheetContent
         className="flex w-[min(22rem,calc(100vw-1rem))] flex-col gap-0 border-r bg-background/95 p-0 backdrop-blur"
         data-testid="canvas-workspace-sidebar-overlay"
+        id={CANVAS_WORKSPACE_SIDEBAR_ID}
         showCloseButton={false}
         side="left"
       >

--- a/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
@@ -61,7 +61,10 @@ export const CanvasWorkspaceSidebarOverlay = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const store = useCanvasPageStore();
   const isOpen = useStore(store, (state) => state.isWorkspaceSidebarOpen);
-  const closeWorkspaceSidebar = useStore(store, (state) => state.closeWorkspaceSidebar);
+  const closeWorkspaceSidebar = useStore(
+    store,
+    (state) => state.closeWorkspaceSidebar,
+  );
   const pipelineId = useStore(store, (state) => state.pipelineId);
   const pipelineName = useStore(store, (state) => state.pipelineName);
   const nodes = useStore(store, (state) => state.nodes);
@@ -70,22 +73,29 @@ export const CanvasWorkspaceSidebarOverlay = () => {
   const importCanvas = useStore(store, (state) => state.importCanvas);
   const handleUndo = useStore(store, (state) => state.handleUndo);
   const handleRedo = useStore(store, (state) => state.handleRedo);
-  const handlePipelineIdChange = useStore(store, (state) => state.handlePipelineIdChange);
-  const openCanvasSettings = useStore(store, (state) => state.openCanvasSettings);
+  const handlePipelineIdChange = useStore(
+    store,
+    (state) => state.handlePipelineIdChange,
+  );
+  const openCanvasSettings = useStore(
+    store,
+    (state) => state.openCanvasSettings,
+  );
 
   const { mutate: updateCanvas, mutation: updateMutation } = useUpdate();
   const { mutate: createCanvas, mutation: createMutation } = useCreate();
-  const displayPipelineName = pipelineName || t("canvas.pipelineTitlePlaceholder");
+  const displayPipelineName =
+    pipelineName || t("canvas.pipelineTitlePlaceholder");
   const isPending = updateMutation.isPending || createMutation.isPending;
-
-  const handleCloseDrawer = () => {
-    closeWorkspaceSidebar();
-  };
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
-      handleCloseDrawer();
+      closeWorkspaceSidebar();
     }
+  };
+
+  const handleCloseDrawer = () => {
+    closeWorkspaceSidebar();
   };
 
   const showImportError = (error: CanvasImportError) => {
@@ -198,8 +208,7 @@ export const CanvasWorkspaceSidebarOverlay = () => {
         data-testid="canvas-workspace-sidebar-overlay"
         id={CANVAS_WORKSPACE_SIDEBAR_ID}
         showCloseButton={false}
-        side="left"
-      >
+        side="left">
         <SheetHeader className="border-b px-4 py-4 pr-12">
           <div className="flex items-center gap-2">
             <span className="flex size-8 items-center justify-center rounded-md bg-primary/10 text-primary">
@@ -207,9 +216,13 @@ export const CanvasWorkspaceSidebarOverlay = () => {
             </span>
             <div className="min-w-0">
               <SheetTitle>
-                {t("canvas.workspaceSidebar.title", { defaultValue: "Workspace" })}
+                {t("canvas.workspaceSidebar.title", {
+                  defaultValue: "Workspace",
+                })}
               </SheetTitle>
-              <SheetDescription className="truncate">{displayPipelineName}</SheetDescription>
+              <SheetDescription className="truncate">
+                {displayPipelineName}
+              </SheetDescription>
             </div>
           </div>
           <SheetClose
@@ -220,8 +233,7 @@ export const CanvasWorkspaceSidebarOverlay = () => {
                 size="icon-sm"
                 variant="ghost"
               />
-            }
-          >
+            }>
             <X className="size-4" />
           </SheetClose>
         </SheetHeader>
@@ -236,20 +248,21 @@ export const CanvasWorkspaceSidebarOverlay = () => {
                 className="justify-start gap-2"
                 disabled={isPending}
                 variant="secondary"
-                onClick={handleSave}
-              >
+                onClick={handleSave}>
                 <Save className="size-4" />
                 {t("canvas.floatingMenu.save")}
               </Button>
               <Button
                 className="justify-start gap-2"
                 variant="ghost"
-                onClick={handleActionClick(exportCanvas)}
-              >
+                onClick={handleActionClick(exportCanvas)}>
                 <FileDown className="size-4" />
                 {t("canvas.floatingMenu.export")}
               </Button>
-              <Button className="justify-start gap-2" variant="ghost" onClick={handleImport}>
+              <Button
+                className="justify-start gap-2"
+                variant="ghost"
+                onClick={handleImport}>
                 <FileUp className="size-4" />
                 {t("canvas.floatingMenu.import")}
               </Button>
@@ -257,24 +270,21 @@ export const CanvasWorkspaceSidebarOverlay = () => {
               <Button
                 className="justify-start gap-2"
                 variant="ghost"
-                onClick={handleActionClick(handleUndo)}
-              >
+                onClick={handleActionClick(handleUndo)}>
                 <Undo2 className="size-4" />
                 {t("canvas.undo")}
               </Button>
               <Button
                 className="justify-start gap-2"
                 variant="ghost"
-                onClick={handleActionClick(handleRedo)}
-              >
+                onClick={handleActionClick(handleRedo)}>
                 <Redo2 className="size-4" />
                 {t("canvas.redo")}
               </Button>
               <Button
                 className="justify-start gap-2"
                 variant="ghost"
-                onClick={handleActionClick(openCanvasSettings)}
-              >
+                onClick={handleActionClick(openCanvasSettings)}>
                 <Settings2 className="size-4" />
                 {t("canvas.settingsDrawer.menuLabel")}
               </Button>
@@ -294,8 +304,7 @@ export const CanvasWorkspaceSidebarOverlay = () => {
                     key={item.to}
                     className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-foreground hover:bg-muted"
                     to={item.to}
-                    onClick={handleCloseDrawer}
-                  >
+                    onClick={handleCloseDrawer}>
                     <Icon className="size-4" />
                     <span>{t(item.labelKey)}</span>
                   </Link>
@@ -309,8 +318,7 @@ export const CanvasWorkspaceSidebarOverlay = () => {
           <Link
             className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted"
             to="/"
-            onClick={handleCloseDrawer}
-          >
+            onClick={handleCloseDrawer}>
             <Home className="size-4" />
             {t("canvas.floatingMenu.backToWorkspace")}
           </Link>
@@ -329,3 +337,4 @@ export const CanvasWorkspaceSidebarOverlay = () => {
     </Sheet>
   );
 };
+

--- a/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
@@ -1,0 +1,328 @@
+import { useRef } from "react";
+import {
+  Activity,
+  Bot,
+  BookOpen,
+  FileDown,
+  FileUp,
+  Home,
+  LayoutDashboard,
+  Layers,
+  Puzzle,
+  Redo2,
+  Save,
+  Server,
+  Settings2,
+  Undo2,
+  Workflow,
+  X,
+  Zap,
+} from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { useCreate, useUpdate } from "@refinedev/core";
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import { ResultAsync } from "neverthrow";
+import { Button } from "@repo/ui/button";
+import { Input } from "@repo/ui/input";
+import { Separator } from "@repo/ui/separator";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@repo/ui/sheet";
+import { ResourceName } from "@/integrations/refine/dataProvider";
+import { toastStore } from "@/store/toastStore";
+import { useCanvasPageStore } from "../_store";
+import {
+  isCanvasImportFileTooLarge,
+  parseCanvasImportJson,
+  type CanvasImportError,
+} from "../utils/canvasImportJson";
+
+const workspaceLinks = [
+  { icon: LayoutDashboard, labelKey: "nav.dashboard", to: "/" },
+  { icon: Layers, labelKey: "nav.pipelines", to: "/pipelines" },
+  { icon: BookOpen, labelKey: "nav.skills", to: "/skills" },
+  { icon: Zap, labelKey: "nav.operations", to: "/pipelines/operations" },
+  { icon: Activity, labelKey: "nav.jobs", to: "/pipelines/jobs" },
+  { icon: Bot, labelKey: "nav.agents", to: "/agents" },
+  { icon: Puzzle, labelKey: "nav.plugins", to: "/plugins" },
+  { icon: Server, labelKey: "nav.runtimes", to: "/runtimes" },
+  { icon: Settings2, labelKey: "nav.settings", to: "/settings" },
+] as const;
+
+export const CanvasWorkspaceSidebarOverlay = () => {
+  const { t } = useTranslation();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const store = useCanvasPageStore();
+  const isOpen = useStore(store, (state) => state.isWorkspaceSidebarOpen);
+  const closeWorkspaceSidebar = useStore(store, (state) => state.closeWorkspaceSidebar);
+  const pipelineId = useStore(store, (state) => state.pipelineId);
+  const pipelineName = useStore(store, (state) => state.pipelineName);
+  const nodes = useStore(store, (state) => state.nodes);
+  const edges = useStore(store, (state) => state.edges);
+  const exportCanvas = useStore(store, (state) => state.exportCanvas);
+  const importCanvas = useStore(store, (state) => state.importCanvas);
+  const handleUndo = useStore(store, (state) => state.handleUndo);
+  const handleRedo = useStore(store, (state) => state.handleRedo);
+  const handlePipelineIdChange = useStore(store, (state) => state.handlePipelineIdChange);
+  const openCanvasSettings = useStore(store, (state) => state.openCanvasSettings);
+
+  const { mutate: updateCanvas, mutation: updateMutation } = useUpdate();
+  const { mutate: createCanvas, mutation: createMutation } = useCreate();
+  const displayPipelineName = pipelineName || t("canvas.pipelineTitlePlaceholder");
+  const isPending = updateMutation.isPending || createMutation.isPending;
+
+  const handleCloseDrawer = () => {
+    closeWorkspaceSidebar();
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      handleCloseDrawer();
+    }
+  };
+
+  const showImportError = (error: CanvasImportError) => {
+    const description =
+      error === "invalid-json"
+        ? t("canvas.importInvalidJson")
+        : error === "file-too-large"
+          ? t("canvas.importFileTooLarge")
+          : t("canvas.importInvalidPipelineJson");
+
+    toastStore.getState().addToast({
+      type: "error",
+      title: t("canvas.importFailed"),
+      description,
+    });
+  };
+
+  const handleSave = () => {
+    if (pipelineId) {
+      updateCanvas({
+        resource: ResourceName.pipelines,
+        id: pipelineId,
+        values: { nodes, edges },
+        successNotification: {
+          type: "success",
+          message: t("canvas.saveSuccess"),
+          description: t("canvas.floatingMenu.saveSuccessDescription", {
+            name: displayPipelineName,
+          }),
+        },
+        errorNotification: {
+          type: "error",
+          message: t("canvas.saveFailed"),
+          description: t("canvas.floatingMenu.saveFailedDescription"),
+        },
+      });
+      handleCloseDrawer();
+
+      return;
+    }
+
+    const newId = crypto.randomUUID();
+    createCanvas(
+      {
+        resource: ResourceName.pipelines,
+        values: {
+          id: newId,
+          name: displayPipelineName,
+          description: "",
+          tags: [],
+          timeoutMs: null,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          nodes,
+          edges,
+        },
+        successNotification: {
+          type: "success",
+          message: t("canvas.saveSuccess"),
+          description: t("canvas.floatingMenu.createSuccessDescription", {
+            name: displayPipelineName,
+          }),
+        },
+        errorNotification: {
+          type: "error",
+          message: t("canvas.saveFailed"),
+          description: t("canvas.floatingMenu.saveFailedDescription"),
+        },
+      },
+      {
+        onSuccess: () => {
+          handlePipelineIdChange(newId);
+        },
+      },
+    );
+    handleCloseDrawer();
+  };
+
+  const handleImport = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    event.target.value = "";
+    handleCloseDrawer();
+
+    if (isCanvasImportFileTooLarge(file)) {
+      showImportError("file-too-large");
+
+      return;
+    }
+
+    void ResultAsync.fromPromise(file.text(), () => "invalid-json" as const)
+      .andThen((text) => parseCanvasImportJson(text))
+      .match(importCanvas, showImportError);
+  };
+
+  const handleActionClick = (action: () => void) => () => {
+    action();
+    handleCloseDrawer();
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={handleOpenChange}>
+      <SheetContent
+        className="flex w-[min(22rem,calc(100vw-1rem))] flex-col gap-0 border-r bg-background/95 p-0 backdrop-blur"
+        data-testid="canvas-workspace-sidebar-overlay"
+        side="left"
+      >
+        <SheetHeader className="border-b px-4 py-4 pr-12">
+          <div className="flex items-center gap-2">
+            <span className="flex size-8 items-center justify-center rounded-md bg-primary/10 text-primary">
+              <Workflow className="size-4" />
+            </span>
+            <div className="min-w-0">
+              <SheetTitle>
+                {t("canvas.workspaceSidebar.title", { defaultValue: "Workspace" })}
+              </SheetTitle>
+              <SheetDescription className="truncate">{displayPipelineName}</SheetDescription>
+            </div>
+          </div>
+          <SheetClose
+            render={
+              <Button
+                aria-label={t("canvas.settingsDrawer.close")}
+                className="absolute right-3 top-3"
+                size="icon-sm"
+                variant="ghost"
+              />
+            }
+          >
+            <X className="size-4" />
+          </SheetClose>
+        </SheetHeader>
+
+        <div className="flex-1 space-y-4 overflow-y-auto p-4">
+          <section className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t("canvas.floatingMenu.menu", { defaultValue: "Canvas" })}
+            </p>
+            <div className="grid gap-2">
+              <Button
+                className="justify-start gap-2"
+                disabled={isPending}
+                variant="secondary"
+                onClick={handleSave}
+              >
+                <Save className="size-4" />
+                {t("canvas.floatingMenu.save")}
+              </Button>
+              <Button
+                className="justify-start gap-2"
+                variant="ghost"
+                onClick={handleActionClick(exportCanvas)}
+              >
+                <FileDown className="size-4" />
+                {t("canvas.floatingMenu.export")}
+              </Button>
+              <Button className="justify-start gap-2" variant="ghost" onClick={handleImport}>
+                <FileUp className="size-4" />
+                {t("canvas.floatingMenu.import")}
+              </Button>
+              <Separator />
+              <Button
+                className="justify-start gap-2"
+                variant="ghost"
+                onClick={handleActionClick(handleUndo)}
+              >
+                <Undo2 className="size-4" />
+                {t("canvas.undo")}
+              </Button>
+              <Button
+                className="justify-start gap-2"
+                variant="ghost"
+                onClick={handleActionClick(handleRedo)}
+              >
+                <Redo2 className="size-4" />
+                {t("canvas.redo")}
+              </Button>
+              <Button
+                className="justify-start gap-2"
+                variant="ghost"
+                onClick={handleActionClick(openCanvasSettings)}
+              >
+                <Settings2 className="size-4" />
+                {t("canvas.settingsDrawer.menuLabel")}
+              </Button>
+            </div>
+          </section>
+
+          <section className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t("nav.workspace")}
+            </p>
+            <div className="grid gap-1">
+              {workspaceLinks.map((item) => {
+                const Icon = item.icon;
+
+                return (
+                  <Link
+                    key={item.to}
+                    className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-foreground hover:bg-muted"
+                    to={item.to}
+                    onClick={handleCloseDrawer}
+                  >
+                    <Icon className="size-4" />
+                    <span>{t(item.labelKey)}</span>
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+
+        <div className="border-t p-4">
+          <Link
+            className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted"
+            to="/"
+            onClick={handleCloseDrawer}
+          >
+            <Home className="size-4" />
+            {t("canvas.floatingMenu.backToWorkspace")}
+          </Link>
+        </div>
+
+        <Input
+          ref={fileInputRef}
+          accept=".json"
+          aria-label={t("canvas.floatingMenu.importJson")}
+          className="hidden"
+          name="canvasImportFile"
+          type="file"
+          onChange={handleFileChange}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.unit.test.tsx
@@ -53,4 +53,12 @@ describe("CanvasWorkspaceSidebarOverlay", () => {
     );
     expect(store.getState().isWorkspaceSidebarOpen).toBe(false);
   });
+
+  it("renders a single close control", () => {
+    renderOpenOverlay();
+
+    expect(
+      screen.getAllByRole("button", { name: /Close|关闭|canvas\.settingsDrawer\.close/i }),
+    ).toHaveLength(1);
+  });
 });

--- a/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.unit.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { CanvasPageStoreContext, createCanvasPageStore } from "../_store";
+import { CanvasWorkspaceSidebarOverlay } from "./CanvasWorkspaceSidebarOverlay";
+
+const refineMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock("@refinedev/core", () => ({
+  useCreate: () => ({ mutate: refineMocks.create, mutation: { isPending: false } }),
+  useUpdate: () => ({ mutate: refineMocks.update, mutation: { isPending: false } }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to, ...props }: React.PropsWithChildren<{ to: string }>) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const renderOpenOverlay = () => {
+  const store = createCanvasPageStore([], [], "pipe-1", "Pipeline");
+  store.setState({ isWorkspaceSidebarOpen: true });
+
+  render(
+    <CanvasPageStoreContext.Provider value={store}>
+      <CanvasWorkspaceSidebarOverlay />
+    </CanvasPageStoreContext.Provider>,
+  );
+
+  return store;
+};
+
+describe("CanvasWorkspaceSidebarOverlay", () => {
+  it("renders workspace links and saves the current pipeline", async () => {
+    const user = userEvent.setup();
+    const store = renderOpenOverlay();
+
+    expect(screen.getByTestId("canvas-workspace-sidebar-overlay")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Dashboard|仪表盘/i })).toHaveAttribute("href", "/");
+
+    await user.click(screen.getByRole("button", { name: /Save|保存/i }));
+
+    expect(refineMocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource: "pipelines",
+        id: "pipe-1",
+      }),
+    );
+    expect(store.getState().isWorkspaceSidebarOpen).toBe(false);
+  });
+});

--- a/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/index.ts
+++ b/apps/app/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/index.ts
@@ -1,0 +1,1 @@
+export * from "./CanvasWorkspaceSidebarOverlay";

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
@@ -53,7 +53,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
   };
 
   return (
-    <div className="group relative overflow-visible">
+    <div className="group relative w-fit overflow-visible">
       <NodeCard
         rightHandle
         bodyClassName="space-y-2"

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
@@ -20,6 +20,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
+  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
   const {
     rightActivePortCount,
@@ -56,6 +57,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
       <NodeCard
         rightHandle
         bodyClassName="space-y-2"
+        compact={nodeCardMode === "compact"}
         description={t("canvas.nodeTypes.file.label")}
         dimmed={dimmed}
         icon={FileCode}

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.unit.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { CanvasPageStoreProvider } from "../_store";
+import { CanvasPageStoreContext, createCanvasPageStore } from "../_store";
 import { FileNode } from "./CodeFileNode";
 
 vi.mock("@xyflow/react", () => ({
@@ -23,7 +23,16 @@ vi.mock("@refinedev/core", () => ({
 }));
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <CanvasPageStoreProvider>{children}</CanvasPageStoreProvider>
+  <CanvasPageStoreContext.Provider
+    value={(() => {
+      const store = createCanvasPageStore();
+      store.setState({ nodeCardMode: "expanded" });
+
+      return store;
+    })()}
+  >
+    {children}
+  </CanvasPageStoreContext.Provider>
 );
 
 const baseData = {

--- a/apps/app/src/pages/CanvasPage/FileNode/FileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FileNode/FileNode.tsx
@@ -20,6 +20,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
+  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
   const { rightPortCount } = useStore(store, useShallow(selectNodePortCounts(id)));
   const [browserOpen, setBrowserOpen] = useState(false);
@@ -50,6 +51,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
       <NodeCard
         rightHandle
         bodyClassName="space-y-2"
+        compact={nodeCardMode === "compact"}
         description={t("canvas.nodeTypes.file.label")}
         dimmed={dimmed}
         icon={FileCode}

--- a/apps/app/src/pages/CanvasPage/FileNode/FileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FileNode/FileNode.tsx
@@ -47,7 +47,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
   };
 
   return (
-    <div className="group relative overflow-visible">
+    <div className="group relative w-fit overflow-visible">
       <NodeCard
         rightHandle
         bodyClassName="space-y-2"

--- a/apps/app/src/pages/CanvasPage/FileNode/FileNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/FileNode/FileNode.unit.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { CanvasPageStoreProvider } from "../_store";
+import { CanvasPageStoreContext, createCanvasPageStore } from "../_store";
 import { FileNode } from "./FileNode";
 
 vi.mock("@xyflow/react", () => ({
@@ -23,7 +23,16 @@ vi.mock("@refinedev/core", () => ({
 }));
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <CanvasPageStoreProvider>{children}</CanvasPageStoreProvider>
+  <CanvasPageStoreContext.Provider
+    value={(() => {
+      const store = createCanvasPageStore();
+      store.setState({ nodeCardMode: "expanded" });
+
+      return store;
+    })()}
+  >
+    {children}
+  </CanvasPageStoreContext.Provider>
 );
 
 const baseData = {

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
@@ -63,7 +63,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
   const handleAddExcluded = (path: string) => handleNodeAddExcludedPath(id, path);
 
   return (
-    <div className="group relative overflow-visible">
+    <div className="group relative w-fit overflow-visible">
       <NodeCard
         rightHandle
         bodyClassName="space-y-2"

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
@@ -24,6 +24,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
+  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
   const handleNodeAddExcludedPath = useStore(store, (s) => s.handleNodeAddExcludedPath);
   const handleNodeRemoveExcludedPath = useStore(store, (s) => s.handleNodeRemoveExcludedPath);
@@ -66,6 +67,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
       <NodeCard
         rightHandle
         bodyClassName="space-y-2"
+        compact={nodeCardMode === "compact"}
         description={t("canvas.nodeTypes.folder.label")}
         dimmed={dimmed}
         icon={Folder}

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.unit.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { CanvasPageStoreProvider } from "../_store";
+import { CanvasPageStoreContext, createCanvasPageStore } from "../_store";
 import { FolderNode } from "./FolderNode";
 
 vi.mock("@xyflow/react", () => ({
@@ -23,8 +23,17 @@ vi.mock("@refinedev/core", () => ({
   }),
 }));
 
+const makeExpandedStore = () => {
+  const store = createCanvasPageStore();
+  store.setState({ nodeCardMode: "expanded" });
+
+  return store;
+};
+
 const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <CanvasPageStoreProvider>{children}</CanvasPageStoreProvider>
+  <CanvasPageStoreContext.Provider value={makeExpandedStore()}>
+    {children}
+  </CanvasPageStoreContext.Provider>
 );
 
 const baseData = {
@@ -82,9 +91,9 @@ describe("FolderNode", () => {
 
     // Simulate re-render with updated data (store would trigger this in real app)
     rerender(
-      <CanvasPageStoreProvider>
+      <CanvasPageStoreContext.Provider value={makeExpandedStore()}>
         <FolderNode data={{ ...data, excludedPaths: ["dist"] }} id="test" />
-      </CanvasPageStoreProvider>,
+      </CanvasPageStoreContext.Provider>,
     );
 
     expect(screen.queryByText("node_modules")).not.toBeInTheDocument();

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx
@@ -81,7 +81,7 @@ export const GitHubProjectNode = ({ id, data, selected }: GitHubProjectNodeProps
   const handleAddExcluded = (path: string) => handleNodeAddExcludedPath(id, path);
 
   return (
-    <div className="group relative overflow-visible">
+    <div className="group relative w-fit overflow-visible">
       <NodeCard
         rightHandle
         bodyClassName="space-y-2"

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx
@@ -27,6 +27,7 @@ export const GitHubProjectNode = ({ id, data, selected }: GitHubProjectNodeProps
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
+  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const [pickOpen, setPickOpen] = useState(false);
   const [connectOpen, setConnectOpen] = useState(false);
   const [localFolderOpen, setLocalFolderOpen] = useState(false);
@@ -84,6 +85,7 @@ export const GitHubProjectNode = ({ id, data, selected }: GitHubProjectNodeProps
       <NodeCard
         rightHandle
         bodyClassName="space-y-2"
+        compact={nodeCardMode === "compact"}
         description={t("canvas.nodeTypes.github-project.label")}
         dimmed={dimmed}
         icon={SiGitHubIcon}

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.unit.test.tsx
@@ -2,7 +2,7 @@ import { render } from "@/test/test-wrapper";
 import { screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ReactFlowProvider } from "@xyflow/react";
-import { CanvasPageStoreProvider } from "../_store";
+import { CanvasPageStoreContext, createCanvasPageStore } from "../_store";
 import { GitHubProjectNode } from "./GitHubProjectNode";
 
 vi.mock("@refinedev/core", () => ({
@@ -17,9 +17,16 @@ vi.mock("@refinedev/core", () => ({
 }));
 
 const wrapper = ({ children }: { children?: React.ReactNode }) => (
-  <CanvasPageStoreProvider>
+  <CanvasPageStoreContext.Provider
+    value={(() => {
+      const store = createCanvasPageStore();
+      store.setState({ nodeCardMode: "expanded" });
+
+      return store;
+    })()}
+  >
     <ReactFlowProvider>{children}</ReactFlowProvider>
-  </CanvasPageStoreProvider>
+  </CanvasPageStoreContext.Provider>
 );
 
 const baseData = {

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
@@ -15,6 +15,7 @@ export interface NodeCardProps extends NodeCardFrameProps {
   rightConnectedPortMask?: number;
   leftHandleCount?: number;
   rightHandleCount?: number;
+  compact?: boolean;
 }
 
 const useCardMaxPortSpread = (
@@ -73,6 +74,7 @@ export const NodeCard = memo(
     rightConnectedPortMask,
     leftHandleCount = 1,
     rightHandleCount = 1,
+    compact = false,
     selected,
     theme,
     icon,
@@ -93,6 +95,7 @@ export const NodeCard = memo(
       <div
         ref={wrapperRef}
         className="group/node-card relative"
+        data-card-mode={compact ? "compact" : "expanded"}
         data-selected={selected ? "true" : "false"}
       >
         <NodeCardFrame
@@ -107,7 +110,7 @@ export const NodeCard = memo(
           theme={theme}
           onLabelChange={handleLabelChange}
         >
-          {children}
+          {compact ? undefined : children}
         </NodeCardFrame>
         {hasPorts && (
           <NodeCardPorts

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
@@ -94,7 +94,7 @@ export const NodeCard = memo(
     return (
       <div
         ref={wrapperRef}
-        className="group/node-card relative"
+        className="canvas-node-pop group/node-card relative"
         data-card-mode={compact ? "compact" : "expanded"}
         data-selected={selected ? "true" : "false"}
       >

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.tsx
@@ -94,7 +94,7 @@ export const NodeCard = memo(
     return (
       <div
         ref={wrapperRef}
-        className="canvas-node-pop group/node-card relative"
+        className="canvas-node-pop group/node-card relative w-fit"
         data-card-mode={compact ? "compact" : "expanded"}
         data-selected={selected ? "true" : "false"}
       >

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
@@ -115,11 +115,17 @@ describe("NodeCard", () => {
       "w-full",
       "min-w-0",
     );
+    expect(container.querySelector('[data-slot="card-description"]')).toHaveClass(
+      "w-full",
+      "max-w-full",
+      "truncate",
+    );
     expect(container.querySelector('[data-slot="card-header"]')).toHaveClass(
       "min-h-14",
       "rounded-none",
     );
     expect(container.querySelector('[data-slot="card-action"]')).toHaveClass(
+      "ml-auto",
       "shrink-0",
       "self-center",
     );

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
@@ -69,6 +69,17 @@ describe("NodeCard", () => {
     expect(screen.getByText("Body content")).toBeInTheDocument();
   });
 
+  it("hides card body when compact", () => {
+    const { container } = render(
+      <NodeCard compact icon={Box} label="Node" theme="emerald">
+        <span>Body content</span>
+      </NodeCard>,
+    );
+
+    expect(screen.queryByText("Body content")).not.toBeInTheDocument();
+    expect(container.firstElementChild).toHaveAttribute("data-card-mode", "compact");
+  });
+
   it("does not render body wrapper when no children", () => {
     const { container } = render(<NodeCard icon={Box} label="Node" theme="emerald" />);
     const wrapper = container.firstElementChild;

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
@@ -287,6 +287,27 @@ describe("NodeCard", () => {
     expect(input).toHaveAttribute("readonly");
   });
 
+  it("sizes editable label input to the title text instead of the header row", () => {
+    const handleLabelChange = vi.fn();
+    render(
+      <NodeCard
+        icon={Box}
+        label="Editable Node"
+        theme="emerald"
+        onLabelChange={handleLabelChange}
+      />,
+    );
+
+    const input = screen.getByLabelText(/Node label|节点标签/);
+    const labelSizer = input.parentElement;
+    const mirrorLabel = labelSizer?.firstElementChild;
+
+    expect(labelSizer).toHaveClass("relative", "inline-block", "max-w-full", "overflow-hidden");
+    expect(mirrorLabel).toHaveClass("invisible", "block", "truncate", "whitespace-pre");
+    expect(input).toHaveClass("absolute", "inset-0", "w-full", "max-w-full", "truncate", "p-0");
+    expect(input).not.toHaveClass("w-auto");
+  });
+
   it("enables editable label when focused by keyboard", () => {
     const handleLabelChange = vi.fn();
     render(

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
@@ -85,7 +85,7 @@ describe("NodeCard", () => {
     const wrapper = container.firstElementChild;
     const card = wrapper?.firstElementChild;
 
-    expect(wrapper).toHaveClass("relative");
+    expect(wrapper).toHaveClass("relative", "w-fit");
     expect(card).toHaveAttribute("data-slot", "card");
     expect(card?.childNodes).toHaveLength(1);
   });
@@ -106,7 +106,7 @@ describe("NodeCard", () => {
       />,
     );
 
-    expect(container.firstElementChild).toHaveClass("relative");
+    expect(container.firstElementChild).toHaveClass("relative", "w-fit");
     expect(container.querySelector('[data-slot="card"]')).toHaveClass(
       "w-72",
       "data-[size=sm]:py-0",
@@ -151,22 +151,30 @@ describe("NodeCard", () => {
     render(<NodeCard leftHandle rightHandle icon={Box} label="Node" theme="orange" />);
 
     expect(screen.getByTestId("target-handle")).toHaveClass(
-      "!left-2.5",
-      "!h-5",
-      "!w-5",
+      "!left-0",
+      "!h-0",
+      "!min-h-0",
+      "!w-0",
+      "!min-w-0",
       "!bg-transparent",
-      "before:!left-0",
+      "before:left-1/2",
+      "after:h-5",
+      "after:w-5",
       "before:opacity-30",
       "before:scale-75",
       "group-hover/node-card:before:opacity-75",
       "before:!bg-orange-500",
     );
     expect(screen.getByTestId("source-handle")).toHaveClass(
-      "!right-2.5",
-      "!h-5",
-      "!w-5",
+      "!right-0",
+      "!h-0",
+      "!min-h-0",
+      "!w-0",
+      "!min-w-0",
       "!bg-transparent",
-      "before:!left-full",
+      "before:left-1/2",
+      "after:h-5",
+      "after:w-5",
       "before:opacity-30",
       "before:scale-75",
       "group-hover/node-card:before:opacity-75",

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCardFrame.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCardFrame.tsx
@@ -75,7 +75,7 @@ export const NodeCardFrame = memo(
             >
               <Icon className={cn("h-4 w-4", t.iconColor)} />
             </div>
-            <div className="flex min-h-8 flex-1 min-w-0 flex-col items-start justify-center">
+            <div className="flex min-h-8 min-w-0 flex-1 flex-col items-start justify-center overflow-hidden">
               {handleChange ? (
                 <span className="relative inline-block max-w-full min-w-0 overflow-hidden align-top">
                   <span
@@ -101,17 +101,19 @@ export const NodeCardFrame = memo(
                   />
                 </span>
               ) : (
-                <CardTitle className="truncate text-xs font-semibold leading-tight">
+                <CardTitle className="w-full max-w-full truncate text-xs font-semibold leading-tight">
                   {label}
                 </CardTitle>
               )}
               {description && (
-                <CardDescription className="truncate text-[10px] leading-tight">
+                <CardDescription className="w-full max-w-full truncate text-[10px] leading-tight">
                   {description}
                 </CardDescription>
               )}
             </div>
-            {headerRight && <CardAction className="shrink-0 self-center">{headerRight}</CardAction>}
+            {headerRight && (
+              <CardAction className="ml-auto shrink-0 self-center">{headerRight}</CardAction>
+            )}
           </div>
         </CardHeader>
         {children && (

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCardFrame.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCardFrame.tsx
@@ -75,23 +75,31 @@ export const NodeCardFrame = memo(
             >
               <Icon className={cn("h-4 w-4", t.iconColor)} />
             </div>
-            <div className="flex min-h-8 flex-1 min-w-0 flex-col justify-center">
+            <div className="flex min-h-8 flex-1 min-w-0 flex-col items-start justify-center">
               {handleChange ? (
-                <input
-                  aria-label={translate("canvas.nodeLabel")}
-                  className={cn(
-                    "nodrag nopan w-auto max-w-full bg-transparent text-xs font-semibold leading-tight [field-sizing:content] focus:outline-none",
-                    isLabelEditing ? "select-text" : "cursor-default select-none",
-                  )}
-                  name="nodeLabel"
-                  readOnly={!isLabelEditing}
-                  value={label}
-                  onBlur={handleLabelBlur}
-                  onChange={handleChange}
-                  onClick={handleLabelClick}
-                  onFocus={handleLabelFocus}
-                  onMouseDown={handleMouseDown}
-                />
+                <span className="relative inline-block max-w-full min-w-0 overflow-hidden align-top">
+                  <span
+                    aria-hidden="true"
+                    className="invisible block max-w-full truncate whitespace-pre text-xs font-semibold leading-tight"
+                  >
+                    {label || " "}
+                  </span>
+                  <input
+                    aria-label={translate("canvas.nodeLabel")}
+                    className={cn(
+                      "nodrag nopan absolute inset-0 h-full w-full min-w-0 max-w-full truncate border-0 bg-transparent p-0 text-xs font-semibold leading-tight focus:outline-none",
+                      isLabelEditing ? "select-text" : "cursor-default select-none",
+                    )}
+                    name="nodeLabel"
+                    readOnly={!isLabelEditing}
+                    value={label}
+                    onBlur={handleLabelBlur}
+                    onChange={handleChange}
+                    onClick={handleLabelClick}
+                    onFocus={handleLabelFocus}
+                    onMouseDown={handleMouseDown}
+                  />
+                </span>
               ) : (
                 <CardTitle className="truncate text-xs font-semibold leading-tight">
                   {label}

--- a/apps/app/src/pages/CanvasPage/NodeCard/NodeCardPorts.tsx
+++ b/apps/app/src/pages/CanvasPage/NodeCard/NodeCardPorts.tsx
@@ -27,7 +27,7 @@ export interface NodeCardPortsProps {
 }
 
 const nodePortClassName =
-  "node-card-port absolute !top-[calc(50%+var(--node-port-offset))] !z-10 !h-5 !w-5 rounded-full !border-0 !bg-transparent !opacity-100 transition-opacity duration-150 ease-out before:content-[''] before:absolute before:left-1/2 before:top-1/2 before:h-2 before:w-2 before:-translate-x-1/2 before:-translate-y-1/2 before:scale-75 before:rounded-full before:opacity-30 before:shadow-[0_0_0_2px_rgba(255,255,255,0.8),0_1px_4px_rgba(15,23,42,0.12)] before:transition-[opacity,transform,box-shadow] before:duration-200 before:ease-out hover:before:scale-125 hover:before:opacity-100 hover:before:shadow-[0_0_0_3px_rgba(255,255,255,0.95),0_2px_8px_rgba(15,23,42,0.28)] group-hover/node-card:before:scale-100 group-hover/node-card:before:opacity-75 group-data-[selected=true]/node-card:before:scale-110 group-data-[selected=true]/node-card:before:opacity-100 data-[connected=true]:before:scale-100 data-[connected=true]:before:opacity-90 data-[active=true]:before:scale-125 data-[active=true]:before:opacity-100";
+  "node-card-port absolute !top-[calc(50%+var(--node-port-offset))] !z-10 !h-0 !min-h-0 !w-0 !min-w-0 !border-0 !bg-transparent !opacity-100 transition-opacity duration-150 ease-out before:content-[''] before:absolute before:left-1/2 before:top-1/2 before:h-2 before:w-2 before:-translate-x-1/2 before:-translate-y-1/2 before:scale-75 before:rounded-full before:opacity-30 before:shadow-[0_0_0_2px_rgba(255,255,255,0.8),0_1px_4px_rgba(15,23,42,0.12)] before:transition-[opacity,transform,box-shadow] before:duration-200 before:ease-out after:content-[''] after:absolute after:left-1/2 after:top-1/2 after:h-5 after:w-5 after:-translate-x-1/2 after:-translate-y-1/2 after:rounded-full hover:before:scale-125 hover:before:opacity-100 hover:before:shadow-[0_0_0_3px_rgba(255,255,255,0.95),0_2px_8px_rgba(15,23,42,0.28)] group-hover/node-card:before:scale-100 group-hover/node-card:before:opacity-75 group-data-[selected=true]/node-card:before:scale-110 group-data-[selected=true]/node-card:before:opacity-100 data-[connected=true]:before:scale-100 data-[connected=true]:before:opacity-90 data-[active=true]:before:scale-125 data-[active=true]:before:opacity-100";
 
 const getNodePortStyle = (offset: number) =>
   ({
@@ -112,8 +112,8 @@ export const NodeCardPorts = ({
   const updateNodeInternals = useUpdateNodeInternals();
   const leftPortOffsets = getNodePortOffsets(leftHandleCount, cardMaxPortSpread);
   const rightPortOffsets = getNodePortOffsets(rightHandleCount, cardMaxPortSpread);
-  const leftPortClassName = cn(nodePortClassName, "!left-2.5 before:!left-0", t.handleColor);
-  const rightPortClassName = cn(nodePortClassName, "!right-2.5 before:!left-full", t.handleColor);
+  const leftPortClassName = cn(nodePortClassName, "!left-0", t.handleColor);
+  const rightPortClassName = cn(nodePortClassName, "!right-0", t.handleColor);
 
   useEffect(() => {
     if (!nodeId) {
@@ -121,6 +121,18 @@ export const NodeCardPorts = ({
     }
 
     updateNodeInternals(nodeId);
+
+    if (typeof requestAnimationFrame === "undefined") {
+      return;
+    }
+
+    const frameId = requestAnimationFrame(() => updateNodeInternals(nodeId));
+    const timeoutId = globalThis.setTimeout(() => updateNodeInternals(nodeId), 200);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      globalThis.clearTimeout(timeoutId);
+    };
   }, [
     cardMaxPortSpread,
     leftHandle,

--- a/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
@@ -54,6 +54,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const { runStatus: nodeRunStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
+  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const { result: operationsResult } = useList<Operation>({
     resource: ResourceName.operations,
   });
@@ -151,6 +152,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
         leftHandle
         rightHandle
         bodyClassName="space-y-2"
+        compact={nodeCardMode === "compact"}
         description={operation?.description || t("nodes.operation.customDescription")}
         dimmed={dimmed}
         headerRight={

--- a/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
@@ -158,7 +158,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
         headerRight={
           <div
             className={cn(
-              "flex shrink-0 items-center gap-1.5 rounded-md border px-2 py-1 shadow-sm",
+              "flex min-w-fit shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border px-2 py-1 shadow-sm",
               data.status === "pass" && "bg-green-50 border-green-100",
               data.status === "fail" && "bg-red-50 border-red-100",
               data.status === "running" && "bg-blue-50 border-blue-100",

--- a/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
@@ -145,7 +145,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
 
   return (
     <div
-      className={cn("group relative overflow-visible", canInspect && "cursor-pointer")}
+      className={cn("group relative w-fit overflow-visible", canInspect && "cursor-pointer")}
       onClick={handleOperationCardClick.bind(null, id)}
     >
       <NodeCard

--- a/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx
@@ -1,4 +1,12 @@
-import { Zap, CheckCircle2, XCircle, Loader2, Circle, Brain, Repeat } from "lucide-react";
+import {
+  Zap,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Circle,
+  Brain,
+  Repeat,
+} from "lucide-react";
 import { type ElementType, type SyntheticEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@repo/ui/lib/utils";
@@ -12,8 +20,17 @@ import {
 } from "@repo/ui/select";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
-import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
-import type { OperationNodeData, NodeRunStatus, Operation, Agent } from "@repo/schemas";
+import {
+  useCanvasPageStore,
+  selectNodeRunState,
+  selectNodePortCounts,
+} from "../_store";
+import type {
+  OperationNodeData,
+  NodeRunStatus,
+  Operation,
+  Agent,
+} from "@repo/schemas";
 import { useList } from "@refinedev/core";
 import { ResourceName } from "@/integrations/refine/dataProvider";
 import { NodeCard } from "../NodeCard";
@@ -24,36 +41,42 @@ export interface OperationNodeProps {
   selected?: boolean;
 }
 
-const statusConfig: Record<NodeRunStatus, { icon: ElementType; color: string; labelKey: string }> =
-  {
-    idle: {
-      icon: Circle,
-      color: "text-gray-400",
-      labelKey: "nodes.operation.statusIdle",
-    },
-    running: {
-      icon: Loader2,
-      color: "text-blue-500 animate-spin",
-      labelKey: "nodes.operation.statusRunning",
-    },
-    pass: {
-      icon: CheckCircle2,
-      color: "text-green-500",
-      labelKey: "nodes.operation.statusPass",
-    },
-    fail: {
-      icon: XCircle,
-      color: "text-red-500",
-      labelKey: "nodes.operation.statusFail",
-    },
-  };
+const statusConfig: Record<
+  NodeRunStatus,
+  { icon: ElementType; color: string; labelKey: string }
+> = {
+  idle: {
+    icon: Circle,
+    color: "text-gray-400",
+    labelKey: "nodes.operation.statusIdle",
+  },
+  running: {
+    icon: Loader2,
+    color: "text-blue-500 animate-spin",
+    labelKey: "nodes.operation.statusRunning",
+  },
+  pass: {
+    icon: CheckCircle2,
+    color: "text-green-500",
+    labelKey: "nodes.operation.statusPass",
+  },
+  fail: {
+    icon: XCircle,
+    color: "text-red-500",
+    labelKey: "nodes.operation.statusFail",
+  },
+};
 
-const stopCanvasInteraction = (event: SyntheticEvent) => event.stopPropagation();
+const stopCanvasInteraction = (event: SyntheticEvent) =>
+  event.stopPropagation();
 
 export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
-  const { runStatus: nodeRunStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
+  const { runStatus: nodeRunStatus, dimmed } = useStore(
+    store,
+    useShallow(selectNodeRunState(id)),
+  );
   const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const { result: operationsResult } = useList<Operation>({
     resource: ResourceName.operations,
@@ -86,7 +109,8 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
       handleOperationMaxLoopChange: s.handleOperationMaxLoopChange,
       handleOperationConditionChange: s.handleOperationConditionChange,
       handleOperationCardClick: s.handleOperationCardClick,
-      handleOperationAgentDropdownOpenChange: s.handleOperationAgentDropdownOpenChange,
+      handleOperationAgentDropdownOpenChange:
+        s.handleOperationAgentDropdownOpenChange,
     })),
   );
   const {
@@ -103,10 +127,16 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
   } = useStore(store, useShallow(selectNodePortCounts(id)));
   const agentOpen = operationAgentDropdownNodeId === id;
 
-  const { icon: StatusIcon, color, labelKey } = statusConfig[data.status ?? "idle"];
+  const {
+    icon: StatusIcon,
+    color,
+    labelKey,
+  } = statusConfig[data.status ?? "idle"];
   const statusLabel = t(labelKey);
 
-  const operation = operations.find((op: Operation) => op.id === data.operationId);
+  const operation = operations.find(
+    (op: Operation) => op.id === data.operationId,
+  );
   const executor = operation?.config.executor;
   const effectiveAgentMode =
     executor?.type === "agent" ? (executor.agentMode ?? "prompt") : undefined;
@@ -118,7 +148,9 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
   const selectedAgentId = data.agentId ?? "";
   const selectedAgent = agents.find((agent) => agent.id === selectedAgentId);
   const isAgentIncompatible =
-    isSkillOperation && !!selectedAgent && selectedAgent.defaultRuntime === "hermes";
+    isSkillOperation &&
+    !!selectedAgent &&
+    selectedAgent.defaultRuntime === "hermes";
   const selectedAgentLabel = isAgentIncompatible
     ? `${selectedAgent.name} (${t("nodes.operation.agentIncompatible")})`
     : selectedAgentId
@@ -138,6 +170,18 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
     onClick: stopCanvasInteraction,
     onKeyDown: stopCanvasInteraction,
   };
+  const handleCardClick = () => {
+    handleOperationCardClick(id);
+  };
+  const handleLabelChange = (value: string) => {
+    handleOperationLabelChange(id, value);
+  };
+  const handleAgentDropdownChange = (open: boolean) => {
+    handleOperationAgentDropdownOpenChange(id, open);
+  };
+  const handleAgentValueChange = (value: string) => {
+    handleOperationAgentChange(id, value);
+  };
   const handleLoopButtonClick = (event: SyntheticEvent) => {
     stopCanvasInteraction(event);
     handleOperationLoopToggle(id);
@@ -145,15 +189,19 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
 
   return (
     <div
-      className={cn("group relative w-fit overflow-visible", canInspect && "cursor-pointer")}
-      onClick={handleOperationCardClick.bind(null, id)}
-    >
+      className={cn(
+        "group relative w-fit overflow-visible",
+        canInspect && "cursor-pointer",
+      )}
+      onClick={handleCardClick}>
       <NodeCard
         leftHandle
         rightHandle
         bodyClassName="space-y-2"
         compact={nodeCardMode === "compact"}
-        description={operation?.description || t("nodes.operation.customDescription")}
+        description={
+          operation?.description || t("nodes.operation.customDescription")
+        }
         dimmed={dimmed}
         headerRight={
           <div
@@ -162,11 +210,12 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
               data.status === "pass" && "bg-green-50 border-green-100",
               data.status === "fail" && "bg-red-50 border-red-100",
               data.status === "running" && "bg-blue-50 border-blue-100",
-              (!data.status || data.status === "idle") && "bg-white border-slate-100",
-            )}
-          >
+              (!data.status || data.status === "idle") &&
+                "bg-white border-slate-100",
+            )}>
             <StatusIcon className={cn("h-3 w-3 shrink-0", color)} />
-            <span className={cn("text-[10px] font-semibold tracking-wide", color)}>
+            <span
+              className={cn("text-[10px] font-semibold tracking-wide", color)}>
               {statusLabel}
             </span>
           </div>
@@ -186,8 +235,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
         runStatus={nodeRunStatus}
         selected={selected}
         theme="violet"
-        onLabelChange={handleOperationLabelChange.bind(null, id)}
-      >
+        onLabelChange={handleLabelChange}>
         {data.config && Object.keys(data.config).length > 0 && (
           <div className="space-y-1">
             <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
@@ -211,8 +259,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
               {operation.acceptedObjectTypes.map((type) => (
                 <span
                   key={type}
-                  className="rounded bg-violet-50 px-1.5 py-0.5 text-[9px] font-medium text-violet-600"
-                >
+                  className="rounded bg-violet-50 px-1.5 py-0.5 text-[9px] font-medium text-violet-600">
                   {objectTypeLabels[type] ?? type}
                 </span>
               ))}
@@ -220,7 +267,9 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
           </div>
         )}
 
-        <div className="nodrag nopan space-y-1.5" {...canvasInteractionHandlers}>
+        <div
+          className="nodrag nopan space-y-1.5"
+          {...canvasInteractionHandlers}>
           <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
             <Brain className="mr-1 inline-block h-3 w-3" />
             {t("nodes.operation.agent")}
@@ -228,27 +277,27 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
           <Select
             open={agentOpen}
             value={selectedAgentId || "__default__"}
-            onOpenChange={handleOperationAgentDropdownOpenChange.bind(null, id)}
-            onValueChange={handleOperationAgentChange.bind(null, id)}
-          >
+            onOpenChange={handleAgentDropdownChange}
+            onValueChange={handleAgentValueChange}>
             <SelectTrigger
               aria-label={t("nodes.operation.agent")}
-              className="nodrag nopan h-8 w-full min-w-0 px-2.5 text-xs"
-            >
+              className="nodrag nopan h-8 w-full min-w-0 px-2.5 text-xs">
               <span className="truncate">{selectedAgentLabel}</span>
             </SelectTrigger>
             <SelectContent
               align="start"
               alignItemWithTrigger={false}
               className="nodrag nopan min-w-44"
-              sideOffset={6}
-            >
+              sideOffset={6}>
               <SelectGroup>
                 <SelectLabel>{t("nodes.operation.agent")}</SelectLabel>
-                <SelectItem value="__default__">{t("nodes.operation.defaultAgent")}</SelectItem>
+                <SelectItem value="__default__">
+                  {t("nodes.operation.defaultAgent")}
+                </SelectItem>
                 {isAgentIncompatible && (
                   <SelectItem disabled value={selectedAgentId}>
-                    {selectedAgent.name} ({t("nodes.operation.agentIncompatible")})
+                    {selectedAgent.name} (
+                    {t("nodes.operation.agentIncompatible")})
                   </SelectItem>
                 )}
                 {selectableAgents.map((agent) => (
@@ -268,7 +317,9 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
           </div>
         )}
 
-        <div className="nodrag nopan space-y-1.5" {...canvasInteractionHandlers}>
+        <div
+          className="nodrag nopan space-y-1.5"
+          {...canvasInteractionHandlers}>
           <button
             className={cn(
               "nodrag nopan flex h-8 w-full items-center gap-1.5 rounded-md border px-2.5 text-[11px] font-medium transition-colors",
@@ -277,10 +328,11 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
                 : "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100",
             )}
             type="button"
-            onClick={handleLoopButtonClick}
-          >
+            onClick={handleLoopButtonClick}>
             <Repeat className="h-3 w-3 shrink-0" />
-            {data.loopEnabled ? t("nodes.operation.loopEnabled") : t("nodes.operation.enableLoop")}
+            {data.loopEnabled
+              ? t("nodes.operation.loopEnabled")
+              : t("nodes.operation.enableLoop")}
           </button>
 
           {data.loopEnabled && (
@@ -298,7 +350,10 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
                   type="number"
                   value={data.maxLoopCount ?? 3}
                   onChange={(e) =>
-                    handleOperationMaxLoopChange(id, Number.parseInt(e.target.value, 10))
+                    handleOperationMaxLoopChange(
+                      id,
+                      Number.parseInt(e.target.value, 10),
+                    )
                   }
                 />
               </div>
@@ -313,7 +368,9 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
                   placeholder={t("nodes.operation.loopConditionPlaceholder")}
                   rows={2}
                   value={data.loopConditionPrompt ?? ""}
-                  onChange={(e) => handleOperationConditionChange(id, e.target.value)}
+                  onChange={(e) =>
+                    handleOperationConditionChange(id, e.target.value)
+                  }
                 />
               </div>
             </div>
@@ -323,3 +380,4 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
     </div>
   );
 };
+

--- a/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/OperationNode/OperationNode.unit.test.tsx
@@ -73,6 +73,7 @@ const renderOperationNode = (
     data,
   } as PipelineNode;
   const store = createCanvasPageStore([node]);
+  store.setState({ nodeCardMode: "expanded" });
 
   const wrapper = ({ children }: React.PropsWithChildren) => (
     <CanvasPageStoreContext.Provider value={store}>

--- a/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
@@ -63,7 +63,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
   const currentMode = data.outputMode ?? "overwrite";
 
   return (
-    <div className="group relative overflow-visible">
+    <div className="group relative w-fit overflow-visible">
       <NodeCard
         leftHandle
         bodyClassName="space-y-2"

--- a/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
@@ -26,6 +26,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
+  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
   const {
     leftActivePortCount,
@@ -66,6 +67,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
       <NodeCard
         leftHandle
         bodyClassName="space-y-2"
+        compact={nodeCardMode === "compact"}
         description={t("nodes.outputLocalPathNode.description")}
         dimmed={dimmed}
         icon={HardDrive}

--- a/apps/app/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.tsx
@@ -39,7 +39,7 @@ export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathN
     updateNodeData(id, { description: e.target.value });
 
   return (
-    <div className="group relative overflow-visible">
+    <div className="group relative w-fit overflow-visible">
       <NodeCard
         leftHandle
         bodyClassName="space-y-2"

--- a/apps/app/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.tsx
@@ -20,6 +20,7 @@ export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathN
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
+  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
   const {
     leftActivePortCount,
@@ -42,6 +43,7 @@ export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathN
       <NodeCard
         leftHandle
         bodyClassName="space-y-2"
+        compact={nodeCardMode === "compact"}
         description={t("nodes.outputProjectPath.description")}
         dimmed={dimmed}
         icon={FolderOutput}

--- a/apps/app/src/pages/CanvasPage/PromptNode/PromptNode.tsx
+++ b/apps/app/src/pages/CanvasPage/PromptNode/PromptNode.tsx
@@ -17,6 +17,7 @@ const handleStopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
 export const PromptNode = ({ id, data, selected }: PromptNodeProps) => {
   const store = useCanvasPageStore();
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
+  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
   const { rightPortCount } = useStore(store, useShallow(selectNodePortCounts(id)));
 
@@ -28,6 +29,7 @@ export const PromptNode = ({ id, data, selected }: PromptNodeProps) => {
     <NodeCard
       rightHandle
       bodyClassName="space-y-2"
+      compact={nodeCardMode === "compact"}
       description="Prompt"
       dimmed={dimmed}
       icon={MessageSquareText}

--- a/apps/app/src/pages/CanvasPage/PromptNode/PromptNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/PromptNode/PromptNode.unit.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { CanvasPageStoreProvider } from "../_store";
+import { CanvasPageStoreContext, createCanvasPageStore } from "../_store";
 import { PromptNode } from "./PromptNode";
 
 vi.mock("@xyflow/react", () => ({
@@ -23,7 +23,16 @@ vi.mock("@refinedev/core", () => ({
 }));
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <CanvasPageStoreProvider>{children}</CanvasPageStoreProvider>
+  <CanvasPageStoreContext.Provider
+    value={(() => {
+      const store = createCanvasPageStore();
+      store.setState({ nodeCardMode: "expanded" });
+
+      return store;
+    })()}
+  >
+    {children}
+  </CanvasPageStoreContext.Provider>
 );
 
 const baseData = {

--- a/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
@@ -1,6 +1,6 @@
 import { sortParentBeforeChildren, type PipelineEdge, type PipelineNode } from "./canvasSlice";
 import type { CanvasPageStoreSlice } from "./canvasPageStore";
-import type { Operation, BuiltinNodeType } from "@repo/schemas";
+import type { Operation, BuiltinNodeType, Skill } from "@repo/schemas";
 import type { PickedProject } from "../GitHubProjectNode/PickProjectDialog";
 import type { ConnectedRepoInfo } from "../GitHubProjectNode/GitHubConnectDialog";
 import type { LocalFolderInfo } from "../GitHubProjectNode/PickLocalFolderDialog";
@@ -45,6 +45,32 @@ const makeLocalizedDefaultNodeData = (type: BuiltinNodeType) => {
   });
 };
 
+const skillBackedOperationId = (skill: Skill) => `skill-operation-${skill.id}`;
+
+const isSkillBackedOperation = (operation: Operation, skill: Skill) => {
+  const executor = operation.config.executor;
+
+  return (
+    executor?.type === "agent" && executor.agentMode === "skill" && executor.skillId === skill.id
+  );
+};
+
+const makeSkillBackedOperation = (skill: Skill): Operation => ({
+  id: skillBackedOperationId(skill),
+  name: skill.label || skill.name,
+  description: skill.description,
+  acceptedObjectTypes: ["file", "folder", "github-project", "prompt"],
+  config: {
+    executor: {
+      type: "agent",
+      agentMode: "skill",
+      skillId: skill.id,
+    },
+    inputs: [],
+    outputs: [],
+  },
+});
+
 export interface ActionsSlice {
   exportCanvas: () => void;
   importCanvas: (data: CanvasImportPayload) => void;
@@ -87,6 +113,7 @@ export interface ActionsSlice {
   createOperationNode: (operation: Operation) => void;
   handleCreateObjectNode: (type: BuiltinNodeType, screenPosition: XYPosition) => void;
   handleCreateOperationNode: (operation: Operation, screenPosition: XYPosition) => void;
+  handleCreateSkillOperationNode: (skill: Skill, screenPosition: XYPosition) => Promise<void>;
   dismissContextMenu: () => void;
   handleContextMenuOpenChange: (open: boolean) => void;
   connectObjectNode: (type: BuiltinNodeType) => void;
@@ -178,6 +205,8 @@ export const createActionsSlice = (
     set({
       selectedNodeId: nodeId,
       selectedEdgeId: null,
+      sidebarPanel: "properties",
+      isPropertiesPanelOpen: true,
       contextMenu: null,
       connectionMenu: null,
       nodeContextMenu: null,
@@ -190,6 +219,8 @@ export const createActionsSlice = (
     set({
       selectedEdgeId: edgeId,
       selectedNodeId: null,
+      sidebarPanel: "components",
+      isPropertiesPanelOpen: false,
       contextMenu: null,
       connectionMenu: null,
       nodeContextMenu: null,
@@ -202,6 +233,8 @@ export const createActionsSlice = (
     set({
       selectedNodeId: null,
       selectedEdgeId: null,
+      sidebarPanel: "components",
+      isPropertiesPanelOpen: false,
       contextMenu: null,
       connectionMenu: null,
       nodeContextMenu: null,
@@ -509,6 +542,57 @@ export const createActionsSlice = (
       data: makeOperationNodeData(operation),
     });
     set({ isQuickAddOpen: false, quickAddQuery: "" });
+  },
+
+  handleCreateSkillOperationNode: async (skill, screenPosition) => {
+    const result = await ResultAsync.fromPromise(
+      (async () => {
+        const listResult = await dataProvider.getList!<Operation>({
+          resource: ResourceName.operations,
+        });
+        const existing = listResult.data.find((operation) =>
+          isSkillBackedOperation(operation, skill),
+        );
+
+        if (existing) {
+          return existing;
+        }
+
+        const createResult = await dataProvider.create!<Operation>({
+          resource: ResourceName.operations,
+          variables: makeSkillBackedOperation(skill),
+        });
+
+        return createResult.data;
+      })(),
+      () => "create-skill-operation-failed" as const,
+    );
+
+    result.match(
+      (operation) => {
+        const position = get().screenToFlowPosition(screenPosition);
+        get().addNodeAndAutoConnect({
+          id: `op-${operation.id}-${Date.now()}`,
+          type: "operation",
+          origin: QUICK_ADD_NODE_ORIGIN,
+          position,
+          data: makeOperationNodeData(operation),
+        });
+        set({ isQuickAddOpen: false, quickAddQuery: "" });
+      },
+      () => {
+        const t = i18n.t.bind(i18n);
+        toastStore.getState().addToast({
+          type: "error",
+          title: t("canvas.skillOperationCreateFailed", {
+            defaultValue: "Failed to add skill",
+          }),
+          description: t("canvas.skillOperationCreateFailedDescription", {
+            defaultValue: "Could not prepare a Skill Operation for this Canvas node.",
+          }),
+        });
+      },
+    );
   },
 
   // TODO: Find if it should be use

--- a/apps/app/src/pages/CanvasPage/_store/actionsSlice.unit.test.ts
+++ b/apps/app/src/pages/CanvasPage/_store/actionsSlice.unit.test.ts
@@ -36,6 +36,30 @@ describe("canvas connection actions", () => {
     expect(store.getState().connectStart).toBeNull();
   });
 
+  it("can undo and redo a created connection", () => {
+    const source = makeNode("source", "file");
+    const target = makeNode("target", "operation");
+    const store = createCanvasPageStore([source, target], [], null, "");
+
+    store.getState().handleConnect({
+      source: source.id,
+      sourceHandle: null,
+      target: target.id,
+      targetHandle: null,
+    });
+
+    expect(store.getState().edges).toHaveLength(1);
+    expect(() => store.getState().handleUndo()).not.toThrow();
+    expect(store.getState().edges).toEqual([]);
+    expect(() => store.getState().handleRedo()).not.toThrow();
+    expect(store.getState().edges).toEqual([
+      expect.objectContaining({
+        source: source.id,
+        target: target.id,
+      }),
+    ]);
+  });
+
   it("keeps the dragged target handle when creating a connected upstream node", () => {
     const source = makeNode("source", "folder");
     const target = makeNode("target", "operation");

--- a/apps/app/src/pages/CanvasPage/_store/historySlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/historySlice.ts
@@ -96,6 +96,13 @@ export interface HistorySlice {
   clearHistory: () => void;
 }
 
+const sortNodesAfterHistoryPatch = (nodes: PipelineNode[]): PipelineNode[] => {
+  const sortedNodes = [...nodes];
+  sortParentBeforeChildren(sortedNodes);
+
+  return sortedNodes;
+};
+
 // ─── Factory ──────────────────────────────────────────────────────────────────
 
 export const createHistorySlice = (
@@ -157,13 +164,11 @@ export const createHistorySlice = (
     };
 
     const prev = applyPatches(current, entry.inversePatches);
-    // Ensure parent-before-children ordering after undo
-    sortParentBeforeChildren(prev.nodes);
     const history = _history.slice(0, -1);
     const future = [entry, ..._future];
 
     set({
-      nodes: prev.nodes,
+      nodes: sortNodesAfterHistoryPatch(prev.nodes),
       edges: prev.edges,
       _history: history,
       _future: future,
@@ -184,13 +189,11 @@ export const createHistorySlice = (
     };
 
     const next = applyPatches(current, entry.patches);
-    // Ensure parent-before-children ordering after redo
-    sortParentBeforeChildren(next.nodes);
     const history = [..._history, entry];
     const future = _future.slice(1);
 
     set({
-      nodes: next.nodes,
+      nodes: sortNodesAfterHistoryPatch(next.nodes),
       edges: next.edges,
       _history: history,
       _future: future,

--- a/apps/app/src/pages/CanvasPage/_store/langflowCanvasStore.unit.test.ts
+++ b/apps/app/src/pages/CanvasPage/_store/langflowCanvasStore.unit.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Operation, Skill } from "@repo/schemas";
+import { createCanvasPageStore } from "./canvasPageStore";
+import type { PipelineNode } from "./canvasSlice";
+
+const dataProviderMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  getList: vi.fn(),
+}));
+
+vi.mock("@/integrations/refine/dataProvider", () => ({
+  ResourceName: {
+    operations: "operations",
+    pipelines: "pipelines",
+    skills: "skills",
+  },
+  dataProvider: {
+    create: dataProviderMocks.create,
+    getList: dataProviderMocks.getList,
+  },
+}));
+
+const fileNode = {
+  id: "file-1",
+  type: "file",
+  position: { x: 0, y: 0 },
+  data: {
+    label: "Source File",
+    nodeType: "file",
+    filePath: "src/index.ts",
+    language: "typescript",
+  },
+} as PipelineNode;
+
+const skill = {
+  id: "skill-error-handling",
+  name: "error-handling",
+  label: "Error Handling",
+  description: "Use neverthrow for errors",
+  category: "code-quality",
+  tags: ["Neverthrow"],
+} as Skill;
+
+const skillOperation = {
+  id: "op-skill-error-handling",
+  name: "Error Handling",
+  description: "Use neverthrow for errors",
+  acceptedObjectTypes: ["file", "folder", "github-project", "prompt"],
+  config: {
+    executor: {
+      type: "agent",
+      agentMode: "skill",
+      skillId: skill.id,
+    },
+    inputs: [],
+    outputs: [],
+  },
+} as Operation;
+
+describe("langflow canvas store state", () => {
+  it("defaults to compact node cards and component panel state", () => {
+    const store = createCanvasPageStore();
+
+    expect(store.getState().nodeCardMode).toBe("compact");
+    expect(store.getState().sidebarPanel).toBe("components");
+    expect(store.getState().isWorkspaceSidebarOpen).toBe(false);
+  });
+
+  it("switches between components and properties as canvas selection changes", () => {
+    const store = createCanvasPageStore([fileNode]);
+
+    store.getState().focusNode(fileNode.id);
+
+    expect(store.getState().selectedNodeId).toBe(fileNode.id);
+    expect(store.getState().sidebarPanel).toBe("properties");
+    expect(store.getState().isPropertiesPanelOpen).toBe(true);
+
+    store.getState().clearSelection();
+
+    expect(store.getState().selectedNodeId).toBeNull();
+    expect(store.getState().sidebarPanel).toBe("components");
+    expect(store.getState().isPropertiesPanelOpen).toBe(false);
+  });
+
+  it("toggles compact and expanded node card mode", () => {
+    const store = createCanvasPageStore();
+
+    store.getState().toggleNodeCardMode();
+
+    expect(store.getState().nodeCardMode).toBe("expanded");
+
+    store.getState().toggleNodeCardMode();
+
+    expect(store.getState().nodeCardMode).toBe("compact");
+  });
+});
+
+describe("langflow skill operation creation", () => {
+  beforeEach(() => {
+    dataProviderMocks.create.mockReset();
+    dataProviderMocks.getList.mockReset();
+  });
+
+  it("reuses an existing skill-backed operation when adding a skill node", async () => {
+    dataProviderMocks.getList.mockResolvedValue({ data: [skillOperation], total: 1 });
+    const store = createCanvasPageStore();
+    store.setState({ screenToFlowPosition: (pos) => ({ x: pos.x / 2, y: pos.y / 2 }) });
+
+    await store.getState().handleCreateSkillOperationNode(skill, { x: 800, y: 600 });
+
+    expect(dataProviderMocks.create).not.toHaveBeenCalled();
+    expect(store.getState().nodes).toEqual([
+      expect.objectContaining({
+        type: "operation",
+        origin: [0.5, 0.5],
+        position: { x: 400, y: 300 },
+        data: expect.objectContaining({
+          operationId: skillOperation.id,
+          operationName: skillOperation.name,
+        }),
+      }),
+    ]);
+  });
+
+  it("creates a backing operation before adding a new skill node", async () => {
+    dataProviderMocks.getList.mockResolvedValue({ data: [], total: 0 });
+    dataProviderMocks.create.mockResolvedValue({ data: skillOperation });
+    const store = createCanvasPageStore();
+
+    await store.getState().handleCreateSkillOperationNode(skill, { x: 100, y: 120 });
+
+    expect(dataProviderMocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource: "operations",
+        variables: expect.objectContaining({
+          id: "skill-operation-skill-error-handling",
+          name: skill.label,
+          config: expect.objectContaining({
+            executor: expect.objectContaining({
+              type: "agent",
+              agentMode: "skill",
+              skillId: skill.id,
+            }),
+          }),
+        }),
+      }),
+    );
+    expect(store.getState().nodes).toHaveLength(1);
+  });
+});

--- a/apps/app/src/pages/CanvasPage/_store/uiSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/uiSlice.ts
@@ -10,6 +10,10 @@ import { DEFAULT_CANVAS_VIEWPORT } from "../utils/canvasViewport";
 
 export type SidebarPanel = "components" | "properties" | "ai-assistant" | null;
 
+export type CanvasComponentCategory = "input" | "operations" | "skills" | "output";
+
+export type NodeCardMode = "compact" | "expanded";
+
 export interface ContextMenuState {
   screenX: number;
   screenY: number;
@@ -56,6 +60,10 @@ export interface UISlice {
   viewportZoom: number;
   canvasSettings: CanvasSettingsState;
   sidebarPanel: SidebarPanel;
+  componentSearchQuery: string;
+  collapsedComponentCategories: Record<CanvasComponentCategory, boolean>;
+  isWorkspaceSidebarOpen: boolean;
+  nodeCardMode: NodeCardMode;
   isSidebarOpen: boolean;
   isPropertiesPanelOpen: boolean;
   isCanvasSettingsOpen: boolean;
@@ -87,6 +95,13 @@ export interface UISlice {
 
   handlePipelineIdChange: (id: string) => void;
   handleSidebarPanelChange: (panel: SidebarPanel) => void;
+  handleComponentSearchChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  setComponentSearchQuery: (query: string) => void;
+  toggleComponentCategory: (category: CanvasComponentCategory) => void;
+  openWorkspaceSidebar: () => void;
+  closeWorkspaceSidebar: () => void;
+  setNodeCardMode: (mode: NodeCardMode) => void;
+  toggleNodeCardMode: () => void;
   handleToggleSidebar: () => void;
   openPropertiesPanel: () => void;
   closePropertiesPanel: () => void;
@@ -148,6 +163,15 @@ export const createUISlice = (
   viewportZoom: DEFAULT_CANVAS_VIEWPORT.zoom,
   canvasSettings: { ...DEFAULT_CANVAS_SETTINGS },
   sidebarPanel: "components",
+  componentSearchQuery: "",
+  collapsedComponentCategories: {
+    input: false,
+    operations: false,
+    skills: false,
+    output: false,
+  },
+  isWorkspaceSidebarOpen: false,
+  nodeCardMode: "compact",
   isSidebarOpen: true,
   isPropertiesPanelOpen: false,
   isCanvasSettingsOpen: false,
@@ -182,6 +206,41 @@ export const createUISlice = (
 
   handleSidebarPanelChange: (panel) => {
     set({ sidebarPanel: panel });
+  },
+
+  handleComponentSearchChange: (event) => {
+    set({ componentSearchQuery: event.target.value });
+  },
+
+  setComponentSearchQuery: (query) => {
+    set({ componentSearchQuery: query });
+  },
+
+  toggleComponentCategory: (category) => {
+    set((state) => ({
+      collapsedComponentCategories: {
+        ...state.collapsedComponentCategories,
+        [category]: !state.collapsedComponentCategories[category],
+      },
+    }));
+  },
+
+  openWorkspaceSidebar: () => {
+    set({ isWorkspaceSidebarOpen: true });
+  },
+
+  closeWorkspaceSidebar: () => {
+    set({ isWorkspaceSidebarOpen: false });
+  },
+
+  setNodeCardMode: (mode) => {
+    set({ nodeCardMode: mode });
+  },
+
+  toggleNodeCardMode: () => {
+    set((state) => ({
+      nodeCardMode: state.nodeCardMode === "compact" ? "expanded" : "compact",
+    }));
   },
 
   handleToggleSidebar: () => {

--- a/apps/app/src/pages/CanvasPage/useCanvasWorkspacePersistence.ts
+++ b/apps/app/src/pages/CanvasPage/useCanvasWorkspacePersistence.ts
@@ -1,0 +1,150 @@
+import { useRef, type ChangeEvent } from "react";
+import { useCreate, useUpdate } from "@refinedev/core";
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import { ResultAsync } from "neverthrow";
+import { ResourceName } from "@/integrations/refine/dataProvider";
+import { toastStore } from "@/store/toastStore";
+import { useCanvasPageStore } from "./_store";
+import {
+  isCanvasImportFileTooLarge,
+  parseCanvasImportJson,
+  type CanvasImportError,
+} from "./utils/canvasImportJson";
+
+interface UseCanvasWorkspacePersistenceOptions {
+  onAfterImportFileSelect?: () => void;
+  onAfterSave?: () => void;
+}
+
+export const useCanvasWorkspacePersistence = ({
+  onAfterImportFileSelect,
+  onAfterSave,
+}: UseCanvasWorkspacePersistenceOptions = {}) => {
+  const { t } = useTranslation();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const store = useCanvasPageStore();
+  const pipelineId = useStore(store, (state) => state.pipelineId);
+  const pipelineName = useStore(store, (state) => state.pipelineName);
+  const nodes = useStore(store, (state) => state.nodes);
+  const edges = useStore(store, (state) => state.edges);
+  const importCanvas = useStore(store, (state) => state.importCanvas);
+  const handlePipelineIdChange = useStore(
+    store,
+    (state) => state.handlePipelineIdChange,
+  );
+  const { mutate: updateCanvas, mutation: updateMutation } = useUpdate();
+  const { mutate: createCanvas, mutation: createMutation } = useCreate();
+
+  const displayPipelineName =
+    pipelineName || t("canvas.pipelineTitlePlaceholder");
+  const isPending = updateMutation.isPending || createMutation.isPending;
+
+  const showImportError = (error: CanvasImportError) => {
+    const description =
+      error === "invalid-json"
+        ? t("canvas.importInvalidJson")
+        : error === "file-too-large"
+          ? t("canvas.importFileTooLarge")
+          : t("canvas.importInvalidPipelineJson");
+
+    toastStore.getState().addToast({
+      type: "error",
+      title: t("canvas.importFailed"),
+      description,
+    });
+  };
+
+  const handleSave = () => {
+    if (pipelineId) {
+      updateCanvas({
+        resource: ResourceName.pipelines,
+        id: pipelineId,
+        values: { nodes, edges },
+        successNotification: {
+          type: "success",
+          message: t("canvas.saveSuccess"),
+          description: t("canvas.floatingMenu.saveSuccessDescription", {
+            name: displayPipelineName,
+          }),
+        },
+        errorNotification: {
+          type: "error",
+          message: t("canvas.saveFailed"),
+          description: t("canvas.floatingMenu.saveFailedDescription"),
+        },
+      });
+      onAfterSave?.();
+
+      return;
+    }
+
+    const newId = crypto.randomUUID();
+    createCanvas(
+      {
+        resource: ResourceName.pipelines,
+        values: {
+          id: newId,
+          name: displayPipelineName,
+          description: "",
+          tags: [],
+          timeoutMs: null,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          nodes,
+          edges,
+        },
+        successNotification: {
+          type: "success",
+          message: t("canvas.saveSuccess"),
+          description: t("canvas.floatingMenu.createSuccessDescription", {
+            name: displayPipelineName,
+          }),
+        },
+        errorNotification: {
+          type: "error",
+          message: t("canvas.saveFailed"),
+          description: t("canvas.floatingMenu.saveFailedDescription"),
+        },
+      },
+      {
+        onSuccess: () => {
+          handlePipelineIdChange(newId);
+        },
+      },
+    );
+    onAfterSave?.();
+  };
+
+  const handleImport = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImportFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    event.target.value = "";
+    onAfterImportFileSelect?.();
+
+    if (isCanvasImportFileTooLarge(file)) {
+      showImportError("file-too-large");
+
+      return;
+    }
+
+    void ResultAsync.fromPromise(file.text(), () => "invalid-json" as const)
+      .andThen((text) => parseCanvasImportJson(text))
+      .match(importCanvas, showImportError);
+  };
+
+  return {
+    fileInputRef,
+    handleImport,
+    handleImportFileChange,
+    handleSave,
+    isPending,
+  };
+};

--- a/apps/app/src/pages/CanvasPage/utils/canvasComponentDragPayload.ts
+++ b/apps/app/src/pages/CanvasPage/utils/canvasComponentDragPayload.ts
@@ -1,0 +1,61 @@
+import { Result } from "neverthrow";
+import type { BuiltinNodeType, Operation, Skill } from "@repo/schemas";
+
+export const CANVAS_COMPONENT_DRAG_MIME = "application/x-ordine-canvas-component";
+
+export type CanvasComponentDragPayload =
+  | {
+      kind: "object";
+      type: BuiltinNodeType;
+    }
+  | {
+      kind: "operation";
+      operation: Operation;
+    }
+  | {
+      kind: "skill";
+      skill: Skill;
+    };
+
+const parseJson = Result.fromThrowable(JSON.parse, () => null);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+export const encodeCanvasComponentDragPayload = (payload: CanvasComponentDragPayload): string =>
+  JSON.stringify(payload);
+
+export const hasCanvasComponentDragPayload = (types: DataTransfer["types"]): boolean =>
+  [...types].includes(CANVAS_COMPONENT_DRAG_MIME);
+
+export const decodeCanvasComponentDragPayload = (
+  raw: string,
+): CanvasComponentDragPayload | null => {
+  const parsed = parseJson(raw);
+  if (parsed.isErr() || !isRecord(parsed.value)) {
+    return null;
+  }
+
+  if (parsed.value.kind === "object" && typeof parsed.value.type === "string") {
+    return {
+      kind: "object",
+      type: parsed.value.type as BuiltinNodeType,
+    };
+  }
+
+  if (parsed.value.kind === "operation" && isRecord(parsed.value.operation)) {
+    return {
+      kind: "operation",
+      operation: parsed.value.operation as Operation,
+    };
+  }
+
+  if (parsed.value.kind === "skill" && isRecord(parsed.value.skill)) {
+    return {
+      kind: "skill",
+      skill: parsed.value.skill as Skill,
+    };
+  }
+
+  return null;
+};

--- a/apps/app/src/pages/CanvasPage/utils/canvasComponentDragPayload.ts
+++ b/apps/app/src/pages/CanvasPage/utils/canvasComponentDragPayload.ts
@@ -1,26 +1,33 @@
 import { Result } from "neverthrow";
-import type { BuiltinNodeType, Operation, Skill } from "@repo/schemas";
+import {
+  BuiltinNodeTypeSchema,
+  OperationSchema,
+  SkillSchema,
+} from "@repo/schemas";
+import { z } from "zod/v4";
 
 export const CANVAS_COMPONENT_DRAG_MIME = "application/x-ordine-canvas-component";
 
-export type CanvasComponentDragPayload =
-  | {
-      kind: "object";
-      type: BuiltinNodeType;
-    }
-  | {
-      kind: "operation";
-      operation: Operation;
-    }
-  | {
-      kind: "skill";
-      skill: Skill;
-    };
+const CanvasComponentDragPayloadSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("object"),
+    type: BuiltinNodeTypeSchema,
+  }),
+  z.object({
+    kind: z.literal("operation"),
+    operation: OperationSchema,
+  }),
+  z.object({
+    kind: z.literal("skill"),
+    skill: SkillSchema,
+  }),
+]);
+
+export type CanvasComponentDragPayload = z.infer<
+  typeof CanvasComponentDragPayloadSchema
+>;
 
 const parseJson = Result.fromThrowable(JSON.parse, () => null);
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
 
 export const encodeCanvasComponentDragPayload = (payload: CanvasComponentDragPayload): string =>
   JSON.stringify(payload);
@@ -32,30 +39,11 @@ export const decodeCanvasComponentDragPayload = (
   raw: string,
 ): CanvasComponentDragPayload | null => {
   const parsed = parseJson(raw);
-  if (parsed.isErr() || !isRecord(parsed.value)) {
+  if (parsed.isErr()) {
     return null;
   }
 
-  if (parsed.value.kind === "object" && typeof parsed.value.type === "string") {
-    return {
-      kind: "object",
-      type: parsed.value.type as BuiltinNodeType,
-    };
-  }
+  const payload = CanvasComponentDragPayloadSchema.safeParse(parsed.value);
 
-  if (parsed.value.kind === "operation" && isRecord(parsed.value.operation)) {
-    return {
-      kind: "operation",
-      operation: parsed.value.operation as Operation,
-    };
-  }
-
-  if (parsed.value.kind === "skill" && isRecord(parsed.value.skill)) {
-    return {
-      kind: "skill",
-      skill: parsed.value.skill as Skill,
-    };
-  }
-
-  return null;
+  return payload.success ? payload.data : null;
 };

--- a/apps/app/src/pages/CanvasPage/utils/canvasComponentDragPayload.unit.test.ts
+++ b/apps/app/src/pages/CanvasPage/utils/canvasComponentDragPayload.unit.test.ts
@@ -1,0 +1,70 @@
+import type { Operation, Skill } from "@repo/schemas";
+import { describe, expect, it } from "vitest";
+import {
+  decodeCanvasComponentDragPayload,
+  encodeCanvasComponentDragPayload,
+} from "./canvasComponentDragPayload";
+
+const validOperation = {
+  id: "review-code",
+  name: "Review Code",
+  description: "Find correctness issues",
+  acceptedObjectTypes: ["file"],
+  config: {
+    inputs: [],
+    outputs: [],
+  },
+} as Operation;
+
+const validSkill = {
+  id: "skill-error-handling",
+  name: "error-handling",
+  label: "Error Handling",
+  description: "Use neverthrow",
+  category: "code-quality",
+  tags: ["neverthrow"],
+} as Skill;
+
+describe("canvasComponentDragPayload", () => {
+  it("decodes valid object, operation, and skill payloads", () => {
+    expect(
+      decodeCanvasComponentDragPayload(
+        encodeCanvasComponentDragPayload({ kind: "object", type: "file" }),
+      ),
+    ).toEqual({ kind: "object", type: "file" });
+
+    expect(
+      decodeCanvasComponentDragPayload(
+        encodeCanvasComponentDragPayload({ kind: "operation", operation: validOperation }),
+      ),
+    ).toEqual({ kind: "operation", operation: validOperation });
+
+    expect(
+      decodeCanvasComponentDragPayload(
+        encodeCanvasComponentDragPayload({ kind: "skill", skill: validSkill }),
+      ),
+    ).toEqual({ kind: "skill", skill: validSkill });
+  });
+
+  it("rejects object payloads with unknown node types", () => {
+    expect(
+      decodeCanvasComponentDragPayload(JSON.stringify({ kind: "object", type: "not-a-node" })),
+    ).toBeNull();
+  });
+
+  it("rejects operation payloads missing required fields", () => {
+    expect(
+      decodeCanvasComponentDragPayload(
+        JSON.stringify({ kind: "operation", operation: { id: "review-code" } }),
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects skill payloads missing required fields", () => {
+    expect(
+      decodeCanvasComponentDragPayload(
+        JSON.stringify({ kind: "skill", skill: { id: "skill-error-handling" } }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/app/src/styles.css
+++ b/apps/app/src/styles.css
@@ -167,3 +167,76 @@
   width: 100%;
   height: 100%;
 }
+
+@keyframes canvas-node-pop {
+  0% {
+    opacity: 0;
+    transform: translateY(8px) scale(0.86);
+  }
+
+  70% {
+    opacity: 1;
+    transform: translateY(0) scale(1.035);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.canvas-node-pop {
+  animation: canvas-node-pop 180ms cubic-bezier(0.2, 0.85, 0.25, 1.2);
+  transform-origin: center;
+}
+
+.canvas-component-drag-image {
+  align-items: center;
+  background: color-mix(in oklch, var(--background) 94%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow:
+    0 18px 40px rgb(15 23 42 / 18%),
+    0 3px 10px rgb(15 23 42 / 12%);
+  color: var(--foreground);
+  display: inline-flex;
+  gap: 10px;
+  left: -9999px;
+  max-width: 260px;
+  min-width: 180px;
+  padding: 10px 12px;
+  pointer-events: none;
+  position: fixed;
+  top: -9999px;
+  transform: scale(0.96);
+  z-index: 9999;
+}
+
+.canvas-component-drag-image__icon {
+  border-radius: 6px;
+  flex: 0 0 auto;
+  height: 28px;
+  width: 28px;
+}
+
+.canvas-component-drag-image__text {
+  flex: 1 1 auto;
+  font-size: 13px;
+  font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.canvas-component-drag-image__meta {
+  color: var(--muted-foreground);
+  flex: 0 0 auto;
+  font-size: 11px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .canvas-node-pop {
+    animation: none;
+  }
+}

--- a/apps/create/src/index.ts
+++ b/apps/create/src/index.ts
@@ -13,10 +13,13 @@ program
   .description("Create a local Ordine instance")
   .version(version)
   .option("-y, --yes", "Non-interactive mode, use defaults", false)
-  .action((opts: { yes: boolean }) => onboard({ nonInteractive: opts.yes }));
+  .action(async (opts: { yes: boolean }) => {
+    const result = await onboard({ nonInteractive: opts.yes });
 
-program.parseAsync().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(message);
-  process.exit(1);
-});
+    if (result.isErr()) {
+      console.error(result.error.message);
+      process.exitCode = 1;
+    }
+  });
+
+await program.parseAsync();

--- a/apps/create/src/migrations.ts
+++ b/apps/create/src/migrations.ts
@@ -1,4 +1,4 @@
-import { ResultAsync } from "neverthrow";
+import { err, ok, Result, ResultAsync, type Result as NeverthrowResult } from "neverthrow";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { PGlite } from "@electric-sql/pglite";
@@ -7,6 +7,78 @@ type SchemaCoverage = "complete" | "empty" | "partial";
 
 const quoteSqlLiteral = (value: string): string =>
   `'${value.replaceAll("'", "''")}'`;
+
+const flattenAsyncResult = <T>(
+  promise: Promise<NeverthrowResult<T, Error>>,
+): ResultAsync<T, Error> => ResultAsync.fromSafePromise(promise).andThen((result) => result);
+
+const toError = (error: unknown, prefix: string): Error =>
+  new Error(`${prefix}: ${error instanceof Error ? error.message : String(error)}`);
+
+const readMigrationFiles = (migrationsDir: string): Result<string[], Error> =>
+  Result.fromThrowable(
+    () => readdirSync(migrationsDir).filter((file) => file.endsWith(".sql")).sort(),
+    (error) => toError(error, "Failed to read migration directory"),
+  )();
+
+const readMigrationFile = (migrationsDir: string, fileName: string): Result<string, Error> =>
+  Result.fromThrowable(
+    () => readFileSync(join(migrationsDir, fileName), "utf8"),
+    (error) => toError(error, `Failed to read migration file "${fileName}"`),
+  )();
+
+const execSql = (db: PGlite, sql: string, context: string): ResultAsync<void, Error> =>
+  ResultAsync.fromPromise(db.exec(sql), (error) => toError(error, context));
+
+const queryRows = <TRow>(
+  db: PGlite,
+  sql: string,
+  context: string,
+): ResultAsync<{ rows: TRow[] }, Error> =>
+  ResultAsync.fromPromise(db.query<TRow>(sql), (error) => toError(error, context));
+
+const insertMigrationRecord = (db: PGlite, fileName: string): ResultAsync<void, Error> =>
+  execSql(
+    db,
+    `INSERT INTO _ordine_migrations (name) VALUES (${quoteSqlLiteral(fileName)})`,
+    `Failed to record migration "${fileName}"`,
+  );
+
+const applyPendingMigrations = (
+  db: PGlite,
+  migrationsDir: string,
+  pendingFiles: string[],
+): ResultAsync<number, Error> => {
+  let chain = ResultAsync.fromSafePromise(Promise.resolve(ok(undefined as void)) as Promise<NeverthrowResult<void, Error>>).andThen((result) => result);
+
+  for (const fileName of pendingFiles) {
+    chain = chain.andThen(() => {
+      const contentResult = readMigrationFile(migrationsDir, fileName);
+      if (contentResult.isErr()) {
+        return ResultAsync.fromSafePromise(
+          Promise.resolve(err(contentResult.error)) as Promise<NeverthrowResult<void, Error>>,
+        ).andThen((result) => result);
+      }
+
+      const statements = contentResult.value
+        .split("--> statement-breakpoint")
+        .map((statement) => statement.trim())
+        .filter((statement) => statement.length > 0);
+
+      let statementChain = ResultAsync.fromSafePromise(Promise.resolve(ok(undefined as void)) as Promise<NeverthrowResult<void, Error>>).andThen((result) => result);
+
+      for (const statement of statements) {
+        statementChain = statementChain.andThen(() =>
+          execSql(db, statement, `Failed to execute migration statement in "${fileName}"`),
+        );
+      }
+
+      return statementChain.andThen(() => insertMigrationRecord(db, fileName));
+    });
+  }
+
+  return chain.map(() => pendingFiles.length);
+};
 
 export const extractCreatedTableNames = (sql: string): string[] =>
   Array.from(sql.matchAll(/^\s*CREATE TABLE "([^"]+)"/gm), (match) => match[1]).filter(
@@ -27,85 +99,103 @@ export const classifySchemaCoverage = (
 };
 
 export const runMigrations = (db: PGlite, migrationsDir: string): ResultAsync<number, Error> =>
-  ResultAsync.fromPromise(
+  flattenAsyncResult(
     (async () => {
-      // Create migrations tracking table
-      await db.exec(`
+      const trackingTableResult = await execSql(
+        db,
+        `
         CREATE TABLE IF NOT EXISTS _ordine_migrations (
           id serial PRIMARY KEY,
           name text NOT NULL UNIQUE,
           applied_at timestamp DEFAULT now() NOT NULL
         )
-      `);
-
-      // Get already-applied migrations
-      const appliedResult = await db.query<{ name: string }>(`SELECT name FROM _ordine_migrations`);
-      const appliedSet = new Set(appliedResult.rows.map((r) => r.name));
-
-      const files = readdirSync(migrationsDir)
-        .filter((f) => f.endsWith(".sql"))
-        .sort();
-
-      if (files.length === 0) {
-        return 0;
+      `,
+        "Failed to create migrations tracking table",
+      );
+      if (trackingTableResult.isErr()) {
+        return err(trackingTableResult.error);
       }
 
-      // If tracking table is empty but database already has user tables,
-      // infer whether we have a complete pre-tracking bootstrap or a partial failure.
+      const appliedResult = await queryRows<{ name: string }>(
+        db,
+        `SELECT name FROM _ordine_migrations`,
+        "Failed to query applied migrations",
+      );
+      if (appliedResult.isErr()) {
+        return err(appliedResult.error);
+      }
+
+      const appliedSet = new Set(appliedResult.value.rows.map((row) => row.name));
+      const filesResult = readMigrationFiles(migrationsDir);
+      if (filesResult.isErr()) {
+        return err(filesResult.error);
+      }
+
+      const files = filesResult.value;
+      if (files.length === 0) {
+        return ok(0);
+      }
+
       if (appliedSet.size === 0) {
-        const tablesResult = await db.query<{ tablename: string }>(
+        const tablesResult = await queryRows<{ tablename: string }>(
+          db,
           `SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename != '_ordine_migrations'`,
+          "Failed to inspect existing schema state",
         );
-        const existingTableNames = tablesResult.rows.map((table) => table.tablename);
+        if (tablesResult.isErr()) {
+          return err(tablesResult.error);
+        }
+
+        const existingTableNames = tablesResult.value.rows.map((table) => table.tablename);
 
         if (existingTableNames.length > 0) {
           if (files.length !== 1) {
-            throw new Error(
-              "Existing databases without migration tracking are only supported when a single initial migration file is present.",
+            return err(
+              new Error(
+                "Existing databases without migration tracking are only supported when a single initial migration file is present.",
+              ),
             );
           }
 
           const initialMigration = files[0];
           if (!initialMigration) {
-            throw new Error("A bootstrap migration file is required to infer existing schema state.");
+            return err(
+              new Error(
+                "A bootstrap migration file is required to infer existing schema state.",
+              ),
+            );
           }
-          const initialMigrationSql = readFileSync(join(migrationsDir, initialMigration), "utf8");
-          const expectedTables = extractCreatedTableNames(initialMigrationSql);
+
+          const initialMigrationSqlResult = readMigrationFile(migrationsDir, initialMigration);
+          if (initialMigrationSqlResult.isErr()) {
+            return err(initialMigrationSqlResult.error);
+          }
+
+          const expectedTables = extractCreatedTableNames(initialMigrationSqlResult.value);
           const schemaCoverage = classifySchemaCoverage(existingTableNames, expectedTables);
 
           if (schemaCoverage === "partial") {
-            throw new Error(
-              "Detected a partially initialized database without migration tracking. Remove the data directory or restore a complete database before rerunning onboarding.",
+            return err(
+              new Error(
+                "Detected a partially initialized database without migration tracking. Remove the data directory or restore a complete database before rerunning onboarding.",
+              ),
             );
           }
 
           if (schemaCoverage === "complete") {
-            await db.exec(
-              `INSERT INTO _ordine_migrations (name) VALUES (${quoteSqlLiteral(initialMigration!)})`,
-            );
+            const recordResult = await insertMigrationRecord(db, initialMigration);
+            if (recordResult.isErr()) {
+              return err(recordResult.error);
+            }
 
-            return 0;
+            return ok(0);
           }
         }
       }
 
-      const pending = files.filter((f) => !appliedSet.has(f));
+      const pendingFiles = files.filter((fileName) => !appliedSet.has(fileName));
+      const applyResult = await applyPendingMigrations(db, migrationsDir, pendingFiles);
 
-      for (const file of pending) {
-        const content = readFileSync(join(migrationsDir, file), "utf8");
-        const statements = content
-          .split("--> statement-breakpoint")
-          .map((s) => s.trim())
-          .filter((s) => s.length > 0);
-
-        for (const statement of statements) {
-          await db.exec(statement);
-        }
-
-        await db.exec(`INSERT INTO _ordine_migrations (name) VALUES (${quoteSqlLiteral(file)})`);
-      }
-
-      return pending.length;
+      return applyResult.isOk() ? ok(applyResult.value) : err(applyResult.error);
     })(),
-    (e) => new Error(`Failed to run migrations: ${e instanceof Error ? e.message : String(e)}`),
   );

--- a/apps/create/src/onboard.ts
+++ b/apps/create/src/onboard.ts
@@ -1,11 +1,11 @@
-import { ok, Result } from "neverthrow";
+import { err, ok, okAsync, errAsync, Result, ResultAsync, type Result as NeverthrowResult } from "neverthrow";
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { randomBytes } from "node:crypto";
 import { fork } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { startEmbeddedPostgres } from "./embedded-pg";
+import { startEmbeddedPostgres, type EmbeddedPgInstance } from "./embedded-pg";
 import { runMigrations } from "./migrations";
 
 export interface OnboardOptions {
@@ -28,6 +28,13 @@ export interface EnvConfig {
 }
 
 const DEFAULT_APP_PORT = 9430;
+
+const flattenAsyncResult = <T>(
+  promise: Promise<NeverthrowResult<T, Error>>,
+): ResultAsync<T, Error> => ResultAsync.fromSafePromise(promise).andThen((result) => result);
+
+const toError = (error: unknown, prefix: string): Error =>
+  new Error(`${prefix}: ${error instanceof Error ? error.message : String(error)}`);
 
 export const resolveDataDir = (custom?: string): string =>
   custom ?? join(homedir(), ".ordine", "default");
@@ -131,105 +138,144 @@ export const formatOutput = (result: OnboardResult): string => {
 const getModuleDir = (): string =>
   dirname(fileURLToPath(import.meta.url));
 
-export const resolveAppServerEntry = (baseDir = getModuleDir()): string => {
+export const resolveAppServerEntry = (baseDir = getModuleDir()): Result<string, Error> => {
   const thisDir = baseDir;
 
   const devPath = join(thisDir, "..", "app", "server", "index.mjs");
-  if (existsSync(devPath)) return devPath;
+  if (existsSync(devPath)) return ok(devPath);
 
   const distPath = join(thisDir, "app", "server", "index.mjs");
-  if (existsSync(distPath)) return distPath;
+  if (existsSync(distPath)) return ok(distPath);
 
-  throw new Error("App server entry not found. Ensure the app is built.");
+  return err(new Error("App server entry not found. Ensure the app is built."));
 };
 
-export const resolveMigrationsDir = (baseDir = getModuleDir()): string => {
+export const resolveMigrationsDir = (baseDir = getModuleDir()): Result<string, Error> => {
   const thisDir = baseDir;
 
   const devPath = join(thisDir, "..", "migrations");
-  if (existsSync(devPath)) return devPath;
+  if (existsSync(devPath)) return ok(devPath);
 
   const distPath = join(thisDir, "migrations");
-  if (existsSync(distPath)) return distPath;
+  if (existsSync(distPath)) return ok(distPath);
 
-  throw new Error("Migrations directory not found. Ensure the app is built.");
+  return err(new Error("Migrations directory not found. Ensure the app is built."));
 };
 
 export const startAppServer = (
   serverEntry: string,
   envConfig: EnvConfig,
-): Promise<void> =>
-  new Promise((resolve, reject) => {
-    const child = fork(serverEntry, [], {
-      env: {
-        ...process.env,
-        NODE_ENV: "production",
-        PORT: String(envConfig.APP_PORT),
-        PGLITE_DATA_DIR: envConfig.PGLITE_DATA_DIR,
-        BETTER_AUTH_SECRET: envConfig.SECRET_KEY,
-        ORDINE_LOCAL_MODE: "true",
-      },
-      stdio: "inherit",
-    });
+): ResultAsync<void, Error> =>
+  flattenAsyncResult(
+    new Promise<NeverthrowResult<void, Error>>((resolve) => {
+      const child = fork(serverEntry, [], {
+        env: {
+          ...process.env,
+          NODE_ENV: "production",
+          PORT: String(envConfig.APP_PORT),
+          PGLITE_DATA_DIR: envConfig.PGLITE_DATA_DIR,
+          BETTER_AUTH_SECRET: envConfig.SECRET_KEY,
+          ORDINE_LOCAL_MODE: "true",
+        },
+        stdio: "inherit",
+      });
 
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code === 0 || code === null) {
-        resolve();
-      } else {
-        reject(new Error(`App server exited with code ${code}`));
-      }
-    });
+      const shutdown = () => {
+        child.kill("SIGTERM");
+      };
+      const cleanup = () => {
+        process.off("SIGINT", shutdown);
+        process.off("SIGTERM", shutdown);
+      };
 
-    const shutdown = () => {
-      child.kill("SIGTERM");
-    };
+      child.on("error", (error) => {
+        cleanup();
+        resolve(err(toError(error, "Failed to start app server")));
+      });
+      child.on("exit", (code) => {
+        cleanup();
+        resolve(
+          code === 0 || code === null
+            ? ok(undefined)
+            : err(new Error(`App server exited with code ${code}`)),
+        );
+      });
 
-    process.on("SIGINT", shutdown);
-    process.on("SIGTERM", shutdown);
-  });
+      process.on("SIGINT", shutdown);
+      process.on("SIGTERM", shutdown);
+    }),
+  );
 
-export const onboard = async (options: OnboardOptions): Promise<void> => {
+const stopEmbeddedPostgres = (pg: EmbeddedPgInstance): ResultAsync<void, Error> =>
+  ResultAsync.fromPromise(pg.stop(), (error) => toError(error, "Failed to stop embedded PostgreSQL"));
+
+const stopWithError = async (
+  pg: EmbeddedPgInstance,
+  originalError: Error,
+): Promise<NeverthrowResult<never, Error>> => {
+  const stopResult = await stopEmbeddedPostgres(pg);
+
+  if (stopResult.isErr()) {
+    return err(
+      new Error(`${originalError.message}; additionally failed to stop embedded PostgreSQL: ${stopResult.error.message}`),
+    );
+  }
+
+  return err(originalError);
+};
+
+const runOnboard = async (options: OnboardOptions): Promise<NeverthrowResult<void, Error>> => {
   const dataDir = resolveDataDir(options.dataDir);
 
   const prepareResult = prepareDataDir(dataDir);
   if (prepareResult.isErr()) {
-    throw new Error(prepareResult.error.message);
+    return err(prepareResult.error);
   }
 
   console.log("Starting embedded PostgreSQL...");
   const pgResult = await startEmbeddedPostgres(dataDir);
   if (pgResult.isErr()) {
-    throw new Error(pgResult.error.message);
+    return err(pgResult.error);
   }
 
   const pg = pgResult.value;
 
   console.log("PostgreSQL ready (PGlite)");
 
-  const existing = isExistingInstall(dataDir);
-  const existingConfig = existing ? readExistingEnv(dataDir).unwrapOr(null) : null;
-  const envConfig = resolveEnvConfig(dataDir, existingConfig, pg.dataDir);
+  const existingConfigResult = isExistingInstall(dataDir) ? readExistingEnv(dataDir) : ok<EnvConfig | null>(null);
+  if (existingConfigResult.isErr()) {
+    return stopWithError(pg, existingConfigResult.error);
+  }
+
+  const envConfig = resolveEnvConfig(dataDir, existingConfigResult.value, pg.dataDir);
 
   const writeResult = writeEnvFile(dataDir, envConfig);
   if (writeResult.isErr()) {
-    await pg.stop();
-    throw new Error(writeResult.error.message);
+    return stopWithError(pg, writeResult.error);
   }
 
-  const migrationsDir = resolveMigrationsDir();
+  const migrationsDirResult = resolveMigrationsDir();
+  if (migrationsDirResult.isErr()) {
+    return stopWithError(pg, migrationsDirResult.error);
+  }
+
   console.log("Running database migrations...");
-  const migrateResult = await runMigrations(pg.db, migrationsDir);
+  const migrateResult = await runMigrations(pg.db, migrationsDirResult.value);
   if (migrateResult.isErr()) {
-    await pg.stop();
-    throw new Error(migrateResult.error.message);
+    return stopWithError(pg, migrateResult.error);
   }
   console.log(`Applied ${migrateResult.value} migration file(s).`);
 
-  // Close PGlite before starting app server (PGlite doesn't support multi-process access)
-  await pg.stop();
+  const stopResult = await stopEmbeddedPostgres(pg);
+  if (stopResult.isErr()) {
+    return err(stopResult.error);
+  }
 
-  const serverEntry = resolveAppServerEntry();
+  const serverEntryResult = resolveAppServerEntry();
+  if (serverEntryResult.isErr()) {
+    return err(serverEntryResult.error);
+  }
+
   const result: OnboardResult = {
     dataDir,
     appUrl: envConfig.APP_URL,
@@ -237,5 +283,10 @@ export const onboard = async (options: OnboardOptions): Promise<void> => {
   };
 
   console.log(formatOutput(result));
-  await startAppServer(serverEntry, envConfig);
+
+  const startServerResult = await startAppServer(serverEntryResult.value, envConfig);
+  return startServerResult.isOk() ? ok(undefined) : err(startServerResult.error);
 };
+
+export const onboard = (options: OnboardOptions): ResultAsync<void, Error> =>
+  flattenAsyncResult(runOnboard(options));

--- a/apps/create/tests/onboard.test.ts
+++ b/apps/create/tests/onboard.test.ts
@@ -244,7 +244,8 @@ describe("resolveAppServerEntry", () => {
     writeFileSync(siblingServerEntry, "export default {};\n", "utf8");
 
     const entry = resolveAppServerEntry(moduleDir);
-    expect(entry).toBe(siblingServerEntry);
+    expect(entry.isOk()).toBe(true);
+    expect(entry._unsafeUnwrap()).toBe(siblingServerEntry);
   });
 
   it("falls back to the bundled dist app when a sibling build is unavailable", () => {
@@ -257,7 +258,8 @@ describe("resolveAppServerEntry", () => {
     writeFileSync(bundledServerEntry, "export default {};\n", "utf8");
 
     const entry = resolveAppServerEntry(moduleDir);
-    expect(entry).toBe(bundledServerEntry);
+    expect(entry.isOk()).toBe(true);
+    expect(entry._unsafeUnwrap()).toBe(bundledServerEntry);
   });
 });
 
@@ -283,7 +285,8 @@ describe("resolveMigrationsDir", () => {
     mkdirSync(siblingMigrationsDir, { recursive: true });
 
     const dir = resolveMigrationsDir(moduleDir);
-    expect(dir).toBe(siblingMigrationsDir);
+    expect(dir.isOk()).toBe(true);
+    expect(dir._unsafeUnwrap()).toBe(siblingMigrationsDir);
   });
 
   it("falls back to the bundled migrations directory when no sibling directory exists", () => {
@@ -295,6 +298,7 @@ describe("resolveMigrationsDir", () => {
     mkdirSync(bundledMigrationsDir, { recursive: true });
 
     const dir = resolveMigrationsDir(moduleDir);
-    expect(dir).toBe(bundledMigrationsDir);
+    expect(dir.isOk()).toBe(true);
+    expect(dir._unsafeUnwrap()).toBe(bundledMigrationsDir);
   });
 });

--- a/packages/agent/src/claude/runClaude.ts
+++ b/packages/agent/src/claude/runClaude.ts
@@ -9,8 +9,6 @@ import type { RunClaudeOptions } from "./schemas/RunClaudeOptionsSchema";
 import type { RunClaudeResult } from "./schemas/RunClaudeResultSchema";
 import type { ToolName } from "./schemas/ToolNameSchema";
 
-export type { SshConnectionOptions } from "./schemas/RunClaudeOptionsSchema";
-
 const shellEscape = (s: string) => `'${s.replaceAll("'", "'\\\\''")}'`;
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN ?? (process.platform === "win32" ? "claude.cmd" : "claude");

--- a/packages/services/src/pipelinesService/generateStructure.unit.test.ts
+++ b/packages/services/src/pipelinesService/generateStructure.unit.test.ts
@@ -25,8 +25,12 @@ const mockSettingsDao = {
     defaultModel: "gpt-4o",
   }),
 };
+const mockAgentRuntimesDao = {
+  findMany: vi.fn().mockResolvedValue([]),
+};
 
 vi.mock("@repo/models", () => ({
+  createAgentRuntimesDao: () => mockAgentRuntimesDao,
   createPipelinesDao: () => mockDao,
   createDistillationsDao: () => ({}),
   createJobsDao: () => ({}),
@@ -106,7 +110,10 @@ describe("generateStructure", () => {
     });
 
     expect(mockRunAgent).toHaveBeenCalledTimes(1);
-    if ("error" in result) throw new Error("unexpected error");
+    expect("error" in result).toBe(false);
+    if ("error" in result) {
+      return;
+    }
     expect(result.nodes).toHaveLength(2);
     expect(result.edges).toHaveLength(1);
     expect(result.nodes[0]!.data.nodeType).toBe("folder");
@@ -172,7 +179,10 @@ describe("generateStructure", () => {
 
     const home = homedir();
     const desktopPath = join(home, "Desktop");
-    if ("error" in result) throw new Error("unexpected error");
+    expect("error" in result).toBe(false);
+    if ("error" in result) {
+      return;
+    }
     const folderNode = result.nodes.find((n) => n.data.nodeType === "folder");
     expect(folderNode!.data).toHaveProperty("folderPath", desktopPath);
 

--- a/scripts/check-schema-exports.ts
+++ b/scripts/check-schema-exports.ts
@@ -11,7 +11,7 @@
  * Usage: tsx scripts/check-schema-exports.ts
  */
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, basename, relative } from "node:path";
 
 const ROOT = join(
@@ -81,13 +81,9 @@ for (const dir of schemaDirs) {
 }
 
 const packagesSchemaSrc = join(ROOT, "packages/schemas/src");
-try {
-  if (statSync(packagesSchemaSrc).isDirectory()) {
-    dirCount++;
-    checkDirFiles(packagesSchemaSrc);
-  }
-} catch {
-  // packages/schemas/src doesn't exist, skip
+if (existsSync(packagesSchemaSrc) && statSync(packagesSchemaSrc).isDirectory()) {
+  dirCount++;
+  checkDirFiles(packagesSchemaSrc);
 }
 
 const sortedFiles = [...allSchemaFiles].sort();


### PR DESCRIPTION
## Summary
- Add the Langflow-style canvas workspace layout and related panels.
- Fix review feedback so operation max loop edits stay numeric and schema-valid.
- Disable the workspace sheet built-in close button to avoid duplicate close controls.

## Verification
- `bun run test src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.unit.test.tsx src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.unit.test.tsx`
- `bun run compile`
- `bun run lint` (passes with existing warnings)
- `git diff --check`

## Notes
- Source branch: `woodfishhhh:issue-49-canvas-langflow-layout`
- Target branch: `forge-town/ordine:develop`