### PR TITLE
fix(skills): address PR #85 review regressions

### DIFF
--- a/apps/app/src/pages/SkillsPage/SkillsPageContent/SkillsPageContent.tsx
+++ b/apps/app/src/pages/SkillsPage/SkillsPageContent/SkillsPageContent.tsx
@@ -85,6 +85,30 @@ export const SkillsPageContent = () => {
     setImportPath(event.target.value);
   };
 
+  const handleCreateDialogOpen = () => {
+    setShowCreateDialog(true);
+  };
+
+  const handleCreateDialogOpenChange = (open: boolean) => {
+    setShowCreateDialog(open);
+  };
+
+  const handleCreateNameInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setCreateForm((current) => ({ ...current, name: event.target.value }));
+  };
+
+  const handleCreateLabelInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setCreateForm((current) => ({ ...current, label: event.target.value }));
+  };
+
+  const handleCreateDescriptionInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setCreateForm((current) => ({ ...current, description: event.target.value }));
+  };
+
+  const handleCreateDialogCancelClick = () => {
+    setShowCreateDialog(false);
+  };
+
   const handlePreviewImportClick = async () => {
     setIsPreviewing(true);
     const response = await dataProvider.custom!<SkillImportPreview>({
@@ -134,6 +158,27 @@ export const SkillsPageContent = () => {
     setIsImporting(false);
   };
 
+  const handleCreateSkillClick = async () => {
+    await createSkill({
+      resource: ResourceName.skills,
+      values: {
+        name: createForm.name.trim(),
+        label: createForm.label.trim(),
+        description: createForm.description.trim(),
+        category: "custom",
+        tags: ["custom"],
+      },
+    });
+    setCreateForm({ name: "", label: "", description: "" });
+    setShowCreateDialog(false);
+    await skillsQuery?.refetch?.();
+  };
+
+  const handleDeleteSkillClick = (skillId: string) => async () => {
+    await deleteSkill({ resource: ResourceName.skills, id: skillId });
+    await skillsQuery?.refetch?.();
+  };
+
   if (skillsQuery?.isLoading) {
     return (
       <div className="flex h-full flex-col overflow-hidden">
@@ -147,7 +192,7 @@ export const SkillsPageContent = () => {
     <div className="flex h-full flex-col overflow-hidden">
       <PageHeader
         actions={
-          <Button size="sm" onClick={() => setShowCreateDialog(true)}>
+          <Button size="sm" onClick={handleCreateDialogOpen}>
             <Plus className="h-4 w-4" />
             Create Skill
           </Button>
@@ -260,7 +305,7 @@ export const SkillsPageContent = () => {
         )}
       </div>
 
-      <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+      <Dialog open={showCreateDialog} onOpenChange={handleCreateDialogOpenChange}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Create Skill</DialogTitle>
@@ -272,7 +317,7 @@ export const SkillsPageContent = () => {
                 className="mt-1 h-8 text-sm"
                 placeholder="skill-name"
                 value={createForm.name}
-                onChange={(e) => setCreateForm((f) => ({ ...f, name: e.target.value }))}
+                onChange={handleCreateNameInputChange}
               />
             </div>
             <div>
@@ -281,7 +326,7 @@ export const SkillsPageContent = () => {
                 className="mt-1 h-8 text-sm"
                 placeholder="Skill Label"
                 value={createForm.label}
-                onChange={(e) => setCreateForm((f) => ({ ...f, label: e.target.value }))}
+                onChange={handleCreateLabelInputChange}
               />
             </div>
             <div>
@@ -290,32 +335,18 @@ export const SkillsPageContent = () => {
                 className="mt-1 h-8 text-sm"
                 placeholder="What this skill does"
                 value={createForm.description}
-                onChange={(e) => setCreateForm((f) => ({ ...f, description: e.target.value }))}
+                onChange={handleCreateDescriptionInputChange}
               />
             </div>
           </div>
           <DialogFooter>
-            <Button size="sm" variant="outline" onClick={() => setShowCreateDialog(false)}>
+            <Button size="sm" variant="outline" onClick={handleCreateDialogCancelClick}>
               Cancel
             </Button>
             <Button
               disabled={!createForm.name.trim() || !createForm.label.trim()}
               size="sm"
-              onClick={async () => {
-                await createSkill({
-                  resource: ResourceName.skills,
-                  values: {
-                    name: createForm.name.trim(),
-                    label: createForm.label.trim(),
-                    description: createForm.description.trim(),
-                    category: "custom",
-                    tags: ["custom"],
-                  },
-                });
-                setCreateForm({ name: "", label: "", description: "" });
-                setShowCreateDialog(false);
-                await skillsQuery?.refetch?.();
-              }}
+              onClick={handleCreateSkillClick}
             >
               Create
             </Button>
@@ -374,10 +405,7 @@ export const SkillsPageContent = () => {
                     className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
                     size="sm"
                     variant="ghost"
-                    onClick={async () => {
-                      await deleteSkill({ resource: ResourceName.skills, id: skill.id });
-                      await skillsQuery?.refetch?.();
-                    }}
+                    onClick={handleDeleteSkillClick(skill.id)}
                   >
                     <Trash2 className="h-3 w-3 text-destructive" />
                   </Button>

--- a/apps/app/src/pages/SkillsPage/SkillsPageContent/SkillsPageContent.unit.test.tsx
+++ b/apps/app/src/pages/SkillsPage/SkillsPageContent/SkillsPageContent.unit.test.tsx
@@ -13,8 +13,8 @@ vi.mock("../_store", () => ({
     createStore(() => ({
       search: "",
       category: "all",
-      handleSetSearch: vi.fn(),
-      handleSetCategory: vi.fn(),
+      handleSearchInputChange: vi.fn(),
+      handleCategoryButtonClick: vi.fn(),
     })),
 }));
 
@@ -22,6 +22,15 @@ vi.mock("@refinedev/core", () => ({
   useList: () => ({
     result: { data: [], total: 0 },
     query: { isLoading: false },
+  }),
+  useDataProvider: () => () => ({
+    custom: vi.fn(),
+  }),
+  useCreate: () => ({
+    mutateAsync: vi.fn(),
+  }),
+  useDelete: () => ({
+    mutateAsync: vi.fn(),
   }),
 }));
 

--- a/packages/services/src/skillsService/createSkillsService.ts
+++ b/packages/services/src/skillsService/createSkillsService.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { readdir, readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { createSkillsDao, type DbConnection } from "@repo/models";
@@ -22,6 +22,12 @@ const SKILL_FILE_NAME = "SKILL.md";
 const MAX_SCAN_DEPTH = 6;
 const IMPORTED_CATEGORY = "imported";
 const IMPORTED_TAG = "imported";
+
+const toCandidateId = ({ name, path }: { name: string; path: string }) => {
+  const pathSuffix = createHash("sha1").update(path.toLowerCase()).digest("hex").slice(0, 8);
+
+  return `imported-${name}-${pathSuffix}`;
+};
 
 const toSlug = (value: string) =>
   value
@@ -52,49 +58,49 @@ const parseFrontmatter = (content: string) => {
   const fields = new Map<string, string>();
 
   const lines = frontmatterRaw.split(/\r?\n/);
-  let i = 0;
-  while (i < lines.length) {
-    const line = lines[i];
+  const lineIndex = { current: 0 };
+  while (lineIndex.current < lines.length) {
+    const line = lines[lineIndex.current];
     if (!line) {
-      i++;
+      lineIndex.current++;
       continue;
     }
     const separatorIndex = line.indexOf(":");
     if (separatorIndex < 0) {
-      i++;
+      lineIndex.current++;
       continue;
     }
 
     const key = line.slice(0, separatorIndex).trim();
-    let rawValue = line.slice(separatorIndex + 1).trim();
+    const rawValue = line.slice(separatorIndex + 1).trim();
 
     if (!key) {
-      i++;
+      lineIndex.current++;
       continue;
     }
 
     if (rawValue === "|" || rawValue === ">") {
       const blockLines: string[] = [];
-      const nextLine = lines[i + 1];
+      const nextLine = lines[lineIndex.current + 1];
       const indentMatch = nextLine ? nextLine.match(/^(\s+)/) : null;
       const blockIndent = indentMatch && indentMatch[1] ? indentMatch[1].length : 2;
-      i++;
-      while (i < lines.length) {
-        const blockLine = lines[i];
+      lineIndex.current++;
+      while (lineIndex.current < lines.length) {
+        const blockLine = lines[lineIndex.current];
         if (!blockLine) {
-          i++;
+          lineIndex.current++;
           continue;
         }
         if (blockLine.trim().length === 0) {
           blockLines.push("");
-          i++;
+          lineIndex.current++;
           continue;
         }
         const spaceMatch = blockLine.match(/^(\s*)/);
         const leadingSpaces = spaceMatch && spaceMatch[1] ? spaceMatch[1].length : 0;
         if (leadingSpaces < blockIndent) break;
         blockLines.push(blockLine.slice(blockIndent));
-        i++;
+        lineIndex.current++;
       }
       const value = blockLines.join("\n").trim();
       if (value) fields.set(key, value);
@@ -103,7 +109,7 @@ const parseFrontmatter = (content: string) => {
 
     const value = rawValue.replaceAll(/^["']|["']$/g, "");
     if (value) fields.set(key, value);
-    i++;
+    lineIndex.current++;
   }
 
   return { fields, body };
@@ -117,7 +123,7 @@ const extractDescription = (body: string, frontmatterDescription?: string): stri
   const firstParagraph = body
     .split(/\n\s*\n/)
     .map((s) => s.trim())
-    .filter((s) => s.length > 0)[0];
+    .find((s) => s.length > 0);
 
   if (!firstParagraph) return "";
 
@@ -137,7 +143,7 @@ const parseSkillFile = ({
   const description = extractDescription(body, fields.get("description"));
 
   return {
-    id: `imported-${name}`,
+    id: toCandidateId({ name, path }),
     name,
     label: toLabel(name) || name,
     description: description || name,

--- a/packages/services/src/skillsService/createSkillsService.unit.test.ts
+++ b/packages/services/src/skillsService/createSkillsService.unit.test.ts
@@ -91,12 +91,28 @@ describe("createSkillsService", () => {
     expect(preview.errors).toEqual([]);
     expect(preview.candidates).toEqual([
       expect.objectContaining({
-        id: "imported-review-code",
+        id: expect.stringMatching(/^imported-review-code-/),
         name: "review-code",
         label: "Review Code",
         description: "Review code carefully",
       }),
     ]);
+  });
+
+  it("previewImport assigns distinct candidate ids when multiple paths normalize to the same name", async () => {
+    const hyphenSkillDir = join(tempDir, "review-code");
+    const underscoreSkillDir = join(tempDir, "review_code");
+    await mkdir(hyphenSkillDir, { recursive: true });
+    await mkdir(underscoreSkillDir, { recursive: true });
+    await writeFile(join(hyphenSkillDir, "SKILL.md"), "# Review Code\nOne");
+    await writeFile(join(underscoreSkillDir, "SKILL.md"), "# Review Code\nTwo");
+
+    const svc = createSkillsService({} as never);
+    const preview = await svc.previewImport({ rootPath: tempDir });
+    const reviewCodeCandidates = preview.candidates.filter((candidate) => candidate.name === "review-code");
+
+    expect(reviewCodeCandidates).toHaveLength(2);
+    expect(new Set(reviewCodeCandidates.map((candidate) => candidate.id)).size).toBe(2);
   });
 
   it("importCandidates creates missing skills", async () => {


### PR DESCRIPTION
## Summary
- make imported skill preview candidate ids path-stable and unique to avoid UI selection collisions
- update Skills page tests for the new Refine hooks and state handlers
- extract named Skills page handlers so app lint passes for this PR file

## Verification
- `bun run test -- createSkillsService.unit.test.ts` in `packages/services`
- `bun run check-types` in `packages/services`
- `bun run lint` in `packages/services`
- `bun run test` in `apps/app`
- `bun run compile` in `apps/app`
- `bun run build` in `apps/app`

## Notes
- `bun run test` in `packages/services` is still red on existing unrelated failures, and the same baseline failures reproduce on the current local branch.