### PR TITLE
[Stack 2/3] refactor: 完善 Canvas 侧栏伸缩与 Agent 面板滚动体验

### DIFF
--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -511,6 +511,11 @@
         "replaceNodeData": "Replace node data: {{nodeId}}"
       }
     },
+    "operationsPanel": {
+      "collapse": "Collapse operations panel",
+      "expand": "Expand operations panel",
+      "resize": "Resize operations panel"
+    },
     "emptyState": {
       "title": "Start with a node",
       "description": "Add an input object or Operation to shape the first pipeline path.",

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -511,6 +511,11 @@
         "replaceNodeData": "替换节点数据: {{nodeId}}"
       }
     },
+    "operationsPanel": {
+      "collapse": "收起操作面板",
+      "expand": "展开操作面板",
+      "resize": "调整操作面板宽度"
+    },
     "emptyState": {
       "title": "从一个节点开始",
       "description": "添加输入对象或 Operation，搭出第一条流水线。",

--- a/apps/app/src/pages/CanvasPage/AgentPanel/AgentPanel.stories.tsx
+++ b/apps/app/src/pages/CanvasPage/AgentPanel/AgentPanel.stories.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useRef } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import type {
+  BaseRecord,
+  GetListParams,
+  GetListResponse,
+  GetOneParams,
+  GetOneResponse,
+} from "@refinedev/core";
+import type {
+  AgentRuntimeConfig,
+  PipelineActionDiagnostic,
+  PipelineActionProposal,
+} from "@repo/schemas";
+import { CanvasPageStoreContext, createCanvasPageStore, type CanvasPageStore } from "../_store";
+import { AgentPanel } from "./AgentPanel";
+import { dataProvider, ResourceName } from "@/integrations/refine/dataProvider";
+
+const storyRuntimes: AgentRuntimeConfig[] = [
+  {
+    id: "runtime-codex",
+    name: "Codex Local",
+    type: "codex",
+    connection: { mode: "local" },
+  },
+];
+
+const overflowDiagnostics: PipelineActionDiagnostic[] = [
+  {
+    code: "DUPLICATE_NODE_ID",
+    severity: "error",
+    message:
+      "Generated node id collides with an existing canvas node and must be renamed before applying the proposal.",
+  },
+  {
+    code: "INVALID_CONNECTION",
+    severity: "warning",
+    message:
+      "One proposed operation is missing an upstream object input and needs manual review before the graph can be saved.",
+  },
+  {
+    code: "INVALID_CONNECTION",
+    severity: "warning",
+    message:
+      "The generated reporting branch still needs a final connection to the output node before it can be applied safely.",
+  },
+  {
+    code: "INVALID_NODE_DATA",
+    severity: "warning",
+    message:
+      "Several generated operation labels should be renamed to match the existing workspace naming convention.",
+  },
+];
+
+const overflowProposal: PipelineActionProposal = {
+  summary:
+    "Expand the pipeline with review, cleanup, reporting, and verification operations while keeping the existing output path intact.",
+  actions: Array.from({ length: 28 }, (_, index) => ({
+    type: "addNode",
+    node: {
+      id: `story-op-${index}`,
+      type: "operation",
+      position: { x: 240 + index * 64, y: 120 + (index % 3) * 80 },
+      data: {
+        nodeType: "operation",
+        operationId: `story-operation-${index}`,
+        operationName: `Story Operation ${index + 1}`,
+        label: `Story Operation ${index + 1}`,
+        status: "idle",
+      },
+    },
+  })),
+};
+
+const AgentPanelStory = ({
+  diagnostics = null,
+  proposal = null,
+}: {
+  diagnostics?: PipelineActionDiagnostic[] | null;
+  proposal?: PipelineActionProposal | null;
+}) => {
+  const storeRef = useRef<CanvasPageStore | null>(null);
+  const originalGetOneRef = useRef(dataProvider.getOne);
+  const originalGetListRef = useRef(dataProvider.getList);
+
+  if (!storeRef.current) {
+    storeRef.current = createCanvasPageStore([], [], "story-pipeline", "Story Pipeline");
+    storeRef.current.setState({
+      agentPanel: {
+        isOpen: true,
+        pendingProposal: proposal,
+        diagnostics,
+        isLoading: false,
+      },
+    });
+  }
+
+  useEffect(() => {
+    const store = storeRef.current;
+    if (!store) {
+      return;
+    }
+
+    store.setState({
+      agentPanel: {
+        isOpen: true,
+        pendingProposal: proposal,
+        diagnostics,
+        isLoading: false,
+      },
+    });
+
+    dataProvider.getOne = async <TData extends BaseRecord = BaseRecord>(params: GetOneParams) => {
+      if (params.resource === ResourceName.settings) {
+        return {
+          data: { id: "default", defaultAgentRuntime: "codex" } as unknown as TData,
+        } satisfies GetOneResponse<TData>;
+      }
+
+      return originalGetOneRef.current!(params) as Promise<GetOneResponse<TData>>;
+    };
+    dataProvider.getList = async <TData extends BaseRecord = BaseRecord>(params: GetListParams) => {
+      if (params.resource === ResourceName.agentRuntimes) {
+        return {
+          data: storyRuntimes as unknown as TData[],
+          total: storyRuntimes.length,
+        } satisfies GetListResponse<TData>;
+      }
+
+      return originalGetListRef.current!(params) as Promise<GetListResponse<TData>>;
+    };
+
+    return () => {
+      dataProvider.getOne = originalGetOneRef.current;
+      dataProvider.getList = originalGetListRef.current;
+    };
+  }, [diagnostics, proposal]);
+
+  return (
+    <CanvasPageStoreContext.Provider value={storeRef.current}>
+      <div className="relative h-[540px] w-[420px] overflow-hidden rounded-md border bg-slate-50">
+        <AgentPanel />
+      </div>
+    </CanvasPageStoreContext.Provider>
+  );
+};
+
+const meta: Meta<typeof AgentPanelStory> = {
+  title: "CanvasPage/AgentPanel",
+  component: AgentPanelStory,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Right-side AI assistant panel for proposing canvas graph edits. Stories focus on overflow behavior for diagnostics and proposal review without a backend.",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AgentPanelStory>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const OverflowContent: Story = {
+  args: {
+    diagnostics: overflowDiagnostics,
+    proposal: overflowProposal,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Long diagnostics and many proposal actions force the middle content area to scroll while the input dock stays pinned to the bottom.",
+      },
+    },
+  },
+};

--- a/apps/app/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/apps/app/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -365,6 +365,37 @@ export const AgentPanel = () => {
   const proposal = agentPanel.pendingProposal as PipelineActionProposal | null;
   const hasProposal = proposal !== null;
 
+  const runtimePicker = (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs font-medium text-muted-foreground">
+        {t("canvas.agentPanel.runtimeLabel")}
+      </span>
+      <Select value={selectedRuntimeId} onValueChange={handleRuntimeValueChange}>
+        <SelectTrigger
+          className="h-8 w-full text-xs"
+          disabled={isLoadingRuntimes || runtimeOptions.length === 0}
+        >
+          <SelectValue
+            placeholder={
+              isLoadingRuntimes
+                ? t("canvas.agentPanel.runtimeLoading")
+                : t("canvas.agentPanel.runtimePlaceholder")
+            }
+          />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {runtimeOptions.map((runtime) => (
+              <SelectItem key={runtime.id} value={runtime.id}>
+                {formatRuntimeLabel(runtime)}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+
   return (
     <div className="absolute bottom-0 right-0 top-0 z-30 flex w-80 flex-col border-l bg-background shadow-lg">
       {/* Header */}
@@ -385,40 +416,10 @@ export const AgentPanel = () => {
         </Button>
       </div>
 
-      {/* Messages */}
-      <div className="border-b px-3 py-2">
-        <div className="flex flex-col gap-1">
-          <span className="text-xs font-medium text-muted-foreground">
-            {t("canvas.agentPanel.runtimeLabel")}
-          </span>
-          <Select value={selectedRuntimeId} onValueChange={handleRuntimeValueChange}>
-            <SelectTrigger
-              className="h-8 w-full text-xs"
-              disabled={isLoadingRuntimes || runtimeOptions.length === 0}
-            >
-              <SelectValue
-                placeholder={
-                  isLoadingRuntimes
-                    ? t("canvas.agentPanel.runtimeLoading")
-                    : t("canvas.agentPanel.runtimePlaceholder")
-                }
-              />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                {runtimeOptions.map((runtime) => (
-                  <SelectItem key={runtime.id} value={runtime.id}>
-                    {formatRuntimeLabel(runtime)}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-
-      <ScrollArea className="flex-1">
+      <ScrollArea className="min-h-0 flex-1" data-testid="agent-panel-scroll-region">
         <div className="flex flex-col gap-3 p-3">
+          <div className="rounded-md border bg-background px-3 py-2">{runtimePicker}</div>
+
           {messages.map((msg) => (
             <div
               key={msg.id}
@@ -440,125 +441,122 @@ export const AgentPanel = () => {
             </div>
           )}
           <div ref={messagesEndRef} />
+          {/* Diagnostics */}
+          {agentPanel.diagnostics && agentPanel.diagnostics.length > 0 && (
+            <div className="flex flex-col gap-2 rounded-md border px-3 py-3">
+              <span className="text-xs font-medium text-muted-foreground">
+                {t("canvas.agentPanel.diagnostics")}
+              </span>
+              {agentPanel.diagnostics.map((d, i) => (
+                <div
+                  key={i}
+                  className={cn(
+                    "flex items-start gap-2 rounded-md px-2.5 py-2 text-xs",
+                    d.severity === "error"
+                      ? "border border-red-200 bg-red-50 text-red-700"
+                      : "border border-amber-200 bg-amber-50 text-amber-700",
+                  )}
+                >
+                  {d.severity === "error" ? (
+                    <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  ) : (
+                    <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  )}
+                  <span>{d.message}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Proposal */}
+          {hasProposal && (
+            <div className="flex flex-col gap-2 rounded-md border px-3 py-3">
+              <span className="text-xs font-medium text-muted-foreground">
+                {t("canvas.agentPanel.proposal")}
+              </span>
+              <div className="rounded-md border bg-muted/50 p-2.5">
+                <p className="mb-2 text-xs font-medium">{proposal.summary}</p>
+                <ul className="flex flex-col gap-1">
+                  {proposal.actions.map((action, i) => (
+                    <li key={i} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                      <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary" />
+                      {getActionLabel(action, t)}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  className="h-8 flex-1 gap-1 text-xs"
+                  disabled={isSending || agentPanel.isLoading || hasBlockingDiagnostics}
+                  size="sm"
+                  variant="default"
+                  onClick={handleApply}
+                >
+                  <Check className="h-3.5 w-3.5" />
+                  {t("canvas.agentPanel.apply")}
+                </Button>
+                <Button
+                  className="h-8 flex-1 gap-1 text-xs"
+                  disabled={isSending || agentPanel.isLoading}
+                  size="sm"
+                  variant="outline"
+                  onClick={handleDiscard}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  {t("canvas.agentPanel.discard")}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {needsRuntimeSetup && (
+            <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50/70 p-3 text-xs text-amber-800">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+              <span>{t("canvas.agentPanel.runtimeNotConfigured")}</span>
+              <a className="font-medium underline underline-offset-2" href="/runtimes">
+                {t("canvas.agentPanel.goToRuntimeSettings")}
+              </a>
+            </div>
+          )}
+
+          <div className="h-1" />
         </div>
       </ScrollArea>
 
-      {/* Diagnostics */}
-      {agentPanel.diagnostics && agentPanel.diagnostics.length > 0 && (
-        <div className="border-t">
-          <div className="flex flex-col gap-2 p-3">
-            <span className="text-xs font-medium text-muted-foreground">
-              {t("canvas.agentPanel.diagnostics")}
-            </span>
-            {agentPanel.diagnostics.map((d, i) => (
-              <div
-                key={i}
-                className={cn(
-                  "flex items-start gap-2 rounded-md px-2.5 py-2 text-xs",
-                  d.severity === "error"
-                    ? "border border-red-200 bg-red-50 text-red-700"
-                    : "border border-amber-200 bg-amber-50 text-amber-700",
-                )}
-              >
-                {d.severity === "error" ? (
-                  <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                ) : (
-                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                )}
-                <span>{d.message}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Proposal */}
-      {hasProposal && (
-        <div className="border-t">
-          <div className="flex flex-col gap-2 p-3">
-            <span className="text-xs font-medium text-muted-foreground">
-              {t("canvas.agentPanel.proposal")}
-            </span>
-            <div className="rounded-md border bg-muted/50 p-2.5">
-              <p className="mb-2 text-xs font-medium">{proposal.summary}</p>
-              <ul className="flex flex-col gap-1">
-                {proposal.actions.map((action, i) => (
-                  <li key={i} className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                    <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary" />
-                    {getActionLabel(action, t)}
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <div className="flex items-center gap-2">
-              <Button
-                className="h-8 flex-1 gap-1 text-xs"
-                disabled={isSending || agentPanel.isLoading || hasBlockingDiagnostics}
-                size="sm"
-                variant="default"
-                onClick={handleApply}
-              >
-                <Check className="h-3.5 w-3.5" />
-                {t("canvas.agentPanel.apply")}
-              </Button>
-              <Button
-                className="h-8 flex-1 gap-1 text-xs"
-                disabled={isSending || agentPanel.isLoading}
-                size="sm"
-                variant="outline"
-                onClick={handleDiscard}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-                {t("canvas.agentPanel.discard")}
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {needsRuntimeSetup && (
-        <div className="border-t bg-amber-50/70">
-          <div className="flex items-center gap-2 p-3 text-xs text-amber-800">
-            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-            <span>{t("canvas.agentPanel.runtimeNotConfigured")}</span>
-            <a className="font-medium underline underline-offset-2" href="/runtimes">
-              {t("canvas.agentPanel.goToRuntimeSettings")}
-            </a>
-          </div>
-        </div>
-      )}
-
       {/* Input */}
-      <div className="flex items-center gap-2 border-t p-3">
-        <Input
-          className="h-9 flex-1 text-sm"
-          disabled={isSending || agentPanel.isLoading || isLoadingRuntimes}
-          placeholder={t("canvas.agentPanel.inputPlaceholder")}
-          value={inputValue}
-          onChange={handleInputValueChange}
-          onKeyDown={handleKeyDown}
-        />
-        <Button
-          aria-label={t("canvas.agentPanel.send")}
-          className="h-9 w-9"
-          disabled={
-            isSending ||
-            agentPanel.isLoading ||
-            isLoadingRuntimes ||
-            !selectedRuntimeId ||
-            !inputValue.trim()
-          }
-          size="icon"
-          title={t("canvas.agentPanel.send")}
-          variant="ghost"
-          onClick={handleSendClick}
-        >
-          {isSending || agentPanel.isLoading ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Send className="h-4 w-4" />
-          )}
-        </Button>
+      <div className="border-t bg-background p-3" data-testid="agent-panel-input-dock">
+        <div className="flex items-center gap-2">
+          <Input
+            className="h-9 flex-1 text-sm"
+            disabled={isSending || agentPanel.isLoading || isLoadingRuntimes}
+            placeholder={t("canvas.agentPanel.inputPlaceholder")}
+            value={inputValue}
+            onChange={handleInputValueChange}
+            onKeyDown={handleKeyDown}
+          />
+          <Button
+            aria-label={t("canvas.agentPanel.send")}
+            className="h-9 w-9"
+            disabled={
+              isSending ||
+              agentPanel.isLoading ||
+              isLoadingRuntimes ||
+              !selectedRuntimeId ||
+              !inputValue.trim()
+            }
+            size="icon"
+            title={t("canvas.agentPanel.send")}
+            variant="ghost"
+            onClick={handleSendClick}
+          >
+            {isSending || agentPanel.isLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -11,6 +11,10 @@ import { err, ok } from "neverthrow";
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
 vi.mock("react-i18next", () => ({
+  initReactI18next: {
+    init: vi.fn(),
+    type: "3rdParty",
+  },
   useTranslation: () => ({
     t: (key: string) => key,
     i18n: { changeLanguage: vi.fn() },
@@ -69,8 +73,14 @@ vi.mock("@repo/ui/button", () => ({
 }));
 
 vi.mock("@repo/ui/scroll-area", () => ({
-  ScrollArea: ({ children, className }: React.PropsWithChildren<{ className?: string }>) => (
-    <div className={className}>{children}</div>
+  ScrollArea: ({
+    children,
+    className,
+    ...props
+  }: React.PropsWithChildren<React.ComponentProps<"div">>) => (
+    <div className={className} {...props}>
+      {children}
+    </div>
   ),
 }));
 
@@ -293,6 +303,53 @@ describe("AgentPanel", () => {
     expect(screen.getByText("canvas.agentPanel.discard")).toBeInTheDocument();
   });
 
+  it("keeps runtime, messages, diagnostics, and proposal inside one scroll region while input stays outside", async () => {
+    const proposal = makeProposal({
+      actions: Array.from({ length: 12 }, (_, index) => ({
+        type: "addNode",
+        node: {
+          id: `op-${index}`,
+          type: "operation",
+          position: { x: 100 + index * 40, y: 100 },
+          data: {
+            nodeType: "operation",
+            operationId: `op-test-${index}`,
+            operationName: `Test Op ${index}`,
+            label: `Test Op ${index}`,
+            status: "idle",
+          },
+        },
+      })),
+    });
+    const diagnostics: PipelineActionDiagnostic[] = [
+      { code: "DUPLICATE_NODE_ID", severity: "error", message: "节点 ID 重复" },
+      { code: "INVALID_CONNECTION", severity: "warning", message: "缺少输入端口" },
+    ];
+
+    render(<AgentPanel />, {
+      wrapper: wrapperWithState({ pendingProposal: proposal, diagnostics }),
+    });
+
+    await waitFor(() => {
+      expect(mockGetList).toHaveBeenCalled();
+    });
+
+    const scrollRegion = screen.getByTestId("agent-panel-scroll-region");
+    expect(scrollRegion).toContainElement(screen.getByText("canvas.agentPanel.runtimeLabel"));
+    expect(scrollRegion).toContainElement(screen.getByText("canvas.agentPanel.proposal"));
+    expect(scrollRegion).toContainElement(screen.getByText("canvas.agentPanel.diagnostics"));
+    expect(scrollRegion).toContainElement(screen.getByText("节点 ID 重复"));
+    expect(scrollRegion).toContainElement(screen.getByText("缺少输入端口"));
+
+    const inputDock = screen.getByTestId("agent-panel-input-dock");
+    expect(inputDock).toContainElement(
+      screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder"),
+    );
+    expect(scrollRegion).not.toContainElement(
+      screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder"),
+    );
+  });
+
   it("applies proposal and shows confirmation", async () => {
     const user = userEvent.setup();
     const proposal = makeProposal();
@@ -390,7 +447,9 @@ describe("AgentPanel", () => {
       expect(mockGetList).toHaveBeenCalled();
     });
 
-    const input = screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder") as HTMLInputElement;
+    const input = screen.getByPlaceholderText(
+      "canvas.agentPanel.inputPlaceholder",
+    ) as HTMLInputElement;
     await user.type(input, "test");
     await user.keyboard("{Enter}");
 
@@ -423,7 +482,9 @@ describe("AgentPanel", () => {
     mockCustom.mockImplementation(() => new Promise(() => {}));
 
     render(<AgentPanel />, { wrapper: wrapperWithState() });
-    const input = screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder") as HTMLInputElement;
+    const input = screen.getByPlaceholderText(
+      "canvas.agentPanel.inputPlaceholder",
+    ) as HTMLInputElement;
     await waitFor(() => {
       expect(mockGetList).toHaveBeenCalled();
     });
@@ -470,7 +531,9 @@ describe("AgentPanel", () => {
     await user.keyboard("{Enter}");
 
     await waitFor(() => {
-      expect(screen.getByRole("link", { name: "canvas.agentPanel.goToRuntimeSettings" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "canvas.agentPanel.goToRuntimeSettings" }),
+      ).toBeInTheDocument();
     });
     const link = screen.getByRole("link", { name: "canvas.agentPanel.goToRuntimeSettings" });
     expect(link).toHaveAttribute("href", "/runtimes");

--- a/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
@@ -1,5 +1,7 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef, type MouseEvent as ReactMouseEvent } from "react";
+import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
+import { Button } from "@repo/ui/button";
 import { selectSelectedNode, useCanvasPageStore } from "../_store";
 import { CanvasFlow } from "../CanvasFlow";
 import { CanvasContextMenu } from "../CanvasContextMenu";
@@ -20,8 +22,10 @@ import { CanvasWorkspaceSidebarOverlay } from "../CanvasWorkspaceSidebarOverlay"
 import { getScreenViewportCenter, getViewportRectCenter } from "../utils/nodePosition";
 
 export const CanvasInner = () => {
+  const { t } = useTranslation();
   const store = useCanvasPageStore();
   const flowViewportRef = useRef<HTMLDivElement>(null);
+  const sidebarResizeStateRef = useRef<{ startClientX: number; startWidth: number } | null>(null);
 
   const contextMenu = useStore(store, (state) => state.contextMenu);
   const connectionMenu = useStore(store, (state) => state.connectionMenu);
@@ -32,6 +36,8 @@ export const CanvasInner = () => {
   const nodes = useStore(store, (state) => state.nodes);
   const sidebarPanel = useStore(store, (state) => state.sidebarPanel);
   const isSidebarOpen = useStore(store, (state) => state.isSidebarOpen);
+  const workspacePanelWidth = useStore(store, (state) => state.workspacePanelWidth);
+  const setWorkspacePanelWidth = useStore(store, (state) => state.setWorkspacePanelWidth);
   const selectedNode = useStore(store, selectSelectedNode);
   const showPropertiesPanel = sidebarPanel === "properties" && !!selectedNode;
 
@@ -40,6 +46,54 @@ export const CanvasInner = () => {
 
     return rect ? getViewportRectCenter(rect) : getScreenViewportCenter();
   }, []);
+
+  const stopSidebarResize = useCallback(() => {
+    if (!sidebarResizeStateRef.current) {
+      return;
+    }
+
+    sidebarResizeStateRef.current = null;
+    document.body.style.removeProperty("cursor");
+    document.body.style.removeProperty("user-select");
+  }, []);
+
+  useEffect(() => {
+    const handleMouseMove = (event: MouseEvent) => {
+      const resizeState = sidebarResizeStateRef.current;
+      if (!resizeState) {
+        return;
+      }
+
+      const delta = event.clientX - resizeState.startClientX;
+      setWorkspacePanelWidth(resizeState.startWidth + delta);
+    };
+
+    const handleMouseUp = () => {
+      stopSidebarResize();
+    };
+
+    globalThis.addEventListener("mousemove", handleMouseMove);
+    globalThis.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      globalThis.removeEventListener("mousemove", handleMouseMove);
+      globalThis.removeEventListener("mouseup", handleMouseUp);
+      stopSidebarResize();
+    };
+  }, [setWorkspacePanelWidth, stopSidebarResize]);
+
+  const handleWorkspacePanelResizeStart = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      sidebarResizeStateRef.current = {
+        startClientX: event.clientX,
+        startWidth: workspacePanelWidth,
+      };
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [workspacePanelWidth],
+  );
 
   return (
     <div
@@ -53,16 +107,31 @@ export const CanvasInner = () => {
 
         <div className="flex min-h-0 flex-1 overflow-hidden">
           {isSidebarOpen && (
-            <aside
-              className="h-full w-[min(22rem,28vw)] min-w-72 shrink-0 border-r bg-background"
-              data-testid="canvas-work-panel"
-            >
-              {showPropertiesPanel ? (
-                <CanvasNodePropertiesPanel />
-              ) : (
-                <CanvasComponentPanel getCreateNodeScreenPosition={getFlowViewportScreenCenter} />
-              )}
-            </aside>
+            <div className="relative shrink-0">
+              <aside
+                className="h-full shrink-0 border-r bg-background"
+                data-testid="canvas-work-panel"
+                style={{ width: `${workspacePanelWidth}px` }}
+              >
+                {showPropertiesPanel ? (
+                  <CanvasNodePropertiesPanel />
+                ) : (
+                  <CanvasComponentPanel getCreateNodeScreenPosition={getFlowViewportScreenCenter} />
+                )}
+              </aside>
+              <Button
+                aria-label={t("canvas.operationsPanel.resize", {
+                  defaultValue: "Resize operations panel",
+                })}
+                className="absolute inset-y-0 -right-2 z-10 h-full w-4 cursor-col-resize rounded-none px-0 touch-none"
+                data-testid="canvas-work-panel-resizer"
+                size="icon"
+                variant="ghost"
+                onMouseDown={handleWorkspacePanelResizeStart}
+              >
+                <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border transition-colors hover:bg-primary" />
+              </Button>
+            </div>
           )}
 
           <main className="relative min-w-0 flex-1 overflow-hidden">

--- a/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ReactFlowProvider } from "@xyflow/react";
@@ -104,6 +104,44 @@ describe("CanvasInner", () => {
     expect(screen.getByTestId("canvas-mini-sidebar")).toBeInTheDocument();
     expect(screen.getByTestId("canvas-component-panel")).toBeInTheDocument();
     expect(screen.getByTestId("canvas-flow-viewport")).toBeInTheDocument();
+  });
+
+  it("renders the workspace panel at the default width with a resize handle", () => {
+    render(<CanvasInner />, { wrapper });
+
+    expect(screen.getByTestId("canvas-work-panel")).toHaveStyle({ width: "352px" });
+    expect(screen.getByTestId("canvas-work-panel-resizer")).toBeInTheDocument();
+  });
+
+  it("clamps the workspace panel width while dragging the resize handle", () => {
+    render(<CanvasInner />, { wrapper });
+
+    const workPanel = screen.getByTestId("canvas-work-panel");
+    const resizeHandle = screen.getByTestId("canvas-work-panel-resizer");
+    const globalWindow = globalThis.window;
+    vi.spyOn(workPanel, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      width: 352,
+      height: 640,
+      top: 0,
+      right: 352,
+      bottom: 640,
+      left: 0,
+      toJSON: () => ({}),
+    });
+
+    fireEvent.mouseDown(resizeHandle, { clientX: 352 });
+    fireEvent.mouseMove(globalWindow, { clientX: 120 });
+    expect(workPanel).toHaveStyle({ width: "288px" });
+
+    fireEvent.mouseMove(globalWindow, { clientX: 460 });
+    expect(workPanel).toHaveStyle({ width: "460px" });
+
+    fireEvent.mouseMove(globalWindow, { clientX: 700 });
+    expect(workPanel).toHaveStyle({ width: "560px" });
+
+    fireEvent.mouseUp(globalWindow);
   });
 
   it("opens the workspace sidebar overlay from the mini sidebar", async () => {

--- a/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx
@@ -50,7 +50,7 @@ export const CanvasToolbar = () => {
   const InteractivityIcon = isCanvasInteractive ? Unlock : Lock;
 
   return (
-    <div className="pointer-events-auto w-max max-w-full" data-testid="canvas-toolbar">
+    <div className="pointer-events-auto shrink-0 w-max max-w-full" data-testid="canvas-toolbar">
       <div className="flex h-10 w-max items-center gap-0.5 rounded-md border bg-background px-1.5 py-1 shadow-md max-[420px]:gap-0 max-[420px]:px-1">
         {/* Zoom controls */}
         <Tooltip>

--- a/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.tsx
@@ -12,10 +12,10 @@ export const CanvasTopChrome = () => {
 
   return (
     <div
-      className="flex min-h-16 items-center gap-3 border-b bg-background/95 px-3 py-3 backdrop-blur"
+      className="flex min-h-16 min-w-0 items-center gap-3 border-b bg-background/95 px-3 py-3 backdrop-blur"
       data-testid="canvas-top-chrome"
     >
-      <div className="min-w-0 flex-1" data-testid="canvas-title-desktop">
+      <div className="min-w-0 flex-1 basis-0" data-testid="canvas-title-desktop">
         <div className="flex h-10 w-full min-w-0 items-center rounded-md border bg-background px-3 shadow-sm">
           <Input
             aria-label={t("canvas.pipelineTitle")}
@@ -28,7 +28,7 @@ export const CanvasTopChrome = () => {
         </div>
       </div>
 
-      <div className="min-w-0 max-w-full overflow-x-auto [scrollbar-width:none]">
+      <div className="min-w-0 max-w-full shrink-0 overflow-x-auto [scrollbar-width:none]">
         <CanvasToolbar />
       </div>
     </div>

--- a/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
@@ -35,6 +35,8 @@ describe("CanvasTopChrome", () => {
     expect(toolbarSlot).not.toBeNull();
     expect(toolbarSlot as HTMLElement).toHaveClass("min-w-0", "max-w-full", "overflow-x-auto");
     expect(screen.getByTestId("canvas-title-desktop")).toHaveClass("min-w-0", "flex-1");
+    expect(screen.getByTestId("canvas-title-desktop").firstElementChild).toHaveClass("min-w-0");
+    expect(toolbarSlot as HTMLElement).toHaveClass("shrink-0");
   });
 
   it("preserves pipeline title editing", async () => {

--- a/apps/app/src/pages/CanvasPage/_store/uiSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/uiSlice.ts
@@ -47,6 +47,13 @@ export const DEFAULT_CANVAS_SETTINGS: CanvasSettingsState = {
   snapToGrid: false,
 };
 
+export const DEFAULT_WORKSPACE_PANEL_WIDTH = 352;
+export const MIN_WORKSPACE_PANEL_WIDTH = 288;
+export const MAX_WORKSPACE_PANEL_WIDTH = 560;
+
+export const clampWorkspacePanelWidth = (width: number) =>
+  Math.min(MAX_WORKSPACE_PANEL_WIDTH, Math.max(MIN_WORKSPACE_PANEL_WIDTH, width));
+
 export interface AgentPanelState {
   isOpen: boolean;
   pendingProposal: PipelineActionProposal | null;
@@ -63,6 +70,7 @@ export interface UISlice {
   componentSearchQuery: string;
   collapsedComponentCategories: Record<CanvasComponentCategory, boolean>;
   isWorkspaceSidebarOpen: boolean;
+  workspacePanelWidth: number;
   nodeCardMode: NodeCardMode;
   isSidebarOpen: boolean;
   isPropertiesPanelOpen: boolean;
@@ -100,6 +108,7 @@ export interface UISlice {
   toggleComponentCategory: (category: CanvasComponentCategory) => void;
   openWorkspaceSidebar: () => void;
   closeWorkspaceSidebar: () => void;
+  setWorkspacePanelWidth: (width: number) => void;
   setNodeCardMode: (mode: NodeCardMode) => void;
   toggleNodeCardMode: () => void;
   handleToggleSidebar: () => void;
@@ -171,6 +180,7 @@ export const createUISlice = (
     output: false,
   },
   isWorkspaceSidebarOpen: false,
+  workspacePanelWidth: DEFAULT_WORKSPACE_PANEL_WIDTH,
   nodeCardMode: "compact",
   isSidebarOpen: true,
   isPropertiesPanelOpen: false,
@@ -231,6 +241,10 @@ export const createUISlice = (
 
   closeWorkspaceSidebar: () => {
     set({ isWorkspaceSidebarOpen: false });
+  },
+
+  setWorkspacePanelWidth: (width) => {
+    set({ workspacePanelWidth: clampWorkspacePanelWidth(width) });
   },
 
   setNodeCardMode: (mode) => {


### PR DESCRIPTION
Closes #88

## Summary
- 为 Canvas 左侧操作面板增加可拖拽改宽能力，默认宽度 352px，限制在 288px 到 560px 之间
- 重构 AI 助手面板布局为“头部固定 + 中间滚动区 + 底部固定输入区”
- 收紧 Canvas 顶栏布局，保证窄视口下标题仍可编辑，toolbar 横向滚动，Run 文案退化为 icon-only
- 补充对应单测与一个 AgentPanel overflow story，用于稳定复现滚动场景

## Verification
- `cd apps/app && bun run test -- AgentPanel/AgentPanel.unit.test.tsx CanvasInner/CanvasInner.unit.test.tsx CanvasTopChrome/CanvasTopChrome.unit.test.tsx CanvasToolbar/CanvasToolbar.unit.test.tsx`
  - 结果：38/38 passed
- `cd apps/app && bun run test -- CanvasMiniSidebar/CanvasMiniSidebar.unit.test.tsx CanvasInner/CanvasInner.unit.test.tsx AgentPanel/AgentPanel.unit.test.tsx CanvasTopChrome/CanvasTopChrome.unit.test.tsx CanvasToolbar/CanvasToolbar.unit.test.tsx CanvasFlow/CanvasFlow.unit.test.tsx`
  - 结果：50/50 passed
- `cd apps/app && bun run lint`
  - 结果：通过，仅剩仓库既有 warnings
- `cd apps/app && bun run compile`
  - 结果：仍被仓库既有问题阻塞
  - 阻塞文件：`apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx`
  - 阻塞原因：`Select onValueChange` 签名不匹配（本次未扩大影响）
- `chrome-devtools` 浏览器验收
  - 真 `/canvas` 页面验证左栏默认宽度 352px，拖拽夹紧到 288px / 560px
  - 真 `/canvas` 页面验证 AgentPanel 存在独立 scroll region，输入 dock 固定在滚动区外
  - `320px` 窄视口验证 toolbar 横向滚动，Run 文案隐藏
  - overflow story 验证 AgentPanel viewport 内部滚动存在

## Screenshots
- `pr-assets/issue-88/canvas-desktop.png`
- `pr-assets/issue-88/canvas-narrow.png`
- `pr-assets/issue-88/canvas-desktop-agent-panel.png`
- `pr-assets/issue-88/agent-panel-overflow.png`

## Notes
- 本次未改动 Agent proposal 数据结构、后端接口或宽度持久化逻辑
- 右侧 AgentPanel 未做可拖拽改宽
- subagent review: no findings / approve
