### PR TITLE
refactor(canvas): move node field handlers into store actions

### DIFF
--- a/apps/app/src/components/FolderBrowserDialog/FolderBrowserDialog.stories.tsx
+++ b/apps/app/src/components/FolderBrowserDialog/FolderBrowserDialog.stories.tsx
@@ -2,9 +2,9 @@ import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Refine } from "@refinedev/core";
 import { canvasStoryDataProvider } from "../../pages/CanvasPage/storybookData";
-import { FolderBrowser } from "./FolderBrowser";
+import { FolderBrowserDialog } from "./FolderBrowserDialog";
 
-const FolderBrowserStory = (args: React.ComponentProps<typeof FolderBrowser>) => {
+const FolderBrowserStory = (args: React.ComponentProps<typeof FolderBrowserDialog>) => {
   const [open, setOpen] = useState(args.open);
   const handleOpenChange = (value: boolean) => setOpen(value);
   const handleSelect = (path: string) => {
@@ -13,13 +13,13 @@ const FolderBrowserStory = (args: React.ComponentProps<typeof FolderBrowser>) =>
   };
 
   return (
-    <FolderBrowser {...args} open={open} onOpenChange={handleOpenChange} onSelect={handleSelect} />
+    <FolderBrowserDialog {...args} open={open} onOpenChange={handleOpenChange} onSelect={handleSelect} />
   );
 };
 
-const meta: Meta<typeof FolderBrowser> = {
+const meta: Meta<typeof FolderBrowserDialog> = {
   title: "CanvasPage/OutputLocalPathNode/FolderBrowser",
-  component: FolderBrowser,
+  component: FolderBrowserDialog,
   tags: ["autodocs"],
   args: {
     open: true,
@@ -47,7 +47,7 @@ const meta: Meta<typeof FolderBrowser> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof FolderBrowser>;
+type Story = StoryObj<typeof FolderBrowserDialog>;
 
 export const FolderMode: Story = {
   render: (args) => <FolderBrowserStory {...args} />,

--- a/apps/app/src/components/FolderBrowserDialog/FolderBrowserDialog.tsx
+++ b/apps/app/src/components/FolderBrowserDialog/FolderBrowserDialog.tsx
@@ -24,7 +24,7 @@ export interface FolderBrowserProps {
   mode?: "folder" | "file";
 }
 
-export const FolderBrowser = ({
+export const FolderBrowserDialog = ({
   open,
   onOpenChange,
   onSelect,

--- a/apps/app/src/components/FolderBrowserDialog/FolderBrowserDialog.unit.test.tsx
+++ b/apps/app/src/components/FolderBrowserDialog/FolderBrowserDialog.unit.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { FolderBrowser } from "./FolderBrowser";
+import { FolderBrowserDialog } from "./FolderBrowserDialog";
 
 const mockEntries = [
   { name: "Desktop", type: "directory", path: "/Users/test/Desktop" },
@@ -35,14 +35,14 @@ const handleSelect = vi.fn();
 
 describe("FolderBrowser", () => {
   it("renders dialog with title when open", async () => {
-    render(<FolderBrowser open onOpenChange={handleOpenChange} onSelect={handleSelect} />);
+    render(<FolderBrowserDialog open onOpenChange={handleOpenChange} onSelect={handleSelect} />);
     await waitFor(() => {
       expect(screen.getByText("选择文件夹")).toBeInTheDocument();
     });
   });
 
   it("displays directory entries (excluding files in folder mode)", async () => {
-    render(<FolderBrowser open onOpenChange={handleOpenChange} onSelect={handleSelect} />);
+    render(<FolderBrowserDialog open onOpenChange={handleOpenChange} onSelect={handleSelect} />);
     expect(screen.getByText("Desktop")).toBeInTheDocument();
     expect(screen.getByText("Documents")).toBeInTheDocument();
     expect(screen.queryByText(".zshrc")).not.toBeInTheDocument();
@@ -50,7 +50,7 @@ describe("FolderBrowser", () => {
 
   it("shows files in file mode", async () => {
     render(
-      <FolderBrowser open mode="file" onOpenChange={handleOpenChange} onSelect={handleSelect} />,
+      <FolderBrowserDialog open mode="file" onOpenChange={handleOpenChange} onSelect={handleSelect} />,
     );
     expect(screen.getByText("Desktop")).toBeInTheDocument();
     expect(screen.getByText(".zshrc")).toBeInTheDocument();
@@ -65,12 +65,12 @@ describe("FolderBrowser", () => {
       .mockReturnValueOnce(makeQueryResult(subEntries));
 
     const { rerender } = render(
-      <FolderBrowser open onOpenChange={handleOpenChange} onSelect={handleSelect} />,
+      <FolderBrowserDialog open onOpenChange={handleOpenChange} onSelect={handleSelect} />,
     );
 
     await user.click(screen.getByText("Desktop"));
 
-    rerender(<FolderBrowser open onOpenChange={handleOpenChange} onSelect={handleSelect} />);
+    rerender(<FolderBrowserDialog open onOpenChange={handleOpenChange} onSelect={handleSelect} />);
 
     expect(mockUseList).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -91,12 +91,12 @@ describe("FolderBrowser", () => {
       .mockReturnValueOnce(makeQueryResult(subEntries));
 
     const { rerender } = render(
-      <FolderBrowser open onOpenChange={handleOpenChangeSpy} onSelect={handleSelectSpy} />,
+      <FolderBrowserDialog open onOpenChange={handleOpenChangeSpy} onSelect={handleSelectSpy} />,
     );
 
     await user.click(screen.getByText("Desktop"));
 
-    rerender(<FolderBrowser open onOpenChange={handleOpenChangeSpy} onSelect={handleSelectSpy} />);
+    rerender(<FolderBrowserDialog open onOpenChange={handleOpenChangeSpy} onSelect={handleSelectSpy} />);
 
     await user.click(screen.getByText("选择此文件夹"));
 
@@ -114,7 +114,7 @@ describe("FolderBrowser", () => {
       },
     });
 
-    render(<FolderBrowser open onOpenChange={handleOpenChange} onSelect={handleSelect} />);
+    render(<FolderBrowserDialog open onOpenChange={handleOpenChange} onSelect={handleSelect} />);
     expect(screen.getByText("加载中...")).toBeInTheDocument();
   });
 
@@ -128,7 +128,7 @@ describe("FolderBrowser", () => {
       },
     });
 
-    render(<FolderBrowser open onOpenChange={handleOpenChange} onSelect={handleSelect} />);
+    render(<FolderBrowserDialog open onOpenChange={handleOpenChange} onSelect={handleSelect} />);
     expect(screen.getByText("Path does not exist")).toBeInTheDocument();
   });
 
@@ -143,7 +143,7 @@ describe("FolderBrowser", () => {
     );
 
     render(
-      <FolderBrowser open mode="file" onOpenChange={handleOpenChange} onSelect={handleSelect} />,
+      <FolderBrowserDialog open mode="file" onOpenChange={handleOpenChange} onSelect={handleSelect} />,
     );
 
     await user.click(screen.getByText(longFileName));

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
@@ -6,7 +6,7 @@ import { useShallow } from "zustand/shallow";
 import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
 import type { FileObjectNodeData } from "@repo/schemas";
 import { NodeCard } from "../NodeCard";
-import { FolderBrowser } from "@/components/FolderBrowser/FolderBrowser";
+import { FolderBrowserDialog } from "@/components/FolderBrowserDialog/FolderBrowserDialog";
 
 export interface FileNodeProps {
   id: string;
@@ -117,7 +117,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
         />
       </NodeCard>
 
-      <FolderBrowser
+      <FolderBrowserDialog
         mode="file"
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
@@ -23,11 +23,11 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
     runStatus,
     dimmed,
     nodeCardMode,
-    handleFileLabelChange,
-    handleFilePathChange,
-    handleFilePathInputChange,
-    handleFileLanguageInputChange,
-    handleFileDescriptionInputChange,
+    handleFileLabelChange: applyFileLabelChange,
+    handleFilePathChange: applyFilePathChange,
+    handleFilePathInputChange: applyFilePathInputChange,
+    handleFileLanguageInputChange: applyFileLanguageInputChange,
+    handleFileDescriptionInputChange: applyFileDescriptionInputChange,
     rightActivePortCount,
     rightActivePortMask,
     rightConnectedPortCount,
@@ -53,6 +53,22 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
     setBrowserOpen(true);
   };
 
+  const handleLabelChange = applyFileLabelChange.bind(null, id);
+
+  const handleFileSelect = applyFilePathChange.bind(null, id);
+
+  const handleFilePathInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    applyFilePathInputChange(id, e.target.value);
+  };
+
+  const handleFileLanguageInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    applyFileLanguageInputChange(id, e.target.value);
+  };
+
+  const handleFileDescriptionInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    applyFileDescriptionInputChange(id, e.target.value);
+  };
+
   const handleBrowserOpenChange = (open: boolean) => {
     setBrowserOpen(open);
   };
@@ -75,7 +91,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
         runStatus={runStatus}
         selected={selected}
         theme="orange"
-        onLabelChange={handleFileLabelChange.bind(null, id)}
+        onLabelChange={handleLabelChange}
       >
         <div className="flex items-center gap-1 rounded-md border border-slate-100 bg-slate-50 px-2 py-1">
           <input
@@ -84,7 +100,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
             name={`${id}-filePath`}
             placeholder="src/file.tsx"
             value={data.filePath}
-            onChange={handleFilePathInputChange.bind(null, id)}
+            onChange={handleFilePathInputChange}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -104,7 +120,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
             name={`${id}-language`}
             placeholder="ts"
             value={data.language ?? ""}
-            onChange={handleFileLanguageInputChange.bind(null, id)}
+            onChange={handleFileLanguageInputChange}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -117,7 +133,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
           placeholder={t("nodes.codeFile.descriptionPlaceholder")}
           rows={2}
           value={data.description ?? ""}
-          onChange={handleFileDescriptionInputChange.bind(null, id)}
+          onChange={handleFileDescriptionInputChange}
           onMouseDown={handleStopPropagation}
         />
       </NodeCard>
@@ -126,7 +142,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
         mode="file"
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
-        onSelect={handleFilePathChange.bind(null, id)}
+        onSelect={handleFileSelect}
       />
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
@@ -19,33 +19,38 @@ const handleStopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
 export const FileNode = ({ id, data, selected }: FileNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
-  const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
-  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
-  const updateNodeData = useStore(store, (s) => s.updateNodeData);
   const {
+    runStatus,
+    dimmed,
+    nodeCardMode,
+    handleFileLabelChange,
+    handleFilePathChange,
+    handleFilePathInputChange,
+    handleFileLanguageInputChange,
+    handleFileDescriptionInputChange,
     rightActivePortCount,
     rightActivePortMask,
     rightConnectedPortCount,
     rightConnectedPortMask,
     rightPortCount,
-  } = useStore(store, useShallow(selectNodePortCounts(id)));
+  } = useStore(
+    store,
+    useShallow((s) => ({
+      ...selectNodeRunState(id)(s),
+      nodeCardMode: s.nodeCardMode,
+      handleFileLabelChange: s.handleFileLabelChange,
+      handleFilePathChange: s.handleFilePathChange,
+      handleFilePathInputChange: s.handleFilePathInputChange,
+      handleFileLanguageInputChange: s.handleFileLanguageInputChange,
+      handleFileDescriptionInputChange: s.handleFileDescriptionInputChange,
+      ...selectNodePortCounts(id)(s),
+    })),
+  );
   const [browserOpen, setBrowserOpen] = useState(false);
-
-  const handleLabelChange = (v: string) => updateNodeData(id, { label: v });
-  const handleFilePathChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    updateNodeData(id, { filePath: e.target.value });
-  const handleLanguageChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    updateNodeData(id, { language: e.target.value });
-  const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-    updateNodeData(id, { description: e.target.value });
 
   const handleBrowseButtonClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     setBrowserOpen(true);
-  };
-
-  const handleFileSelect = (path: string) => {
-    updateNodeData(id, { filePath: path });
   };
 
   const handleBrowserOpenChange = (open: boolean) => {
@@ -70,7 +75,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
         runStatus={runStatus}
         selected={selected}
         theme="orange"
-        onLabelChange={handleLabelChange}
+        onLabelChange={handleFileLabelChange.bind(null, id)}
       >
         <div className="flex items-center gap-1 rounded-md border border-slate-100 bg-slate-50 px-2 py-1">
           <input
@@ -79,7 +84,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
             name={`${id}-filePath`}
             placeholder="src/file.tsx"
             value={data.filePath}
-            onChange={handleFilePathChange}
+            onChange={handleFilePathInputChange.bind(null, id)}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -99,7 +104,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
             name={`${id}-language`}
             placeholder="ts"
             value={data.language ?? ""}
-            onChange={handleLanguageChange}
+            onChange={handleFileLanguageInputChange.bind(null, id)}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -112,7 +117,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
           placeholder={t("nodes.codeFile.descriptionPlaceholder")}
           rows={2}
           value={data.description ?? ""}
-          onChange={handleDescriptionChange}
+          onChange={handleFileDescriptionInputChange.bind(null, id)}
           onMouseDown={handleStopPropagation}
         />
       </NodeCard>
@@ -121,7 +126,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
         mode="file"
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
-        onSelect={handleFileSelect}
+        onSelect={handleFilePathChange.bind(null, id)}
       />
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/CodeFileNode/CodeFileNode.unit.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { CanvasPageStoreContext, createCanvasPageStore } from "../_store";
+import { CanvasPageStoreContext, createCanvasPageStore, type CanvasPageStore } from "../_store";
 import { FileNode } from "./CodeFileNode";
 
 vi.mock("@xyflow/react", () => ({
@@ -22,19 +22,6 @@ vi.mock("@refinedev/core", () => ({
   }),
 }));
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <CanvasPageStoreContext.Provider
-    value={(() => {
-      const store = createCanvasPageStore();
-      store.setState({ nodeCardMode: "expanded" });
-
-      return store;
-    })()}
-  >
-    {children}
-  </CanvasPageStoreContext.Provider>
-);
-
 const baseData = {
   nodeType: "file" as const,
   label: "main.ts",
@@ -43,31 +30,66 @@ const baseData = {
   description: "应用入口文件",
 };
 
+const makeStore = (data = baseData, id = "test"): CanvasPageStore => {
+  const store = createCanvasPageStore([
+    {
+      id,
+      type: "file",
+      position: { x: 0, y: 0 },
+      data,
+    },
+  ]);
+  store.setState({ nodeCardMode: "expanded" });
+
+  return store;
+};
+
+const makeWrapper =
+  (store: CanvasPageStore) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <CanvasPageStoreContext.Provider value={store}>{children}</CanvasPageStoreContext.Provider>
+  );
+
 describe("CodeFileNode", () => {
   it("renders label", () => {
-    render(<FileNode data={baseData} id="test" />, { wrapper });
+    render(<FileNode data={baseData} id="test" />, { wrapper: makeWrapper(makeStore()) });
     expect(screen.getByDisplayValue("main.ts")).toBeInTheDocument();
   });
 
   it("renders filePath", () => {
-    render(<FileNode data={baseData} id="test" />, { wrapper });
+    render(<FileNode data={baseData} id="test" />, { wrapper: makeWrapper(makeStore()) });
     expect(screen.getByDisplayValue("src/main.ts")).toBeInTheDocument();
   });
 
   it("renders language badge", () => {
-    render(<FileNode data={baseData} id="test" />, { wrapper });
+    render(<FileNode data={baseData} id="test" />, { wrapper: makeWrapper(makeStore()) });
     expect(screen.getByDisplayValue("typescript")).toBeInTheDocument();
   });
 
   it("renders description", () => {
-    render(<FileNode data={baseData} id="test" />, { wrapper });
+    render(<FileNode data={baseData} id="test" />, { wrapper: makeWrapper(makeStore()) });
     expect(screen.getByDisplayValue("应用入口文件")).toBeInTheDocument();
   });
 
   it("shows placeholder when filePath is empty", () => {
+    const store = makeStore({ ...baseData, filePath: "" });
     render(<FileNode data={{ ...baseData, filePath: "" }} id="test" />, {
-      wrapper,
+      wrapper: makeWrapper(store),
     });
     expect(screen.getByPlaceholderText("src/file.tsx")).toBeInTheDocument();
+  });
+
+  it("writes the typed code file path back to the store as a plain string", () => {
+    const store = makeStore();
+    render(<FileNode data={baseData} id="test" />, {
+      wrapper: makeWrapper(store),
+    });
+
+    fireEvent.change(screen.getByDisplayValue("src/main.ts"), {
+      target: { value: "src/lib/index.ts" },
+    });
+
+    const updatedNode = store.getState().nodes.find((node) => node.id === "test");
+    expect(updatedNode?.data).toEqual(expect.objectContaining({ filePath: "src/lib/index.ts" }));
   });
 });

--- a/apps/app/src/pages/CanvasPage/FileNode/FileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FileNode/FileNode.tsx
@@ -23,11 +23,11 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
     runStatus,
     dimmed,
     nodeCardMode,
-    handleFileLabelChange,
-    handleFilePathChange,
-    handleFilePathInputChange,
-    handleFileLanguageInputChange,
-    handleFileDescriptionInputChange,
+    handleFileLabelChange: applyFileLabelChange,
+    handleFilePathChange: applyFilePathChange,
+    handleFilePathInputChange: applyFilePathInputChange,
+    handleFileLanguageInputChange: applyFileLanguageInputChange,
+    handleFileDescriptionInputChange: applyFileDescriptionInputChange,
     rightPortCount,
   } = useStore(
     store,
@@ -49,6 +49,22 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
     setBrowserOpen(true);
   };
 
+  const handleLabelChange = applyFileLabelChange.bind(null, id);
+
+  const handleFileSelect = applyFilePathChange.bind(null, id);
+
+  const handleFilePathInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    applyFilePathInputChange(id, e.target.value);
+  };
+
+  const handleFileLanguageInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    applyFileLanguageInputChange(id, e.target.value);
+  };
+
+  const handleFileDescriptionInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    applyFileDescriptionInputChange(id, e.target.value);
+  };
+
   const handleBrowserOpenChange = (open: boolean) => {
     setBrowserOpen(open);
   };
@@ -67,7 +83,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
         runStatus={runStatus}
         selected={selected}
         theme="orange"
-        onLabelChange={handleFileLabelChange.bind(null, id)}
+        onLabelChange={handleLabelChange}
       >
         <div className="flex items-center gap-1 rounded-md border border-slate-100 bg-slate-50 px-2 py-1">
           <input
@@ -76,7 +92,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
             name={`${id}-filePath`}
             placeholder="src/file.tsx"
             value={data.filePath}
-            onChange={handleFilePathInputChange.bind(null, id)}
+            onChange={handleFilePathInputChange}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -96,7 +112,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
             name={`${id}-language`}
             placeholder="ts"
             value={data.language ?? ""}
-            onChange={handleFileLanguageInputChange.bind(null, id)}
+            onChange={handleFileLanguageInputChange}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -109,7 +125,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
           placeholder={t("nodes.codeFile.descriptionPlaceholder")}
           rows={2}
           value={data.description ?? ""}
-          onChange={handleFileDescriptionInputChange.bind(null, id)}
+          onChange={handleFileDescriptionInputChange}
           onMouseDown={handleStopPropagation}
         />
       </NodeCard>
@@ -118,7 +134,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
         mode="file"
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
-        onSelect={handleFilePathChange.bind(null, id)}
+        onSelect={handleFileSelect}
       />
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/FileNode/FileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FileNode/FileNode.tsx
@@ -6,7 +6,7 @@ import { useShallow } from "zustand/shallow";
 import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
 import type { FileObjectNodeData } from "@repo/schemas";
 import { NodeCard } from "../NodeCard";
-import { FolderBrowser } from "@/components/FolderBrowser/FolderBrowser";
+import { FolderBrowserDialog } from "@/components/FolderBrowserDialog/FolderBrowserDialog";
 
 export interface FileNodeProps {
   id: string;
@@ -114,7 +114,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
         />
       </NodeCard>
 
-      <FolderBrowser
+      <FolderBrowserDialog
         mode="file"
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}

--- a/apps/app/src/pages/CanvasPage/FileNode/FileNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FileNode/FileNode.tsx
@@ -19,27 +19,34 @@ const handleStopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
 export const FileNode = ({ id, data, selected }: FileNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
-  const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
-  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
-  const updateNodeData = useStore(store, (s) => s.updateNodeData);
-  const { rightPortCount } = useStore(store, useShallow(selectNodePortCounts(id)));
+  const {
+    runStatus,
+    dimmed,
+    nodeCardMode,
+    handleFileLabelChange,
+    handleFilePathChange,
+    handleFilePathInputChange,
+    handleFileLanguageInputChange,
+    handleFileDescriptionInputChange,
+    rightPortCount,
+  } = useStore(
+    store,
+    useShallow((s) => ({
+      ...selectNodeRunState(id)(s),
+      nodeCardMode: s.nodeCardMode,
+      handleFileLabelChange: s.handleFileLabelChange,
+      handleFilePathChange: s.handleFilePathChange,
+      handleFilePathInputChange: s.handleFilePathInputChange,
+      handleFileLanguageInputChange: s.handleFileLanguageInputChange,
+      handleFileDescriptionInputChange: s.handleFileDescriptionInputChange,
+      ...selectNodePortCounts(id)(s),
+    })),
+  );
   const [browserOpen, setBrowserOpen] = useState(false);
-
-  const handleLabelChange = (v: string) => updateNodeData(id, { label: v });
-  const handleFilePathChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    updateNodeData(id, { filePath: e.target.value });
-  const handleLanguageChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    updateNodeData(id, { language: e.target.value });
-  const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-    updateNodeData(id, { description: e.target.value });
 
   const handleBrowseButtonClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     setBrowserOpen(true);
-  };
-
-  const handleFileSelect = (path: string) => {
-    updateNodeData(id, { filePath: path });
   };
 
   const handleBrowserOpenChange = (open: boolean) => {
@@ -60,7 +67,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
         runStatus={runStatus}
         selected={selected}
         theme="orange"
-        onLabelChange={handleLabelChange}
+        onLabelChange={handleFileLabelChange.bind(null, id)}
       >
         <div className="flex items-center gap-1 rounded-md border border-slate-100 bg-slate-50 px-2 py-1">
           <input
@@ -69,7 +76,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
             name={`${id}-filePath`}
             placeholder="src/file.tsx"
             value={data.filePath}
-            onChange={handleFilePathChange}
+            onChange={handleFilePathInputChange.bind(null, id)}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -89,7 +96,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
             name={`${id}-language`}
             placeholder="ts"
             value={data.language ?? ""}
-            onChange={handleLanguageChange}
+            onChange={handleFileLanguageInputChange.bind(null, id)}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -102,7 +109,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
           placeholder={t("nodes.codeFile.descriptionPlaceholder")}
           rows={2}
           value={data.description ?? ""}
-          onChange={handleDescriptionChange}
+          onChange={handleFileDescriptionInputChange.bind(null, id)}
           onMouseDown={handleStopPropagation}
         />
       </NodeCard>
@@ -111,7 +118,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
         mode="file"
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
-        onSelect={handleFileSelect}
+        onSelect={handleFilePathChange.bind(null, id)}
       />
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/FileNode/FileNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/FileNode/FileNode.unit.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { CanvasPageStoreContext, createCanvasPageStore } from "../_store";
+import { CanvasPageStoreContext, createCanvasPageStore, type CanvasPageStore } from "../_store";
 import { FileNode } from "./FileNode";
 
 vi.mock("@xyflow/react", () => ({
@@ -22,19 +22,6 @@ vi.mock("@refinedev/core", () => ({
   }),
 }));
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <CanvasPageStoreContext.Provider
-    value={(() => {
-      const store = createCanvasPageStore();
-      store.setState({ nodeCardMode: "expanded" });
-
-      return store;
-    })()}
-  >
-    {children}
-  </CanvasPageStoreContext.Provider>
-);
-
 const baseData = {
   nodeType: "file" as const,
   label: "main.ts",
@@ -43,31 +30,66 @@ const baseData = {
   description: "应用入口文件",
 };
 
+const makeStore = (data = baseData, id = "test"): CanvasPageStore => {
+  const store = createCanvasPageStore([
+    {
+      id,
+      type: "file",
+      position: { x: 0, y: 0 },
+      data,
+    },
+  ]);
+  store.setState({ nodeCardMode: "expanded" });
+
+  return store;
+};
+
+const makeWrapper =
+  (store: CanvasPageStore) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <CanvasPageStoreContext.Provider value={store}>{children}</CanvasPageStoreContext.Provider>
+  );
+
 describe("FileNode", () => {
   it("renders label", () => {
-    render(<FileNode data={baseData} id="test" />, { wrapper });
+    render(<FileNode data={baseData} id="test" />, { wrapper: makeWrapper(makeStore()) });
     expect(screen.getByDisplayValue("main.ts")).toBeInTheDocument();
   });
 
   it("renders filePath", () => {
-    render(<FileNode data={baseData} id="test" />, { wrapper });
+    render(<FileNode data={baseData} id="test" />, { wrapper: makeWrapper(makeStore()) });
     expect(screen.getByDisplayValue("src/main.ts")).toBeInTheDocument();
   });
 
   it("renders language badge", () => {
-    render(<FileNode data={baseData} id="test" />, { wrapper });
+    render(<FileNode data={baseData} id="test" />, { wrapper: makeWrapper(makeStore()) });
     expect(screen.getByDisplayValue("typescript")).toBeInTheDocument();
   });
 
   it("renders description", () => {
-    render(<FileNode data={baseData} id="test" />, { wrapper });
+    render(<FileNode data={baseData} id="test" />, { wrapper: makeWrapper(makeStore()) });
     expect(screen.getByDisplayValue("应用入口文件")).toBeInTheDocument();
   });
 
   it("shows placeholder when filePath is empty", () => {
+    const store = makeStore({ ...baseData, filePath: "" });
     render(<FileNode data={{ ...baseData, filePath: "" }} id="test" />, {
-      wrapper,
+      wrapper: makeWrapper(store),
     });
     expect(screen.getByPlaceholderText("src/file.tsx")).toBeInTheDocument();
+  });
+
+  it("writes the typed file path back to the store as a plain string", () => {
+    const store = makeStore();
+    render(<FileNode data={baseData} id="test" />, {
+      wrapper: makeWrapper(store),
+    });
+
+    fireEvent.change(screen.getByDisplayValue("src/main.ts"), {
+      target: { value: "src/next.tsx" },
+    });
+
+    const updatedNode = store.getState().nodes.find((node) => node.id === "test");
+    expect(updatedNode?.data).toEqual(expect.objectContaining({ filePath: "src/next.tsx" }));
   });
 });

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
@@ -6,7 +6,7 @@ import { useShallow } from "zustand/shallow";
 import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
 import type { FolderObjectNodeData } from "@repo/schemas";
 import { NodeCard } from "../NodeCard";
-import { FolderBrowser } from "@/components/FolderBrowser/FolderBrowser";
+import { FolderBrowserDialog } from "@/components/FolderBrowserDialog/FolderBrowserDialog";
 import { FolderTreePreview } from "./FolderTreePreview";
 import { Input } from "@repo/ui/input";
 import { Button } from "@repo/ui/button";
@@ -144,7 +144,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
         />
       </NodeCard>
 
-      <FolderBrowser
+      <FolderBrowserDialog
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
         onSelect={handleFolderSelect}

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
@@ -23,44 +23,47 @@ const handleStopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
 export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
-  const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
-  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
-  const updateNodeData = useStore(store, (s) => s.updateNodeData);
-  const handleNodeAddExcludedPath = useStore(store, (s) => s.handleNodeAddExcludedPath);
-  const handleNodeRemoveExcludedPath = useStore(store, (s) => s.handleNodeRemoveExcludedPath);
   const {
+    runStatus,
+    dimmed,
+    nodeCardMode,
+    handleFolderLabelChange,
+    handleFolderPathChange,
+    handleFolderPathInputChange,
+    handleFolderDescriptionInputChange,
+    handleNodeAddExcludedPath,
+    handleNodeRemoveExcludedPath,
     rightActivePortCount,
     rightActivePortMask,
     rightConnectedPortCount,
     rightConnectedPortMask,
     rightPortCount,
-  } = useStore(store, useShallow(selectNodePortCounts(id)));
+  } = useStore(
+    store,
+    useShallow((s) => ({
+      ...selectNodeRunState(id)(s),
+      nodeCardMode: s.nodeCardMode,
+      handleFolderLabelChange: s.handleFolderLabelChange,
+      handleFolderPathChange: s.handleFolderPathChange,
+      handleFolderPathInputChange: s.handleFolderPathInputChange,
+      handleFolderDescriptionInputChange: s.handleFolderDescriptionInputChange,
+      handleNodeAddExcludedPath: s.handleNodeAddExcludedPath,
+      handleNodeRemoveExcludedPath: s.handleNodeRemoveExcludedPath,
+      ...selectNodePortCounts(id)(s),
+    })),
+  );
   const [browserOpen, setBrowserOpen] = useState(false);
 
   const excludedPaths: string[] = Array.isArray(data.excludedPaths) ? data.excludedPaths : [];
-
-  const handleLabelChange = (v: string) => updateNodeData(id, { label: v });
-  const handleFolderPathChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    updateNodeData(id, { folderPath: e.target.value });
-  const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-    updateNodeData(id, { description: e.target.value });
 
   const handleFolderButtonClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     setBrowserOpen(true);
   };
 
-  const handleFolderSelect = (path: string) => {
-    updateNodeData(id, { folderPath: path });
-  };
-
   const handleBrowserOpenChange = (open: boolean) => {
     setBrowserOpen(open);
   };
-
-  const handleRemoveExcluded = (path: string) => handleNodeRemoveExcludedPath(id, path);
-
-  const handleAddExcluded = (path: string) => handleNodeAddExcludedPath(id, path);
 
   return (
     <div className="group relative w-fit overflow-visible">
@@ -80,14 +83,14 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
         runStatus={runStatus}
         selected={selected}
         theme="orange"
-        onLabelChange={handleLabelChange}
+        onLabelChange={handleFolderLabelChange.bind(null, id)}
       >
         <div className="flex items-center gap-1 rounded-md border border-slate-100 bg-slate-50 px-2 py-1">
           <Input
             className="nodrag nopan font-mono text-[11px] font-semibold text-slate-700 bg-transparent focus:outline-none flex-1 min-w-0 border-none shadow-none p-0 h-auto"
             placeholder="src/components/"
             value={data.folderPath}
-            onChange={handleFolderPathChange}
+            onChange={handleFolderPathInputChange.bind(null, id)}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -118,7 +121,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
                   size="icon-xs"
                   type="button"
                   variant="ghost"
-                  onClick={() => handleRemoveExcluded(ep)}
+                  onClick={handleNodeRemoveExcludedPath.bind(null, id, ep)}
                   onMouseDown={handleStopPropagation}
                 >
                   <X className="h-2.5 w-2.5" />
@@ -131,7 +134,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
         <FolderTreePreview
           excludedPaths={excludedPaths}
           folderPath={data.folderPath}
-          onExclude={handleAddExcluded}
+          onExclude={handleNodeAddExcludedPath.bind(null, id)}
         />
 
         <Textarea
@@ -139,7 +142,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
           placeholder={t("canvas.folderDescPlaceholder")}
           rows={2}
           value={data.description ?? ""}
-          onChange={handleDescriptionChange}
+          onChange={handleFolderDescriptionInputChange.bind(null, id)}
           onMouseDown={handleStopPropagation}
         />
       </NodeCard>
@@ -147,7 +150,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
       <FolderBrowserDialog
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
-        onSelect={handleFolderSelect}
+        onSelect={handleFolderPathChange.bind(null, id)}
       />
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.tsx
@@ -27,10 +27,10 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
     runStatus,
     dimmed,
     nodeCardMode,
-    handleFolderLabelChange,
-    handleFolderPathChange,
-    handleFolderPathInputChange,
-    handleFolderDescriptionInputChange,
+    handleFolderLabelChange: applyFolderLabelChange,
+    handleFolderPathChange: applyFolderPathChange,
+    handleFolderPathInputChange: applyFolderPathInputChange,
+    handleFolderDescriptionInputChange: applyFolderDescriptionInputChange,
     handleNodeAddExcludedPath,
     handleNodeRemoveExcludedPath,
     rightActivePortCount,
@@ -61,6 +61,18 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
     setBrowserOpen(true);
   };
 
+  const handleLabelChange = applyFolderLabelChange.bind(null, id);
+
+  const handleFolderSelect = applyFolderPathChange.bind(null, id);
+
+  const handleFolderPathInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    applyFolderPathInputChange(id, e.target.value);
+  };
+
+  const handleFolderDescriptionInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    applyFolderDescriptionInputChange(id, e.target.value);
+  };
+
   const handleBrowserOpenChange = (open: boolean) => {
     setBrowserOpen(open);
   };
@@ -83,14 +95,14 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
         runStatus={runStatus}
         selected={selected}
         theme="orange"
-        onLabelChange={handleFolderLabelChange.bind(null, id)}
+        onLabelChange={handleLabelChange}
       >
         <div className="flex items-center gap-1 rounded-md border border-slate-100 bg-slate-50 px-2 py-1">
           <Input
             className="nodrag nopan font-mono text-[11px] font-semibold text-slate-700 bg-transparent focus:outline-none flex-1 min-w-0 border-none shadow-none p-0 h-auto"
             placeholder="src/components/"
             value={data.folderPath}
-            onChange={handleFolderPathInputChange.bind(null, id)}
+            onChange={handleFolderPathInputChange}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -142,7 +154,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
           placeholder={t("canvas.folderDescPlaceholder")}
           rows={2}
           value={data.description ?? ""}
-          onChange={handleFolderDescriptionInputChange.bind(null, id)}
+          onChange={handleFolderDescriptionInputChange}
           onMouseDown={handleStopPropagation}
         />
       </NodeCard>
@@ -150,7 +162,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
       <FolderBrowserDialog
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
-        onSelect={handleFolderPathChange.bind(null, id)}
+        onSelect={handleFolderSelect}
       />
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/FolderNode/FolderNode.unit.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { CanvasPageStoreContext, createCanvasPageStore } from "../_store";
+import { CanvasPageStoreContext, createCanvasPageStore, type CanvasPageStore } from "../_store";
 import { FolderNode } from "./FolderNode";
 
 vi.mock("@xyflow/react", () => ({
@@ -23,8 +23,15 @@ vi.mock("@refinedev/core", () => ({
   }),
 }));
 
-const makeExpandedStore = () => {
-  const store = createCanvasPageStore();
+const makeExpandedStore = (data = baseData, id = "test"): CanvasPageStore => {
+  const store = createCanvasPageStore([
+    {
+      id,
+      type: "folder",
+      position: { x: 0, y: 0 },
+      data,
+    },
+  ]);
   store.setState({ nodeCardMode: "expanded" });
 
   return store;
@@ -60,8 +67,11 @@ describe("FolderNode", () => {
   });
 
   it("shows placeholder when folderPath is empty", () => {
+    const store = makeExpandedStore({ ...baseData, folderPath: "" });
     render(<FolderNode data={{ ...baseData, folderPath: "" }} id="test" />, {
-      wrapper,
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <CanvasPageStoreContext.Provider value={store}>{children}</CanvasPageStoreContext.Provider>
+      ),
     });
     expect(screen.getByPlaceholderText("src/components/")).toBeInTheDocument();
   });
@@ -74,6 +84,24 @@ describe("FolderNode", () => {
     render(<FolderNode data={data} id="test" />, { wrapper });
     expect(screen.getByText("node_modules")).toBeInTheDocument();
     expect(screen.getByText("dist")).toBeInTheDocument();
+  });
+
+  it("writes the typed folder path back to the store as a plain string", () => {
+    const store = makeExpandedStore();
+    render(<FolderNode data={baseData} id="test" />, {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <CanvasPageStoreContext.Provider value={store}>{children}</CanvasPageStoreContext.Provider>
+      ),
+    });
+
+    fireEvent.change(screen.getByDisplayValue("apps/app/src"), {
+      target: { value: "apps/app/components" },
+    });
+
+    const updatedNode = store.getState().nodes.find((node) => node.id === "test");
+    expect(updatedNode?.data).toEqual(
+      expect.objectContaining({ folderPath: "apps/app/components" }),
+    );
   });
 
   it("removes an excluded path when its remove button is clicked", async () => {

--- a/apps/app/src/pages/CanvasPage/GitHubProjectNode/PickLocalFolderDialog.tsx
+++ b/apps/app/src/pages/CanvasPage/GitHubProjectNode/PickLocalFolderDialog.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@repo/ui/button";
 import { Input } from "@repo/ui/input";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@repo/ui/dialog";
-import { FolderBrowser } from "@/components/FolderBrowser/FolderBrowser";
+import { FolderBrowserDialog } from "@/components/FolderBrowserDialog/FolderBrowserDialog";
 
 export interface LocalFolderInfo {
   localPath: string;
@@ -106,7 +106,7 @@ export const PickLocalFolderDialog = ({
         </DialogContent>
       </Dialog>
 
-      <FolderBrowser
+      <FolderBrowserDialog
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
         onSelect={handleFolderSelect}

--- a/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
@@ -6,7 +6,7 @@ import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
 import { NodeCard } from "../NodeCard";
-import { FolderBrowser } from "@/components/FolderBrowser/FolderBrowser";
+import { FolderBrowserDialog } from "@/components/FolderBrowserDialog/FolderBrowserDialog";
 
 export interface OutputLocalPathNodeProps {
   id: string;
@@ -157,7 +157,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
         />
       </NodeCard>
 
-      <FolderBrowser
+      <FolderBrowserDialog
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
         onSelect={handleFolderSelect}

--- a/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
@@ -7,6 +7,10 @@ import { useShallow } from "zustand/shallow";
 import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
 import { NodeCard } from "../NodeCard";
 import { FolderBrowserDialog } from "@/components/FolderBrowserDialog/FolderBrowserDialog";
+import { Button } from "@repo/ui/button";
+import { Input } from "@repo/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui/select";
+import { Textarea } from "@repo/ui/textarea";
 
 export interface OutputLocalPathNodeProps {
   id: string;
@@ -29,12 +33,12 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
     runStatus,
     dimmed,
     nodeCardMode,
-    handleOutputLocalPathLabelChange,
-    handleOutputLocalPathChange,
-    handleOutputLocalPathInputChange,
-    handleOutputLocalPathFileNameInputChange,
-    handleOutputLocalPathModeChange,
-    handleOutputLocalPathDescriptionInputChange,
+    handleOutputLocalPathLabelChange: applyOutputLocalPathLabelChange,
+    handleOutputLocalPathChange: applyOutputLocalPathChange,
+    handleOutputLocalPathInputChange: applyOutputLocalPathInputChange,
+    handleOutputLocalPathFileNameInputChange: applyOutputLocalPathFileNameInputChange,
+    handleOutputLocalPathModeChange: applyOutputLocalPathModeChange,
+    handleOutputLocalPathDescriptionInputChange: applyOutputLocalPathDescriptionInputChange,
     leftActivePortCount,
     leftActivePortMask,
     leftConnectedPortCount,
@@ -61,6 +65,28 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
     setBrowserOpen(true);
   };
 
+  const handleLabelChange = applyOutputLocalPathLabelChange.bind(null, id);
+
+  const handleFolderSelect = applyOutputLocalPathChange.bind(null, id);
+
+  const handleLocalPathInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    applyOutputLocalPathInputChange(id, e.target.value);
+  };
+
+  const handleFileNameInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    applyOutputLocalPathFileNameInputChange(id, e.target.value);
+  };
+
+  const handleOutputModeChange = (value: OutputMode | null) => {
+    if (!value) return;
+
+    applyOutputLocalPathModeChange(id, value);
+  };
+
+  const handleDescriptionInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    applyOutputLocalPathDescriptionInputChange(id, e.target.value);
+  };
+
   const handleBrowserOpenChange = (open: boolean) => {
     setBrowserOpen(open);
   };
@@ -85,41 +111,42 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
         runStatus={runStatus}
         selected={selected}
         theme="teal"
-        onLabelChange={handleOutputLocalPathLabelChange.bind(null, id)}
+        onLabelChange={handleLabelChange}
       >
         <div className="flex items-center gap-1 rounded-md border border-teal-100 bg-teal-50 px-2 py-1">
           <span className="shrink-0 text-[10px] font-medium text-teal-500">
             {t("nodes.outputLocalPathNode.pathLabel")}
           </span>
-          <input
-            className="nodrag nopan flex-1 min-w-0 bg-transparent font-mono text-[11px] font-semibold text-teal-800 focus:outline-none"
+          <Input
+            className="nodrag nopan flex-1 min-w-0 bg-transparent font-mono text-[11px] font-semibold text-teal-800 focus:outline-none border-none shadow-none p-0 h-auto"
             placeholder="/Users/you/Desktop/output"
             value={data.localPath}
-            onChange={handleOutputLocalPathInputChange.bind(null, id)}
+            onChange={handleLocalPathInputChange}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
           />
-          <button
-            className="nodrag nopan shrink-0 rounded p-0.5 text-teal-400 hover:bg-teal-100 hover:text-teal-700 transition-colors"
+          <Button
+            className="nodrag nopan shrink-0 rounded p-0.5 text-teal-400 hover:bg-teal-100 hover:text-teal-700 transition-colors h-auto"
             title={t("nodes.outputLocalPathNode.browseFolder")}
             type="button"
+            variant="ghost"
             onClick={handleFolderButtonClick}
             onMouseDown={handleStopPropagation}
           >
             <FolderOpen className="h-3.5 w-3.5" />
-          </button>
+          </Button>
         </div>
 
         <div className="flex items-center gap-1 rounded-md border border-teal-100 bg-teal-50 px-2 py-1">
           <span className="shrink-0 text-[10px] font-medium text-teal-500">
             {t("nodes.outputLocalPathNode.filenameLabel")}
           </span>
-          <input
-            className="nodrag nopan flex-1 min-w-0 bg-transparent font-mono text-[11px] font-semibold text-teal-800 focus:outline-none"
+          <Input
+            className="nodrag nopan flex-1 min-w-0 bg-transparent font-mono text-[11px] font-semibold text-teal-800 focus:outline-none border-none shadow-none p-0 h-auto"
             placeholder="output.md"
             value={data.outputFileName ?? ""}
-            onChange={handleOutputLocalPathFileNameInputChange.bind(null, id)}
+            onChange={handleFileNameInputChange}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -130,19 +157,22 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
           <span className="shrink-0 text-[10px] font-medium text-teal-500">
             {t("nodes.outputLocalPathNode.writeModeLabel")}
           </span>
-          <select
-            className="nodrag nopan flex-1 min-w-0 bg-transparent text-[11px] font-semibold text-teal-800 focus:outline-none cursor-pointer"
-            value={currentMode}
-            onChange={handleOutputLocalPathModeChange.bind(null, id)}
-            onClick={handleStopPropagation}
-            onMouseDown={handleStopPropagation}
-          >
-            {Object.values(OUTPUT_MODE_ENUM).map((mode) => (
-              <option key={mode} value={mode}>
-                {t(MODE_LABEL_KEYS[mode])}
-              </option>
-            ))}
-          </select>
+          <Select value={currentMode} onValueChange={handleOutputModeChange}>
+            <SelectTrigger
+              className="nodrag nopan h-6 flex-1 min-w-0 border-none bg-transparent px-0 py-0 text-[11px] font-semibold text-teal-800 shadow-none focus:ring-0"
+              onClick={handleStopPropagation}
+              onMouseDown={handleStopPropagation}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.values(OUTPUT_MODE_ENUM).map((mode) => (
+                <SelectItem key={mode} value={mode}>
+                  {t(MODE_LABEL_KEYS[mode])}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
 
         {currentMode === "error_if_exists" && (
@@ -152,12 +182,12 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
           </div>
         )}
 
-        <textarea
-          className="nodrag nopan text-[11px] text-slate-500 bg-transparent w-full resize-none focus:outline-none focus:bg-slate-50 focus:ring-1 focus:ring-slate-200 rounded px-1"
+        <Textarea
+          className="nodrag nopan text-[11px] text-slate-500 bg-transparent w-full resize-none focus:outline-none focus:bg-slate-50 focus:ring-1 focus:ring-slate-200 rounded px-1 border-none shadow-none min-h-0 p-0"
           placeholder={t("nodes.outputLocalPathNode.descriptionPlaceholder")}
           rows={2}
           value={data.description ?? ""}
-          onChange={handleOutputLocalPathDescriptionInputChange.bind(null, id)}
+          onChange={handleDescriptionInputChange}
           onMouseDown={handleStopPropagation}
         />
       </NodeCard>
@@ -165,7 +195,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
       <FolderBrowserDialog
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
-        onSelect={handleOutputLocalPathChange.bind(null, id)}
+        onSelect={handleFolderSelect}
       />
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
@@ -25,35 +25,40 @@ const MODE_LABEL_KEYS: Record<OutputMode, string> = {
 export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
-  const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
-  const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
-  const updateNodeData = useStore(store, (s) => s.updateNodeData);
   const {
+    runStatus,
+    dimmed,
+    nodeCardMode,
+    handleOutputLocalPathLabelChange,
+    handleOutputLocalPathChange,
+    handleOutputLocalPathInputChange,
+    handleOutputLocalPathFileNameInputChange,
+    handleOutputLocalPathModeChange,
+    handleOutputLocalPathDescriptionInputChange,
     leftActivePortCount,
     leftActivePortMask,
     leftConnectedPortCount,
     leftConnectedPortMask,
     leftPortCount,
-  } = useStore(store, useShallow(selectNodePortCounts(id)));
+  } = useStore(
+    store,
+    useShallow((s) => ({
+      ...selectNodeRunState(id)(s),
+      nodeCardMode: s.nodeCardMode,
+      handleOutputLocalPathLabelChange: s.handleOutputLocalPathLabelChange,
+      handleOutputLocalPathChange: s.handleOutputLocalPathChange,
+      handleOutputLocalPathInputChange: s.handleOutputLocalPathInputChange,
+      handleOutputLocalPathFileNameInputChange: s.handleOutputLocalPathFileNameInputChange,
+      handleOutputLocalPathModeChange: s.handleOutputLocalPathModeChange,
+      handleOutputLocalPathDescriptionInputChange: s.handleOutputLocalPathDescriptionInputChange,
+      ...selectNodePortCounts(id)(s),
+    })),
+  );
   const [browserOpen, setBrowserOpen] = useState(false);
-
-  const handleLabelChange = (v: string) => updateNodeData(id, { label: v });
-  const handleLocalPathChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    updateNodeData(id, { localPath: e.target.value });
-  const handleFileNameChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    updateNodeData(id, { outputFileName: e.target.value });
-  const handleModeChange = (e: React.ChangeEvent<HTMLSelectElement>) =>
-    updateNodeData(id, { outputMode: e.target.value as OutputMode });
-  const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-    updateNodeData(id, { description: e.target.value });
 
   const handleFolderButtonClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     setBrowserOpen(true);
-  };
-
-  const handleFolderSelect = (path: string) => {
-    updateNodeData(id, { localPath: path });
   };
 
   const handleBrowserOpenChange = (open: boolean) => {
@@ -80,7 +85,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
         runStatus={runStatus}
         selected={selected}
         theme="teal"
-        onLabelChange={handleLabelChange}
+        onLabelChange={handleOutputLocalPathLabelChange.bind(null, id)}
       >
         <div className="flex items-center gap-1 rounded-md border border-teal-100 bg-teal-50 px-2 py-1">
           <span className="shrink-0 text-[10px] font-medium text-teal-500">
@@ -90,7 +95,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
             className="nodrag nopan flex-1 min-w-0 bg-transparent font-mono text-[11px] font-semibold text-teal-800 focus:outline-none"
             placeholder="/Users/you/Desktop/output"
             value={data.localPath}
-            onChange={handleLocalPathChange}
+            onChange={handleOutputLocalPathInputChange.bind(null, id)}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -114,7 +119,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
             className="nodrag nopan flex-1 min-w-0 bg-transparent font-mono text-[11px] font-semibold text-teal-800 focus:outline-none"
             placeholder="output.md"
             value={data.outputFileName ?? ""}
-            onChange={handleFileNameChange}
+            onChange={handleOutputLocalPathFileNameInputChange.bind(null, id)}
             onClick={handleStopPropagation}
             onKeyDown={handleStopPropagation}
             onMouseDown={handleStopPropagation}
@@ -128,7 +133,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
           <select
             className="nodrag nopan flex-1 min-w-0 bg-transparent text-[11px] font-semibold text-teal-800 focus:outline-none cursor-pointer"
             value={currentMode}
-            onChange={handleModeChange}
+            onChange={handleOutputLocalPathModeChange.bind(null, id)}
             onClick={handleStopPropagation}
             onMouseDown={handleStopPropagation}
           >
@@ -152,7 +157,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
           placeholder={t("nodes.outputLocalPathNode.descriptionPlaceholder")}
           rows={2}
           value={data.description ?? ""}
-          onChange={handleDescriptionChange}
+          onChange={handleOutputLocalPathDescriptionInputChange.bind(null, id)}
           onMouseDown={handleStopPropagation}
         />
       </NodeCard>
@@ -160,7 +165,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
       <FolderBrowserDialog
         open={browserOpen}
         onOpenChange={handleBrowserOpenChange}
-        onSelect={handleFolderSelect}
+        onSelect={handleOutputLocalPathChange.bind(null, id)}
       />
     </div>
   );

--- a/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.unit.test.tsx
+++ b/apps/app/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.unit.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { CanvasPageStoreContext, createCanvasPageStore, type CanvasPageStore } from "../_store";
+import { OutputLocalPathNode } from "./OutputLocalPathNode";
+
+vi.mock("@xyflow/react", () => ({
+  Handle: () => null,
+  Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
+  ReactFlowProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  useNodeId: () => "test",
+  useUpdateNodeInternals: () => () => undefined,
+}));
+
+vi.mock("@/components/FolderBrowserDialog/FolderBrowserDialog", () => ({
+  FolderBrowserDialog: ({
+    onSelect: handleSelect,
+  }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onSelect: (path: string) => void;
+  }) => (
+    <button type="button" onClick={() => handleSelect("/workspace/from-browser")}>
+      mock-select-folder
+    </button>
+  ),
+}));
+
+const baseData = {
+  nodeType: "output-local-path" as const,
+  label: "Write Local Report",
+  localPath: "/workspace/ordine/output",
+  outputFileName: "review.md",
+  outputMode: "overwrite" as const,
+  description: "Writes the review result to a local markdown file.",
+};
+
+const makeStore = (data = baseData, id = "test"): CanvasPageStore => {
+  const store = createCanvasPageStore([
+    {
+      id,
+      type: "output-local-path",
+      position: { x: 0, y: 0 },
+      data,
+    },
+  ]);
+  store.setState({ nodeCardMode: "expanded" });
+
+  return store;
+};
+
+const makeWrapper =
+  (store: CanvasPageStore) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <CanvasPageStoreContext.Provider value={store}>{children}</CanvasPageStoreContext.Provider>
+  );
+
+describe("OutputLocalPathNode", () => {
+  it("renders the local path, file name, and description", () => {
+    render(<OutputLocalPathNode data={baseData} id="test" />, {
+      wrapper: makeWrapper(makeStore()),
+    });
+
+    expect(screen.getByDisplayValue("/workspace/ordine/output")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("review.md")).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("Writes the review result to a local markdown file."),
+    ).toBeInTheDocument();
+  });
+
+  it("writes the typed local path back to the store as a plain string", () => {
+    const store = makeStore();
+    render(<OutputLocalPathNode data={baseData} id="test" />, {
+      wrapper: makeWrapper(store),
+    });
+
+    fireEvent.change(screen.getByDisplayValue("/workspace/ordine/output"), {
+      target: { value: "/workspace/reports" },
+    });
+
+    const updatedNode = store.getState().nodes.find((node) => node.id === "test");
+    expect(updatedNode?.data).toEqual(expect.objectContaining({ localPath: "/workspace/reports" }));
+  });
+
+  it("writes the browser-selected path back to the store", async () => {
+    const user = userEvent.setup();
+    const store = makeStore();
+    render(<OutputLocalPathNode data={baseData} id="test" />, {
+      wrapper: makeWrapper(store),
+    });
+
+    await user.click(screen.getByRole("button", { name: "mock-select-folder" }));
+
+    const updatedNode = store.getState().nodes.find((node) => node.id === "test");
+    expect(updatedNode?.data).toEqual(
+      expect.objectContaining({ localPath: "/workspace/from-browser" }),
+    );
+  });
+});

--- a/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
@@ -153,41 +153,23 @@ export interface ActionsSlice {
   // File node actions
   handleFileLabelChange: (nodeId: string, label: string) => void;
   handleFilePathChange: (nodeId: string, filePath: string) => void;
-  handleFilePathInputChange: (nodeId: string, e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleFileLanguageInputChange: (nodeId: string, e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleFileDescriptionInputChange: (
-    nodeId: string,
-    e: React.ChangeEvent<HTMLTextAreaElement>,
-  ) => void;
+  handleFilePathInputChange: (nodeId: string, filePath: string) => void;
+  handleFileLanguageInputChange: (nodeId: string, language: string) => void;
+  handleFileDescriptionInputChange: (nodeId: string, description: string) => void;
 
   // Folder node actions
   handleFolderLabelChange: (nodeId: string, label: string) => void;
   handleFolderPathChange: (nodeId: string, folderPath: string) => void;
-  handleFolderPathInputChange: (nodeId: string, e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleFolderDescriptionInputChange: (
-    nodeId: string,
-    e: React.ChangeEvent<HTMLTextAreaElement>,
-  ) => void;
+  handleFolderPathInputChange: (nodeId: string, folderPath: string) => void;
+  handleFolderDescriptionInputChange: (nodeId: string, description: string) => void;
 
   // Output local path node actions
   handleOutputLocalPathLabelChange: (nodeId: string, label: string) => void;
   handleOutputLocalPathChange: (nodeId: string, localPath: string) => void;
-  handleOutputLocalPathInputChange: (
-    nodeId: string,
-    e: React.ChangeEvent<HTMLInputElement>,
-  ) => void;
-  handleOutputLocalPathFileNameInputChange: (
-    nodeId: string,
-    e: React.ChangeEvent<HTMLInputElement>,
-  ) => void;
-  handleOutputLocalPathModeChange: (
-    nodeId: string,
-    e: React.ChangeEvent<HTMLSelectElement>,
-  ) => void;
-  handleOutputLocalPathDescriptionInputChange: (
-    nodeId: string,
-    e: React.ChangeEvent<HTMLTextAreaElement>,
-  ) => void;
+  handleOutputLocalPathInputChange: (nodeId: string, localPath: string) => void;
+  handleOutputLocalPathFileNameInputChange: (nodeId: string, outputFileName: string) => void;
+  handleOutputLocalPathModeChange: (nodeId: string, outputMode: OutputMode) => void;
+  handleOutputLocalPathDescriptionInputChange: (nodeId: string, description: string) => void;
 }
 
 export const createActionsSlice = (
@@ -899,16 +881,16 @@ export const createActionsSlice = (
     get().updateNodeData(nodeId, { filePath });
   },
 
-  handleFilePathInputChange: (nodeId, e) => {
-    get().updateNodeData(nodeId, { filePath: e.target.value });
+  handleFilePathInputChange: (nodeId, filePath) => {
+    get().updateNodeData(nodeId, { filePath });
   },
 
-  handleFileLanguageInputChange: (nodeId, e) => {
-    get().updateNodeData(nodeId, { language: e.target.value });
+  handleFileLanguageInputChange: (nodeId, language) => {
+    get().updateNodeData(nodeId, { language });
   },
 
-  handleFileDescriptionInputChange: (nodeId, e) => {
-    get().updateNodeData(nodeId, { description: e.target.value });
+  handleFileDescriptionInputChange: (nodeId, description) => {
+    get().updateNodeData(nodeId, { description });
   },
 
   // ── Folder node actions ────────────────────────────────────────────────
@@ -921,12 +903,12 @@ export const createActionsSlice = (
     get().updateNodeData(nodeId, { folderPath });
   },
 
-  handleFolderPathInputChange: (nodeId, e) => {
-    get().updateNodeData(nodeId, { folderPath: e.target.value });
+  handleFolderPathInputChange: (nodeId, folderPath) => {
+    get().updateNodeData(nodeId, { folderPath });
   },
 
-  handleFolderDescriptionInputChange: (nodeId, e) => {
-    get().updateNodeData(nodeId, { description: e.target.value });
+  handleFolderDescriptionInputChange: (nodeId, description) => {
+    get().updateNodeData(nodeId, { description });
   },
 
   // ── Output local path node actions ─────────────────────────────────────
@@ -939,19 +921,19 @@ export const createActionsSlice = (
     get().updateNodeData(nodeId, { localPath });
   },
 
-  handleOutputLocalPathInputChange: (nodeId, e) => {
-    get().updateNodeData(nodeId, { localPath: e.target.value });
+  handleOutputLocalPathInputChange: (nodeId, localPath) => {
+    get().updateNodeData(nodeId, { localPath });
   },
 
-  handleOutputLocalPathFileNameInputChange: (nodeId, e) => {
-    get().updateNodeData(nodeId, { outputFileName: e.target.value });
+  handleOutputLocalPathFileNameInputChange: (nodeId, outputFileName) => {
+    get().updateNodeData(nodeId, { outputFileName });
   },
 
-  handleOutputLocalPathModeChange: (nodeId, e) => {
-    get().updateNodeData(nodeId, { outputMode: e.target.value as OutputMode });
+  handleOutputLocalPathModeChange: (nodeId, outputMode) => {
+    get().updateNodeData(nodeId, { outputMode });
   },
 
-  handleOutputLocalPathDescriptionInputChange: (nodeId, e) => {
-    get().updateNodeData(nodeId, { description: e.target.value });
+  handleOutputLocalPathDescriptionInputChange: (nodeId, description) => {
+    get().updateNodeData(nodeId, { description });
   },
 });

--- a/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
@@ -149,6 +149,22 @@ export interface ActionsSlice {
   handleOperationAgentDropdownClose: () => void;
   handleOperationAgentDropdownToggle: (nodeId: string) => void;
   handleOperationAgentDropdownOpenChange: (nodeId: string, open: boolean) => void;
+
+  // File node actions
+  handleFileLabelChange: (nodeId: string, label: string) => void;
+  handleFilePathChange: (nodeId: string, filePath: string) => void;
+  handleFilePathInputChange: (
+    nodeId: string,
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => void;
+  handleFileLanguageInputChange: (
+    nodeId: string,
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => void;
+  handleFileDescriptionInputChange: (
+    nodeId: string,
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+  ) => void;
 }
 
 export const createActionsSlice = (
@@ -848,5 +864,27 @@ export const createActionsSlice = (
 
   handleOperationAgentDropdownOpenChange: (nodeId, open) => {
     set({ operationAgentDropdownNodeId: open ? nodeId : null });
+  },
+
+  // ── File node actions ──────────────────────────────────────────────────
+
+  handleFileLabelChange: (nodeId, label) => {
+    get().updateNodeData(nodeId, { label });
+  },
+
+  handleFilePathChange: (nodeId, filePath) => {
+    get().updateNodeData(nodeId, { filePath });
+  },
+
+  handleFilePathInputChange: (nodeId, e) => {
+    get().updateNodeData(nodeId, { filePath: e.target.value });
+  },
+
+  handleFileLanguageInputChange: (nodeId, e) => {
+    get().updateNodeData(nodeId, { language: e.target.value });
+  },
+
+  handleFileDescriptionInputChange: (nodeId, e) => {
+    get().updateNodeData(nodeId, { description: e.target.value });
   },
 });

--- a/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
+++ b/apps/app/src/pages/CanvasPage/_store/actionsSlice.ts
@@ -1,6 +1,6 @@
 import { sortParentBeforeChildren, type PipelineEdge, type PipelineNode } from "./canvasSlice";
 import type { CanvasPageStoreSlice } from "./canvasPageStore";
-import type { Operation, BuiltinNodeType, Skill } from "@repo/schemas";
+import type { Operation, BuiltinNodeType, Skill, OutputMode } from "@repo/schemas";
 import type { PickedProject } from "../GitHubProjectNode/PickProjectDialog";
 import type { ConnectedRepoInfo } from "../GitHubProjectNode/GitHubConnectDialog";
 import type { LocalFolderInfo } from "../GitHubProjectNode/PickLocalFolderDialog";
@@ -153,15 +153,38 @@ export interface ActionsSlice {
   // File node actions
   handleFileLabelChange: (nodeId: string, label: string) => void;
   handleFilePathChange: (nodeId: string, filePath: string) => void;
-  handleFilePathInputChange: (
-    nodeId: string,
-    e: React.ChangeEvent<HTMLInputElement>,
-  ) => void;
-  handleFileLanguageInputChange: (
-    nodeId: string,
-    e: React.ChangeEvent<HTMLInputElement>,
-  ) => void;
+  handleFilePathInputChange: (nodeId: string, e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleFileLanguageInputChange: (nodeId: string, e: React.ChangeEvent<HTMLInputElement>) => void;
   handleFileDescriptionInputChange: (
+    nodeId: string,
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+  ) => void;
+
+  // Folder node actions
+  handleFolderLabelChange: (nodeId: string, label: string) => void;
+  handleFolderPathChange: (nodeId: string, folderPath: string) => void;
+  handleFolderPathInputChange: (nodeId: string, e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleFolderDescriptionInputChange: (
+    nodeId: string,
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+  ) => void;
+
+  // Output local path node actions
+  handleOutputLocalPathLabelChange: (nodeId: string, label: string) => void;
+  handleOutputLocalPathChange: (nodeId: string, localPath: string) => void;
+  handleOutputLocalPathInputChange: (
+    nodeId: string,
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => void;
+  handleOutputLocalPathFileNameInputChange: (
+    nodeId: string,
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => void;
+  handleOutputLocalPathModeChange: (
+    nodeId: string,
+    e: React.ChangeEvent<HTMLSelectElement>,
+  ) => void;
+  handleOutputLocalPathDescriptionInputChange: (
     nodeId: string,
     e: React.ChangeEvent<HTMLTextAreaElement>,
   ) => void;
@@ -885,6 +908,50 @@ export const createActionsSlice = (
   },
 
   handleFileDescriptionInputChange: (nodeId, e) => {
+    get().updateNodeData(nodeId, { description: e.target.value });
+  },
+
+  // ── Folder node actions ────────────────────────────────────────────────
+
+  handleFolderLabelChange: (nodeId, label) => {
+    get().updateNodeData(nodeId, { label });
+  },
+
+  handleFolderPathChange: (nodeId, folderPath) => {
+    get().updateNodeData(nodeId, { folderPath });
+  },
+
+  handleFolderPathInputChange: (nodeId, e) => {
+    get().updateNodeData(nodeId, { folderPath: e.target.value });
+  },
+
+  handleFolderDescriptionInputChange: (nodeId, e) => {
+    get().updateNodeData(nodeId, { description: e.target.value });
+  },
+
+  // ── Output local path node actions ─────────────────────────────────────
+
+  handleOutputLocalPathLabelChange: (nodeId, label) => {
+    get().updateNodeData(nodeId, { label });
+  },
+
+  handleOutputLocalPathChange: (nodeId, localPath) => {
+    get().updateNodeData(nodeId, { localPath });
+  },
+
+  handleOutputLocalPathInputChange: (nodeId, e) => {
+    get().updateNodeData(nodeId, { localPath: e.target.value });
+  },
+
+  handleOutputLocalPathFileNameInputChange: (nodeId, e) => {
+    get().updateNodeData(nodeId, { outputFileName: e.target.value });
+  },
+
+  handleOutputLocalPathModeChange: (nodeId, e) => {
+    get().updateNodeData(nodeId, { outputMode: e.target.value as OutputMode });
+  },
+
+  handleOutputLocalPathDescriptionInputChange: (nodeId, e) => {
     get().updateNodeData(nodeId, { description: e.target.value });
   },
 });

--- a/apps/app/src/pages/CanvasPage/_store/actionsSlice.unit.test.ts
+++ b/apps/app/src/pages/CanvasPage/_store/actionsSlice.unit.test.ts
@@ -11,6 +11,49 @@ const makeNode = (id: string, type: PipelineNode["type"]): PipelineNode =>
     data: { label: id, nodeType: type },
   }) as PipelineNode;
 
+const makeFileNode = (id: string): PipelineNode =>
+  ({
+    id,
+    type: "file",
+    position: { x: 0, y: 0 },
+    data: {
+      label: "main.ts",
+      nodeType: "file",
+      filePath: "src/main.ts",
+      language: "typescript",
+      description: "entry file",
+    },
+  }) as PipelineNode;
+
+const makeFolderNode = (id: string): PipelineNode =>
+  ({
+    id,
+    type: "folder",
+    position: { x: 0, y: 0 },
+    data: {
+      label: "src",
+      nodeType: "folder",
+      folderPath: "apps/app/src",
+      description: "source folder",
+      excludedPaths: [],
+    },
+  }) as PipelineNode;
+
+const makeOutputLocalPathNode = (id: string): PipelineNode =>
+  ({
+    id,
+    type: "output-local-path",
+    position: { x: 0, y: 0 },
+    data: {
+      label: "report",
+      nodeType: "output-local-path",
+      localPath: "/tmp/output",
+      outputFileName: "report.md",
+      outputMode: "overwrite",
+      description: "write report locally",
+    },
+  }) as PipelineNode;
+
 describe("canvas connection actions", () => {
   it("keeps the dragged source handle when creating a connected node", () => {
     const source = makeNode("source", "operation");
@@ -137,5 +180,55 @@ describe("canvas connection actions", () => {
 
     expect(store.getState().connectStart).toBeNull();
     expect(store.getState().connectionMenu).toBeNull();
+  });
+});
+
+describe("semantic node field actions", () => {
+  it("updates file, folder, and local output fields from plain values", () => {
+    const fileNode = makeFileNode("file-1");
+    const folderNode = makeFolderNode("folder-1");
+    const outputNode = makeOutputLocalPathNode("output-1");
+    const store = createCanvasPageStore([fileNode, folderNode, outputNode], [], null, "");
+    const state = store.getState();
+
+    expect(() =>
+      state.handleFilePathInputChange(fileNode.id, "src/next.tsx" as never),
+    ).not.toThrow();
+    expect(() =>
+      state.handleFolderPathInputChange(folderNode.id, "apps/app/components" as never),
+    ).not.toThrow();
+    expect(() =>
+      state.handleOutputLocalPathInputChange(outputNode.id, "/workspace/reports" as never),
+    ).not.toThrow();
+    expect(() =>
+      state.handleOutputLocalPathFileNameInputChange(outputNode.id, "summary.md" as never),
+    ).not.toThrow();
+    expect(() =>
+      state.handleOutputLocalPathModeChange(outputNode.id, "auto_rename" as never),
+    ).not.toThrow();
+    expect(() =>
+      state.handleOutputLocalPathDescriptionInputChange(
+        outputNode.id,
+        "store action takes plain values" as never,
+      ),
+    ).not.toThrow();
+
+    const nextState = store.getState();
+    const updatedFileNode = nextState.nodes.find((node) => node.id === fileNode.id);
+    const updatedFolderNode = nextState.nodes.find((node) => node.id === folderNode.id);
+    const updatedOutputNode = nextState.nodes.find((node) => node.id === outputNode.id);
+
+    expect(updatedFileNode?.data).toEqual(expect.objectContaining({ filePath: "src/next.tsx" }));
+    expect(updatedFolderNode?.data).toEqual(
+      expect.objectContaining({ folderPath: "apps/app/components" }),
+    );
+    expect(updatedOutputNode?.data).toEqual(
+      expect.objectContaining({
+        localPath: "/workspace/reports",
+        outputFileName: "summary.md",
+        outputMode: "auto_rename",
+        description: "store action takes plain values",
+      }),
+    );
   });
 });

--- a/apps/app/src/pages/OperationDetailPage/OperationRunPanel/OperationRunPanel.tsx
+++ b/apps/app/src/pages/OperationDetailPage/OperationRunPanel/OperationRunPanel.tsx
@@ -12,7 +12,7 @@ import { useCustom, useCustomMutation, useOne } from "@refinedev/core";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { ResourceName } from "@/integrations/refine/dataProvider";
-import { FolderBrowser } from "@/components/FolderBrowser/FolderBrowser";
+import { FolderBrowserDialog } from "@/components/FolderBrowserDialog/FolderBrowserDialog";
 import { useOperationDetailPageStore } from "../_store";
 
 type JobStatus = "queued" | "running" | "done" | "failed" | "cancelled" | "expired";
@@ -180,7 +180,7 @@ export const OperationRunPanel = ({ operationId }: OperationRunPanelProps) => {
                   <FolderOpen className="h-3.5 w-3.5" />
                 </Button>
               </div>
-              <FolderBrowser
+              <FolderBrowserDialog
                 mode="file"
                 open={isBrowserOpen}
                 onOpenChange={handleBrowserOpenChange}


### PR DESCRIPTION
## Summary
- move FileNode, CodeFileNode, FolderNode, and OutputLocalPathNode field update logic out of components and into semantic canvas store actions
- update node components to select handlers with useShallow and bind node ids directly in JSX
- keep FolderBrowserDialog usage across affected file/folder selection flows

## Review focus
- Components in this PR scope should no longer call updateNodeData directly for these node field updates
- Field and dialog callbacks should use store-level semantic handlers, with id binding via .bind(null, id)
- Business update logic should live in actionsSlice instead of component-local wrapper functions

## Checks
- Passed: targeted oxfmt check for touched Canvas node/store files
- Passed: grep scan confirmed updateNodeData remains only in actionsSlice for the reviewed nodes
- Passed: bun run test src/pages/CanvasPage/FileNode/FileNode.unit.test.tsx src/pages/CanvasPage/CodeFileNode/CodeFileNode.unit.test.tsx src/pages/CanvasPage/FolderNode/FolderNode.unit.test.tsx
- Not clean: app compile currently fails in existing OperationNode Select handler typing, unrelated to this change
- Not clean: app lint currently reports existing violations in CanvasFlow, CanvasMiniSidebar, CanvasSettingsDrawer, and related files outside this change