### PR TITLE
feat(i18n): complete English and Chinese locale files (COD-139)

### DIFF
--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -32,7 +32,11 @@
     "new": "New",
     "clear": "Clear",
     "noResults": "No matching results",
-    "generating": "Generating..."
+    "generating": "Generating...",
+    "metadata": "Metadata",
+    "createdAt": "Created",
+    "updatedAt": "Updated",
+    "clearSearch": "Clear search"
   },
   "nav": {
     "dashboard": "Dashboard",
@@ -57,7 +61,23 @@
     "preview": "Preview",
     "plugins": "Plugins",
     "agents": "Agents",
-    "logout": "Log out"
+    "logout": "Log out",
+    "groups": {
+      "assembly": "Assembly",
+      "capabilities": "Capabilities",
+      "monitor": "Monitor"
+    },
+    "items": {
+      "agents": "Agents",
+      "components": "Components",
+      "connectors": "Connectors",
+      "jobs": "Jobs",
+      "localAgents": "Local Agents",
+      "nodes": "Nodes",
+      "pipelines": "Pipelines",
+      "skills": "Skills",
+      "usage": "Usage"
+    }
   },
   "plugins": {
     "title": "Plugins",
@@ -72,7 +92,8 @@
     "noObjects": "No object types registered"
   },
   "sidebar": {
-    "user": "Ordine User"
+    "user": "Ordine User",
+    "reopen": "Show sidebar"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -105,7 +126,7 @@
     "quickActionBestPracticesSub": "View coding standards"
   },
   "jobs": {
-    "title": "Jobs Monitor",
+    "title": "Jobs",
     "running": "Running",
     "queued": "Queued",
     "done": "Done",
@@ -131,7 +152,6 @@
     "noLogs": "No logs",
     "status": "Status",
     "statusQueued": "Queued",
-    "statusRunning": "Running",
     "statusDone": "Done",
     "statusFailed": "Failed",
     "statusCancelled": "Cancelled",
@@ -149,7 +169,112 @@
     "typeCustom": "Custom",
     "typePipeline": "Pipeline",
     "inProgress": "In Progress",
-    "result": "Result"
+    "result": "Result",
+    "agentRuns": {
+      "collapse": "Collapse",
+      "showAll": "Show all ({{count}} chars)"
+    },
+    "calendar": {
+      "live": "live",
+      "nextWeek": "Next week",
+      "noEventRoutines": "no event-triggered routines",
+      "onEvent": "on {{event}}",
+      "previousWeek": "Previous week",
+      "ranLegend": "ran",
+      "schedule": "Schedule",
+      "scheduledLegend": "scheduled",
+      "thisWeek": "this week",
+      "today": "Today"
+    },
+    "drawer": {
+      "close": "Close",
+      "noSteps": "No pipeline snapshot for this job.",
+      "noTrace": "No trace yet.",
+      "openCanvas": "Open pipeline on canvas",
+      "runtime_one": "Runtime · {{count}} step",
+      "runtime_other": "Runtime · {{count}} steps",
+      "trace": "Trace"
+    },
+    "emptyBody": "Launch a run or adjust the current filters.",
+    "emptyTitle": "No jobs yet",
+    "hasRoutine": "has routine",
+    "newRoutine": "New Routine",
+    "newRun": "New Run",
+    "noMatchTitle": "No matching jobs",
+    "pickPipeline": "Schedule which pipeline?",
+    "scheduleEditor": {
+      "cancel": "Cancel",
+      "close": "Close",
+      "cronExpression": "Cron expression",
+      "cronParts": {
+        "day": "day",
+        "hour": "hour",
+        "minute": "min",
+        "month": "month",
+        "weekday": "wday"
+      },
+      "delete": "Remove routine",
+      "enabledToggle": "Enabled",
+      "event": "Event",
+      "presets": {
+        "daily": "Daily 06:00",
+        "dailyHuman": "Runs every day at 06:00",
+        "hourly": "Every hour",
+        "hourlyHuman": "Runs at minute 0 of every hour",
+        "weekdays": "Weekdays 09:00",
+        "weekdaysHuman": "Runs Mon–Fri at 09:00",
+        "weekly": "Weekly Mon",
+        "weeklyHuman": "Runs every Monday at 09:00"
+      },
+      "presetsLabel": "Presets",
+      "save": "Save schedule",
+      "summary": {
+        "cron": "Runs on cron {{cron}}",
+        "event": "Runs on every {{event}}",
+        "manual": "Runs only when you press Run"
+      },
+      "title": "Schedule",
+      "trigger": "Trigger",
+      "triggers": {
+        "cron": "Schedule",
+        "event": "On event",
+        "manual": "Manual"
+      }
+    },
+    "searchPlaceholder": "Search jobs…",
+    "statusPaused": "Paused",
+    "subtitle": "Concurrent work orders. Operate the fleet — pause, rerun, step in. The how lives on the canvas.",
+    "summary": "{{running}} running · {{queued}} queued · {{waiting}} waiting on you · {{failed}} failed",
+    "table": {
+      "actionFailed": "Action failed",
+      "actions": {
+        "cancel": "Stop",
+        "cancelDone": "Stopped {{jobId}}",
+        "pause": "Pause",
+        "pauseDone": "Paused {{jobId}}",
+        "rerun": "Re-run",
+        "rerunDone": "Re-run started",
+        "resume": "Resume",
+        "resumeDone": "Resumed {{jobId}}",
+        "review": "Review"
+      },
+      "byRoutine": "routine",
+      "headers": {
+        "actions": "Actions",
+        "cost": "Cost",
+        "duration": "Duration",
+        "job": "Job",
+        "started": "Started",
+        "status": "Status"
+      }
+    },
+    "views": {
+      "calendar": "Calendar",
+      "list": "List"
+    },
+    "typeDistillation": "Distillation",
+    "typeOperation": "Operation",
+    "typeRefinement": "Refinement"
   },
   "distillations": {
     "title": "Distillations",
@@ -289,7 +414,17 @@
     "sortCategoryAsc": "Category A → Z",
     "count": "",
     "descriptionPlaceholder": "Briefly describe what this operation does",
-    "promptPlaceholder": "You are a code review expert, please analyze the following code..."
+    "promptPlaceholder": "You are a code review expert, please analyze the following code...",
+    "editTitle": "Edit Operation",
+    "run": {
+      "inputContent": "Content",
+      "inputContentPlaceholder": "Or paste content directly...",
+      "inputPath": "File Path",
+      "inputPathPlaceholder": "/path/to/file-or-folder",
+      "run": "Run",
+      "running": "Running...",
+      "title": "Run Operation"
+    }
   },
   "pipelines": {
     "title": "Pipelines",
@@ -400,7 +535,10 @@
       "snapToGrid": {
         "label": "Snap nodes to grid",
         "description": "Align dragged nodes to the canvas grid."
-      }
+      },
+      "nodeCardMode.label": "Node card mode",
+      "nodeCardMode.compact": "Compact",
+      "nodeCardMode.expanded": "Expanded"
     },
     "workspaceSidebar": {
       "title": "Workspace"
@@ -524,7 +662,8 @@
         "removeEdge": "Remove edge: {{edgeId}}",
         "reconnectEdge": "Reconnect edge: {{edgeId}}",
         "replaceNodeData": "Replace node data: {{nodeId}}"
-      }
+      },
+      "contextReset": "The canvas changed, so the attached context was cleared."
     },
     "operationsPanel": {
       "collapse": "Collapse operations panel",
@@ -692,7 +831,9 @@
     "disclosureFull": "Tree + file contents",
     "sourceTypeGitHub": "GitHub",
     "sourceTypeLocal": "Local folder",
-    "removeExclude": "Remove exclude"
+    "removeExclude": "Remove exclude",
+    "skillOperationCreateFailed": "Failed to add skill",
+    "skillOperationCreateFailedDescription": "Could not prepare a Skill Operation for this Canvas node."
   },
   "projects": {
     "title": "GitHub Projects",
@@ -800,6 +941,30 @@
     "codeSnippetTitlePlaceholder": "e.g. Good example / Bad example"
   },
   "skills": {
+    "pageStructure": "Page Structure",
+    "pageStructureDesc": "Generate standard page Anatomy: Wrapper + Content + optional Store, ensuring clear layered page structure.",
+    "stateManagement": "State Management Store",
+    "stateManagementDesc": "Create Store based on Zustand slice pattern, including Context Provider and type-safe hooks.",
+    "daoLayer": "DAO Layer",
+    "daoLayerDesc": "Create data access objects using Drizzle ORM standards, ensuring naming, type safety and query performance.",
+    "serviceLayer": "Service Layer",
+    "serviceLayerDesc": "Create Service following tRPC + Service + DAO architecture, separating business logic from data access.",
+    "formComponent": "Form Components",
+    "formComponentDesc": "Create form components following standards, including field validation, state management and UI structure.",
+    "schemaValidation": "Schema Validation",
+    "schemaValidationDesc": "Define database tables using Drizzle ORM schema, ensuring naming, relationships and index configuration standards.",
+    "barrelExport": "Barrel Export",
+    "barrelExportDesc": "Generate and check index.ts barrel export files, ensuring all index files only do re-export.",
+    "errorHandling": "Error Handling",
+    "errorHandlingDesc": "Standardize neverthrow-based error handling, keeping errors explicit and eliminating try-catch from application code.",
+    "dbNaming": "Database Table Naming",
+    "dbNamingDesc": "Verify and correct database table definition naming standards, including table names, column names and indexes.",
+    "svgIcon": "SVG Icon Standards",
+    "svgIconDesc": "Manage SVG icons in React TypeScript projects, ensuring naming, encapsulation and export standards.",
+    "oneComponent": "One Component Per File",
+    "oneComponentDesc": "Enforce one React/Vue component per file, no multiple components in one file.",
+    "refineTrpc": "Refine tRPC Standards",
+    "refineTrpcDesc": "Access data in React components through Refine hooks via DataProvider, no direct tRPC calls.",
     "title": "Skills",
     "noSkills": "No skills found",
     "createOperation": "Create Operation",
@@ -822,7 +987,7 @@
     "createOperation.generatePipeline": "Generate Pipeline Draft",
     "createOperation.generatePipelineSuccess": "Pipeline draft created successfully",
     "createOperation.generatePipelineError": "Failed to create pipeline draft",
-    "createOperation.outputNamePlaceholder": "output name",
+    "createOperation.outputNamePlaceholder": "Output name",
     "categories": {
       "all": "All",
       "page": "Page structure",
@@ -837,7 +1002,13 @@
     "language": "Language",
     "selectLanguage": "Select language",
     "timezone": "Timezone",
-    "appearance": "Appearance",
+    "appearance": {
+      "dark": "Dark",
+      "hint": "Applies immediately and is remembered on this device.",
+      "label": "Appearance",
+      "light": "Light",
+      "system": "System"
+    },
     "sections": {
       "profile": "Profile",
       "notifications": "Notifications",
@@ -845,7 +1016,12 @@
       "language": "Language & Region",
       "security": "Security",
       "agentRuntimes": "Agent Runtimes",
-      "developer": "Developer"
+      "developer": "Developer",
+      "advanced": "Advanced",
+      "autonomy": "Autonomy",
+      "defaults": "Defaults",
+      "keyboard": "Keyboard",
+      "project": "Project"
     },
     "saveChanges": "Save changes",
     "saved": "Saved ✓",
@@ -909,6 +1085,121 @@
       "keyPathPlaceholder": "~/.ssh/id_rsa",
       "remove": "Remove",
       "empty": "No agent runtimes configured. Add one to enable remote execution."
+    },
+    "advanced": {
+      "description": "Storage, data version, and maintenance facts for this machine.",
+      "rows": {
+        "dataDirectory": {
+          "hint": "All local pipelines, runs, and conversations live here.",
+          "label": "Data directory"
+        },
+        "localMode": {
+          "hint": "Start flag that bypasses login for local development.",
+          "label": "Local mode"
+        },
+        "schemaVersion": {
+          "hint": "Latest applied local database migration.",
+          "label": "Schema version"
+        }
+      },
+      "title": "Advanced"
+    },
+    "autonomy": {
+      "decrease": "Fewer retries",
+      "description": "How far self-heal goes before stopping and explaining.",
+      "deviceScope": "Stored on this device and sent with each run.",
+      "increase": "More retries",
+      "selfHeal": "Self-heal retries",
+      "selfHealHint": "How many rounds the engine retries a failing step before it stops. 0 = stop on first failure.",
+      "title": "Autonomy"
+    },
+    "defaults": {
+      "apiKey": "API key",
+      "apiKeyHint": "Stored locally and masked in the UI.",
+      "description": "What the Agent Bar reaches for first when assembling an executor.",
+      "model": "Default model",
+      "outputPath": "Default output path",
+      "runtime": "Default Local Agent",
+      "runtimeFix": "Switch to {{name}}",
+      "runtimeFixed": "Default runtime switched to {{name}}",
+      "runtimeInvalid": "Saved runtime “{{value}}” is not detected on this machine — Agent requests will fail until you pick a detected one.",
+      "save": "Save defaults",
+      "saveFailed": "Couldn't save defaults",
+      "saved": "Defaults saved",
+      "title": "Defaults",
+      "toggleKey": "Toggle key visibility"
+    },
+    "groups": {
+      "data": "Data",
+      "execution": "Execution",
+      "workspace": "Workspace"
+    },
+    "keyboard": {
+      "description": "Canvas shortcuts. Read-only for now.",
+      "groups": {
+        "editing": "Editing",
+        "navigation": "Navigation"
+      },
+      "shortcuts": {
+        "boxSelect": {
+          "keys": "drag on canvas",
+          "label": "Box-select"
+        },
+        "delete": {
+          "keys": "⌫ / Del",
+          "label": "Delete selection"
+        },
+        "drillOut": {
+          "keys": "Esc",
+          "label": "Drill out / clear selection"
+        },
+        "pan": {
+          "keys": "middle-drag",
+          "label": "Pan"
+        },
+        "redo": {
+          "keys": "⌘ ⇧ Z",
+          "label": "Redo"
+        },
+        "undo": {
+          "keys": "⌘ Z",
+          "label": "Undo"
+        },
+        "zoom": {
+          "keys": "⌘ scroll",
+          "label": "Zoom"
+        }
+      },
+      "title": "Keyboard"
+    },
+    "notifications": {
+      "description": "What gets pushed to the notification center, what stays silent.",
+      "done": "Run completed",
+      "doneHint": "A job you started finishes clean.",
+      "failed": "Run failed",
+      "failedHint": "Always worth knowing — includes runs started by a routine.",
+      "title": "Notifications",
+      "waiting": "Waiting on you",
+      "waitingHint": "A run paused for sign-off or a question."
+    },
+    "project": {
+      "clearCancel": "Cancel",
+      "clearConfirm": "Clear history",
+      "clearConfirmBody": "All saved Agent threads across pipelines will be removed. Pipelines, operations and runs are kept.",
+      "clearConfirmTitle": "Clear conversation history?",
+      "clearDone": "Conversation history cleared",
+      "clearFailed": "Failed to clear history",
+      "clearHistory": "Clear conversation history",
+      "clearHistoryHint": "Removes saved Agent threads. Pipelines are kept.",
+      "description": "Name and description for the workspace selected in the sidebar.",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "What this workspace is for…",
+      "empty": "No project selected yet — create one from the sidebar.",
+      "name": "Project name",
+      "save": "Save project",
+      "saveFailed": "Couldn't save the project",
+      "saved": "Project saved",
+      "title": "Project"
     }
   },
   "runtimes": {
@@ -943,7 +1234,11 @@
     "save": "Save",
     "saved": "Saved",
     "delete": "Delete",
-    "confirmDelete": "Confirm Delete"
+    "confirmDelete": "Confirm Delete",
+    "confirmSync": "Sync changes",
+    "noChanges": "No runtime changes detected.",
+    "scanResults": "Runtime scan results",
+    "scanResultsDescription": "Review detected runtime changes before syncing."
   },
   "errors": {
     "notFound": "Page not found",
@@ -977,7 +1272,14 @@
       "maxLoopCountAria": "Maximum loop count",
       "acceptanceCondition": "Acceptance condition",
       "loopConditionAria": "Loop acceptance condition",
-      "loopConditionPlaceholder": "Describe what the output must satisfy..."
+      "loopConditionPlaceholder": "Describe what the output must satisfy...",
+      "statusCancelled": "Cancelled",
+      "statusDone": "Done",
+      "statusFailed": "Failed",
+      "statusQueued": "Queued",
+      "statusRetrying": "Retrying",
+      "statusSkipped": "Skipped",
+      "statusWaitingForUser": "Waiting for you"
     },
     "outputLocalPath": {
       "label": "Path",
@@ -1071,32 +1373,6 @@
     "projectListEmpty": "Project library is empty. Connect a GitHub repository from the Projects page first.",
     "projectListNoResults": "No matching projects"
   },
-  "skills": {
-    "pageStructure": "Page Structure",
-    "pageStructureDesc": "Generate standard page Anatomy: Wrapper + Content + optional Store, ensuring clear layered page structure.",
-    "stateManagement": "State Management Store",
-    "stateManagementDesc": "Create Store based on Zustand slice pattern, including Context Provider and type-safe hooks.",
-    "daoLayer": "DAO Layer",
-    "daoLayerDesc": "Create data access objects using Drizzle ORM standards, ensuring naming, type safety and query performance.",
-    "serviceLayer": "Service Layer",
-    "serviceLayerDesc": "Create Service following tRPC + Service + DAO architecture, separating business logic from data access.",
-    "formComponent": "Form Components",
-    "formComponentDesc": "Create form components following standards, including field validation, state management and UI structure.",
-    "schemaValidation": "Schema Validation",
-    "schemaValidationDesc": "Define database tables using Drizzle ORM schema, ensuring naming, relationships and index configuration standards.",
-    "barrelExport": "Barrel Export",
-    "barrelExportDesc": "Generate and check index.ts barrel export files, ensuring all index files only do re-export.",
-    "errorHandling": "Error Handling",
-    "errorHandlingDesc": "Standardize neverthrow-based error handling, keeping errors explicit and eliminating try-catch from application code.",
-    "dbNaming": "Database Table Naming",
-    "dbNamingDesc": "Verify and correct database table definition naming standards, including table names, column names and indexes.",
-    "svgIcon": "SVG Icon Standards",
-    "svgIconDesc": "Manage SVG icons in React TypeScript projects, ensuring naming, encapsulation and export standards.",
-    "oneComponent": "One Component Per File",
-    "oneComponentDesc": "Enforce one React/Vue component per file, no multiple components in one file.",
-    "refineTrpc": "Refine tRPC Standards",
-    "refineTrpcDesc": "Access data in React components through Refine hooks via DataProvider, no direct tRPC calls."
-  },
   "time": {
     "minutesAgo": "{{minutes}} minutes ago",
     "hoursAgo": "{{hours}} hours ago",
@@ -1111,8 +1387,439 @@
     "noPipelines": "No Pipelines yet",
     "createPipeline": "Create one",
     "objectsCount": "{{count}} objects",
-    "noPipelineSelected": "\u2014 No pipeline selected",
-    "entireProject": "Entire project"
+    "noPipelineSelected": "— No pipeline selected",
+    "entireProject": "Entire project",
+    "canvas": {
+      "edges": {
+        "defaultLabel": "data"
+      },
+      "empty": {
+        "description": "Start with a node, then connect inputs, operations, and outputs into a runnable pipeline.",
+        "seed": "Seed node",
+        "seedLabel": "Starter prompt",
+        "title": "Start with a node..."
+      },
+      "nodes": {
+        "actions": {
+          "configure": "Configure node",
+          "delete": "Delete node",
+          "duplicate": "Duplicate node",
+          "ask": "Ask the Agent about this node",
+          "openThread": "Open this node's thread"
+        },
+        "compound": {
+          "childCount_one": "{{count}} child node",
+          "childCount_other": "{{count}} child nodes",
+          "openHint": "Double-click to open inside"
+        },
+        "file": {
+          "input": "File input",
+          "noFileSelected": "No file selected"
+        },
+        "folder": {
+          "input": "Folder input",
+          "noFolderSelected": "No folder selected"
+        },
+        "github": {
+          "detail": "GitHub"
+        },
+        "kind": {
+          "compound": "{{kind}} compound",
+          "custom": "custom",
+          "file": "File",
+          "folder": "Folder",
+          "github": "GitHub project",
+          "operation": "Operation",
+          "output": "Output",
+          "port": "Port",
+          "prompt": "Prompt"
+        },
+        "operation": {
+          "generatorDetail": "Draft candidate",
+          "generatorKind": "Generator",
+          "loopMax": "Loop · max {{count}}",
+          "qualityGateDetail": "Pass / revise",
+          "qualityGateKind": "Gate",
+          "verifierDetail": "Review criteria",
+          "verifierKind": "Verifier"
+        },
+        "output": {
+          "compoundOutput": "Compound output",
+          "localOutput": "Local output",
+          "projectOutput": "Project output"
+        },
+        "ports": {
+          "left": "Input port {{index}}",
+          "right": "Output port {{index}}"
+        },
+        "preview": {
+          "modified": "edited",
+          "new": "new",
+          "reuse": "reused"
+        },
+        "prompt": {
+          "compoundInput": "Compound input",
+          "empty": "Empty prompt",
+          "input": "Prompt input"
+        },
+        "status": {
+          "cancelled": "Cancelled",
+          "done": "Completed",
+          "failed": "Needs attention",
+          "idle": "Ready",
+          "queued": "Queued",
+          "retrying": "Retrying",
+          "running": "Working...",
+          "skipped": "Skipped",
+          "waitingForUser": "Checkpoint · review"
+        }
+      },
+      "chrome": {
+        "breadcrumb": {
+          "agent": "Agent",
+          "compoundFallback": "Compound",
+          "drillOut": "Drill out",
+          "renameTitle": "Click to rename"
+        },
+        "run": {
+          "noRunnableNodes": "Add an operation node to run",
+          "rerun": "Re-run",
+          "run": "Run",
+          "startFailed": "Couldn't start the run",
+          "started": "Run started",
+          "startedDescription": "Job {{jobId}} is running",
+          "stop": "Stop",
+          "stopFailed": "Couldn't stop the run",
+          "stopped": "Run stopped"
+        },
+        "states": {
+          "cancelled": "Cancelled",
+          "done": "Done",
+          "failed": "Failed",
+          "idle": "Idle",
+          "queued": "Queued",
+          "retrying": "Retrying",
+          "running": "Running",
+          "skipped": "Skipped",
+          "title": "Node run states",
+          "trigger": "States",
+          "waitingForUser": "Awaiting you"
+        },
+        "version": {
+          "current": "current",
+          "history": "History",
+          "overwrite": "Overwrite v{{version}}",
+          "saveAsNew": "Save as new version",
+          "saveAsNewSuccess": "Saved as v{{version}}",
+          "saveChanges": "Save changes",
+          "saveFailed": "Save failed",
+          "saveSuccess": "Saved over v{{version}}",
+          "saved": "saved",
+          "state": {
+            "done": "completed",
+            "draft": "draft",
+            "running": "running"
+          },
+          "unsaved": "unsaved"
+        },
+        "toolbar": {
+          "pan": "Pan",
+          "resetView": "Reset view",
+          "select": "Select / box-select",
+          "zoomIn": "Zoom in",
+          "zoomOut": "Zoom out"
+        },
+        "components": {
+          "emptyGroup": "Nothing here yet",
+          "groups": {
+            "compound": "Compound",
+            "inputObjects": "Input Objects",
+            "operations": "Operations",
+            "output": "Output"
+          },
+          "hint": "Click to drop on canvas, or drag one in.",
+          "items": {
+            "council": "Council",
+            "delegation": "Delegation",
+            "file": "File",
+            "folder": "Folder",
+            "github-project": "GitHub Project",
+            "output-local-path": "Local Path",
+            "output-project-path": "Project Path",
+            "prompt": "Prompt",
+            "verify": "Verify"
+          },
+          "trigger": "Components"
+        }
+      },
+      "nodeConfig": {
+        "checkpoint": {
+          "afterStep": "after this step finishes",
+          "pauseForReview": "Pause for review",
+          "title": "Checkpoint"
+        },
+        "close": "Close",
+        "done": "Done",
+        "editable": "editable",
+        "executor": {
+          "defaultRuntime": "Default runtime",
+          "hint": "Runtime and skill choices are saved on the node override.",
+          "noSkill": "No skill override",
+          "operationOnly": "Executors apply to operation nodes.",
+          "runtime": "Runtime",
+          "skill": "Skill",
+          "title": "Executor"
+        },
+        "io": {
+          "inputs": "Inputs",
+          "noInputs": "No incoming data.",
+          "noOutputs": "No outgoing data.",
+          "outputs": "Outputs",
+          "title": "Input / Output"
+        },
+        "lastRun": {
+          "noOutput": "No run output yet.",
+          "output": "Output",
+          "status": "Status",
+          "title": "Status · last run"
+        },
+        "prompt": {
+          "loopCondition": "Loop condition prompt",
+          "promptText": "Prompt text",
+          "title": "Prompt / Instruction",
+          "unavailable": "This node does not expose a prompt."
+        },
+        "reset": "Reset"
+      },
+      "edgeInspector": {
+        "clear": "Clear",
+        "close": "Close",
+        "condition": "Condition",
+        "deleteEdge": "Delete edge",
+        "dropped": "dropped",
+        "flow": "Flow",
+        "maxRetries": "Max retries",
+        "noMappings": "New connection · fields are inferred at run time.",
+        "noTransform": "No transform steps.",
+        "onFail": "On fail",
+        "qualityGate": "Quality Gate",
+        "qualityPlaceholder": "non-empty or required text",
+        "sourceField": "Source field",
+        "targetInput": "Target input",
+        "title": "Data Contract",
+        "toggleHint": "Tap a field to toggle whether it flows downstream · {{enabled}}/{{total}} on",
+        "transform": "Transform"
+      },
+      "compose": {
+        "askSelection": "Ask about selection",
+        "compose": "Compose into compound",
+        "defaultLabel": "Compound step",
+        "drillHint": "Inside compound · changes here write back to the parent pipeline. Esc to drill out.",
+        "selected_one": "{{count}} selected",
+        "selected_other": "{{count}} selected"
+      },
+      "run": {
+        "approveContinue": "Approve & continue",
+        "checkpointBody": "This step is marked as a checkpoint. Approve to let the run continue, or edit the step before resuming.",
+        "checkpointNext": "The run is holding until you decide.",
+        "checkpointSubtitle": "Paused after {{node}} · the run is holding",
+        "checkpointTitle": "Checkpoint · review before continuing",
+        "consoleTitle": "Run console",
+        "dismiss": "Dismiss",
+        "editStep": "Edit step",
+        "lines_one": "{{count}} line",
+        "lines_other": "{{count}} lines",
+        "notifications": {
+          "cancelled": "Run cancelled — {{title}}",
+          "done": "Run completed — {{title}}",
+          "expired": "Run expired — {{title}}",
+          "failed": "Run failed — {{title}}"
+        },
+        "resumeFailed": "Couldn't resume the run",
+        "resumed": "Checkpoint approved — continuing",
+        "waiting": "Waiting for the first step…"
+      },
+      "ask": {
+        "cancel": "Cancel",
+        "hint": "Adds a node-anchored message to the Agent conversation.",
+        "placeholder": "Tell the Agent what to change here…",
+        "send": "Send to Agent",
+        "title": "Ask about {{node}}"
+      }
+    },
+    "agentBar": {
+      "actionTitles": {
+        "addEdge": "Add edge",
+        "addNode": "Add {{nodeType}}",
+        "reconnectEdge": "Reconnect edge",
+        "removeEdge": "Remove edge",
+        "removeNode": "Remove node",
+        "replaceNodeData": "Update node"
+      },
+      "applied": {
+        "hint": "Applied — the nodes are on the canvas, yours to edit. Click any node to reference it here, or hit Run."
+      },
+      "checkpoint": {
+        "controls": "Run controls",
+        "nextNode": "next node",
+        "pause": "Pause",
+        "resume": "Resume",
+        "review": "Review",
+        "waiting": "Checkpoint · paused at {{node}}"
+      },
+      "collapse": "Collapse Agent Bar",
+      "composer": {
+        "attach": "Add attachments",
+        "attachMenu": {
+          "files": "Attach files",
+          "folder": "Attach folder"
+        },
+        "messageLabel": "Message",
+        "nameOnly": "name only",
+        "nameOnlyHint": "Binary file — only the filename is shared with the agent.",
+        "placeholder": "Describe a goal, drop a sample, or revise...",
+        "placeholderWithRefs": "Ask the Agent to change the referenced nodes...",
+        "removeAttachment": "Remove {{name}}",
+        "reverseDefault": "Reverse-engineer a pipeline from the attached sample: {{names}}",
+        "send": "Send message"
+      },
+      "context": {
+        "footer": {
+          "editing": "Window budget selects by state · editing prioritizes Canvas / selection.",
+          "running": "Window budget selects by state · run-time prioritizes Run / runtime."
+        },
+        "itemCount_one": "{{count}} item",
+        "itemCount_other": "{{count}} items",
+        "items": {
+          "annotations": "Canvas annotations",
+          "annotationsWith": "Canvas annotations · {{count}}",
+          "memory": "Memory summary",
+          "nodeRuntime": "Node runtime",
+          "project": "Project info",
+          "runState": "Run state",
+          "selection": "Selection",
+          "selectionWith": "Selection · {{refs}}",
+          "snapshot": "Pipeline snapshot",
+          "thread": "Conversation thread"
+        },
+        "rules": {
+          "always": "always",
+          "notImplemented": "not yet",
+          "runtime": "run-time priority",
+          "whenPresent": "when present",
+          "whenSelected": "when selected",
+          "windowed": "windowed"
+        },
+        "summary": {
+          "annotations": "+ annotations",
+          "default": "canvas + thread",
+          "running": "prioritizing run + runtime",
+          "selection": "+ selection"
+        },
+        "title": "Context"
+      },
+      "empty": {
+        "intro": "New canvas — tell me what to make, or drop a finished sample and I'll reverse-engineer the pipeline behind it.",
+        "suggestChangelog": "Summarize a GitHub repo into a changelog",
+        "suggestQuiz": "Turn my textbook PDFs into a Notion quiz",
+        "suggestReverse": "Upload a finished sample → reverse-engineer it"
+      },
+      "error": {
+        "tryPrefix": "Try:"
+      },
+      "errors": {
+        "AGENT_FAILED": "The local agent did not respond. It may not be running or is misconfigured — retry, or check the agent runtime.",
+        "BAD_AGENT_OUTPUT": "The agent responded, but I could not turn it into a valid proposal. This is usually transient — please retry.",
+        "INVALID_SNAPSHOT": "The canvas state could not be read. Reload the page and try again.",
+        "RUNTIME_NOT_FOUND": "The configured agent runtime is not available on this machine, so I cannot draft proposals. Pick a detected runtime in Settings → Defaults.",
+        "actions": {
+          "openSettings": "Open Settings",
+          "retry": "Retry"
+        },
+        "proposalDropped": "(The drafted proposal failed validation and was discarded — ask me to try again.)"
+      },
+      "messageActions": {
+        "copied": "Copied",
+        "copy": "Copy",
+        "edit": "Edit",
+        "retry": "Retry"
+      },
+      "proposal": {
+        "actionCount_one": "{{count}} graph action",
+        "actionCount_other": "{{count}} graph actions",
+        "apply": "Apply",
+        "askFix": "Ask agent to fix",
+        "blocked": "Resolve diagnostics before applying",
+        "loopBadge": "loop ×{{count}}",
+        "newOperationBadge": "new op",
+        "reject": "Reject",
+        "revise": "Revise"
+      },
+      "refChipTitle": "Hover to highlight · click to focus on canvas",
+      "removeRef": "Remove {{label}}",
+      "reopen": "Open Agent Bar",
+      "replies": {
+        "appliedNotSaved": "I applied the proposal locally, but could not save it yet.",
+        "appliedSaved": "Applied the proposal and saved the pipeline.",
+        "drafted": "I drafted a pipeline proposal.",
+        "fixRequest": "Please fix the validation errors in the proposal and submit a corrected version.",
+        "missingInputSource": "Heads up — this pipeline has no input source yet. Click the first node to configure its input, or tell me e.g. \"add a folder input\" and I will wire one in before you run.",
+        "noSafeChange": "I could not find a safe graph change for that request.",
+        "rejected": "Rejected the current proposal.",
+        "rejectedWithProposal": "Rejected the proposal “{{summary}}”.",
+        "requestFailed": "I could not reach the agent to draft a proposal. Please try again.",
+        "reviseHint": "Tell me what to revise and I will draft a new proposal.",
+        "reviseHintWithProposal": "Withdrew the proposal “{{summary}}”. Tell me what to revise and I will draft a new one."
+      },
+      "reversing": {
+        "intro": "Reading the sample — inferring the steps that produce it.",
+        "steps": {
+          "draft": "Drafting pipeline",
+          "draftDetail": "assembling nodes and edges",
+          "matched": "Matched components",
+          "matchedDetail": "reusable from your library",
+          "steps": "Inferred steps",
+          "stepsDetail": "parse → generate → verify → export",
+          "structure": "Read structure",
+          "structureDetail": "format, sections, citations"
+        }
+      },
+      "stages": {
+        "analyzing": "Analyzing the sample…",
+        "done": "Wrapping up…",
+        "drafting": "Drafting the proposal…",
+        "thinking": "Reading your request…",
+        "validating": "Validating the proposal…"
+      },
+      "subtitle": {
+        "applied": "Reading · canvas",
+        "clarify": "Reading · goal",
+        "done": "Run complete · asset saved",
+        "empty": "New canvas · no pipeline yet",
+        "proposal": "Drafting · proposal ready",
+        "refsSelected_one": "{{count}} reference selected",
+        "refsSelected_other": "{{count}} references selected",
+        "reversing": "Reading · sample",
+        "running": "Watching · live",
+        "watching": "Watching · {{jobId}} · live"
+      },
+      "thinking": "Thinking…",
+      "thread": {
+        "emptyBody": "All annotations on this node are resolved.",
+        "emptyTitle": "No open notes here",
+        "resolve": "Resolve",
+        "showAll": "Show all",
+        "title": "Thread"
+      },
+      "title": "Agent",
+      "userAction": {
+        "askAgent": "Ask agent",
+        "askDraft": "The executor needs something on node {{node}}: {{message}} — please handle it or tell me what to do.",
+        "openConfig": "Open node config",
+        "title": "Action needed ({{count}})"
+      }
+    },
+    "notFoundPipeline": "Pipeline not found"
   },
   "validation": {
     "nameRequired": "Name is required",
@@ -1147,6 +1854,28 @@
       "cancel": "Cancel",
       "save": "Save",
       "create": "Create"
+    }
+  },
+  "notifications": {
+    "clear": "Clear all",
+    "emptyBody": "Run, self-heal & connector events show here.",
+    "emptyTitle": "All clear",
+    "markRead": "Mark read",
+    "open": "open",
+    "title": "Notifications"
+  },
+  "components": {
+    "findForMe": {
+      "assetFallback": "Reusable pipeline asset",
+      "close": "Close",
+      "empty": "Nothing distilled yet — run a pipeline to grow the library.",
+      "intro": "Most reusable assets, ranked by how often they ran:",
+      "ranking": "Ranking by reuse and relevance",
+      "searching": "Searching your library…",
+      "subtitle": "The Agent scans your component library",
+      "title": "Find for me",
+      "usedTimes_one": "ran {{count}}×",
+      "usedTimes_other": "ran {{count}}×"
     }
   }
 }

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -35,7 +35,8 @@
     "metadata": "元数据",
     "createdAt": "创建时间",
     "updatedAt": "更新时间",
-    "generating": "生成中..."
+    "generating": "生成中...",
+    "clearSearch": "清除搜索"
   },
   "nav": {
     "dashboard": "仪表盘",
@@ -60,7 +61,23 @@
     "preview": "预览",
     "plugins": "插件",
     "agents": "智能体",
-    "logout": "退出登录"
+    "logout": "退出登录",
+    "groups": {
+      "assembly": "装配",
+      "capabilities": "能力",
+      "monitor": "监控"
+    },
+    "items": {
+      "agents": "智能体",
+      "components": "组件",
+      "connectors": "连接器",
+      "jobs": "工单",
+      "localAgents": "本地智能体",
+      "nodes": "节点",
+      "pipelines": "流水线",
+      "skills": "技能",
+      "usage": "用量"
+    }
   },
   "plugins": {
     "title": "插件",
@@ -75,7 +92,8 @@
     "noObjects": "暂无已注册的对象类型"
   },
   "sidebar": {
-    "user": "Ordine 用户"
+    "user": "Ordine 用户",
+    "reopen": "展开侧栏"
   },
   "dashboard": {
     "title": "仪表盘",
@@ -108,7 +126,7 @@
     "quickActionBestPracticesSub": "查看编码规范"
   },
   "jobs": {
-    "title": "Jobs 监控",
+    "title": "工单",
     "running": "运行中",
     "queued": "排队中",
     "done": "已完成",
@@ -134,7 +152,6 @@
     "noLogs": "暂无日志",
     "status": "状态",
     "statusQueued": "排队中",
-    "statusRunning": "运行中",
     "statusDone": "完成",
     "statusFailed": "失败",
     "statusCancelled": "已取消",
@@ -152,7 +169,112 @@
     "typeCustom": "自定义",
     "typePipeline": "Pipeline",
     "inProgress": "进行中",
-    "result": "执行结果"
+    "result": "执行结果",
+    "agentRuns": {
+      "collapse": "收起",
+      "showAll": "展开全部（{{count}} 字符）"
+    },
+    "calendar": {
+      "live": "实时",
+      "nextWeek": "下一周",
+      "noEventRoutines": "暂无事件触发的 Routine",
+      "onEvent": "{{event}} 触发",
+      "previousWeek": "上一周",
+      "ranLegend": "已运行",
+      "schedule": "排程",
+      "scheduledLegend": "已排期",
+      "thisWeek": "本周",
+      "today": "今天"
+    },
+    "drawer": {
+      "close": "关闭",
+      "noSteps": "该工单没有 Pipeline 快照。",
+      "noTrace": "暂无日志。",
+      "openCanvas": "在画布中打开 Pipeline",
+      "runtime_one": "运行时 · {{count}} 步",
+      "runtime_other": "运行时 · {{count}} 步",
+      "trace": "日志"
+    },
+    "emptyBody": "发起一次运行，或调整当前筛选。",
+    "emptyTitle": "还没有工单",
+    "hasRoutine": "已有 Routine",
+    "newRoutine": "新建 Routine",
+    "newRun": "新建运行",
+    "noMatchTitle": "没有匹配的工单",
+    "pickPipeline": "为哪条 Pipeline 排程？",
+    "scheduleEditor": {
+      "cancel": "取消",
+      "close": "关闭",
+      "cronExpression": "Cron 表达式",
+      "cronParts": {
+        "day": "日",
+        "hour": "时",
+        "minute": "分",
+        "month": "月",
+        "weekday": "周"
+      },
+      "delete": "移除 Routine",
+      "enabledToggle": "启用",
+      "event": "事件",
+      "presets": {
+        "daily": "每天 06:00",
+        "dailyHuman": "每天 06:00 运行",
+        "hourly": "每小时",
+        "hourlyHuman": "每小时的第 0 分钟运行",
+        "weekdays": "工作日 09:00",
+        "weekdaysHuman": "周一至周五 09:00 运行",
+        "weekly": "每周一",
+        "weeklyHuman": "每周一 09:00 运行"
+      },
+      "presetsLabel": "预设",
+      "save": "保存排程",
+      "summary": {
+        "cron": "按 cron {{cron}} 运行",
+        "event": "每次 {{event}} 时运行",
+        "manual": "仅在你点击 Run 时运行"
+      },
+      "title": "排程",
+      "trigger": "触发方式",
+      "triggers": {
+        "cron": "定时",
+        "event": "事件触发",
+        "manual": "手动"
+      }
+    },
+    "searchPlaceholder": "搜索工单…",
+    "statusPaused": "已暂停",
+    "subtitle": "并发工单控制台。指挥机群 — 暂停、重跑、随时介入。执行细节在画布上看。",
+    "summary": "{{running}} 运行中 · {{queued}} 排队 · {{waiting}} 等待你 · {{failed}} 失败",
+    "table": {
+      "actionFailed": "操作失败",
+      "actions": {
+        "cancel": "停止",
+        "cancelDone": "已停止 {{jobId}}",
+        "pause": "暂停",
+        "pauseDone": "已暂停 {{jobId}}",
+        "rerun": "重新运行",
+        "rerunDone": "已发起重跑",
+        "resume": "继续",
+        "resumeDone": "已继续 {{jobId}}",
+        "review": "去处理"
+      },
+      "byRoutine": "routine",
+      "headers": {
+        "actions": "操作",
+        "cost": "花费",
+        "duration": "耗时",
+        "job": "工单",
+        "started": "开始",
+        "status": "状态"
+      }
+    },
+    "views": {
+      "calendar": "日历",
+      "list": "列表"
+    },
+    "typeDistillation": "蒸馏",
+    "typeOperation": "Operation",
+    "typeRefinement": "精炼"
   },
   "distillations": {
     "title": "蒸馏",
@@ -289,7 +411,20 @@
     "sortCategoryAsc": "分类 A → Z",
     "count": "个",
     "descriptionPlaceholder": "简单描述这个操作做什么",
-    "promptPlaceholder": "你是一个代码审查专家，请分析以下代码..."
+    "promptPlaceholder": "你是一个代码审查专家，请分析以下代码...",
+    "applicableObjects": "适用对象",
+    "systemPrompt": "系统提示词",
+    "editTitle": "编辑 Operation",
+    "executorLabel": "执行方式",
+    "run": {
+      "inputContent": "内容",
+      "inputContentPlaceholder": "或直接粘贴内容...",
+      "inputPath": "文件路径",
+      "inputPathPlaceholder": "/path/to/file-or-folder",
+      "run": "运行",
+      "running": "运行中...",
+      "title": "运行 Operation"
+    }
   },
   "pipelines": {
     "title": "流水线",
@@ -400,7 +535,10 @@
       "snapToGrid": {
         "label": "节点吸附到网格",
         "description": "拖动节点时对齐到画布网格。"
-      }
+      },
+      "nodeCardMode.label": "节点卡片模式",
+      "nodeCardMode.compact": "紧凑",
+      "nodeCardMode.expanded": "展开"
     },
     "workspaceSidebar": {
       "title": "工作区"
@@ -524,7 +662,8 @@
         "removeEdge": "删除连线: {{edgeId}}",
         "reconnectEdge": "重连连线: {{edgeId}}",
         "replaceNodeData": "替换节点数据: {{nodeId}}"
-      }
+      },
+      "contextReset": "画布已变更，已清除附加的上下文。"
     },
     "operationsPanel": {
       "collapse": "收起操作面板",
@@ -692,7 +831,9 @@
     "disclosureFull": "目录结构 + 文件内容",
     "sourceTypeGitHub": "GitHub",
     "sourceTypeLocal": "本地文件夹",
-    "removeExclude": "移除排除"
+    "removeExclude": "移除排除",
+    "skillOperationCreateFailed": "添加 Skill 失败",
+    "skillOperationCreateFailedDescription": "无法为该 Canvas 节点准备 Skill Operation。"
   },
   "projects": {
     "title": "GitHub 项目",
@@ -800,7 +941,31 @@
     "codeSnippetTitlePlaceholder": "例如：正确示例 / 错误示例"
   },
   "skills": {
-    "title": "技能",
+    "pageStructure": "页面结构",
+    "pageStructureDesc": "生成标准的页面 Anatomy：Wrapper + Content + 可选 Store，确保页面结构清晰分层。",
+    "stateManagement": "状态管理 Store",
+    "stateManagementDesc": "基于 Zustand slice 模式创建 Store，包含 Context Provider 和类型安全的 hook。",
+    "daoLayer": "DAO 层",
+    "daoLayerDesc": "使用 Drizzle ORM 规范创建数据访问对象，确保命名、类型安全和查询性能。",
+    "serviceLayer": "Service 层",
+    "serviceLayerDesc": "按照 tRPC + Service + DAO 架构创建 Service，分离业务逻辑与数据访问。",
+    "formComponent": "表单组件",
+    "formComponentDesc": "创建符合规范的表单组件，包含字段验证、状态管理和 UI 结构。",
+    "schemaValidation": "Schema 校验",
+    "schemaValidationDesc": "使用 Drizzle ORM schema 定义数据库表，确保命名、关系和索引配置规范。",
+    "barrelExport": "桶导出规范",
+    "barrelExportDesc": "生成和检查 index.ts 桶导出文件，确保所有 index 文件仅做 re-export。",
+    "errorHandling": "错误处理",
+    "errorHandlingDesc": "规范 neverthrow 式错误处理，保持错误显式传递，并在应用代码中消除 try-catch。",
+    "dbNaming": "数据库表命名",
+    "dbNamingDesc": "验证和修正数据库表定义的命名规范，包括表名、列名和索引。",
+    "svgIcon": "SVG 图标规范",
+    "svgIconDesc": "管理 React TypeScript 项目中的 SVG 图标，确保命名、封装和导出规范。",
+    "oneComponent": "单组件单文件",
+    "oneComponentDesc": "强制每个文件只包含一个 React/Vue 组件，不允许多组件共存。",
+    "refineTrpc": "Refine tRPC 规范",
+    "refineTrpcDesc": "在 React 组件中通过 Refine hooks 经由 DataProvider 访问数据，禁止直接调用 tRPC。",
+    "title": "Skills",
     "noSkills": "暂无 Skills",
     "createOperation": "创建 Operation",
     "createOperation.dialogTitle": "从 Skill 创建 Operation",
@@ -819,9 +984,9 @@
     "createOperation.saveAsOperationsSuccess": "Operations 创建成功",
     "createOperation.saveAsOperationsPartialSuccess": "{{total}} 个步骤中 {{succeeded}} 个创建成功，部分步骤失败",
     "createOperation.saveAsOperationsError": "创建 Operations 失败",
-    "createOperation.generatePipeline": "生成 Pipeline Draft",
-    "createOperation.generatePipelineSuccess": "Pipeline Draft 创建成功",
-    "createOperation.generatePipelineError": "创建 Pipeline Draft 失败",
+    "createOperation.generatePipeline": "生成 Pipeline 草稿",
+    "createOperation.generatePipelineSuccess": "Pipeline 草稿创建成功",
+    "createOperation.generatePipelineError": "创建 Pipeline 草稿失败",
     "createOperation.outputNamePlaceholder": "输出名称",
     "categories": {
       "all": "全部",
@@ -837,7 +1002,13 @@
     "language": "语言",
     "selectLanguage": "选择语言",
     "timezone": "时区",
-    "appearance": "外观",
+    "appearance": {
+      "dark": "深色",
+      "hint": "立即生效，并在本设备记住该选择。",
+      "label": "外观",
+      "light": "浅色",
+      "system": "跟随系统"
+    },
     "sections": {
       "profile": "个人信息",
       "notifications": "通知",
@@ -845,7 +1016,12 @@
       "language": "语言与地区",
       "security": "安全",
       "agentRuntimes": "Agent Runtimes",
-      "developer": "开发者"
+      "developer": "开发者",
+      "advanced": "高级",
+      "autonomy": "自主性",
+      "defaults": "默认项",
+      "keyboard": "快捷键",
+      "project": "项目"
     },
     "saveChanges": "保存更改",
     "saved": "已保存 ✓",
@@ -909,6 +1085,121 @@
       "keyPathPlaceholder": "~/.ssh/id_rsa",
       "remove": "删除",
       "empty": "尚未配置 Agent 运行时。添加一个以启用远程执行。"
+    },
+    "advanced": {
+      "description": "本机的存储、数据版本与维护信息。",
+      "rows": {
+        "dataDirectory": {
+          "hint": "本地的 Pipeline、运行与对话都存在这里。",
+          "label": "数据目录"
+        },
+        "localMode": {
+          "hint": "本地开发跳过登录的启动参数。",
+          "label": "本地模式"
+        },
+        "schemaVersion": {
+          "hint": "本地数据库已应用的最新迁移。",
+          "label": "数据版本"
+        }
+      },
+      "title": "高级"
+    },
+    "autonomy": {
+      "decrease": "减少重试",
+      "description": "自愈在停下来向你解释之前能走多远。",
+      "deviceScope": "保存在本设备，并随每次运行一起下发。",
+      "increase": "增加重试",
+      "selfHeal": "自愈重试轮数",
+      "selfHealHint": "失败步骤自动重试的轮数。0 = 首次失败即停止。",
+      "title": "自主性"
+    },
+    "defaults": {
+      "apiKey": "API Key",
+      "apiKeyHint": "仅存储在本机，界面中默认隐藏。",
+      "description": "Agent Bar 组装执行器时优先使用的默认项。",
+      "model": "默认模型",
+      "outputPath": "默认输出路径",
+      "runtime": "默认 Local Agent",
+      "runtimeFix": "切换为 {{name}}",
+      "runtimeFixed": "默认 runtime 已切换为 {{name}}",
+      "runtimeInvalid": "已保存的 runtime「{{value}}」未在本机检测到——修正前 Agent 请求会全部失败。",
+      "save": "保存默认项",
+      "saveFailed": "保存失败",
+      "saved": "默认项已保存",
+      "title": "默认项",
+      "toggleKey": "显示/隐藏 Key"
+    },
+    "groups": {
+      "data": "数据",
+      "execution": "执行",
+      "workspace": "工作区"
+    },
+    "keyboard": {
+      "description": "画布快捷键速查，当前为只读。",
+      "groups": {
+        "editing": "编辑",
+        "navigation": "导航"
+      },
+      "shortcuts": {
+        "boxSelect": {
+          "keys": "画布拖拽",
+          "label": "框选"
+        },
+        "delete": {
+          "keys": "⌫ / Del",
+          "label": "删除选中"
+        },
+        "drillOut": {
+          "keys": "Esc",
+          "label": "钻出 / 清除选择"
+        },
+        "pan": {
+          "keys": "中键拖拽",
+          "label": "平移"
+        },
+        "redo": {
+          "keys": "⌘ ⇧ Z",
+          "label": "重做"
+        },
+        "undo": {
+          "keys": "⌘ Z",
+          "label": "撤销"
+        },
+        "zoom": {
+          "keys": "⌘ 滚轮",
+          "label": "缩放"
+        }
+      },
+      "title": "快捷键"
+    },
+    "notifications": {
+      "description": "哪些事件推送到通知中心，哪些保持安静。",
+      "done": "运行完成",
+      "doneHint": "你发起的任务顺利跑完。",
+      "failed": "运行失败",
+      "failedHint": "永远值得知道——包括 Routine 触发的运行。",
+      "title": "通知",
+      "waiting": "等待你处理",
+      "waitingHint": "运行暂停等待签核或回答问题。"
+    },
+    "project": {
+      "clearCancel": "取消",
+      "clearConfirm": "确认清除",
+      "clearConfirmBody": "将删除所有流水线下保存的 Agent 对话线程。Pipelines、算子与运行记录均保留。",
+      "clearConfirmTitle": "清除对话历史？",
+      "clearDone": "对话历史已清除",
+      "clearFailed": "清除失败",
+      "clearHistory": "清除对话历史",
+      "clearHistoryHint": "删除已保存的 Agent 对话线程，Pipelines 保留。",
+      "description": "编辑侧栏当前选中项目的名称与描述。",
+      "descriptionLabel": "描述",
+      "descriptionPlaceholder": "这个工作区是做什么的…",
+      "empty": "还没有选中项目 — 先在侧栏创建一个。",
+      "name": "项目名称",
+      "save": "保存项目",
+      "saveFailed": "保存失败",
+      "saved": "项目已保存",
+      "title": "项目"
     }
   },
   "runtimes": {
@@ -943,7 +1234,11 @@
     "save": "保存",
     "saved": "已保存",
     "delete": "删除",
-    "confirmDelete": "确认删除"
+    "confirmDelete": "确认删除",
+    "confirmSync": "同步变更",
+    "noChanges": "未检测到运行时变更。",
+    "scanResults": "运行时扫描结果",
+    "scanResultsDescription": "同步前请检查检测到的运行时变更。"
   },
   "errors": {
     "notFound": "页面不存在",
@@ -977,7 +1272,14 @@
       "maxLoopCountAria": "最大循环次数",
       "acceptanceCondition": "验收条件",
       "loopConditionAria": "循环验收条件",
-      "loopConditionPlaceholder": "描述输出需要满足的条件..."
+      "loopConditionPlaceholder": "描述输出需要满足的条件...",
+      "statusCancelled": "已取消",
+      "statusDone": "已完成",
+      "statusFailed": "失败",
+      "statusQueued": "排队中",
+      "statusRetrying": "重试中",
+      "statusSkipped": "已跳过",
+      "statusWaitingForUser": "等待你处理"
     },
     "outputLocalPath": {
       "label": "路径",
@@ -1071,32 +1373,6 @@
     "projectListEmpty": "项目库为空，请先在「项目」页面连接 GitHub 仓库",
     "projectListNoResults": "未找到匹配的项目"
   },
-  "skills": {
-    "pageStructure": "页面结构",
-    "pageStructureDesc": "生成标准的页面 Anatomy：Wrapper + Content + 可选 Store，确保页面结构清晰分层。",
-    "stateManagement": "状态管理 Store",
-    "stateManagementDesc": "基于 Zustand slice 模式创建 Store，包含 Context Provider 和类型安全的 hook。",
-    "daoLayer": "DAO 层",
-    "daoLayerDesc": "使用 Drizzle ORM 规范创建数据访问对象，确保命名、类型安全和查询性能。",
-    "serviceLayer": "Service 层",
-    "serviceLayerDesc": "按照 tRPC + Service + DAO 架构创建 Service，分离业务逻辑与数据访问。",
-    "formComponent": "表单组件",
-    "formComponentDesc": "创建符合规范的表单组件，包含字段验证、状态管理和 UI 结构。",
-    "schemaValidation": "Schema 校验",
-    "schemaValidationDesc": "使用 Drizzle ORM schema 定义数据库表，确保命名、关系和索引配置规范。",
-    "barrelExport": "桶导出规范",
-    "barrelExportDesc": "生成和检查 index.ts 桶导出文件，确保所有 index 文件仅做 re-export。",
-    "errorHandling": "错误处理",
-    "errorHandlingDesc": "规范 neverthrow 式错误处理，保持错误显式传递，并在应用代码中消除 try-catch。",
-    "dbNaming": "数据库表命名",
-    "dbNamingDesc": "验证和修正数据库表定义的命名规范，包括表名、列名和索引。",
-    "svgIcon": "SVG 图标规范",
-    "svgIconDesc": "管理 React TypeScript 项目中的 SVG 图标，确保命名、封装和导出规范。",
-    "oneComponent": "单组件单文件",
-    "oneComponentDesc": "强制每个文件只包含一个 React/Vue 组件，不允许多组件共存。",
-    "refineTrpc": "Refine tRPC 规范",
-    "refineTrpcDesc": "在 React 组件中通过 Refine hooks 经由 DataProvider 访问数据，禁止直接调用 tRPC。"
-  },
   "workspace": {
     "title": "工作区",
     "notFound": "项目不存在",
@@ -1107,7 +1383,438 @@
     "createPipeline": "去创建",
     "objectsCount": "{{count}} 个对象",
     "noPipelineSelected": "— 未选 Pipeline",
-    "entireProject": "整个项目"
+    "entireProject": "整个项目",
+    "canvas": {
+      "edges": {
+        "defaultLabel": "数据"
+      },
+      "empty": {
+        "description": "先放一个节点，再把输入、Operation 和输出连接成可运行的 Pipeline。",
+        "seed": "添加种子节点",
+        "seedLabel": "起始 Prompt",
+        "title": "从一个节点开始..."
+      },
+      "nodes": {
+        "actions": {
+          "configure": "配置节点",
+          "delete": "删除节点",
+          "duplicate": "复制节点",
+          "ask": "向 Agent 询问该节点",
+          "openThread": "打开该节点的线程"
+        },
+        "compound": {
+          "childCount_one": "{{count}} 个子节点",
+          "childCount_other": "{{count}} 个子节点",
+          "openHint": "双击进入内部"
+        },
+        "file": {
+          "input": "文件输入",
+          "noFileSelected": "未选择文件"
+        },
+        "folder": {
+          "input": "文件夹输入",
+          "noFolderSelected": "未选择文件夹"
+        },
+        "github": {
+          "detail": "GitHub"
+        },
+        "kind": {
+          "compound": "{{kind}} 复合节点",
+          "custom": "自定义",
+          "file": "文件",
+          "folder": "文件夹",
+          "github": "GitHub 项目",
+          "operation": "Operation",
+          "output": "输出",
+          "port": "端口",
+          "prompt": "Prompt"
+        },
+        "operation": {
+          "generatorDetail": "生成候选稿",
+          "generatorKind": "生成器",
+          "loopMax": "循环 · 最多 {{count}} 次",
+          "qualityGateDetail": "通过 / 修订",
+          "qualityGateKind": "质检门",
+          "verifierDetail": "校验标准",
+          "verifierKind": "校验器"
+        },
+        "output": {
+          "compoundOutput": "复合节点输出",
+          "localOutput": "本地输出",
+          "projectOutput": "项目输出"
+        },
+        "ports": {
+          "left": "输入端口 {{index}}",
+          "right": "输出端口 {{index}}"
+        },
+        "preview": {
+          "modified": "修改",
+          "new": "新增",
+          "reuse": "复用"
+        },
+        "prompt": {
+          "compoundInput": "复合节点输入",
+          "empty": "空 Prompt",
+          "input": "Prompt 输入"
+        },
+        "status": {
+          "cancelled": "已取消",
+          "done": "已完成",
+          "failed": "需要处理",
+          "idle": "就绪",
+          "queued": "排队中",
+          "retrying": "重试中",
+          "running": "执行中...",
+          "skipped": "已跳过",
+          "waitingForUser": "等待检查点确认"
+        }
+      },
+      "chrome": {
+        "breadcrumb": {
+          "agent": "Agent",
+          "compoundFallback": "复合节点",
+          "drillOut": "钻出",
+          "renameTitle": "点击重命名"
+        },
+        "run": {
+          "noRunnableNodes": "添加一个 Operation 节点后才能运行",
+          "rerun": "重新运行",
+          "run": "运行",
+          "startFailed": "运行启动失败",
+          "started": "已开始运行",
+          "startedDescription": "工单 {{jobId}} 运行中",
+          "stop": "停止",
+          "stopFailed": "停止运行失败",
+          "stopped": "已停止运行"
+        },
+        "states": {
+          "cancelled": "已取消",
+          "done": "完成",
+          "failed": "失败",
+          "idle": "空闲",
+          "queued": "排队中",
+          "retrying": "重试中",
+          "running": "运行中",
+          "skipped": "已跳过",
+          "title": "节点运行状态",
+          "trigger": "状态",
+          "waitingForUser": "等待确认"
+        },
+        "version": {
+          "current": "当前",
+          "history": "历史版本",
+          "overwrite": "覆盖 v{{version}}",
+          "saveAsNew": "另存为新版本",
+          "saveAsNewSuccess": "已另存为 v{{version}}",
+          "saveChanges": "保存修改",
+          "saveFailed": "保存失败",
+          "saveSuccess": "已覆盖保存 v{{version}}",
+          "saved": "已保存",
+          "state": {
+            "done": "已完成",
+            "draft": "草稿",
+            "running": "运行中"
+          },
+          "unsaved": "未保存"
+        },
+        "toolbar": {
+          "pan": "平移",
+          "resetView": "复位视图",
+          "select": "选择 / 框选",
+          "zoomIn": "放大",
+          "zoomOut": "缩小"
+        },
+        "components": {
+          "emptyGroup": "暂无可用项",
+          "groups": {
+            "compound": "复合节点",
+            "inputObjects": "输入对象",
+            "operations": "工序",
+            "output": "输出"
+          },
+          "hint": "点击放置到画布中心，或直接拖入。",
+          "items": {
+            "council": "Council",
+            "delegation": "Delegation",
+            "file": "文件",
+            "folder": "文件夹",
+            "github-project": "GitHub 项目",
+            "output-local-path": "本地路径",
+            "output-project-path": "项目路径",
+            "prompt": "Prompt",
+            "verify": "Verify"
+          },
+          "trigger": "组件"
+        }
+      },
+      "nodeConfig": {
+        "checkpoint": {
+          "afterStep": "该步骤完成后暂停",
+          "pauseForReview": "暂停以供审核",
+          "title": "检查点"
+        },
+        "close": "关闭",
+        "done": "完成",
+        "editable": "可编辑",
+        "executor": {
+          "defaultRuntime": "默认运行时",
+          "hint": "运行时与技能选择保存为该节点的覆盖配置。",
+          "noSkill": "不覆盖技能",
+          "operationOnly": "执行器仅适用于 Operation 节点。",
+          "runtime": "运行时",
+          "skill": "技能",
+          "title": "执行器"
+        },
+        "io": {
+          "inputs": "输入",
+          "noInputs": "暂无上游数据。",
+          "noOutputs": "暂无下游数据。",
+          "outputs": "输出",
+          "title": "输入 / 输出"
+        },
+        "lastRun": {
+          "noOutput": "暂无运行输出。",
+          "output": "输出",
+          "status": "状态",
+          "title": "状态 · 上次运行"
+        },
+        "prompt": {
+          "loopCondition": "循环条件提示词",
+          "promptText": "提示词",
+          "title": "提示词 / 指令",
+          "unavailable": "该节点没有可编辑的提示词。"
+        },
+        "reset": "重置"
+      },
+      "edgeInspector": {
+        "clear": "清空",
+        "close": "关闭",
+        "condition": "条件",
+        "deleteEdge": "删除连线",
+        "dropped": "不传递",
+        "flow": "流向",
+        "maxRetries": "最大重试",
+        "noMappings": "新连接 · 字段将在运行时推断。",
+        "noTransform": "暂无转换步骤。",
+        "onFail": "失败时",
+        "qualityGate": "质量门",
+        "qualityPlaceholder": "非空或必须包含的文本",
+        "sourceField": "源字段",
+        "targetInput": "目标输入",
+        "title": "数据契约",
+        "toggleHint": "点击字段切换是否向下游传递 · {{enabled}}/{{total}} 开启",
+        "transform": "转换"
+      },
+      "compose": {
+        "askSelection": "就选区提问",
+        "compose": "合成复合节点",
+        "defaultLabel": "复合步骤",
+        "drillHint": "复合节点内部 · 修改会写回父 Pipeline。按 Esc 钻出。",
+        "selected_one": "已选 {{count}} 个",
+        "selected_other": "已选 {{count}} 个"
+      },
+      "run": {
+        "approveContinue": "通过并继续",
+        "checkpointBody": "该步骤被标记为检查点。通过后运行继续，也可以先编辑该步骤再恢复。",
+        "checkpointNext": "运行已挂起，等待你的决定。",
+        "checkpointSubtitle": "在 {{node}} 之后暂停 · 运行挂起中",
+        "checkpointTitle": "检查点 · 审核后继续",
+        "consoleTitle": "运行控制台",
+        "dismiss": "关闭",
+        "editStep": "编辑步骤",
+        "lines_one": "{{count}} 行",
+        "lines_other": "{{count}} 行",
+        "notifications": {
+          "cancelled": "运行已取消——{{title}}",
+          "done": "运行完成——{{title}}",
+          "expired": "运行已过期——{{title}}",
+          "failed": "运行失败——{{title}}"
+        },
+        "resumeFailed": "恢复运行失败",
+        "resumed": "检查点已通过 — 继续运行",
+        "waiting": "等待第一个步骤…"
+      },
+      "ask": {
+        "cancel": "取消",
+        "hint": "会以节点锚定消息的形式进入 Agent 对话。",
+        "placeholder": "告诉 Agent 这里要改什么…",
+        "send": "发送给 Agent",
+        "title": "就 {{node}} 提问"
+      }
+    },
+    "agentBar": {
+      "actionTitles": {
+        "addEdge": "新增连线",
+        "addNode": "新增 {{nodeType}} 节点",
+        "reconnectEdge": "重连连线",
+        "removeEdge": "删除连线",
+        "removeNode": "删除节点",
+        "replaceNodeData": "更新节点"
+      },
+      "applied": {
+        "hint": "已应用 — 节点已在画布上，随时可编辑。点选任意节点即可在这里引用它，或直接点 Run。"
+      },
+      "checkpoint": {
+        "controls": "运行控制",
+        "nextNode": "下一节点",
+        "pause": "暂停",
+        "resume": "继续",
+        "review": "去审核",
+        "waiting": "检查点 · 暂停于 {{node}}"
+      },
+      "collapse": "收起 Agent Bar",
+      "composer": {
+        "attach": "添加附件",
+        "attachMenu": {
+          "files": "上传文件",
+          "folder": "上传文件夹"
+        },
+        "messageLabel": "消息",
+        "nameOnly": "仅文件名",
+        "nameOnlyHint": "二进制文件——只有文件名会提供给 Agent 分析。",
+        "placeholder": "描述目标、上传样本，或继续修改…",
+        "placeholderWithRefs": "让 Agent 修改引用的节点…",
+        "removeAttachment": "移除 {{name}}",
+        "reverseDefault": "根据附件样本逆向生成 Pipeline：{{names}}",
+        "send": "发送"
+      },
+      "context": {
+        "footer": {
+          "editing": "上下文按状态选取 · 编辑时优先携带画布与选区。",
+          "running": "上下文按状态选取 · 运行时优先携带运行与节点状态。"
+        },
+        "itemCount_one": "{{count}} 项",
+        "itemCount_other": "{{count}} 项",
+        "items": {
+          "annotations": "画布批注",
+          "annotationsWith": "画布批注 · {{count}}",
+          "memory": "记忆摘要",
+          "nodeRuntime": "节点运行时",
+          "project": "项目信息",
+          "runState": "运行状态",
+          "selection": "选区",
+          "selectionWith": "选区 · {{refs}}",
+          "snapshot": "Pipeline 快照",
+          "thread": "对话线程"
+        },
+        "rules": {
+          "always": "始终",
+          "notImplemented": "未实现",
+          "runtime": "运行时优先",
+          "whenPresent": "存在时",
+          "whenSelected": "选中时",
+          "windowed": "滑动窗口"
+        },
+        "summary": {
+          "annotations": "+ 批注",
+          "default": "画布 + 线程",
+          "running": "优先运行 + 节点状态",
+          "selection": "+ 选区"
+        },
+        "title": "上下文"
+      },
+      "empty": {
+        "intro": "新画布 — 告诉我要做什么，或拖入一个成品样本，我会逆向推导出生成它的 Pipeline。",
+        "suggestChangelog": "把 GitHub 仓库总结成 changelog",
+        "suggestQuiz": "把我的教材 PDF 变成 Notion 测验",
+        "suggestReverse": "上传成品样本 → 逆向工程"
+      },
+      "error": {
+        "tryPrefix": "建议："
+      },
+      "errors": {
+        "AGENT_FAILED": "本地 Agent 没有响应。它可能没在运行或配置有误——可以重试，或检查 Agent runtime。",
+        "BAD_AGENT_OUTPUT": "Agent 有响应，但我没能把它转成有效提案。这通常是偶发问题——请重试。",
+        "INVALID_SNAPSHOT": "画布状态读取失败，请刷新页面后重试。",
+        "RUNTIME_NOT_FOUND": "配置的 Agent runtime 在本机不可用，无法生成提案。请到 Settings → Defaults 选择一个已检测到的 runtime。",
+        "actions": {
+          "openSettings": "打开 Settings",
+          "retry": "重试"
+        },
+        "proposalDropped": "（生成的提案未通过校验已被丢弃——可以让我再试一次。）"
+      },
+      "messageActions": {
+        "copied": "已复制",
+        "copy": "复制",
+        "edit": "编辑",
+        "retry": "重试"
+      },
+      "proposal": {
+        "actionCount_one": "{{count}} 个图操作",
+        "actionCount_other": "{{count}} 个图操作",
+        "apply": "应用",
+        "askFix": "让 Agent 修复",
+        "blocked": "先解决诊断问题再应用",
+        "loopBadge": "迭代 ×{{count}}",
+        "newOperationBadge": "新算子",
+        "reject": "拒绝",
+        "revise": "修改"
+      },
+      "refChipTitle": "悬停高亮 · 点击在画布上定位",
+      "removeRef": "移除 {{label}}",
+      "reopen": "展开 Agent Bar",
+      "replies": {
+        "appliedNotSaved": "提案已在本地应用，但保存失败。",
+        "appliedSaved": "提案已应用并保存到 Pipeline。",
+        "drafted": "我起草了一份 Pipeline 提案。",
+        "fixRequest": "请修复提案中的校验错误，并重新提交修正后的提案。",
+        "missingInputSource": "提醒：这条流水线还没有输入源。点击首个节点配置输入，或直接告诉我（例如“加一个文件夹输入”），我会在运行前帮你接好。",
+        "noSafeChange": "这个请求我找不到安全的图结构改动。",
+        "rejected": "已拒绝当前提案。",
+        "rejectedWithProposal": "已拒绝提案「{{summary}}」。",
+        "requestFailed": "我没能联系上 Agent 生成提案，请稍后重试。",
+        "reviseHint": "告诉我要修改什么，我会重新起草提案。",
+        "reviseHintWithProposal": "已撤回提案「{{summary}}」，告诉我要修改什么，我会重新起草。"
+      },
+      "reversing": {
+        "intro": "正在阅读样本 — 推断生成它的步骤。",
+        "steps": {
+          "draft": "起草 Pipeline",
+          "draftDetail": "组装节点与连线",
+          "matched": "匹配组件",
+          "matchedDetail": "从你的组件库复用",
+          "steps": "推断步骤",
+          "stepsDetail": "解析 → 生成 → 校验 → 导出",
+          "structure": "读取结构",
+          "structureDetail": "格式、分节、引用"
+        }
+      },
+      "stages": {
+        "analyzing": "正在分析样本…",
+        "done": "即将完成…",
+        "drafting": "正在起草提案…",
+        "thinking": "正在读取请求…",
+        "validating": "正在校验提案…"
+      },
+      "subtitle": {
+        "applied": "阅读中 · 画布",
+        "clarify": "阅读中 · 目标",
+        "done": "运行完成 · 资产已沉淀",
+        "empty": "新画布 · 暂无 pipeline",
+        "proposal": "起草中 · 方案就绪",
+        "refsSelected_one": "已选 {{count}} 个引用",
+        "refsSelected_other": "已选 {{count}} 个引用",
+        "reversing": "阅读中 · 样本",
+        "running": "观察中 · 实时",
+        "watching": "观察中 · {{jobId}} · 实时"
+      },
+      "thinking": "思考中…",
+      "thread": {
+        "emptyBody": "该节点上的批注都已处理完。",
+        "emptyTitle": "这里没有未处理的批注",
+        "resolve": "标记已解决",
+        "showAll": "查看全部",
+        "title": "线程"
+      },
+      "title": "Agent",
+      "userAction": {
+        "askAgent": "让 Agent 处理",
+        "askDraft": "执行器在节点 {{node}} 需要补充：{{message}}——请帮我处理或告诉我该怎么做。",
+        "openConfig": "打开节点配置",
+        "title": "需要你处理（{{count}}）"
+      }
+    },
+    "notFoundPipeline": "找不到该 Pipeline"
   },
   "validation": {
     "nameRequired": "名称不能为空",
@@ -1143,5 +1850,32 @@
       "save": "保存",
       "create": "创建"
     }
+  },
+  "notifications": {
+    "clear": "全部清空",
+    "emptyBody": "运行、自愈与连接器事件会出现在这里。",
+    "emptyTitle": "暂无通知",
+    "markRead": "全部已读",
+    "open": "打开",
+    "title": "通知"
+  },
+  "components": {
+    "findForMe": {
+      "assetFallback": "可复用的 Pipeline 资产",
+      "close": "关闭",
+      "empty": "还没有沉淀的资产 — 跑通一条 Pipeline 后这里会增长。",
+      "intro": "按运行次数排序的最可复用资产：",
+      "ranking": "按复用度与相关性排序",
+      "searching": "正在扫描你的组件库…",
+      "subtitle": "Agent 扫描你的组件库",
+      "title": "帮我找",
+      "usedTimes_one": "运行 {{count}} 次",
+      "usedTimes_other": "运行 {{count}} 次"
+    }
+  },
+  "time": {
+    "daysAgo": "{{days}} 天前",
+    "hoursAgo": "{{hours}} 小时前",
+    "minutesAgo": "{{minutes}} 分钟前"
   }
 }

--- a/packages/views/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.unit.test.tsx
@@ -103,11 +103,11 @@ describe("CanvasSettingsDrawer", () => {
 
     expect(store.getState().nodeCardMode).toBe("compact");
 
-    await user.click(screen.getByRole("button", { name: /Expanded/i }));
+    await user.click(screen.getByRole("button", { name: /Expanded|展开/i }));
 
     expect(store.getState().nodeCardMode).toBe("expanded");
 
-    await user.click(screen.getByRole("button", { name: /Compact/i }));
+    await user.click(screen.getByRole("button", { name: /Compact|紧凑/i }));
 
     expect(store.getState().nodeCardMode).toBe("compact");
   });


### PR DESCRIPTION
## Summary

- sync the complete Ordinctor English and Simplified Chinese locale corpus into the current app
- preserve keys still used on `develop`, fill all active locale references, and keep en/zh key sets and interpolation tokens identical
- localize the Canvas node-card mode controls and make their regression test locale-aware

## Validation

- custom locale verification: 1,521 parity-matched keys, 634 active references across 481 source files, matching interpolation tokens, and runtime en/zh switching
- `bun --filter @repo/views test` (51 files, 239 tests)
- `bun --filter @ordine/app test` (57 files, 274 tests)
- `bun --filter @ordine/app compile`
- `bun --filter @ordine/app build`
- `bun --filter @ordine/app lint`
- focused `oxfmt` check and `git diff --check`
- browser smoke: Settings language switched `zh-CN -> en-US -> zh-CN`; sidebar, page title, section labels, form labels, and actions all changed language

## Visual impact

No visual styling changes; this PR updates localized copy and language-switch behavior only.

Linear: [COD-139](https://linear.app/code-forge-official/issue/COD-139/28featurei18n-locale-files-or-i18n%E5%9B%BD%E9%99%85%E5%8C%96%E8%AF%AD%E8%A8%80%E6%96%87%E4%BB%B6)