### PR TITLE
fix(services): 处理 #125 合并后 woodfish 的三个 review 意见

### DIFF
--- a/packages/models/src/daos/connectorsDao/connectorsDao.ts
+++ b/packages/models/src/daos/connectorsDao/connectorsDao.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { connectorsTable } from "@repo/db-schema";
 import type { ConnectorConfig, ConnectorMethod } from "@repo/schemas";
 import type { DbExecutor } from "../../types";
@@ -58,7 +58,7 @@ export class ConnectorsDao {
         and(
           eq(connectorsTable.id, id),
           eq(connectorsTable.method, expectedMethod),
-          eq(connectorsTable.config, expectedConfig),
+          sql`${connectorsTable.config} = ${JSON.stringify(expectedConfig)}::jsonb`,
         ),
       )
       .returning();

--- a/packages/models/src/daos/connectorsDao/connectorsDao.ts
+++ b/packages/models/src/daos/connectorsDao/connectorsDao.ts
@@ -1,5 +1,6 @@
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { connectorsTable } from "@repo/db-schema";
+import type { ConnectorConfig, ConnectorMethod } from "@repo/schemas";
 import type { DbExecutor } from "../../types";
 
 export class ConnectorsDao {
@@ -34,6 +35,32 @@ export class ConnectorsDao {
       .update(connectorsTable)
       .set({ ...patch, updatedAt: new Date() })
       .where(eq(connectorsTable.id, id))
+      .returning();
+
+    return updated;
+  }
+
+  /**
+   * Compare-and-set update: only writes if the row still matches the expected
+   * method and config snapshot. Returns undefined when the predicate fails,
+   * allowing callers to turn the missed write into a concurrency conflict.
+   */
+  async updateIfConfigUnchanged(
+    id: string,
+    patch: Partial<Omit<typeof connectorsTable.$inferInsert, "id">>,
+    expectedMethod: ConnectorMethod,
+    expectedConfig: ConnectorConfig,
+  ) {
+    const [updated] = await this.executor
+      .update(connectorsTable)
+      .set({ ...patch, updatedAt: new Date() })
+      .where(
+        and(
+          eq(connectorsTable.id, id),
+          eq(connectorsTable.method, expectedMethod),
+          eq(connectorsTable.config, expectedConfig),
+        ),
+      )
       .returning();
 
     return updated;

--- a/packages/models/src/daos/connectorsDao/connectorsDao.unit.test.ts
+++ b/packages/models/src/daos/connectorsDao/connectorsDao.unit.test.ts
@@ -43,4 +43,18 @@ describe("ConnectorsDao", () => {
     expect(limit).toHaveBeenCalledWith(1);
     expect(set).toHaveBeenCalledWith(expect.objectContaining({ status: "connected" }));
   });
+
+  it("updates only when method and config match the expected snapshot", async () => {
+    await expect(
+      dao.updateIfConfigUnchanged(
+        connector.id,
+        { status: "connected" },
+        connector.method,
+        connector.config,
+      ),
+    ).resolves.toEqual(connector);
+
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({ status: "connected" }));
+    expect(where).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/models/src/daos/conversationMessagesDao/conversationMessagesDao.ts
+++ b/packages/models/src/daos/conversationMessagesDao/conversationMessagesDao.ts
@@ -26,10 +26,18 @@ export class ConversationMessagesDao {
     const query = this.executor
       .select()
       .from(conversationMessagesTable)
-      .where(eq(conversationMessagesTable.pipelineId, pipelineId))
-      .orderBy(asc(conversationMessagesTable.createdAt));
+      .where(eq(conversationMessagesTable.pipelineId, pipelineId));
 
-    return limit === undefined ? query : query.limit(limit);
+    if (limit === undefined) {
+      return query.orderBy(asc(conversationMessagesTable.createdAt));
+    }
+
+    // Latest N in chronological order: take DESC + limit, then reverse.
+    const rows = await query
+      .orderBy(desc(conversationMessagesTable.createdAt))
+      .limit(limit);
+
+    return rows.reverse();
   }
 
   async create(data: typeof conversationMessagesTable.$inferInsert) {

--- a/packages/models/src/daos/conversationMessagesDao/conversationMessagesDao.ts
+++ b/packages/models/src/daos/conversationMessagesDao/conversationMessagesDao.ts
@@ -9,7 +9,7 @@ export class ConversationMessagesDao {
     return this.executor
       .select()
       .from(conversationMessagesTable)
-      .orderBy(desc(conversationMessagesTable.createdAt));
+      .orderBy(desc(conversationMessagesTable.createdAt), desc(conversationMessagesTable.id));
   }
 
   async findById(id: string) {
@@ -29,12 +29,14 @@ export class ConversationMessagesDao {
       .where(eq(conversationMessagesTable.pipelineId, pipelineId));
 
     if (limit === undefined) {
-      return query.orderBy(asc(conversationMessagesTable.createdAt));
+      return query.orderBy(
+        asc(conversationMessagesTable.createdAt),
+        asc(conversationMessagesTable.id),
+      );
     }
 
-    // Latest N in chronological order: take DESC + limit, then reverse.
     const rows = await query
-      .orderBy(desc(conversationMessagesTable.createdAt))
+      .orderBy(desc(conversationMessagesTable.createdAt), desc(conversationMessagesTable.id))
       .limit(limit);
 
     return rows.reverse();

--- a/packages/models/src/daos/domainDaos.integration.test.ts
+++ b/packages/models/src/daos/domainDaos.integration.test.ts
@@ -214,4 +214,40 @@ describe("COD-116 domain DAOs with PGlite", () => {
       "message-5",
     ]);
   });
+
+  it("returns the latest pipeline messages in a stable order when created_at ties", async () => {
+    const projects = createProjectsDao(executor);
+    const messages = createConversationMessagesDao(executor);
+
+    await projects.create({ id: "project-order", name: "Ordered" });
+    await executor.insert(pipelinesTable).values({
+      id: "pipeline-order",
+      name: "Ordering",
+      projectId: "project-order",
+    });
+
+    const createdAt = new Date("2026-01-02T00:00:00.000Z");
+    for (const i of [1, 2, 3, 4, 5]) {
+      await messages.create({
+        id: `message-${i}`,
+        pipelineId: "pipeline-order",
+        role: "user",
+        content: `Message ${i}`,
+        createdAt,
+      });
+    }
+
+    await expect(messages.findManyByPipelineId("pipeline-order")).resolves.toEqual([
+      expect.objectContaining({ id: "message-1" }),
+      expect.objectContaining({ id: "message-2" }),
+      expect.objectContaining({ id: "message-3" }),
+      expect.objectContaining({ id: "message-4" }),
+      expect.objectContaining({ id: "message-5" }),
+    ]);
+    await expect(messages.findManyByPipelineId("pipeline-order", 3)).resolves.toEqual([
+      expect.objectContaining({ id: "message-3" }),
+      expect.objectContaining({ id: "message-4" }),
+      expect.objectContaining({ id: "message-5" }),
+    ]);
+  });
 });

--- a/packages/models/src/daos/domainDaos.integration.test.ts
+++ b/packages/models/src/daos/domainDaos.integration.test.ts
@@ -184,4 +184,34 @@ describe("COD-116 domain DAOs with PGlite", () => {
     expect(await assets.findById("asset-1")).toBeUndefined();
     expect(await connectors.findById("connector-1")).toBeUndefined();
   });
+
+  it("returns the latest N conversation messages in chronological order", async () => {
+    const messages = createConversationMessagesDao(executor);
+
+    await executor
+      .insert(pipelinesTable)
+      .values({ id: "pipeline-messages", name: "Messages", projectId: "project-1" });
+
+    for (const i of [1, 2, 3, 4, 5]) {
+      await messages.create({
+        id: `msg-${i}`,
+        pipelineId: "pipeline-messages",
+        role: "user",
+        content: `message-${i}`,
+        createdAt: new Date(`2026-01-0${i}T00:00:00Z`),
+      });
+    }
+
+    const latest = await messages.findManyByPipelineId("pipeline-messages", 3);
+    expect(latest.map((m) => m.content)).toEqual(["message-3", "message-4", "message-5"]);
+
+    const all = await messages.findManyByPipelineId("pipeline-messages");
+    expect(all.map((m) => m.content)).toEqual([
+      "message-1",
+      "message-2",
+      "message-3",
+      "message-4",
+      "message-5",
+    ]);
+  });
 });

--- a/packages/services/src/connectorsService/createConnectorsService.ts
+++ b/packages/services/src/connectorsService/createConnectorsService.ts
@@ -25,18 +25,19 @@ const sanitizeUpdatePatch = (
   patch: UpdateConnectorPatch,
   current: Connector,
 ): UpdateConnectorPatch => {
-  const configChanged = patch.config !== undefined;
-  const methodChanged = patch.method !== undefined && patch.method !== current.method;
+  const sanitized = denyManualConnected(patch);
+  const configChanged = sanitized.config !== undefined;
+  const methodChanged = sanitized.method !== undefined && sanitized.method !== current.method;
 
-  if (!configChanged && !methodChanged) return denyManualConnected(patch);
+  if (!configChanged && !methodChanged) return sanitized;
 
   const config = configChanged
-    ? { ...(patch.config as Record<string, unknown>) }
+    ? { ...(sanitized.config as Record<string, unknown>) }
     : { ...(current.config as Record<string, unknown>) };
   delete config.tools;
   delete config.lastError;
 
-  return { ...patch, config, status: "needs_setup", lastSyncAt: null };
+  return { ...sanitized, config, status: "needs_setup", lastSyncAt: null };
 };
 
 const withLastError = (config: ConnectorConfig, lastError: string): Record<string, unknown> => ({
@@ -44,9 +45,33 @@ const withLastError = (config: ConnectorConfig, lastError: string): Record<strin
   lastError,
 });
 
+const stripHandshakeArtifacts = (config: ConnectorConfig): Record<string, unknown> => {
+  const next = { ...(config as Record<string, unknown>) };
+  delete next.tools;
+  delete next.lastError;
+
+  return next;
+};
+
 /** Full structural comparison; both sides come from the same jsonb column. */
 const sameConfig = (a: ConnectorConfig, b: ConnectorConfig): boolean =>
   JSON.stringify(a) === JSON.stringify(b);
+
+const persistIfConfigUnchanged = async (
+  dao: ConnectorsDao,
+  id: string,
+  expected: Pick<Connector, "method" | "config">,
+  patch: UpdateConnectorPatch,
+  conflictMessage: string,
+): Promise<Result<Connector, Error>> => {
+  const updated = await dao.updateIfConfigUnchanged(id, patch, expected.method, expected.config);
+  if (updated) return ok(updated);
+
+  const current = await dao.findById(id);
+  if (!current) return err(new NotFoundError("Connector", id));
+
+  return err(new ConflictError(conflictMessage));
+};
 
 export const createConnectorsService = (db: DbConnection) => {
   const dao = createConnectorsDao(db);
@@ -63,14 +88,19 @@ export const createConnectorsService = (db: DbConnection) => {
     const row = await dao.findById(id);
     if (!row) return err(new NotFoundError("Connector", id));
 
-    const failSetup = async (message: string): Promise<Result<Connector, Error>> => {
-      await dao.update(id, {
-        status: "needs_setup",
-        config: withLastError(row.config, message),
-      });
-
-      return err(toServiceError(new Error(message), "Connect connector"));
-    };
+    const failSetup = async (message: string): Promise<Result<Connector, Error>> =>
+      persistIfConfigUnchanged(
+        dao,
+        id,
+        row,
+        {
+          status: "needs_setup",
+          config: withLastError(stripHandshakeArtifacts(row.config), message),
+        },
+        "Connector configuration changed during handshake; connect again",
+      ).then((result) =>
+        result.isOk() ? err(toServiceError(new Error(message), "Connect connector")) : result,
+      );
 
     // Only MCP connectors have a handshake; direct-api/built-in never connect here.
     if (row.method !== "mcp") {
@@ -95,7 +125,7 @@ export const createConnectorsService = (db: DbConnection) => {
     // handshake was in flight; a stale result must never overwrite fresh config.
     const current = await dao.findById(id);
     if (!current) return err(new NotFoundError("Connector", id));
-    if (!sameConfig(current.config, config)) {
+    if (current.method !== row.method || !sameConfig(current.config, config)) {
       // Discard the stale handshake. The concurrent update() already reset the
       // status to needs_setup (sanitizeUpdatePatch), so nothing is written here.
       // ConflictError keeps 409 semantics: state changed concurrently, retry.
@@ -105,10 +135,17 @@ export const createConnectorsService = (db: DbConnection) => {
     }
 
     if (handshake.isErr()) {
-      await dao.update(id, {
-        status: "error",
-        config: withLastError(current.config, handshake.error),
-      });
+      const failed = await persistIfConfigUnchanged(
+        dao,
+        id,
+        row,
+        {
+          status: "error",
+          config: withLastError(stripHandshakeArtifacts(current.config), handshake.error),
+        },
+        "Connector configuration changed during handshake; connect again",
+      );
+      if (failed.isErr()) return failed;
 
       return err(toServiceError(new Error(handshake.error), "Connect connector"));
     }
@@ -121,26 +158,40 @@ export const createConnectorsService = (db: DbConnection) => {
     };
     delete merged.lastError;
 
-    // Compare-and-set against the snapshot that was handshaken: if method or
-    // config changed between the handshake and this write, the update must fail
-    // rather than overwrite fresh state with stale handshake data.
-    const updated = await dao.updateIfConfigUnchanged(
+    return persistIfConfigUnchanged(
+      dao,
       id,
+      row,
       {
         status: "connected",
         config: merged,
         lastSyncAt: new Date(),
       },
-      row.method,
-      config,
+      "Connector configuration changed during handshake; connect again",
     );
-    if (!updated) {
-      return err(
-        new ConflictError("Connector configuration changed during handshake; connect again"),
-      );
+  };
+
+  const updateImpl = async (
+    id: string,
+    patch: UpdateConnectorPatch,
+  ): Promise<Result<Connector, Error>> => {
+    const current = await dao.findById(id);
+    if (!current) return err(new NotFoundError("Connector", id));
+
+    const sanitized = sanitizeUpdatePatch(patch, current);
+    if (sanitized.method === undefined && sanitized.config === undefined) {
+      const updated = await dao.update(id, sanitized);
+
+      return updated ? ok(updated) : err(new NotFoundError("Connector", id));
     }
 
-    return ok(updated);
+    return persistIfConfigUnchanged(
+      dao,
+      id,
+      current,
+      sanitized,
+      "Connector changed while updating; retry",
+    );
   };
 
   return {
@@ -157,20 +208,9 @@ export const createConnectorsService = (db: DbConnection) => {
         toServiceError(error, "Create connector"),
       ),
     update: (id: string, patch: UpdateConnectorPatch) =>
-      ResultAsync.fromPromise(dao.findById(id), (error) =>
+      ResultAsync.fromPromise(updateImpl(id, patch), (error) =>
         toServiceError(error, "Update connector"),
-      )
-        .andThen((current) =>
-          current ? okAsync(current) : errAsync(new NotFoundError("Connector", id)),
-        )
-        .andThen((current) =>
-          ResultAsync.fromPromise(dao.update(id, sanitizeUpdatePatch(patch, current)), (error) =>
-            toServiceError(error, "Update connector"),
-          ),
-        )
-        .andThen((connector) =>
-          connector ? okAsync(connector) : errAsync(new NotFoundError("Connector", id)),
-        ),
+      ).andThen((result) => result),
     /**
      * DAO/handshake rejections are normalized like every other method: callers
      * always receive a Result (isErr), never a rejected promise.

--- a/packages/services/src/connectorsService/createConnectorsService.ts
+++ b/packages/services/src/connectorsService/createConnectorsService.ts
@@ -17,17 +17,26 @@ const denyManualConnected = <T extends { status?: string | null }>(data: T): T =
   data.status === "connected" ? { ...data, status: "needs_setup" } : data;
 
 /**
- * A config edit invalidates any previous handshake: status falls back to
- * needs_setup and client-supplied tools are stripped — the tool list may only
- * be backfilled by a real handshake (connect()).
+ * A config or method edit invalidates any previous handshake: status falls back
+ * to needs_setup, client-supplied tools are stripped, and lastSyncAt is cleared.
+ * Only a real handshake (connect()) may backfill tools and lastSyncAt.
  */
-const sanitizeUpdatePatch = (patch: UpdateConnectorPatch): UpdateConnectorPatch => {
-  if (!patch.config) return denyManualConnected(patch);
+const sanitizeUpdatePatch = (
+  patch: UpdateConnectorPatch,
+  current: Connector,
+): UpdateConnectorPatch => {
+  const configChanged = patch.config !== undefined;
+  const methodChanged = patch.method !== undefined && patch.method !== current.method;
 
-  const config = { ...(patch.config as Record<string, unknown>) };
+  if (!configChanged && !methodChanged) return denyManualConnected(patch);
+
+  const config = configChanged
+    ? { ...(patch.config as Record<string, unknown>) }
+    : { ...(current.config as Record<string, unknown>) };
   delete config.tools;
+  delete config.lastError;
 
-  return { ...patch, config, status: "needs_setup" };
+  return { ...patch, config, status: "needs_setup", lastSyncAt: null };
 };
 
 const withLastError = (config: ConnectorConfig, lastError: string): Record<string, unknown> => ({
@@ -111,12 +120,25 @@ export const createConnectorsService = (db: DbConnection) => {
       tools: handshake.value,
     };
     delete merged.lastError;
-    const updated = await dao.update(id, {
-      status: "connected",
-      config: merged,
-      lastSyncAt: new Date(),
-    });
-    if (!updated) return err(new NotFoundError("Connector", id));
+
+    // Compare-and-set against the snapshot that was handshaken: if method or
+    // config changed between the handshake and this write, the update must fail
+    // rather than overwrite fresh state with stale handshake data.
+    const updated = await dao.updateIfConfigUnchanged(
+      id,
+      {
+        status: "connected",
+        config: merged,
+        lastSyncAt: new Date(),
+      },
+      row.method,
+      config,
+    );
+    if (!updated) {
+      return err(
+        new ConflictError("Connector configuration changed during handshake; connect again"),
+      );
+    }
 
     return ok(updated);
   };
@@ -135,11 +157,20 @@ export const createConnectorsService = (db: DbConnection) => {
         toServiceError(error, "Create connector"),
       ),
     update: (id: string, patch: UpdateConnectorPatch) =>
-      ResultAsync.fromPromise(dao.update(id, sanitizeUpdatePatch(patch)), (error) =>
+      ResultAsync.fromPromise(dao.findById(id), (error) =>
         toServiceError(error, "Update connector"),
-      ).andThen((connector) =>
-        connector ? okAsync(connector) : errAsync(new NotFoundError("Connector", id)),
-      ),
+      )
+        .andThen((current) =>
+          current ? okAsync(current) : errAsync(new NotFoundError("Connector", id)),
+        )
+        .andThen((current) =>
+          ResultAsync.fromPromise(dao.update(id, sanitizeUpdatePatch(patch, current)), (error) =>
+            toServiceError(error, "Update connector"),
+          ),
+        )
+        .andThen((connector) =>
+          connector ? okAsync(connector) : errAsync(new NotFoundError("Connector", id)),
+        ),
     /**
      * DAO/handshake rejections are normalized like every other method: callers
      * always receive a Result (isErr), never a rejected promise.

--- a/packages/services/src/connectorsService/createConnectorsService.unit.test.ts
+++ b/packages/services/src/connectorsService/createConnectorsService.unit.test.ts
@@ -45,7 +45,9 @@ describe("connectorsService.connect", () => {
     const config = { transport: "stdio", command: "npx", args: ["x"], custom: "keep-me" };
     findById.mockResolvedValue(stdioRow({ config }));
     listMcpToolsStdio.mockResolvedValue(ok([{ name: "read_file", description: "d" }]));
-    updateIfConfigUnchanged.mockImplementation((_id, patch) => Promise.resolve({ ...stdioRow(), ...patch }));
+    updateIfConfigUnchanged.mockImplementation((_id, patch) =>
+      Promise.resolve({ ...stdioRow(), ...patch }),
+    );
 
     const result = await svc().connect("c1");
 
@@ -54,7 +56,10 @@ describe("connectorsService.connect", () => {
       "c1",
       expect.objectContaining({
         status: "connected",
-        config: expect.objectContaining({ tools: [{ name: "read_file", description: "d" }], custom: "keep-me" }),
+        config: expect.objectContaining({
+          tools: [{ name: "read_file", description: "d" }],
+          custom: "keep-me",
+        }),
         lastSyncAt: expect.any(Date),
       }),
       "mcp",
@@ -67,51 +72,51 @@ describe("connectorsService.connect", () => {
   it("on handshake failure with valid config: sets error + lastError, never connected", async () => {
     findById.mockResolvedValue(stdioRow());
     listMcpToolsStdio.mockResolvedValue(err("boom"));
-    update.mockResolvedValue(stdioRow({ status: "error" }));
+    updateIfConfigUnchanged.mockResolvedValue(stdioRow({ status: "error" }));
 
     const result = await svc().connect("c1");
 
     expect(result.isErr()).toBe(true);
-    const patch = update.mock.calls[0]![1];
+    const patch = updateIfConfigUnchanged.mock.calls[0]![1];
     expect(patch.status).toBe("error");
     expect(patch.config.lastError).toBe("boom");
   });
 
   it("on unconfigured (legacy {}) config: falls back to needs_setup + lastError without handshaking", async () => {
     findById.mockResolvedValue(stdioRow({ config: {} }));
-    update.mockResolvedValue(stdioRow());
+    updateIfConfigUnchanged.mockResolvedValue(stdioRow());
 
     const result = await svc().connect("c1");
 
     expect(result.isErr()).toBe(true);
     expect(listMcpToolsStdio).not.toHaveBeenCalled();
-    const patch = update.mock.calls[0]![1];
+    const patch = updateIfConfigUnchanged.mock.calls[0]![1];
     expect(patch.status).toBe("needs_setup");
     expect(patch.config.lastError).toContain("not configured");
   });
 
   it("on http transport: falls back to needs_setup + lastError (not error) without handshaking", async () => {
     findById.mockResolvedValue(stdioRow({ config: { transport: "http", url: "https://x/sse" } }));
-    update.mockResolvedValue(stdioRow());
+    updateIfConfigUnchanged.mockResolvedValue(stdioRow());
 
     const result = await svc().connect("c1");
 
     expect(result.isErr()).toBe(true);
     expect(listMcpToolsStdio).not.toHaveBeenCalled();
-    const patch = update.mock.calls[0]![1];
+    const patch = updateIfConfigUnchanged.mock.calls[0]![1];
     expect(patch.status).toBe("needs_setup");
     expect(patch.config.lastError).toBe("http transport is not supported yet");
   });
 
   it("on non-mcp method: falls back to needs_setup + lastError without handshaking", async () => {
     findById.mockResolvedValue(stdioRow({ method: "direct-api" }));
-    update.mockResolvedValue(stdioRow());
+    updateIfConfigUnchanged.mockResolvedValue(stdioRow());
 
     const result = await svc().connect("c1");
 
     expect(result.isErr()).toBe(true);
     expect(listMcpToolsStdio).not.toHaveBeenCalled();
-    const patch = update.mock.calls[0]![1];
+    const patch = updateIfConfigUnchanged.mock.calls[0]![1];
     expect(patch.status).toBe("needs_setup");
     expect(patch.config.lastError).toContain("does not support MCP handshake");
   });
@@ -141,12 +146,19 @@ describe("connectorsService.connect", () => {
 
     expect(result.isErr()).toBe(true);
     expect(result._unsafeUnwrapErr().message).toContain("changed during handshake");
-    expect(updateIfConfigUnchanged).toHaveBeenCalledWith(
-      "c1",
-      expect.anything(),
-      "mcp",
-      config,
-    );
+    expect(updateIfConfigUnchanged).toHaveBeenCalledWith("c1", expect.anything(), "mcp", config);
+  });
+
+  it("returns Conflict when a handshake failure races with a config edit", async () => {
+    findById.mockResolvedValueOnce(stdioRow()).mockResolvedValueOnce(stdioRow());
+    listMcpToolsStdio.mockResolvedValue(err("boom"));
+    updateIfConfigUnchanged.mockResolvedValue(undefined);
+
+    const result = await svc().connect("c1");
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr().name).toBe("ConflictError");
+    expect(updateIfConfigUnchanged).toHaveBeenCalledTimes(1);
   });
 
   it("returns NotFound when connector missing", async () => {
@@ -177,77 +189,110 @@ describe("connectorsService manual-status guard", () => {
   it("update coerces a manual connected status to needs_setup", async () => {
     findById.mockResolvedValue(stdioRow());
     update.mockResolvedValue(stdioRow());
+
     await svc().update("c1", { status: "connected" } as never);
+
     expect(update.mock.calls[0]![1].status).toBe("needs_setup");
   });
 
-  it("update with config drops connected status and strips forged tools", async () => {
-    findById.mockResolvedValue(stdioRow());
-    update.mockResolvedValue(stdioRow());
+  it("update with config drops connected status, strips forged tools, and clears sync state", async () => {
+    findById.mockResolvedValue(
+      stdioRow({
+        method: "mcp",
+        status: "connected",
+        lastSyncAt: new Date("2026-01-01"),
+        config: {
+          transport: "stdio",
+          command: "npx",
+          tools: [{ name: "real_tool" }],
+          lastError: "old boom",
+          custom: "keep",
+        },
+      }),
+    );
+    updateIfConfigUnchanged.mockResolvedValue(stdioRow());
+
     await svc().update("c1", {
       status: "connected",
       config: {
         transport: "stdio",
         command: "npx",
         tools: [{ name: "forged_tool" }],
+        lastError: "forged",
       },
     } as never);
 
-    const patch = update.mock.calls[0]![1];
+    const [id, patch, method, config] = updateIfConfigUnchanged.mock.calls[0]!;
+    expect(id).toBe("c1");
+    expect(method).toBe("mcp");
+    expect(config).toEqual({
+      transport: "stdio",
+      command: "npx",
+      tools: [{ name: "real_tool" }],
+      lastError: "old boom",
+      custom: "keep",
+    });
     expect(patch.status).toBe("needs_setup");
     expect(patch.config.tools).toBeUndefined();
+    expect(patch.config.lastError).toBeUndefined();
     expect(patch.config.command).toBe("npx");
+    expect(patch.lastSyncAt).toBeNull();
+  });
+
+  it("update with method change resets handshake state using a config snapshot CAS", async () => {
+    findById.mockResolvedValue(
+      stdioRow({
+        method: "mcp",
+        status: "connected",
+        lastSyncAt: new Date("2026-01-01"),
+        config: {
+          transport: "stdio",
+          command: "npx",
+          tools: [{ name: "real_tool" }],
+          lastError: "old boom",
+          custom: "keep",
+        },
+      }),
+    );
+    updateIfConfigUnchanged.mockResolvedValue(
+      stdioRow({ method: "direct-api", status: "needs_setup" }),
+    );
+
+    await svc().update("c1", { method: "direct-api" } as never);
+
+    const [id, patch, method] = updateIfConfigUnchanged.mock.calls[0]!;
+    expect(id).toBe("c1");
+    expect(method).toBe("mcp");
+    expect(patch.status).toBe("needs_setup");
+    expect(patch.config.tools).toBeUndefined();
+    expect(patch.config.lastError).toBeUndefined();
+    expect(patch.config.custom).toBe("keep");
     expect(patch.lastSyncAt).toBeNull();
   });
 
   it("update with config resets status to needs_setup even when no status is given", async () => {
     findById.mockResolvedValue(stdioRow());
-    update.mockResolvedValue(stdioRow());
+    updateIfConfigUnchanged.mockResolvedValue(stdioRow());
+
     await svc().update("c1", {
       config: { transport: "stdio", command: "other" },
     } as never);
 
-    expect(update.mock.calls[0]![1].status).toBe("needs_setup");
-  });
-});
-
-describe("connectorsService method-change invalidation", () => {
-  afterEach(() => vi.clearAllMocks());
-
-  it("update that changes method resets status to needs_setup and clears handshake state", async () => {
-    findById.mockResolvedValue(
-      stdioRow({
-        status: "connected",
-        config: { transport: "stdio", command: "npx", tools: [{ name: "tool" }] },
-        lastSyncAt: new Date(),
-      }),
-    );
-    update.mockResolvedValue(stdioRow());
-
-    await svc().update("c1", { method: "direct-api" } as never);
-
-    const patch = update.mock.calls[0]![1];
-    expect(patch.status).toBe("needs_setup");
-    expect(patch.config.tools).toBeUndefined();
-    expect(patch.config.command).toBe("npx");
-    expect(patch.lastSyncAt).toBeNull();
+    expect(updateIfConfigUnchanged.mock.calls[0]![1].status).toBe("needs_setup");
   });
 
-  it("update that keeps method does not touch existing config", async () => {
-    findById.mockResolvedValue(
-      stdioRow({
-        status: "connected",
-        config: { transport: "stdio", command: "npx", tools: [{ name: "tool" }] },
-        lastSyncAt: new Date(),
-      }),
-    );
-    update.mockResolvedValue(stdioRow());
+  it("update returns Conflict when a method/config snapshot is stale", async () => {
+    findById
+      .mockResolvedValueOnce(stdioRow({ config: { transport: "stdio", command: "npx" } }))
+      .mockResolvedValueOnce(stdioRow({ config: { transport: "stdio", command: "changed" } }));
+    updateIfConfigUnchanged.mockResolvedValue(undefined);
 
-    await svc().update("c1", { name: "renamed" } as never);
+    const result = await svc().update("c1", {
+      config: { transport: "stdio", command: "other" },
+    } as never);
 
-    const patch = update.mock.calls[0]![1];
-    expect(patch.status).toBeUndefined();
-    expect(patch.config).toBeUndefined();
-    expect(patch.lastSyncAt).toBeUndefined();
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr().name).toBe("ConflictError");
+    expect(updateIfConfigUnchanged).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/services/src/connectorsService/createConnectorsService.unit.test.ts
+++ b/packages/services/src/connectorsService/createConnectorsService.unit.test.ts
@@ -4,11 +4,19 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const listMcpToolsStdio = vi.fn();
 const findById = vi.fn();
 const update = vi.fn();
+const updateIfConfigUnchanged = vi.fn();
 const create = vi.fn();
 
 vi.mock("@repo/agent", () => ({ listMcpToolsStdio: (...a: unknown[]) => listMcpToolsStdio(...a) }));
 vi.mock("@repo/models", () => ({
-  createConnectorsDao: () => ({ findById, update, create, findMany: vi.fn(), delete: vi.fn() }),
+  createConnectorsDao: () => ({
+    findById,
+    update,
+    updateIfConfigUnchanged,
+    create,
+    findMany: vi.fn(),
+    delete: vi.fn(),
+  }),
 }));
 
 import { createConnectorsService } from "./createConnectorsService";
@@ -37,17 +45,23 @@ describe("connectorsService.connect", () => {
     const config = { transport: "stdio", command: "npx", args: ["x"], custom: "keep-me" };
     findById.mockResolvedValue(stdioRow({ config }));
     listMcpToolsStdio.mockResolvedValue(ok([{ name: "read_file", description: "d" }]));
-    update.mockImplementation((_id, patch) => Promise.resolve({ ...stdioRow(), ...patch }));
+    updateIfConfigUnchanged.mockImplementation((_id, patch) => Promise.resolve({ ...stdioRow(), ...patch }));
 
     const result = await svc().connect("c1");
 
     expect(result.isOk()).toBe(true);
-    const patch = update.mock.calls[0]![1];
-    expect(patch.status).toBe("connected");
-    expect(patch.config.tools).toEqual([{ name: "read_file", description: "d" }]);
-    expect(patch.config.custom).toBe("keep-me");
+    expect(updateIfConfigUnchanged).toHaveBeenCalledWith(
+      "c1",
+      expect.objectContaining({
+        status: "connected",
+        config: expect.objectContaining({ tools: [{ name: "read_file", description: "d" }], custom: "keep-me" }),
+        lastSyncAt: expect.any(Date),
+      }),
+      "mcp",
+      config,
+    );
+    const patch = updateIfConfigUnchanged.mock.calls[0]![1];
     expect(patch.config.lastError).toBeUndefined();
-    expect(patch.lastSyncAt).toBeInstanceOf(Date);
   });
 
   it("on handshake failure with valid config: sets error + lastError, never connected", async () => {
@@ -114,7 +128,25 @@ describe("connectorsService.connect", () => {
 
     expect(result.isErr()).toBe(true);
     expect(result._unsafeUnwrapErr().message).toContain("changed during handshake");
-    expect(update).not.toHaveBeenCalled();
+    expect(updateIfConfigUnchanged).not.toHaveBeenCalled();
+  });
+
+  it("returns a conflict when the connector is edited between re-read and final write", async () => {
+    const config = { transport: "stdio", command: "npx", args: ["x"] };
+    findById.mockResolvedValue(stdioRow({ config }));
+    listMcpToolsStdio.mockResolvedValue(ok([{ name: "read_file" }]));
+    updateIfConfigUnchanged.mockResolvedValue(undefined);
+
+    const result = await svc().connect("c1");
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr().message).toContain("changed during handshake");
+    expect(updateIfConfigUnchanged).toHaveBeenCalledWith(
+      "c1",
+      expect.anything(),
+      "mcp",
+      config,
+    );
   });
 
   it("returns NotFound when connector missing", async () => {
@@ -143,12 +175,14 @@ describe("connectorsService manual-status guard", () => {
   });
 
   it("update coerces a manual connected status to needs_setup", async () => {
+    findById.mockResolvedValue(stdioRow());
     update.mockResolvedValue(stdioRow());
     await svc().update("c1", { status: "connected" } as never);
     expect(update.mock.calls[0]![1].status).toBe("needs_setup");
   });
 
   it("update with config drops connected status and strips forged tools", async () => {
+    findById.mockResolvedValue(stdioRow());
     update.mockResolvedValue(stdioRow());
     await svc().update("c1", {
       status: "connected",
@@ -163,14 +197,57 @@ describe("connectorsService manual-status guard", () => {
     expect(patch.status).toBe("needs_setup");
     expect(patch.config.tools).toBeUndefined();
     expect(patch.config.command).toBe("npx");
+    expect(patch.lastSyncAt).toBeNull();
   });
 
   it("update with config resets status to needs_setup even when no status is given", async () => {
+    findById.mockResolvedValue(stdioRow());
     update.mockResolvedValue(stdioRow());
     await svc().update("c1", {
       config: { transport: "stdio", command: "other" },
     } as never);
 
     expect(update.mock.calls[0]![1].status).toBe("needs_setup");
+  });
+});
+
+describe("connectorsService method-change invalidation", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("update that changes method resets status to needs_setup and clears handshake state", async () => {
+    findById.mockResolvedValue(
+      stdioRow({
+        status: "connected",
+        config: { transport: "stdio", command: "npx", tools: [{ name: "tool" }] },
+        lastSyncAt: new Date(),
+      }),
+    );
+    update.mockResolvedValue(stdioRow());
+
+    await svc().update("c1", { method: "direct-api" } as never);
+
+    const patch = update.mock.calls[0]![1];
+    expect(patch.status).toBe("needs_setup");
+    expect(patch.config.tools).toBeUndefined();
+    expect(patch.config.command).toBe("npx");
+    expect(patch.lastSyncAt).toBeNull();
+  });
+
+  it("update that keeps method does not touch existing config", async () => {
+    findById.mockResolvedValue(
+      stdioRow({
+        status: "connected",
+        config: { transport: "stdio", command: "npx", tools: [{ name: "tool" }] },
+        lastSyncAt: new Date(),
+      }),
+    );
+    update.mockResolvedValue(stdioRow());
+
+    await svc().update("c1", { name: "renamed" } as never);
+
+    const patch = update.mock.calls[0]![1];
+    expect(patch.status).toBeUndefined();
+    expect(patch.config).toBeUndefined();
+    expect(patch.lastSyncAt).toBeUndefined();
   });
 });


### PR DESCRIPTION
## 背景
#125 合并时 woodfish 在 approve 后又追加了三个行级评论（2 P1 + 1 P2）。本 PR 作为 follow-up 补修。

## 修复内容
1. **connectorsService.update**: method 变更时会像 config 变更一样重置为 needs_setup，清空 tools/lastError 和 lastSyncAt，防止 MCP connector 切到 direct-api 后仍挂着旧 tools 和 connected 状态。
2. **connectorsService.connect**: 最终写入改用 compare-and-set（updateIfConfigUnchanged），按握手前的 method + config 快照做条件更新，重读和最终写入之间被并发编辑覆盖时会返回 409 Conflict。
3. **conversationMessagesDao.findManyByPipelineId**: 带 limit 时返回最新的 N 条并恢复时间升序，而不是最老的 N 条。

## 验证
- packages/services: tsc pass, 254/254 tests pass
- packages/models: tsc pass, 67/67 tests pass
- 修改的文件 oxlint clean

## Review 来源
- https://github.com/forge-town/ordine/pull/125#discussion_r3601828130
- https://github.com/forge-town/ordine/pull/125#discussion_r3601828327
- https://github.com/forge-town/ordine/pull/125#discussion_r3601833864