### PR TITLE
docs: 添加 Claude Code 规范桥接入口（COD-211）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,32 +37,32 @@ ordine/
 
 ### apps/app 关键路径
 
-| 路径 | 说明 |
-|------|------|
-| `src/pages/` | 页面组件，每路由一目录 |
-| `src/pages/<Page>/_store/` | 页面级 Zustand slice |
-| `src/routes/` | TanStack Router 路由定义 |
-| `src/integrations/trpc/routers/` | tRPC 路由 |
-| `src/components/` | 共享 UI 组件 |
-| `e2e/` | Playwright E2E 测试 |
+| 路径                             | 说明                     |
+| -------------------------------- | ------------------------ |
+| `src/pages/`                     | 页面组件，每路由一目录   |
+| `src/pages/<Page>/_store/`       | 页面级 Zustand slice     |
+| `src/routes/`                    | TanStack Router 路由定义 |
+| `src/integrations/trpc/routers/` | tRPC 路由                |
+| `src/components/`                | 共享 UI 组件             |
+| `e2e/`                           | Playwright E2E 测试      |
 
 ---
 
 ## 二、技术栈
 
-| 层 | 技术 |
-|----|------|
-| 前端框架 | React 19 + TanStack Router |
-| 数据获取 | tRPC + Refine + TanStack Query |
-| 状态管理 | Zustand（slice 模式） |
-| UI 组件 | Tailwind CSS v4 + shadcn/ui |
-| 后端框架 | Hono（Bun runtime） |
-| ORM | Drizzle ORM + postgres |
-| 类型验证 | Zod（类型全部由 `z.infer` 派生） |
+| 层       | 技术                                             |
+| -------- | ------------------------------------------------ |
+| 前端框架 | React 19 + TanStack Router                       |
+| 数据获取 | tRPC + Refine + TanStack Query                   |
+| 状态管理 | Zustand（slice 模式）                            |
+| UI 组件  | Tailwind CSS v4 + shadcn/ui                      |
+| 后端框架 | Hono（Bun runtime）                              |
+| ORM      | Drizzle ORM + postgres                           |
+| 类型验证 | Zod（类型全部由 `z.infer` 派生）                 |
 | 错误处理 | neverthrow（`Result<T,E>` / `ResultAsync<T,E>`） |
-| 测试 | Vitest（单元）+ Playwright（E2E） |
-| 格式化 | oxfmt |
-| Lint | oxlint |
+| 测试     | Vitest（单元）+ Playwright（E2E）                |
+| 格式化   | oxfmt                                            |
+| Lint     | oxlint                                           |
 
 ---
 
@@ -106,15 +106,35 @@ bun run knip          # 检测未使用导出
 
 ## 五、Git & PR 工作流
 
+### Linear 协同开发流程
+
+- 开始 issue 开发前，必须先用 Linear（或用户给出的 Linear 上下文）查看
+  `Code Nerds` / `Ordine` project 的当前 issue 状态、描述、评论与
+  relations；不要只凭标题编号或本地记忆开工。
+- 执行顺序以 Linear 的 `blockedBy` / `blocks` 关系和当前状态为准，标题里的 `#` 编号只作参考；被未完成 issue 阻塞的任务不得当作已解锁处理。
+- 已经在 Linear 拆好的 issue 不要重新规划或重复创建；直接按现有 issue 描述、验收标准、评论和依赖推进。
+- 动手改代码前，先向用户明确准备做哪个 issue、为什么现在可开工、依赖/阻塞情况是什么；用户确认或没有异议后再切分支和修改文件。
+- 选定 issue 后，当前会话有 Linear 写权限/工具时，将 Linear 状态更新为
+  `In Progress`；若无写权限/工具，必须向用户说明未更新，不能假装已同步。
+  如果发现依赖未合并、权限/工具不可用或范围需要重新拍板，停下说明，并在
+  Linear 评论或对话中记录阻塞证据。
+- PR 创建后，当前会话有 Linear 写权限/工具时，将 Linear 状态更新为
+  `In Review` 并附 PR 链接；若无写权限/工具，必须在最终回复中明确说明
+  Linear 未同步，并在 PR 描述中写清 issue ID、验证结果、交叉 review 证据与
+  剩余风险。
+
 ### 分支规则
 
 - **不得**向上游 `forge-town/ordine` 推送工作分支
 - 所有 feature/fix 分支在 fork `woodfishhhh/ordine` 下创建并推送
-- 从最新 `upstream/develop` 切出，PR 目标指向 `upstream/develop`（非 `main`）
+- 从最新的上游 `develop` 切出，PR 目标指向 `forge-town/ordine` 的
+  `develop`（非 `main`）；不同工作树的上游 remote 名可能是 `origin` 或
+  `upstream`，操作前先用 `git remote -v` 确认。
 
 ```bash
-git fetch upstream
-git checkout develop && git merge upstream/develop
+git remote -v
+git fetch <upstream-remote>
+git checkout develop && git merge <upstream-remote>/develop
 git checkout -b issue-<N>-<slug>
 git push origin issue-<N>-<slug>
 ```
@@ -127,15 +147,41 @@ git push origin issue-<N>-<slug>
 
 类型：`feat` `fix` `refactor` `docs` `test` `chore` `perf` `ci`
 
+### 独立交叉 Review 门（硬性）
+
+- 每个 issue 的实现与本地验证完成后、提交 PR 前，必须做一次独立交叉
+  review：review 工具必须独立于当前执行 agent，优先调用 **Claude Code
+  MCP**，对该 issue 相对 PR base 的完整 diff 做 review。
+- 本门默认适用于所有 Linear 风险标签（红/黄/绿）；如历史规则或旧记忆存在
+  “绿标免审”说法，在本仓库以本节为准。只有用户在当次任务中明确豁免时才可
+  跳过独立交叉 review。
+- 如当前会话没有 Claude Code MCP，但用户或项目规则允许等价执行，可用
+  Claude Code CLI、独立 sub-agent 或其它独立代码审查工具审查完整 diff，并在
+  PR 说明中记录降级原因、命令/工具与覆盖范围。
+- 不得只抽查文件，也不得用当前执行 agent 的自审代替独立交叉 review。
+- Review 必须覆盖 bug、回归、安全、性能、可维护性和测试缺口，并按严重性输出带文件/行号的 finding。
+- 所有 finding 必须在提交 PR 前逐条处理：修复，或在 PR 说明中记录不采纳理由与证据。未解决的高/中严重性 finding 阻塞 PR。
+- Review 后若发生影响行为或架构的实质修改，必须再次用同等级独立 review
+  工具复审相关 diff，并重新运行受影响测试。
+- PR 说明必须记录交叉 review 证据：review 工具、覆盖的 diff/base、finding 及处理结果。
+- 只有在项目/用户明确要求特定工具（如 Claude Code MCP）时，该工具不可用、
+  调用失败或无法覆盖完整 diff 才阻塞 PR；否则使用用户或项目规则认可的独立
+  review 工具继续。没有任何可用且被认可的独立 review 工具时，必须停下确认，
+  不得静默跳过或换成同一 agent 自审后继续提 PR。
+
 ### 提交前检查清单
 
+- [ ] 已通过 Linear（或用户给出的 Linear 上下文）确认 issue scope、依赖拓扑和当前状态
+- [ ] 如本会话无 Linear 写权限/工具，已声明“未更新 Linear 状态”，并在 PR 或最终回复中记录
 - [ ] `bun run quality` 全部通过
 - [ ] `bun run format:check` 无差异
 - [ ] 无硬编码密钥或凭据
 - [ ] 受影响 UI 已在浏览器中验证（截图存入 `pr-assets/`）
+- [ ] 已完成独立交叉 review（Claude Code MCP / CLI / 用户认可的等价工具），finding 已全部处理或有证据地记录
 
 ### PR 说明要求
 
+- 所有 PR：写明 Linear issue ID、验证结果、独立交叉 review 证据（工具/命令、降级原因、覆盖的 diff/base、finding 与处理结果）和剩余风险
 - 前端视觉变更：附 before/after 截图（desktop + narrow viewport）
 - 前端行为变更无视觉差异：说明"无视觉样式截图差异"并附浏览器验证证据
 
@@ -143,12 +189,12 @@ git push origin issue-<N>-<slug>
 
 ## 六、已知本地环境问题
 
-| 问题 | 说明 |
-|------|------|
-| Nitro 构建失败 | 全量 `bun run build` 时 Nitro 无法解析 Node 内置 `https`（来自全局 `C:/Users/woodfish/node_modules/ws`），属本地 env 问题，不影响 app/server 构建 |
-| E2E fixture 超时 | Playwright E2E 在本地 `/login` networkidle 前超时，属已知本地问题 |
-| 全量 tsc 阻塞 | `apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx` 存在 Select `onValueChange` 签名不匹配，阻塞全量 tsc |
-| 本地模式登录 | 绕过登录需 `ORDINE_LOCAL_MODE=true` 启动 Vite；路由按 `local@ordine.local` 是否存在判断 sign-up，而非 users 总数 |
+| 问题             | 说明                                                                                                                                            |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Nitro 构建失败   | 全量 `bun run build` 时 Nitro 无法解析 Node 内置 `https`（来自全局 `C:/Users/<user>/node_modules/ws`），属本地 env 问题，不影响 app/server 构建 |
+| E2E fixture 超时 | Playwright E2E 在本地 `/login` networkidle 前超时，属已知本地问题                                                                               |
+| 全量 tsc 阻塞    | `apps/app/src/pages/CanvasPage/OperationNode/OperationNode.tsx` 存在 Select `onValueChange` 签名不匹配，阻塞全量 tsc                            |
+| 本地模式登录     | 绕过登录需 `ORDINE_LOCAL_MODE=true` 启动 Vite；路由按 `local@ordine.local` 是否存在判断 sign-up，而非 users 总数                                |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,9 @@ file automatically for every session, because many sessions are not code edits.
 
 Claude-specific working notes:
 
-- Work on a feature/fix branch and open PRs against the upstream `develop`
-  branch.
+- Work on a feature/fix branch and open PRs against the upstream repository's
+  `develop` branch. Confirm the remote name with `git remote -v`; it may be
+  `origin` or `upstream` depending on the worktree.
 - Do not push directly to protected or upstream mainline branches.
 - Keep `CLAUDE.md` public-safe: no credentials, internal-only details, or local
   personal paths.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# Claude Code Entry Point
+
+@AGENTS.md
+
+This file is a thin bridge for Claude Code sessions. `AGENTS.md` remains the
+single source of truth for repository workflow, project structure, Git/PR rules,
+verification expectations, and known local environment issues.
+
+Before editing code, read `CodeGuidelines.md`; it is the authoritative source
+for backend-first development, error handling, Zod-derived types, DAO/Service
+boundaries, frontend data access, and testing rules. Do not import the whole
+file automatically for every session, because many sessions are not code edits.
+
+Claude-specific working notes:
+
+- Work on a feature/fix branch and open PRs against the upstream `develop`
+  branch.
+- Do not push directly to protected or upstream mainline branches.
+- Keep `CLAUDE.md` public-safe: no credentials, internal-only details, or local
+  personal paths.
+- Treat `bun run quality` and `bun run format:check` as the default completion
+  gate; add browser evidence for UI behavior or visual changes.
+- Keep this file small. Update `AGENTS.md` or `CodeGuidelines.md` when changing
+  the actual team rules.


### PR DESCRIPTION
## Summary
- Add root `CLAUDE.md` as the Claude Code entry point.
- Keep `AGENTS.md` as the single source of truth and point code-editing sessions to `CodeGuidelines.md` without duplicating it.
- Port the Codex-side Linear collaboration workflow into `AGENTS.md`: inspect Linear issue scope/status/relations first, announce the target issue before coding, avoid title-number ordering, and sync/declare Linear status updates honestly.
- Port the independent cross-review gate into `AGENTS.md`: every issue requires an independent review before PR unless the user explicitly exempts it, with Claude Code MCP preferred and approved equivalent tools allowed when MCP is unavailable.
- Generalize upstream remote wording so agents confirm `origin`/`upstream` before branching.

## Verification
- `bunx oxfmt --config packages/oxc-formatter-config/oxfmt.json --check AGENTS.md CLAUDE.md` passed.
- `git diff --check` passed.
- Claude Code CLI reviewed the document diff multiple rounds; findings about MCP fallback, Linear write availability, PR base wording, and green-label review ambiguity were addressed in the final docs.
- Sensitive text scan found no credentials; existing fork/workspace identifiers remain project workflow references, and the prior local Windows username path is anonymized to `C:/Users/<user>/node_modules/ws`.
- Earlier `bun run quality` was attempted and is blocked by existing `@repo/models` `ordine-return(newline-before-return)` lint baseline errors in pipeline agent DAO files, unrelated to this docs-only change.
- Earlier `bun run format:check` was attempted and is blocked by existing repository-wide formatting baseline issues; targeted checks for changed docs passed.

## Visual Evidence
No visual difference; docs-only repository entrypoint/workflow change.

Linear: COD-211