### PR TITLE
feat: inject connector MCP tools into Claude Code runs

### DIFF
--- a/packages/agent-engine/src/agentEngine.unit.test.ts
+++ b/packages/agent-engine/src/agentEngine.unit.test.ts
@@ -70,6 +70,27 @@ describe("agentEngine", () => {
     expect(result.usage).toBeNull();
   });
 
+  it("passes MCP injection options to runClaude for claude-code", async () => {
+    await agentEngine.run({
+      agent: "claude-code",
+      mode: "direct",
+      systemPrompt: "You can publish",
+      userPrompt: "Publish this project",
+      cwd: "/tmp/test",
+      allowedTools: ["Read"],
+      mcpConfigPath: "/tmp/ordine-mcp.json",
+      mcpToolNames: ["mcp__GitHub__create_issue"],
+    });
+
+    expect(runClaude).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedTools: ["Read"],
+        mcpConfigPath: "/tmp/ordine-mcp.json",
+        mcpToolNames: ["mcp__GitHub__create_issue"],
+      }),
+    );
+  });
+
   it("derives usage totals when the claude result event reports modelUsage", async () => {
     vi.mocked(runClaude).mockResolvedValueOnce({
       text: "with usage",

--- a/packages/agent-engine/src/drivers.ts
+++ b/packages/agent-engine/src/drivers.ts
@@ -30,6 +30,8 @@ const runLocalClaudeDirect = async (opts: AgentRunOptions): Promise<DriverResult
     onProgress: toAsyncProgress(opts.onProgress),
     extraEnv,
     ssh: opts.ssh,
+    mcpConfigPath: opts.mcpConfigPath,
+    mcpToolNames: opts.mcpToolNames ? [...opts.mcpToolNames] : undefined,
   });
   return { text: result.text, events: result.events };
 };

--- a/packages/agent-engine/src/types.ts
+++ b/packages/agent-engine/src/types.ts
@@ -53,4 +53,6 @@ export interface AgentRunOptions {
   model?: string;
   githubToken?: string;
   ssh?: SshConnectionOptions;
+  mcpConfigPath?: string;
+  mcpToolNames?: readonly string[];
 }

--- a/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.ts
+++ b/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.ts
@@ -1,8 +1,14 @@
+import { rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ResultAsync } from "neverthrow";
 import { agentEngine, type AgentInputAttachment } from "@repo/agent-engine";
 import { logger } from "@repo/logger";
 import { TRACE_MARKER, type AgentRuntime, type SshConnection } from "@repo/schemas";
+import type { ClaudeMcpInjection } from "../../connectorsService";
 import { resolveCwd } from "../resolveCwd";
+
+export type ClaudeMcpInjectionProvider = () => Promise<ClaudeMcpInjection | null>;
 
 export interface AgentRunnerOptions {
   agent: AgentRuntime;
@@ -19,7 +25,58 @@ export interface AgentRunnerOptions {
   model?: string;
   githubToken?: string;
   ssh?: SshConnection;
+  getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
 }
+
+type PreparedClaudeMcpInjection = {
+  configPath: string;
+  toolNames: string[];
+};
+
+const writeClaudeMcpConfig = async (
+  injection: ClaudeMcpInjection,
+): Promise<PreparedClaudeMcpInjection> => {
+  const configPath = join(tmpdir(), `ordine-claude-mcp-${crypto.randomUUID()}.json`);
+  await writeFile(
+    configPath,
+    `${JSON.stringify({ mcpServers: injection.mcpServers }, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+
+  return { configPath, toolNames: injection.toolNames };
+};
+
+const prepareClaudeMcpInjection = async ({
+  agent,
+  ssh,
+  getClaudeMcpInjection,
+}: {
+  agent: AgentRuntime;
+  ssh?: SshConnection;
+  getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
+}): Promise<PreparedClaudeMcpInjection | null> => {
+  if (agent !== "claude-code") return null;
+  if (ssh) return null;
+  if (!getClaudeMcpInjection) return null;
+
+  const injection = await getClaudeMcpInjection();
+  if (!injection) return null;
+
+  return writeClaudeMcpConfig(injection);
+};
+
+const cleanupClaudeMcpConfig = async ({
+  configPath,
+  logPrefix,
+}: {
+  configPath: string;
+  logPrefix: string;
+}): Promise<void> => {
+  const cleanup = await ResultAsync.fromPromise(rm(configPath, { force: true }), (error) => error);
+  if (cleanup.isErr()) {
+    logger.warn({ err: cleanup.error, configPath }, `${logPrefix}: failed to remove MCP config`);
+  }
+};
 
 export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
   const {
@@ -36,6 +93,7 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
     apiKey,
     model,
     githubToken,
+    getClaudeMcpInjection,
   } = opts;
 
   logger.info(
@@ -63,8 +121,34 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
   }
   const cwd = cwdResult.value;
 
-  const engineResult = await ResultAsync.fromPromise(
-    agentEngine.run({
+  if (agent === "claude-code" && opts.ssh && getClaudeMcpInjection) {
+    logger.warn({ agent, host: opts.ssh.host }, `${logPrefix}: MCP tools skipped for SSH runtime`);
+    await onProgress?.(`${logPrefix}: MCP tools skipped for SSH runtime`);
+  }
+
+  const mcpInjectionResult = await ResultAsync.fromPromise(
+    prepareClaudeMcpInjection({ agent, ssh: opts.ssh, getClaudeMcpInjection }),
+    (error) => error,
+  );
+  if (mcpInjectionResult.isErr()) {
+    const errMsg =
+      mcpInjectionResult.error instanceof Error
+        ? mcpInjectionResult.error.message
+        : String(mcpInjectionResult.error);
+    logger.error({ err: errMsg, agent }, `${logPrefix}: MCP injection setup failed`);
+    await onProgress?.(`${logPrefix}: MCP injection setup FAILED — ${errMsg}`);
+    throw new Error(`${agent} MCP injection setup failed: ${errMsg}`, {
+      cause: mcpInjectionResult.error,
+    });
+  }
+  const mcpInjection = mcpInjectionResult.value;
+
+  const runWithMcpInjection = (async () => {
+    if (mcpInjection) {
+      await onProgress?.(`${logPrefix}: MCP tools injected — ${mcpInjection.toolNames.join(", ")}`);
+    }
+
+    return agentEngine.run({
       agent,
       mode: "direct",
       systemPrompt,
@@ -79,6 +163,16 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
       model,
       githubToken,
       ssh: opts.ssh,
+      mcpConfigPath: mcpInjection?.configPath,
+      mcpToolNames: mcpInjection?.toolNames,
+    });
+  })();
+
+  const engineResult = await ResultAsync.fromPromise(
+    runWithMcpInjection.finally(async () => {
+      if (mcpInjection) {
+        await cleanupClaudeMcpConfig({ configPath: mcpInjection.configPath, logPrefix });
+      }
     }),
     (error) => error,
   );

--- a/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.unit.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { access, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi, beforeEach, afterAll } from "vitest";
@@ -85,6 +86,131 @@ describe("runAgent", () => {
             filename: "diagram.png",
           }),
         ],
+      }),
+    );
+  });
+
+  it("injects connected connector MCP config for claude-code and removes the temp file", async () => {
+    const captured = { configPath: "", configContent: "" };
+
+    vi.mocked(agentEngine.run).mockImplementationOnce(async (opts) => {
+      captured.configPath = opts.mcpConfigPath ?? "";
+      captured.configContent = await readFile(captured.configPath, "utf8");
+
+      return { text: "output", usage: null };
+    });
+
+    const onProgress = vi.fn();
+    await runAgent({
+      ...baseOpts,
+      onProgress,
+      getClaudeMcpInjection: async () => ({
+        mcpServers: {
+          GitHub: { command: "github-mcp", args: ["--stdio"], env: { GH_TOKEN: "x" } },
+        },
+        toolNames: ["mcp__GitHub__create_issue"],
+      }),
+    });
+
+    expect(agentEngine.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mcpConfigPath: captured.configPath,
+        mcpToolNames: ["mcp__GitHub__create_issue"],
+      }),
+    );
+    expect(JSON.parse(captured.configContent)).toEqual({
+      mcpServers: {
+        GitHub: { command: "github-mcp", args: ["--stdio"], env: { GH_TOKEN: "x" } },
+      },
+    });
+    expect(onProgress).toHaveBeenCalledWith("test: MCP tools injected — mcp__GitHub__create_issue");
+    await expect(access(captured.configPath)).rejects.toThrow();
+  });
+
+  it("removes the temp MCP config when progress reporting fails after config creation", async () => {
+    const uuidSpy = vi
+      .spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce(
+        "11111111-1111-4111-8111-111111111111" as ReturnType<typeof crypto.randomUUID>,
+      );
+    const configPath = join(
+      tmpdir(),
+      "ordine-claude-mcp-11111111-1111-4111-8111-111111111111.json",
+    );
+    const onProgress = vi.fn(async (line: string) => {
+      if (line.includes("MCP tools injected")) {
+        throw new Error("progress down");
+      }
+    });
+
+    await expect(
+      runAgent({
+        ...baseOpts,
+        onProgress,
+        getClaudeMcpInjection: async () => ({
+          mcpServers: { GitHub: { command: "github-mcp" } },
+          toolNames: ["mcp__GitHub__create_issue"],
+        }),
+      }),
+    ).rejects.toThrow("progress down");
+
+    expect(agentEngine.run).not.toHaveBeenCalled();
+    await expect(access(configPath)).rejects.toThrow();
+    uuidSpy.mockRestore();
+  });
+
+  it("skips MCP config when no connected connector can be injected", async () => {
+    const getClaudeMcpInjection = vi.fn().mockResolvedValue(null);
+
+    await runAgent({ ...baseOpts, getClaudeMcpInjection });
+
+    expect(getClaudeMcpInjection).toHaveBeenCalledTimes(1);
+    expect(agentEngine.run).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        mcpConfigPath: expect.any(String),
+      }),
+    );
+  });
+
+  it("skips connector MCP injection for SSH-backed claude-code runs", async () => {
+    const getClaudeMcpInjection = vi.fn().mockResolvedValue({
+      mcpServers: { GitHub: { command: "github-mcp" } },
+      toolNames: ["mcp__GitHub__create_issue"],
+    });
+    const onProgress = vi.fn();
+
+    await runAgent({
+      ...baseOpts,
+      ssh: { mode: "ssh", host: "remote.example.com", user: "runner" },
+      onProgress,
+      getClaudeMcpInjection,
+    });
+
+    expect(getClaudeMcpInjection).not.toHaveBeenCalled();
+    expect(onProgress).toHaveBeenCalledWith("test: MCP tools skipped for SSH runtime");
+    expect(agentEngine.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ssh: { mode: "ssh", host: "remote.example.com", user: "runner" },
+        mcpConfigPath: undefined,
+        mcpToolNames: undefined,
+      }),
+    );
+  });
+
+  it("does not read connector MCP config for non-claude runtimes", async () => {
+    const getClaudeMcpInjection = vi.fn().mockResolvedValue({
+      mcpServers: { GitHub: { command: "github-mcp" } },
+      toolNames: ["mcp__GitHub"],
+    });
+
+    await runAgent({ ...baseOpts, agent: "mastra", getClaudeMcpInjection });
+
+    expect(getClaudeMcpInjection).not.toHaveBeenCalled();
+    expect(agentEngine.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: "mastra",
+        mcpConfigPath: undefined,
+        mcpToolNames: undefined,
       }),
     );
   });

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
@@ -19,8 +19,10 @@ import {
   createSettingsDao,
   createPipelineRunsDao,
   createAgentRuntimesDao,
+  createConnectorsDao,
   type DbConnection,
 } from "@repo/models";
+import { buildClaudeMcpInjection, type ClaudeMcpInjection } from "../../connectorsService";
 
 export class PipelineNotFoundError extends Error {
   constructor(pipelineId: string) {
@@ -57,6 +59,7 @@ export const createPipelineRunnerService = (db: DbConnection) => {
   const agentSpansDao = createAgentSpansDao(db);
   const settingsDao = createSettingsDao(db);
   const agentRuntimesDao = createAgentRuntimesDao(db);
+  const connectorsDao = createConnectorsDao(db);
 
   initObs(jobTracesDao);
   initSpanRecorder({ agentRawExportsDao, agentSpansDao });
@@ -97,12 +100,14 @@ export const createPipelineRunnerService = (db: DbConnection) => {
     model,
     defaultAgent,
     ssh,
+    getClaudeMcpInjection,
   }: {
     jobId: string;
     apiKey?: string;
     model?: string;
     defaultAgent?: AgentRuntime;
     ssh?: SshConnection;
+    getClaudeMcpInjection?: () => Promise<ClaudeMcpInjection | null>;
   }) =>
     pipelineRunnerEngineDeps.build({
       evaluateLoopCondition: loopEvaluatorFactory({ jobId }),
@@ -111,7 +116,20 @@ export const createPipelineRunnerService = (db: DbConnection) => {
       model,
       defaultAgent,
       ssh,
+      getClaudeMcpInjection,
     });
+
+  const buildClaudeMcpInjectionProvider = () => {
+    const cache: { value?: Promise<ClaudeMcpInjection | null> } = {};
+
+    return () => {
+      cache.value ??= connectorsDao
+        .findMany()
+        .then((connectors) => buildClaudeMcpInjection(connectors));
+
+      return cache.value;
+    };
+  };
 
   return {
     startRun: async (opts: {
@@ -182,6 +200,7 @@ export const createPipelineRunnerService = (db: DbConnection) => {
             model: settings.defaultModel,
             defaultAgent: settings.defaultAgentRuntime,
             ssh,
+            getClaudeMcpInjection: buildClaudeMcpInjectionProvider(),
           }),
           runControl: pipelineRunControl.buildForJob(jobId),
           onRunSettled: () => pipelineRunControl.clear(jobId),

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { pipelineRunControl } from "../runControl";
 
-const { mockJobsDao } = vi.hoisted(() => ({
+const { mockJobsDao, mockConnectorsDao } = vi.hoisted(() => ({
   mockJobsDao: {
     findById: vi.fn(),
     updateStatus: vi.fn().mockResolvedValue(undefined),
     create: vi.fn().mockResolvedValue(undefined),
     setNodeStatuses: vi.fn().mockResolvedValue(undefined),
+  },
+  mockConnectorsDao: {
+    findMany: vi.fn().mockResolvedValue([]),
   },
 }));
 
@@ -32,6 +35,7 @@ vi.mock("@repo/models", () => ({
   createSettingsDao: vi.fn(() => ({ get: vi.fn().mockResolvedValue({}) })),
   createPipelineRunsDao: vi.fn(() => ({})),
   createAgentRuntimesDao: vi.fn(() => ({ findMany: vi.fn().mockResolvedValue([]) })),
+  createConnectorsDao: vi.fn(() => mockConnectorsDao),
 }));
 
 import type { DbConnection } from "@repo/models";
@@ -47,6 +51,7 @@ describe("createPipelineRunnerService run controls", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockJobsDao.updateStatus.mockResolvedValue(undefined);
+    mockConnectorsDao.findMany.mockResolvedValue([]);
   });
 
   it("resumeRun releases a checkpoint waiter while the job status is still running", async () => {
@@ -56,19 +61,19 @@ describe("createPipelineRunnerService run controls", () => {
 
     // The engine suspends on a checkpoint node; the job status stays "running".
     const control = pipelineRunControl.buildForJob(jobId);
-    let released = false;
+    const releaseState = { released: false };
     const waiting = control
       .waitForResume?.({ jobId, nodeId: "n1", reason: "checkpoint" })
       .then(() => {
-        released = true;
+        releaseState.released = true;
       });
-    expect(released).toBe(false);
+    expect(releaseState.released).toBe(false);
 
     const result = await service.resumeRun(jobId);
     await waiting;
 
     expect(result.isOk()).toBe(true);
-    expect(released).toBe(true);
+    expect(releaseState.released).toBe(true);
     expect(mockJobsDao.updateStatus).toHaveBeenCalledWith(jobId, "running", undefined);
 
     pipelineRunControl.clear(jobId);

--- a/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.ts
+++ b/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.ts
@@ -3,6 +3,7 @@ import { skillExecutor } from "../skillExecutor";
 import { structuredOutput } from "../structuredOutput";
 import type { PipelineEngineDeps } from "@repo/pipeline-engine";
 import type { AgentRuntime, SshConnection } from "@repo/schemas";
+import type { ClaudeMcpInjectionProvider } from "../agentRunner/agentRunner";
 import type { LoopEvaluatorFn } from "../loopEvaluator";
 
 export const pipelineRunnerEngineDeps = {
@@ -13,6 +14,7 @@ export const pipelineRunnerEngineDeps = {
     model,
     defaultAgent,
     ssh,
+    getClaudeMcpInjection,
   }: {
     evaluateLoopCondition: LoopEvaluatorFn;
     jobId?: string;
@@ -20,6 +22,7 @@ export const pipelineRunnerEngineDeps = {
     model?: string;
     defaultAgent?: AgentRuntime;
     ssh?: SshConnection;
+    getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
   }): PipelineEngineDeps => ({
     runPrompt: (o) =>
       promptExecutor.run({
@@ -29,6 +32,7 @@ export const pipelineRunnerEngineDeps = {
         apiKey,
         model,
         ssh,
+        getClaudeMcpInjection,
       }),
     runSkill: (o) =>
       skillExecutor.run({
@@ -38,6 +42,7 @@ export const pipelineRunnerEngineDeps = {
         apiKey,
         model,
         ssh,
+        getClaudeMcpInjection,
       }),
     structuredJsonToMarkdown: (content) => structuredOutput.toMarkdown({ content }),
     evaluateLoopCondition,

--- a/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.unit.test.ts
@@ -130,4 +130,32 @@ describe("pipelineRunnerEngineDeps", () => {
       }),
     );
   });
+
+  it("passes Claude MCP injection provider to prompt and skill executors", () => {
+    const getClaudeMcpInjection = vi.fn().mockResolvedValue(null);
+    const deps = pipelineRunnerEngineDeps.build({
+      evaluateLoopCondition,
+      jobId: "job-1",
+      getClaudeMcpInjection,
+    });
+
+    deps.runPrompt({
+      prompt: "publish",
+      inputContent: "content",
+      inputPath: "/tmp/project",
+    });
+    deps.runSkill({
+      skillId: "skill-1",
+      skillDescription: "desc",
+      inputContent: "content",
+      inputPath: "/tmp/project",
+    });
+
+    expect(promptExecutor.run).toHaveBeenCalledWith(
+      expect.objectContaining({ getClaudeMcpInjection }),
+    );
+    expect(skillExecutor.run).toHaveBeenCalledWith(
+      expect.objectContaining({ getClaudeMcpInjection }),
+    );
+  });
 });

--- a/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.ts
+++ b/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.ts
@@ -2,7 +2,7 @@ import { ResultAsync, errAsync } from "neverthrow";
 import { logger } from "@repo/logger";
 import type { OperationRuntimeContext, RunPromptOptions } from "@repo/pipeline-engine";
 import { TRACE_MARKER, type OutputItem, type SshConnection } from "@repo/schemas";
-import { runAgent } from "../agentRunner/agentRunner";
+import { runAgent, type ClaudeMcpInjectionProvider } from "../agentRunner/agentRunner";
 
 export class PromptExecutionError extends Error {
   constructor(
@@ -16,7 +16,10 @@ export class PromptExecutionError extends Error {
 
 const PROMPT_AGENT_ID = "prompt-executor";
 
-type PromptExecutorOptions = RunPromptOptions & { ssh?: SshConnection };
+type PromptExecutorOptions = RunPromptOptions & {
+  ssh?: SshConnection;
+  getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
+};
 
 /**
  * Instruct the executor to emit a structured user-action marker when it cannot
@@ -117,6 +120,7 @@ const run = ({
   outputItems,
   outputDir,
   runtimeContext,
+  getClaudeMcpInjection,
 }: PromptExecutorOptions): ResultAsync<string, PromptExecutionError> => {
   if (!prompt?.trim()) {
     return errAsync(new PromptExecutionError("Prompt text is empty"));
@@ -142,6 +146,7 @@ const run = ({
         model,
         githubToken,
         ssh,
+        getClaudeMcpInjection,
       });
       if (onChunk) await onChunk(raw);
 

--- a/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.ts
+++ b/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.ts
@@ -14,7 +14,7 @@ import type {
   RunSkillOptions as EngineRunSkillOptions,
 } from "@repo/pipeline-engine";
 import type { OutputItem, SshConnection } from "@repo/schemas";
-import { runAgent } from "../agentRunner/agentRunner";
+import { runAgent, type ClaudeMcpInjectionProvider } from "../agentRunner/agentRunner";
 
 const CHECK_OUTPUT_EXAMPLE: CheckOutput = {
   type: "check" as const,
@@ -83,6 +83,7 @@ export class SkillExecutionError extends Error {
 type RunSkillExecutorOptions = EngineRunSkillOptions & {
   jobId?: string;
   ssh?: SshConnection;
+  getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
 };
 
 export const DEFAULT_SKILL_SYSTEM_PROMPT = [
@@ -213,6 +214,7 @@ const run = ({
   outputItems,
   outputDir,
   runtimeContext,
+  getClaudeMcpInjection,
 }: RunSkillExecutorOptions): ResultAsync<string, SkillExecutionError> => {
   const effectiveSystemPrompt = systemPrompt ?? DEFAULT_SKILL_SYSTEM_PROMPT;
   const userPrompt = buildSkillUserPrompt({
@@ -248,6 +250,7 @@ const run = ({
         apiKey,
         model,
         ssh,
+        getClaudeMcpInjection,
       });
 
       if (raw.length === 0) {


### PR DESCRIPTION
## Summary
- Inject connected MCP connector configs into local Claude Code pipeline runs via a generated temporary `--mcp-config` file
- Pass connector MCP tool names through agent-engine into Claude allowed tools
- Skip connector MCP injection for SSH-backed Claude runs because the local temp config path is not visible remotely
- Clean generated MCP config files after success or failure

## Scope
This PR is the Claude Code adapter implementation first. Runtime-agnostic connector injection for Codex, Kimi Code, OpenCode, Hermes, and unsupported fallbacks is tracked in COD-294.

## Verification
- bunx oxfmt packages/agent-engine/src/types.ts packages/agent-engine/src/drivers.ts packages/agent-engine/src/agentEngine.unit.test.ts packages/services/src/pipelineRunnerService/agentRunner/agentRunner.ts packages/services/src/pipelineRunnerService/agentRunner/agentRunner.unit.test.ts packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts packages/services/src/pipelineRunnerService/engineDeps/engineDeps.ts packages/services/src/pipelineRunnerService/engineDeps/engineDeps.unit.test.ts packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.ts packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.ts --check
- cd packages/services && bun run check-types
- cd packages/services && bun run test -- pipelineRunnerService/agentRunner/agentRunner.unit.test.ts pipelineRunnerService/engineDeps/engineDeps.unit.test.ts pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
- cd packages/services && bunx oxlint --config ./.oxlintrc.json src/pipelineRunnerService/agentRunner/agentRunner.ts src/pipelineRunnerService/agentRunner/agentRunner.unit.test.ts src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts src/pipelineRunnerService/engineDeps/engineDeps.ts src/pipelineRunnerService/engineDeps/engineDeps.unit.test.ts src/pipelineRunnerService/promptExecutor/promptExecutor.ts src/pipelineRunnerService/skillExecutor/skillExecutor.ts
- cd packages/agent-engine && bun run check-types && bun run test
- cd packages/agent-engine && bunx oxlint src/types.ts src/drivers.ts src/agentEngine.unit.test.ts
- git diff --check

## Known baseline failures
- `bun run quality` still fails in `@repo/models` on existing `ordine-return(newline-before-return)` errors in pipeline agent DAO files
- `bun run format:check` still reports existing repo-wide formatting drift in 175 files

No visual changes.