### PR TITLE
「Feature」「Connectors」作为用户，我希望不同 runtime 自己注入 Connector ｜ Runtime adapter connector injection

### DIFF
--- a/packages/agent-engine/src/agentEngine.ts
+++ b/packages/agent-engine/src/agentEngine.ts
@@ -2,7 +2,13 @@ import { DRIVERS } from "./drivers";
 import { extractTokenTotals, recordObservability } from "./obs/observability";
 import type { AgentRunOptions, AgentRunOutcome, AgentUsage } from "./types";
 
-export type { AgentInputAttachment, AgentRunOptions, AgentRunOutcome, AgentUsage } from "./types";
+export type {
+  AgentInputAttachment,
+  AgentRunOptions,
+  AgentRunOutcome,
+  AgentUsage,
+  McpConnectorInjectionProvider,
+} from "./types";
 
 const supportsImageAttachments = (agent: AgentRunOptions["agent"]) => agent === "mastra";
 

--- a/packages/agent-engine/src/agentEngine.unit.test.ts
+++ b/packages/agent-engine/src/agentEngine.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ClaudeStreamEvent } from "@repo/agent";
+import { runClaude, runCodex, runHermes, runMastra, type ClaudeStreamEvent } from "@repo/agent";
 
 const fakeClaudeEvents: ClaudeStreamEvent[] = [
   {
@@ -12,16 +12,21 @@ const fakeClaudeEvents: ClaudeStreamEvent[] = [
 ];
 
 vi.mock("@repo/agent", () => ({
+  hasMcpConnectorInjection: (injection?: { mcpServers?: Record<string, unknown> } | null) =>
+    !!injection && Object.keys(injection.mcpServers ?? {}).length > 0,
   runClaude: vi.fn(async (opts: { onProgress?: (s: string) => Promise<void> }) => {
     await opts.onProgress?.("progress");
+
     return { text: "fake claude output", events: fakeClaudeEvents };
   }),
   runCodex: vi.fn(async (opts: { onProgress?: (s: string) => Promise<void> }) => {
     await opts.onProgress?.("progress");
+
     return "fake codex output";
   }),
   runHermes: vi.fn(async (opts: { onProgress?: (s: string) => Promise<void> }) => {
     await opts.onProgress?.("progress");
+
     return {
       isErr: () => false,
       value: "fake hermes output",
@@ -29,10 +34,12 @@ vi.mock("@repo/agent", () => ({
   }),
   runMastra: vi.fn(async (opts: { onProgress?: (s: string) => Promise<void> }) => {
     await opts.onProgress?.("progress");
+
     return { text: "fake mastra output", events: [] };
   }),
   runOpenclaw: vi.fn(async (opts: { onProgress?: (s: string) => Promise<void> }) => {
     await opts.onProgress?.("progress");
+
     return { text: "fake openclaw output" };
   }),
 }));
@@ -46,7 +53,6 @@ vi.mock("@repo/logger", () => ({
 }));
 
 import { agentEngine } from "./agentEngine";
-import { runClaude, runHermes, runMastra } from "@repo/agent";
 import { recordAgentRunWithSpans } from "@repo/obs";
 
 describe("agentEngine", () => {
@@ -70,7 +76,7 @@ describe("agentEngine", () => {
     expect(result.usage).toBeNull();
   });
 
-  it("passes MCP injection options to runClaude for claude-code", async () => {
+  it("writes claude mcp config for connector injection", async () => {
     await agentEngine.run({
       agent: "claude-code",
       mode: "direct",
@@ -78,15 +84,19 @@ describe("agentEngine", () => {
       userPrompt: "Publish this project",
       cwd: "/tmp/test",
       allowedTools: ["Read"],
-      mcpConfigPath: "/tmp/ordine-mcp.json",
-      mcpToolNames: ["mcp__GitHub__create_issue"],
+      connectorInjection: {
+        mcpServers: {
+          GitHub: { command: "github-mcp" },
+        },
+        toolNames: ["mcp__GitHub__create_issue"],
+      },
     });
 
     expect(runClaude).toHaveBeenCalledWith(
       expect.objectContaining({
         allowedTools: ["Read"],
-        mcpConfigPath: "/tmp/ordine-mcp.json",
         mcpToolNames: ["mcp__GitHub__create_issue"],
+        mcpConfigPath: expect.stringContaining("ordine-claude-mcp-"),
       }),
     );
   });
@@ -156,11 +166,23 @@ describe("agentEngine", () => {
       systemPrompt: "Analyze this",
       userPrompt: "Hello",
       cwd: "/tmp/test",
+      connectorInjection: {
+        mcpServers: { linear: { type: "http", url: "https://mcp.linear.app/mcp" } },
+        toolNames: ["mcp__linear"],
+      },
     });
 
     expect(result.text).toBe("fake codex output");
     // Non-claude runtimes have no event stream → usage is unavailable (null), not a fake 0.
     expect(result.usage).toBeNull();
+    expect(runCodex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectorInjection: {
+          mcpServers: { linear: { type: "http", url: "https://mcp.linear.app/mcp" } },
+          toolNames: ["mcp__linear"],
+        },
+      }),
+    );
   });
 
   it("dispatches to runHermes for hermes", async () => {

--- a/packages/agent-engine/src/agentEngine.unit.test.ts
+++ b/packages/agent-engine/src/agentEngine.unit.test.ts
@@ -70,6 +70,27 @@ describe("agentEngine", () => {
     expect(result.usage).toBeNull();
   });
 
+  it("passes MCP injection options to runClaude for claude-code", async () => {
+    await agentEngine.run({
+      agent: "claude-code",
+      mode: "direct",
+      systemPrompt: "You can publish",
+      userPrompt: "Publish this project",
+      cwd: "/tmp/test",
+      allowedTools: ["Read"],
+      mcpConfigPath: "/tmp/ordine-mcp.json",
+      mcpToolNames: ["mcp__GitHub__create_issue"],
+    });
+
+    expect(runClaude).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedTools: ["Read"],
+        mcpConfigPath: "/tmp/ordine-mcp.json",
+        mcpToolNames: ["mcp__GitHub__create_issue"],
+      }),
+    );
+  });
+
   it("derives usage totals when the claude result event reports modelUsage", async () => {
     vi.mocked(runClaude).mockResolvedValueOnce({
       text: "with usage",

--- a/packages/agent-engine/src/agentEngine.unit.test.ts
+++ b/packages/agent-engine/src/agentEngine.unit.test.ts
@@ -185,6 +185,71 @@ describe("agentEngine", () => {
     );
   });
 
+  it("loads only the selected connector tools inside a supported adapter", async () => {
+    const injection = {
+      mcpServers: { github: { command: "github-mcp" } },
+      toolNames: ["mcp__github__read_issue"],
+    };
+    const getMcpConnectorInjection = vi.fn().mockResolvedValue(injection);
+
+    await agentEngine.run({
+      agent: "codex",
+      mode: "direct",
+      systemPrompt: "Analyze this",
+      userPrompt: "Hello",
+      cwd: "/tmp/test",
+      allowedTools: ["Read", "mcp__github__read_issue"],
+      getMcpConnectorInjection,
+    });
+
+    expect(getMcpConnectorInjection).toHaveBeenCalledWith(["mcp__github__read_issue"]);
+    expect(runCodex).toHaveBeenCalledWith(
+      expect.objectContaining({ connectorInjection: injection }),
+    );
+  });
+
+  it("does not resolve connector credentials for Codex SSH runtimes", async () => {
+    const getMcpConnectorInjection = vi.fn();
+    const onProgress = vi.fn();
+
+    await agentEngine.run({
+      agent: "codex",
+      mode: "direct",
+      systemPrompt: "Analyze this",
+      userPrompt: "Hello",
+      cwd: "/tmp/test",
+      ssh: { host: "remote.example.com", user: "runner" },
+      allowedTools: ["mcp__github__read_issue"],
+      getMcpConnectorInjection,
+      onProgress,
+    });
+
+    expect(getMcpConnectorInjection).not.toHaveBeenCalled();
+    expect(runCodex).toHaveBeenCalledWith(
+      expect.objectContaining({ connectorInjection: undefined }),
+    );
+    expect(onProgress).toHaveBeenCalledWith(expect.stringContaining("codex skipped"));
+  });
+
+  it("does not resolve connector credentials for unsupported runtimes", async () => {
+    const getMcpConnectorInjection = vi.fn();
+    const onProgress = vi.fn();
+
+    await agentEngine.run({
+      agent: "mastra",
+      mode: "direct",
+      systemPrompt: "Analyze this",
+      userPrompt: "Hello",
+      cwd: "/tmp/test",
+      allowedTools: ["mcp__github__read_issue"],
+      getMcpConnectorInjection,
+      onProgress,
+    });
+
+    expect(getMcpConnectorInjection).not.toHaveBeenCalled();
+    expect(onProgress).toHaveBeenCalledWith(expect.stringContaining("mastra skipped"));
+  });
+
   it("dispatches to runHermes for hermes", async () => {
     const result = await agentEngine.run({
       agent: "hermes",

--- a/packages/agent-engine/src/agentEngine.unit.test.ts
+++ b/packages/agent-engine/src/agentEngine.unit.test.ts
@@ -208,26 +208,26 @@ describe("agentEngine", () => {
     );
   });
 
-  it("does not resolve connector credentials for Codex SSH runtimes", async () => {
+  it("rejects Codex SSH runtimes before resolving connector credentials", async () => {
     const getMcpConnectorInjection = vi.fn();
     const onProgress = vi.fn();
 
-    await agentEngine.run({
-      agent: "codex",
-      mode: "direct",
-      systemPrompt: "Analyze this",
-      userPrompt: "Hello",
-      cwd: "/tmp/test",
-      ssh: { host: "remote.example.com", user: "runner" },
-      allowedTools: ["mcp__github__read_issue"],
-      getMcpConnectorInjection,
-      onProgress,
-    });
+    await expect(
+      agentEngine.run({
+        agent: "codex",
+        mode: "direct",
+        systemPrompt: "Analyze this",
+        userPrompt: "Hello",
+        cwd: "/tmp/test",
+        ssh: { host: "remote.example.com", user: "runner" },
+        allowedTools: ["mcp__github__read_issue"],
+        getMcpConnectorInjection,
+        onProgress,
+      }),
+    ).rejects.toThrow("Codex SSH runtime is not supported yet");
 
     expect(getMcpConnectorInjection).not.toHaveBeenCalled();
-    expect(runCodex).toHaveBeenCalledWith(
-      expect.objectContaining({ connectorInjection: undefined }),
-    );
+    expect(runCodex).not.toHaveBeenCalled();
     expect(onProgress).toHaveBeenCalledWith(expect.stringContaining("codex skipped"));
   });
 

--- a/packages/agent-engine/src/drivers.ts
+++ b/packages/agent-engine/src/drivers.ts
@@ -39,6 +39,26 @@ const describeConnectorInjection = (injection: McpConnectorInjection): string =>
     ? injection.toolNames.join(", ")
     : Object.keys(injection.mcpServers).join(", ");
 
+const selectedConnectorToolNames = (opts: AgentRunOptions): readonly string[] =>
+  opts.allowedTools?.filter((toolName) => toolName.startsWith("mcp__")) ?? [];
+
+const runtimeToolNames = (opts: AgentRunOptions): readonly string[] | undefined =>
+  opts.allowedTools?.filter((toolName) => !toolName.startsWith("mcp__"));
+
+const loadConnectorInjection = async (
+  opts: AgentRunOptions,
+): Promise<McpConnectorInjection | undefined> => {
+  if (hasMcpConnectorInjection(opts.connectorInjection)) return opts.connectorInjection;
+  const selectedTools = selectedConnectorToolNames(opts);
+  if (!opts.getMcpConnectorInjection || selectedTools.length === 0) return undefined;
+
+  return (await opts.getMcpConnectorInjection(selectedTools)) ?? undefined;
+};
+
+const hasRequestedConnectorInjection = (opts: AgentRunOptions): boolean =>
+  hasMcpConnectorInjection(opts.connectorInjection) ||
+  (!!opts.getMcpConnectorInjection && selectedConnectorToolNames(opts).length > 0);
+
 const writeClaudeMcpConfig = async (
   injection: McpConnectorInjection,
 ): Promise<PreparedClaudeMcpInjection> => {
@@ -72,7 +92,7 @@ const reportConnectorInjectionSkipped = async (
   opts: AgentRunOptions,
   reason: string,
 ): Promise<void> => {
-  if (!hasMcpConnectorInjection(opts.connectorInjection)) return;
+  if (!hasRequestedConnectorInjection(opts)) return;
 
   logger.warn({ agent: opts.agent, reason }, "connector injection skipped");
   await opts.onProgress?.(`[Connector Injection] ${opts.agent} skipped: ${reason}`);
@@ -80,9 +100,10 @@ const reportConnectorInjectionSkipped = async (
 
 const runLocalClaudeDirect = async (opts: AgentRunOptions): Promise<DriverResult> => {
   const extraEnv = opts.githubToken ? { GITHUB_TOKEN: opts.githubToken } : undefined;
+  const selectedRuntimeTools = runtimeToolNames(opts);
   const effectiveTools =
-    opts.allowedTools && opts.allowedTools.length > 0
-      ? (opts.allowedTools as ToolName[])
+    selectedRuntimeTools && selectedRuntimeTools.length > 0
+      ? (selectedRuntimeTools as ToolName[])
       : undefined;
 
   if (opts.ssh) {
@@ -92,15 +113,15 @@ const runLocalClaudeDirect = async (opts: AgentRunOptions): Promise<DriverResult
     );
   }
 
-  const preparedMcp =
-    opts.ssh || !hasMcpConnectorInjection(opts.connectorInjection)
-      ? null
-      : await writeClaudeMcpConfig(opts.connectorInjection);
+  const connectorInjection = opts.ssh ? undefined : await loadConnectorInjection(opts);
+  const preparedMcp = !hasMcpConnectorInjection(connectorInjection)
+    ? null
+    : await writeClaudeMcpConfig(connectorInjection);
 
   const runWithMcp = (async () => {
-    if (preparedMcp && opts.connectorInjection) {
+    if (preparedMcp && connectorInjection) {
       await opts.onProgress?.(
-        `[Connector Injection] claude-code injected: ${describeConnectorInjection(opts.connectorInjection)}`,
+        `[Connector Injection] claude-code injected: ${describeConnectorInjection(connectorInjection)}`,
       );
     }
 
@@ -127,12 +148,26 @@ const runLocalClaudeDirect = async (opts: AgentRunOptions): Promise<DriverResult
 };
 
 const runCodexDirect = async (opts: AgentRunOptions): Promise<DriverResult> => {
+  if (opts.ssh) {
+    await reportConnectorInjectionSkipped(
+      opts,
+      "SSH runtime cannot safely use local Codex MCP configuration",
+    );
+  }
+
+  const connectorInjection = opts.ssh ? undefined : await loadConnectorInjection(opts);
+  if (connectorInjection) {
+    await opts.onProgress?.(
+      `[Connector Injection] codex injected: ${describeConnectorInjection(connectorInjection)}`,
+    );
+  }
+
   const text = await runCodex({
     systemPrompt: opts.systemPrompt,
     userPrompt: opts.userPrompt,
     cwd: opts.cwd,
     onProgress: toAsyncProgress(opts.onProgress),
-    connectorInjection: opts.connectorInjection,
+    connectorInjection,
   });
 
   return { text, events: [] };
@@ -168,7 +203,7 @@ const runHermesDirect = async (opts: AgentRunOptions): Promise<DriverResult> => 
     userPrompt: opts.userPrompt,
     cwd: opts.cwd,
     model: opts.model,
-    allowedTools: opts.allowedTools,
+    allowedTools: runtimeToolNames(opts),
     onProgress: toAsyncProgress(opts.onProgress),
   });
 

--- a/packages/agent-engine/src/drivers.ts
+++ b/packages/agent-engine/src/drivers.ts
@@ -149,13 +149,11 @@ const runLocalClaudeDirect = async (opts: AgentRunOptions): Promise<DriverResult
 
 const runCodexDirect = async (opts: AgentRunOptions): Promise<DriverResult> => {
   if (opts.ssh) {
-    await reportConnectorInjectionSkipped(
-      opts,
-      "SSH runtime cannot safely use local Codex MCP configuration",
-    );
+    await reportConnectorInjectionSkipped(opts, "Codex SSH runtime is not supported yet");
+    throw new Error("Codex SSH runtime is not supported yet");
   }
 
-  const connectorInjection = opts.ssh ? undefined : await loadConnectorInjection(opts);
+  const connectorInjection = await loadConnectorInjection(opts);
   if (connectorInjection) {
     await opts.onProgress?.(
       `[Connector Injection] codex injected: ${describeConnectorInjection(connectorInjection)}`,

--- a/packages/agent-engine/src/drivers.ts
+++ b/packages/agent-engine/src/drivers.ts
@@ -1,5 +1,18 @@
-import { runClaude, runCodex, runHermes, runMastra, runOpenclaw, type ToolName } from "@repo/agent";
-import { AgentRuntime } from "@repo/schemas";
+import { rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  hasMcpConnectorInjection,
+  runClaude,
+  runCodex,
+  runHermes,
+  runMastra,
+  runOpenclaw,
+  type McpConnectorInjection,
+  type ToolName,
+} from "@repo/agent";
+import { logger } from "@repo/logger";
+import type { AgentRuntime } from "@repo/schemas";
 import type { AgentRunOptions, DriverResult } from "./types";
 
 type DriverFn = (opts: AgentRunOptions) => Promise<DriverResult>;
@@ -16,23 +29,100 @@ const toAsyncProgress = (
   };
 };
 
+type PreparedClaudeMcpInjection = {
+  configPath: string;
+  toolNames: readonly string[];
+};
+
+const describeConnectorInjection = (injection: McpConnectorInjection): string =>
+  injection.toolNames.length > 0
+    ? injection.toolNames.join(", ")
+    : Object.keys(injection.mcpServers).join(", ");
+
+const writeClaudeMcpConfig = async (
+  injection: McpConnectorInjection,
+): Promise<PreparedClaudeMcpInjection> => {
+  const configPath = join(tmpdir(), `ordine-claude-mcp-${crypto.randomUUID()}.json`);
+  await writeFile(
+    configPath,
+    `${JSON.stringify({ mcpServers: injection.mcpServers }, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+
+  return { configPath, toolNames: injection.toolNames };
+};
+
+const cleanupClaudeMcpConfig = async ({
+  configPath,
+  agent,
+}: {
+  configPath: string;
+  agent: AgentRuntime;
+}): Promise<void> => {
+  const cleanup = await rm(configPath, { force: true }).then(
+    () => null,
+    (error) => error,
+  );
+  if (cleanup) {
+    logger.warn({ err: cleanup, configPath, agent }, "connector injection: cleanup failed");
+  }
+};
+
+const reportConnectorInjectionSkipped = async (
+  opts: AgentRunOptions,
+  reason: string,
+): Promise<void> => {
+  if (!hasMcpConnectorInjection(opts.connectorInjection)) return;
+
+  logger.warn({ agent: opts.agent, reason }, "connector injection skipped");
+  await opts.onProgress?.(`[Connector Injection] ${opts.agent} skipped: ${reason}`);
+};
+
 const runLocalClaudeDirect = async (opts: AgentRunOptions): Promise<DriverResult> => {
   const extraEnv = opts.githubToken ? { GITHUB_TOKEN: opts.githubToken } : undefined;
   const effectiveTools =
     opts.allowedTools && opts.allowedTools.length > 0
       ? (opts.allowedTools as ToolName[])
       : undefined;
-  const result = await runClaude({
-    systemPrompt: opts.systemPrompt,
-    userPrompt: opts.userPrompt,
-    cwd: opts.cwd,
-    ...(effectiveTools ? { allowedTools: effectiveTools } : {}),
-    onProgress: toAsyncProgress(opts.onProgress),
-    extraEnv,
-    ssh: opts.ssh,
-    mcpConfigPath: opts.mcpConfigPath,
-    mcpToolNames: opts.mcpToolNames ? [...opts.mcpToolNames] : undefined,
+
+  if (opts.ssh) {
+    await reportConnectorInjectionSkipped(
+      opts,
+      "SSH runtime cannot access a local generated MCP config",
+    );
+  }
+
+  const preparedMcp =
+    opts.ssh || !hasMcpConnectorInjection(opts.connectorInjection)
+      ? null
+      : await writeClaudeMcpConfig(opts.connectorInjection);
+
+  const runWithMcp = (async () => {
+    if (preparedMcp && opts.connectorInjection) {
+      await opts.onProgress?.(
+        `[Connector Injection] claude-code injected: ${describeConnectorInjection(opts.connectorInjection)}`,
+      );
+    }
+
+    return runClaude({
+      systemPrompt: opts.systemPrompt,
+      userPrompt: opts.userPrompt,
+      cwd: opts.cwd,
+      ...(effectiveTools ? { allowedTools: effectiveTools } : {}),
+      onProgress: toAsyncProgress(opts.onProgress),
+      extraEnv,
+      ssh: opts.ssh,
+      mcpConfigPath: preparedMcp?.configPath,
+      mcpToolNames: preparedMcp ? [...preparedMcp.toolNames] : undefined,
+    });
+  })();
+
+  const result = await runWithMcp.finally(async () => {
+    if (preparedMcp) {
+      await cleanupClaudeMcpConfig({ configPath: preparedMcp.configPath, agent: opts.agent });
+    }
   });
+
   return { text: result.text, events: result.events };
 };
 
@@ -42,11 +132,18 @@ const runCodexDirect = async (opts: AgentRunOptions): Promise<DriverResult> => {
     userPrompt: opts.userPrompt,
     cwd: opts.cwd,
     onProgress: toAsyncProgress(opts.onProgress),
+    connectorInjection: opts.connectorInjection,
   });
+
   return { text, events: [] };
 };
 
 const runMastraDirect = async (opts: AgentRunOptions): Promise<DriverResult> => {
+  await reportConnectorInjectionSkipped(
+    opts,
+    "runtime adapter does not yet support run-level MCP injection",
+  );
+
   const result = await runMastra({
     systemPrompt: opts.systemPrompt,
     userPrompt: opts.userPrompt,
@@ -56,10 +153,16 @@ const runMastraDirect = async (opts: AgentRunOptions): Promise<DriverResult> => 
     model: opts.model,
     onProgress: toAsyncProgress(opts.onProgress),
   });
+
   return result;
 };
 
 const runHermesDirect = async (opts: AgentRunOptions): Promise<DriverResult> => {
+  await reportConnectorInjectionSkipped(
+    opts,
+    "runtime adapter does not yet support run-level MCP injection",
+  );
+
   const result = await runHermes({
     systemPrompt: opts.systemPrompt,
     userPrompt: opts.userPrompt,
@@ -78,6 +181,11 @@ const runHermesDirect = async (opts: AgentRunOptions): Promise<DriverResult> => 
 };
 
 const runOpenclawDirect = async (opts: AgentRunOptions): Promise<DriverResult> => {
+  await reportConnectorInjectionSkipped(
+    opts,
+    "runtime adapter does not yet support run-level MCP injection",
+  );
+
   const result = await runOpenclaw({
     systemPrompt: opts.systemPrompt,
     userPrompt: opts.userPrompt,

--- a/packages/agent-engine/src/drivers.ts
+++ b/packages/agent-engine/src/drivers.ts
@@ -30,6 +30,8 @@ const runLocalClaudeDirect = async (opts: AgentRunOptions): Promise<DriverResult
     onProgress: toAsyncProgress(opts.onProgress),
     extraEnv,
     ssh: opts.ssh,
+    mcpConfigPath: opts.mcpConfigPath,
+    mcpToolNames: opts.mcpToolNames ? [...opts.mcpToolNames] : undefined,
   });
   return { text: result.text, events: result.events };
 };

--- a/packages/agent-engine/src/types.ts
+++ b/packages/agent-engine/src/types.ts
@@ -2,6 +2,7 @@ import { type AgentRuntime } from "@repo/schemas";
 import type {
   AgentInputAttachment as RuntimeAgentInputAttachment,
   ClaudeStreamEvent,
+  McpConnectorInjection,
   SshConnectionOptions,
 } from "@repo/agent";
 
@@ -53,6 +54,5 @@ export interface AgentRunOptions {
   model?: string;
   githubToken?: string;
   ssh?: SshConnectionOptions;
-  mcpConfigPath?: string;
-  mcpToolNames?: readonly string[];
+  connectorInjection?: McpConnectorInjection;
 }

--- a/packages/agent-engine/src/types.ts
+++ b/packages/agent-engine/src/types.ts
@@ -53,4 +53,6 @@ export interface AgentRunOptions {
   model?: string;
   githubToken?: string;
   ssh?: SshConnectionOptions;
+  mcpConfigPath?: string;
+  mcpToolNames?: readonly string[];
 }

--- a/packages/agent-engine/src/types.ts
+++ b/packages/agent-engine/src/types.ts
@@ -39,6 +39,10 @@ export interface DriverResult {
   events: ClaudeStreamEvent[];
 }
 
+export type McpConnectorInjectionProvider = (
+  selectedToolNames: readonly string[],
+) => Promise<McpConnectorInjection | null>;
+
 export interface AgentRunOptions {
   agent: AgentRuntime;
   mode: "direct";
@@ -55,4 +59,5 @@ export interface AgentRunOptions {
   githubToken?: string;
   ssh?: SshConnectionOptions;
   connectorInjection?: McpConnectorInjection;
+  getMcpConnectorInjection?: McpConnectorInjectionProvider;
 }

--- a/packages/agent/src/codex/runCodex.ts
+++ b/packages/agent/src/codex/runCodex.ts
@@ -1,5 +1,4 @@
-import { readFile, unlink } from "node:fs";
-import { copyFile, mkdtemp, rm } from "node:fs/promises";
+import { copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { hasMcpConnectorInjection, type McpConnectorInjection } from "../mcp";
@@ -26,7 +25,6 @@ export const CODEX_SANDBOX_MODES = {
 } as const;
 
 const TOML_KEY_RE = /^[A-Za-z0-9_-]+$/;
-const CODEX_PROCESS_ENV_NAMES = new Set(["CODEX_HOME", "HOME", "PATH"]);
 
 const tomlKey = (key: string): string => (TOML_KEY_RE.test(key) ? key : JSON.stringify(key));
 
@@ -44,84 +42,104 @@ const tomlValue = (value: unknown): string => {
   throw new Error("unsupported codex config value");
 };
 
-const buildCodexMcpOverrides = (
+const tomlTable = (path: readonly string[]): string => `[${path.map(tomlKey).join(".")}]`;
+
+const envLookupName = (name: string): string =>
+  process.platform === "win32" ? name.toLowerCase() : name;
+
+const setChildEnvValue = (env: Record<string, string>, name: string, value: string): void => {
+  const lookupName = envLookupName(name);
+  for (const existingName of Object.keys({ ...process.env, ...env })) {
+    if (envLookupName(existingName) !== lookupName) continue;
+    const existingValue = env[existingName] ?? process.env[existingName];
+    if (existingValue !== undefined && existingValue !== value) {
+      throw new Error(`MCP headers define conflicting values for env ${name}`);
+    }
+  }
+
+  env[name] = value;
+};
+
+const buildCodexMcpConfig = (
   injection?: McpConnectorInjection,
-): { configArgs: string[]; env: Record<string, string> } => {
+): { configToml: string | null; env: Record<string, string> } => {
   if (!hasMcpConnectorInjection(injection)) {
-    return { configArgs: [], env: {} };
+    return { configToml: null, env: {} };
   }
 
   const env: Record<string, string> = {};
-  const configArgs: string[] = [];
+  const lines: string[] = [];
 
-  for (const [serverName, serverEntry] of Object.entries(injection.mcpServers)) {
-    const serverPrefix = `mcp_servers.${serverName}`;
+  for (const [serverIndex, [serverName, serverEntry]] of Object.entries(
+    injection.mcpServers,
+  ).entries()) {
+    const serverPath = ["mcp_servers", serverName];
     const enabledTools = injection.toolNames
       .filter((toolName) => toolName.startsWith(`mcp__${serverName}__`))
       .map((toolName) => toolName.slice(`mcp__${serverName}__`.length));
 
-    const serverConfig: Record<string, unknown> = {};
+    lines.push(tomlTable(serverPath));
     if ("command" in serverEntry) {
-      serverConfig.command = serverEntry.command;
-      if (serverEntry.args) serverConfig.args = serverEntry.args;
-      if (serverEntry.env) {
-        serverConfig.env_vars = Object.keys(serverEntry.env).sort();
-        for (const [envName, envValue] of Object.entries(serverEntry.env)) {
-          if (CODEX_PROCESS_ENV_NAMES.has(envName)) {
-            throw new Error(
-              `MCP server ${serverName} cannot override Codex process env ${envName}`,
-            );
-          }
-          if (env[envName] !== undefined && env[envName] !== envValue) {
-            throw new Error(`MCP servers define conflicting values for env ${envName}`);
-          }
-          env[envName] = envValue;
-        }
-      }
+      lines.push(`command = ${tomlValue(serverEntry.command)}`);
+      if (serverEntry.args) lines.push(`args = ${tomlValue(serverEntry.args)}`);
       if (enabledTools.length > 0) {
-        serverConfig.enabled_tools = enabledTools;
+        lines.push(`enabled_tools = ${tomlValue(enabledTools)}`);
+      }
+      if (serverEntry.env) {
+        lines.push("");
+        lines.push(tomlTable([...serverPath, "env"]));
+        for (const [envName, envValue] of Object.entries(serverEntry.env)) {
+          lines.push(`${tomlKey(envName)} = ${tomlValue(envValue)}`);
+        }
       }
     } else {
-      serverConfig.url = serverEntry.url;
-      if (serverEntry.headers) {
-        const envHeaders: Record<string, string> = {};
-        for (const [headerName, headerValue] of Object.entries(serverEntry.headers)) {
-          const envName = `ORDINE_MCP_${serverName.toUpperCase().replaceAll(/[^A-Z0-9]/g, "_")}_${headerName.toUpperCase().replaceAll(/[^A-Z0-9]/g, "_")}`;
-          env[envName] = headerValue;
-          envHeaders[headerName] = envName;
-        }
-        if (Object.keys(envHeaders).length > 0) {
-          serverConfig.env_http_headers = envHeaders;
-        }
-      }
+      lines.push(`url = ${tomlValue(serverEntry.url)}`);
       if (enabledTools.length > 0) {
-        serverConfig.enabled_tools = enabledTools;
+        lines.push(`enabled_tools = ${tomlValue(enabledTools)}`);
+      }
+      if (serverEntry.headers) {
+        lines.push("");
+        lines.push(tomlTable([...serverPath, "env_http_headers"]));
+        for (const [headerIndex, [headerName, headerValue]] of Object.entries(
+          serverEntry.headers,
+        ).entries()) {
+          const envName = `ORDINE_MCP_${serverIndex}_${headerIndex}`;
+          setChildEnvValue(env, envName, headerValue);
+          lines.push(`${tomlKey(headerName)} = ${tomlValue(envName)}`);
+        }
       }
     }
 
-    configArgs.push("-c", `${serverPrefix}=${tomlValue(serverConfig)}`);
+    lines.push("");
   }
 
-  return { configArgs, env };
+  return { configToml: lines.join("\n"), env };
 };
 
-const createIsolatedCodexHome = async (): Promise<string> => {
+const createIsolatedCodexHome = async (configToml: string): Promise<string> => {
   const isolatedHome = await mkdtemp(join(tmpdir(), "ordine-codex-home-"));
-
   const sourceHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
-  const authCopy = await copyFile(
-    join(sourceHome, "auth.json"),
-    join(isolatedHome, "auth.json"),
-  ).then(
-    () => null,
-    (error: NodeJS.ErrnoException) => error,
-  );
-  if (authCopy && authCopy.code !== "ENOENT") {
+  const setup = copyFile(join(sourceHome, "auth.json"), join(isolatedHome, "auth.json"))
+    .catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== "ENOENT") throw error;
+    })
+    .then(() => writeFile(join(isolatedHome, "config.toml"), configToml, { mode: 0o600 }));
+  await setup.catch(async (error) => {
     await rm(isolatedHome, { recursive: true, force: true });
-    throw authCopy;
-  }
+    throw error;
+  });
 
   return isolatedHome;
+};
+
+const cleanupPath = async (path: string, label: string): Promise<void> => {
+  const cleanup = await rm(path, { recursive: true, force: true }).then(
+    () => null,
+    (error) => error,
+  );
+  if (cleanup) {
+    logger.debug({ err: String(cleanup) }, `runCodex: failed to remove ${label}`);
+  }
 };
 
 export const runCodex = async ({
@@ -143,13 +161,12 @@ export const runCodex = async ({
     tmpdir(),
     `ordine-codex-last-message-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`,
   );
-  const codexMcpOverrides = buildCodexMcpOverrides(connectorInjection);
-  const isolatedCodexHome = hasMcpConnectorInjection(connectorInjection)
-    ? await createIsolatedCodexHome()
+  const codexMcpConfig = buildCodexMcpConfig(connectorInjection);
+  const isolatedCodexHome = codexMcpConfig.configToml
+    ? await createIsolatedCodexHome(codexMcpConfig.configToml)
     : undefined;
 
   const args = [
-    ...codexMcpOverrides.configArgs,
     "exec",
     "--sandbox",
     sandbox,
@@ -166,95 +183,85 @@ export const runCodex = async ({
   }
 
   logger.info({ cwd, sandbox }, "runCodex: starting");
-  await onProgress?.(`[Codex] Starting codex exec (cwd=${cwd}, sandbox=${sandbox})...`);
 
-  return new Promise<string>((resolve, reject) => {
-    const removeOutputFile = () => {
-      unlink(outputFile, (error) => {
-        if (error && error.code !== "ENOENT") {
-          logger.debug({ err: error.message }, "runCodex: failed to remove output file");
-        }
+  const execution = async (): Promise<string> => {
+    await onProgress?.(`[Codex] Starting codex exec (cwd=${cwd}, sandbox=${sandbox})...`);
+
+    return new Promise<string>((resolve, reject) => {
+      const child = spawnCommand(CODEX_BIN, args, {
+        cwd,
+        stdio: ["pipe", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          ...codexMcpConfig.env,
+          ...(isolatedCodexHome ? { CODEX_HOME: isolatedCodexHome } : {}),
+        },
       });
-    };
-    const removeIsolatedCodexHome = () => {
-      if (!isolatedCodexHome) return;
-      void rm(isolatedCodexHome, { recursive: true, force: true }).then(
-        () => undefined,
-        (error) => logger.debug({ err: String(error) }, "runCodex: failed to remove isolated home"),
-      );
-    };
 
-    const child = spawnCommand(CODEX_BIN, args, {
-      cwd,
-      stdio: ["pipe", "pipe", "pipe"],
-      env: {
-        ...process.env,
-        ...codexMcpOverrides.env,
-        ...(isolatedCodexHome ? { CODEX_HOME: isolatedCodexHome } : {}),
-      },
-    });
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
 
-    const stdoutChunks: Buffer[] = [];
-    const stderrChunks: Buffer[] = [];
+      child.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+      child.stderr.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
 
-    child.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
-    child.stderr.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+      const prompt = `<system>${systemPrompt}</system>\n\n${truncatedPrompt}`;
+      child.stdin.write(prompt);
+      child.stdin.end();
 
-    const prompt = `<system>${systemPrompt}</system>\n\n${truncatedPrompt}`;
-    child.stdin.write(prompt);
-    child.stdin.end();
+      const timer = setTimeout(() => {
+        child.kill("SIGTERM");
+        reject(new Error(`codex timed out after ${timeoutMs / 1000}s`));
+      }, timeoutMs);
 
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      removeOutputFile();
-      removeIsolatedCodexHome();
-      reject(new Error(`codex timed out after ${timeoutMs / 1000}s`));
-    }, timeoutMs);
+      child.on("error", (error) => {
+        clearTimeout(timer);
+        logger.error({ err: error.message }, "runCodex: spawn error");
+        void onProgress?.(`[Codex] Spawn error: ${error.message}`);
+        reject(error);
+      });
 
-    child.on("error", (error) => {
-      clearTimeout(timer);
-      removeOutputFile();
-      removeIsolatedCodexHome();
-      logger.error({ err: error.message }, "runCodex: spawn error");
-      void onProgress?.(`[Codex] Spawn error: ${error.message}`);
-      reject(error);
-    });
-
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      const stdout = Buffer.concat(stdoutChunks).toString("utf8");
-      const stderr = Buffer.concat(stderrChunks).toString("utf8");
-      readFile(outputFile, "utf8", (readError, fileOutput) => {
-        removeOutputFile();
-        removeIsolatedCodexHome();
-        const output = readError ? stdout : fileOutput;
-
-        if (code !== 0 && output.trim().length === 0) {
-          logger.error({ code, stderr: stderr.slice(0, 500) }, "runCodex: non-zero exit");
-          void onProgress?.(`[Codex] Exit code ${code}: ${stderr.slice(0, 200)}`);
-          reject(new Error(`codex exited with code ${code}: ${stderr.slice(0, 500)}`));
-
-          return;
-        }
-
-        if (code !== 0) {
-          logger.warn(
-            { code, outputLen: output.length, stderr: stderr.slice(0, 300) },
-            "runCodex: non-zero exit but output present, using output",
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+        void (async () => {
+          const output = await readFile(outputFile, "utf8").then(
+            (fileOutput) => fileOutput,
+            () => stdout,
           );
-          void onProgress?.(
-            `[Codex] Exit code ${code} (non-fatal, ${output.length} chars captured)`,
-          );
-        }
 
-        if (stderr) {
-          logger.debug({ stderr: stderr.slice(0, 500) }, "runCodex: stderr");
-        }
+          if (code !== 0 && output.trim().length === 0) {
+            logger.error({ code, stderr: stderr.slice(0, 500) }, "runCodex: non-zero exit");
+            void onProgress?.(`[Codex] Exit code ${code}: ${stderr.slice(0, 200)}`);
+            reject(new Error(`codex exited with code ${code}: ${stderr.slice(0, 500)}`));
 
-        logger.info({ len: output.length }, "runCodex: complete");
-        void onProgress?.(`[Codex] Complete (${output.length} chars)`);
-        resolve(output);
+            return;
+          }
+
+          if (code !== 0) {
+            logger.warn(
+              { code, outputLen: output.length, stderr: stderr.slice(0, 300) },
+              "runCodex: non-zero exit but output present, using output",
+            );
+            void onProgress?.(
+              `[Codex] Exit code ${code} (non-fatal, ${output.length} chars captured)`,
+            );
+          }
+
+          if (stderr) {
+            logger.debug({ stderr: stderr.slice(0, 500) }, "runCodex: stderr");
+          }
+
+          logger.info({ len: output.length }, "runCodex: complete");
+          void onProgress?.(`[Codex] Complete (${output.length} chars)`);
+          resolve(output);
+        })();
       });
     });
+  };
+
+  return execution().finally(async () => {
+    await cleanupPath(outputFile, "output file");
+    if (isolatedCodexHome) await cleanupPath(isolatedCodexHome, "isolated home");
   });
 };

--- a/packages/agent/src/codex/runCodex.ts
+++ b/packages/agent/src/codex/runCodex.ts
@@ -1,5 +1,6 @@
 import { readFile, unlink } from "node:fs";
-import { tmpdir } from "node:os";
+import { copyFile, mkdtemp, rm } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { hasMcpConnectorInjection, type McpConnectorInjection } from "../mcp";
 import { logger } from "@repo/logger";
@@ -25,9 +26,9 @@ export const CODEX_SANDBOX_MODES = {
 } as const;
 
 const TOML_KEY_RE = /^[A-Za-z0-9_-]+$/;
+const CODEX_PROCESS_ENV_NAMES = new Set(["CODEX_HOME", "HOME", "PATH"]);
 
-const tomlKey = (key: string): string =>
-  TOML_KEY_RE.test(key) ? key : JSON.stringify(key);
+const tomlKey = (key: string): string => (TOML_KEY_RE.test(key) ? key : JSON.stringify(key));
 
 const tomlValue = (value: unknown): string => {
   if (typeof value === "string") return JSON.stringify(value);
@@ -66,6 +67,14 @@ const buildCodexMcpOverrides = (
       if (serverEntry.env) {
         serverConfig.env_vars = Object.keys(serverEntry.env).sort();
         for (const [envName, envValue] of Object.entries(serverEntry.env)) {
+          if (CODEX_PROCESS_ENV_NAMES.has(envName)) {
+            throw new Error(
+              `MCP server ${serverName} cannot override Codex process env ${envName}`,
+            );
+          }
+          if (env[envName] !== undefined && env[envName] !== envValue) {
+            throw new Error(`MCP servers define conflicting values for env ${envName}`);
+          }
           env[envName] = envValue;
         }
       }
@@ -90,13 +99,29 @@ const buildCodexMcpOverrides = (
       }
     }
 
-    configArgs.push(
-      "-c",
-      `${serverPrefix}=${tomlValue(serverConfig)}`,
-    );
+    configArgs.push("-c", `${serverPrefix}=${tomlValue(serverConfig)}`);
   }
 
   return { configArgs, env };
+};
+
+const createIsolatedCodexHome = async (): Promise<string> => {
+  const isolatedHome = await mkdtemp(join(tmpdir(), "ordine-codex-home-"));
+
+  const sourceHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
+  const authCopy = await copyFile(
+    join(sourceHome, "auth.json"),
+    join(isolatedHome, "auth.json"),
+  ).then(
+    () => null,
+    (error: NodeJS.ErrnoException) => error,
+  );
+  if (authCopy && authCopy.code !== "ENOENT") {
+    await rm(isolatedHome, { recursive: true, force: true });
+    throw authCopy;
+  }
+
+  return isolatedHome;
 };
 
 export const runCodex = async ({
@@ -119,6 +144,9 @@ export const runCodex = async ({
     `ordine-codex-last-message-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`,
   );
   const codexMcpOverrides = buildCodexMcpOverrides(connectorInjection);
+  const isolatedCodexHome = hasMcpConnectorInjection(connectorInjection)
+    ? await createIsolatedCodexHome()
+    : undefined;
 
   const args = [
     ...codexMcpOverrides.configArgs,
@@ -148,11 +176,22 @@ export const runCodex = async ({
         }
       });
     };
+    const removeIsolatedCodexHome = () => {
+      if (!isolatedCodexHome) return;
+      void rm(isolatedCodexHome, { recursive: true, force: true }).then(
+        () => undefined,
+        (error) => logger.debug({ err: String(error) }, "runCodex: failed to remove isolated home"),
+      );
+    };
 
     const child = spawnCommand(CODEX_BIN, args, {
       cwd,
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, ...codexMcpOverrides.env },
+      env: {
+        ...process.env,
+        ...codexMcpOverrides.env,
+        ...(isolatedCodexHome ? { CODEX_HOME: isolatedCodexHome } : {}),
+      },
     });
 
     const stdoutChunks: Buffer[] = [];
@@ -168,12 +207,14 @@ export const runCodex = async ({
     const timer = setTimeout(() => {
       child.kill("SIGTERM");
       removeOutputFile();
+      removeIsolatedCodexHome();
       reject(new Error(`codex timed out after ${timeoutMs / 1000}s`));
     }, timeoutMs);
 
     child.on("error", (error) => {
       clearTimeout(timer);
       removeOutputFile();
+      removeIsolatedCodexHome();
       logger.error({ err: error.message }, "runCodex: spawn error");
       void onProgress?.(`[Codex] Spawn error: ${error.message}`);
       reject(error);
@@ -185,6 +226,7 @@ export const runCodex = async ({
       const stderr = Buffer.concat(stderrChunks).toString("utf8");
       readFile(outputFile, "utf8", (readError, fileOutput) => {
         removeOutputFile();
+        removeIsolatedCodexHome();
         const output = readError ? stdout : fileOutput;
 
         if (code !== 0 && output.trim().length === 0) {

--- a/packages/agent/src/codex/runCodex.ts
+++ b/packages/agent/src/codex/runCodex.ts
@@ -1,6 +1,7 @@
 import { readFile, unlink } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { hasMcpConnectorInjection, type McpConnectorInjection } from "../mcp";
 import { logger } from "@repo/logger";
 import { spawnCommand } from "../spawn/spawnCommand";
 
@@ -12,6 +13,7 @@ export interface RunCodexOptions {
   model?: string;
   timeoutMs?: number;
   onProgress?: (line: string) => Promise<void>;
+  connectorInjection?: McpConnectorInjection;
 }
 
 const CODEX_BIN = process.platform === "win32" ? "codex.cmd" : "codex";
@@ -22,6 +24,81 @@ export const CODEX_SANDBOX_MODES = {
   fullAccess: "danger-full-access",
 } as const;
 
+const TOML_KEY_RE = /^[A-Za-z0-9_-]+$/;
+
+const tomlKey = (key: string): string =>
+  TOML_KEY_RE.test(key) ? key : JSON.stringify(key);
+
+const tomlValue = (value: unknown): string => {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => tomlValue(item)).join(", ")}]`;
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, entryValue]) => `${tomlKey(key)} = ${tomlValue(entryValue)}`);
+
+    return `{ ${entries.join(", ")} }`;
+  }
+
+  throw new Error("unsupported codex config value");
+};
+
+const buildCodexMcpOverrides = (
+  injection?: McpConnectorInjection,
+): { configArgs: string[]; env: Record<string, string> } => {
+  if (!hasMcpConnectorInjection(injection)) {
+    return { configArgs: [], env: {} };
+  }
+
+  const env: Record<string, string> = {};
+  const configArgs: string[] = [];
+
+  for (const [serverName, serverEntry] of Object.entries(injection.mcpServers)) {
+    const serverPrefix = `mcp_servers.${serverName}`;
+    const enabledTools = injection.toolNames
+      .filter((toolName) => toolName.startsWith(`mcp__${serverName}__`))
+      .map((toolName) => toolName.slice(`mcp__${serverName}__`.length));
+
+    const serverConfig: Record<string, unknown> = {};
+    if ("command" in serverEntry) {
+      serverConfig.command = serverEntry.command;
+      if (serverEntry.args) serverConfig.args = serverEntry.args;
+      if (serverEntry.env) {
+        serverConfig.env_vars = Object.keys(serverEntry.env).sort();
+        for (const [envName, envValue] of Object.entries(serverEntry.env)) {
+          env[envName] = envValue;
+        }
+      }
+      if (enabledTools.length > 0) {
+        serverConfig.enabled_tools = enabledTools;
+      }
+    } else {
+      serverConfig.url = serverEntry.url;
+      if (serverEntry.headers) {
+        const envHeaders: Record<string, string> = {};
+        for (const [headerName, headerValue] of Object.entries(serverEntry.headers)) {
+          const envName = `ORDINE_MCP_${serverName.toUpperCase().replaceAll(/[^A-Z0-9]/g, "_")}_${headerName.toUpperCase().replaceAll(/[^A-Z0-9]/g, "_")}`;
+          env[envName] = headerValue;
+          envHeaders[headerName] = envName;
+        }
+        if (Object.keys(envHeaders).length > 0) {
+          serverConfig.env_http_headers = envHeaders;
+        }
+      }
+      if (enabledTools.length > 0) {
+        serverConfig.enabled_tools = enabledTools;
+      }
+    }
+
+    configArgs.push(
+      "-c",
+      `${serverPrefix}=${tomlValue(serverConfig)}`,
+    );
+  }
+
+  return { configArgs, env };
+};
+
 export const runCodex = async ({
   systemPrompt,
   userPrompt,
@@ -30,6 +107,7 @@ export const runCodex = async ({
   model,
   timeoutMs = 10 * 60 * 1000,
   onProgress,
+  connectorInjection,
 }: RunCodexOptions): Promise<string> => {
   const MAX_INPUT_CHARS = 50_000;
   const truncatedPrompt =
@@ -40,8 +118,10 @@ export const runCodex = async ({
     tmpdir(),
     `ordine-codex-last-message-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`,
   );
+  const codexMcpOverrides = buildCodexMcpOverrides(connectorInjection);
 
   const args = [
+    ...codexMcpOverrides.configArgs,
     "exec",
     "--sandbox",
     sandbox,
@@ -72,7 +152,7 @@ export const runCodex = async ({
     const child = spawnCommand(CODEX_BIN, args, {
       cwd,
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env },
+      env: { ...process.env, ...codexMcpOverrides.env },
     });
 
     const stdoutChunks: Buffer[] = [];

--- a/packages/agent/src/codex/runCodex.unit.test.ts
+++ b/packages/agent/src/codex/runCodex.unit.test.ts
@@ -162,6 +162,58 @@ describe("runCodex", () => {
     expect(args).toContain("o3");
   });
 
+  it("injects MCP servers via codex config overrides without leaking secrets into args", async () => {
+    const promise = runCodex({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+      connectorInjection: {
+        mcpServers: {
+          linear: {
+            type: "http",
+            url: "https://mcp.linear.app/mcp",
+            headers: { Authorization: "Bearer secret" },
+          },
+          fs: {
+            command: "npx",
+            args: ["-y", "server-fs"],
+            env: { TOKEN: "secret" },
+          },
+        },
+        toolNames: ["mcp__linear", "mcp__fs__read_file"],
+      },
+    });
+
+    await tick();
+    testState.mockProc.stdout.push("ok");
+    testState.mockProc.stdout.push(null);
+    testState.mockProc.stderr.push(null);
+    testState.mockProc.emit("close", 0);
+
+    await promise;
+
+    const [bin, args, spawnOpts] = spawnMock.mock.calls[0] as unknown as [
+      string,
+      string[],
+      Record<string, unknown>,
+    ];
+    expect(bin).toBeDefined();
+    expect(args.indexOf("-c")).toBeLessThan(args.indexOf("exec"));
+    expect(args.join(" ")).toContain("mcp_servers.linear");
+    expect(args.join(" ")).toContain("mcp_servers.fs");
+    expect(args.join(" ")).toContain("env_vars");
+    expect(args.join(" ")).toContain("enabled_tools");
+    expect(args.join(" ")).not.toContain("secret");
+
+    const env = spawnOpts.env as Record<string, string>;
+    expect(env.TOKEN).toBe("secret");
+    const headerEnvName = Object.keys(env).find((key) =>
+      key.startsWith("ORDINE_MCP_LINEAR_AUTHORIZATION"),
+    );
+    expect(headerEnvName).toBeDefined();
+    expect(env[headerEnvName!]).toBe("Bearer secret");
+  });
+
   it("rejects on timeout", async () => {
     vi.useFakeTimers();
 

--- a/packages/agent/src/codex/runCodex.unit.test.ts
+++ b/packages/agent/src/codex/runCodex.unit.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { EventEmitter, Readable, Writable } from "node:stream";
 
 vi.mock("@repo/logger", () => ({
@@ -39,6 +42,19 @@ const waitForSpawn = async () => {
   while (spawnMock.mock.calls.length === 0) {
     await new Promise((resolve) => setTimeout(resolve, 0));
   }
+};
+
+const isolatedCodexHomes = async (): Promise<string[]> => {
+  const entries = await readdir(tmpdir());
+
+  return entries.filter((name) => name.startsWith("ordine-codex-home-")).sort();
+};
+
+const codexHomeFromEnv = (env: Record<string, string | undefined>): string => {
+  const codexHome = env.CODEX_HOME;
+  expect(codexHome).toBeDefined();
+
+  return codexHome!;
 };
 
 describe("runCodex", () => {
@@ -115,15 +131,24 @@ describe("runCodex", () => {
       systemPrompt: "sys",
       userPrompt: "user",
       cwd: "/tmp",
+      connectorInjection: {
+        mcpServers: { fs: { command: "fs-mcp" } },
+        toolNames: ["mcp__fs"],
+      },
     });
 
     await waitForSpawn();
+    const spawnOpts = (
+      spawnMock.mock.calls[0] as unknown as [string, string[], { env: Record<string, string> }]
+    )[2];
+    const codexHome = codexHomeFromEnv(spawnOpts.env);
     testState.mockProc.stdout.push(null);
     testState.mockProc.stderr.push("error details");
     testState.mockProc.stderr.push(null);
     testState.mockProc.emit("close", 1);
 
     await expect(promise).rejects.toThrow(/exited with code 1/);
+    expect(existsSync(codexHome)).toBe(false);
   });
 
   it("uses workspace-write sandbox when write tools are requested", async () => {
@@ -167,7 +192,7 @@ describe("runCodex", () => {
     expect(args).toContain("o3");
   });
 
-  it("injects MCP servers via codex config overrides without leaking secrets into args", async () => {
+  it("injects MCP servers through an isolated config without leaking secrets", async () => {
     const promise = runCodex({
       systemPrompt: "sys",
       userPrompt: "user",
@@ -190,70 +215,184 @@ describe("runCodex", () => {
     });
 
     await waitForSpawn();
+    const [bin, args, spawnOpts] = spawnMock.mock.calls[0] as unknown as [
+      string,
+      string[],
+      Record<string, unknown>,
+    ];
+    const env = spawnOpts.env as Record<string, string>;
+    const codexHome = codexHomeFromEnv(env);
+    const configPath = join(codexHome, "config.toml");
+    const config = await readFile(configPath, "utf8");
+
+    expect(bin).toBeDefined();
+    expect(args).not.toContain("-c");
+    expect(args.join(" ")).not.toContain("secret");
+    expect(config).toContain("[mcp_servers.linear]");
+    expect(config).toContain('url = "https://mcp.linear.app/mcp"');
+    expect(config).toContain("[mcp_servers.fs]");
+    expect(config).toContain("[mcp_servers.fs.env]");
+    expect(config).toContain('TOKEN = "secret"');
+    expect(config).toContain('enabled_tools = ["read_file"]');
+    expect(env.TOKEN).not.toBe("secret");
+    expect(env.ORDINE_MCP_0_0).toBe("Bearer secret");
+
     testState.mockProc.stdout.push("ok");
     testState.mockProc.stdout.push(null);
     testState.mockProc.stderr.push(null);
     testState.mockProc.emit("close", 0);
 
     await promise;
-
-    const [bin, args, spawnOpts] = spawnMock.mock.calls[0] as unknown as [
-      string,
-      string[],
-      Record<string, unknown>,
-    ];
-    expect(bin).toBeDefined();
-    expect(args.indexOf("-c")).toBeLessThan(args.indexOf("exec"));
-    expect(args.join(" ")).toContain("mcp_servers.linear");
-    expect(args.join(" ")).toContain("mcp_servers.fs");
-    expect(args.join(" ")).toContain("env_vars");
-    expect(args.join(" ")).toContain("enabled_tools");
-    expect(args.join(" ")).not.toContain("secret");
-
-    const env = spawnOpts.env as Record<string, string>;
-    expect(env.TOKEN).toBe("secret");
-    const headerEnvName = Object.keys(env).find((key) =>
-      key.startsWith("ORDINE_MCP_LINEAR_AUTHORIZATION"),
-    );
-    expect(headerEnvName).toBeDefined();
-    expect(env[headerEnvName!]).toBe("Bearer secret");
-    expect(env.CODEX_HOME).toContain("ordine-codex-home-");
-    expect(existsSync(`${env.CODEX_HOME}/config.toml`)).toBe(false);
+    expect(existsSync(codexHome)).toBe(false);
   });
 
-  it("rejects conflicting stdio MCP environment values", async () => {
-    await expect(
-      runCodex({
-        systemPrompt: "sys",
-        userPrompt: "user",
-        cwd: "/tmp",
-        connectorInjection: {
-          mcpServers: {
-            first: { command: "first-mcp", env: { TOKEN: "first" } },
-            second: { command: "second-mcp", env: { TOKEN: "second" } },
+  it("isolates same-named stdio environment values per MCP server", async () => {
+    const promise = runCodex({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+      connectorInjection: {
+        mcpServers: {
+          first: { command: "first-mcp", env: { TOKEN: "first" } },
+          second: { command: "second-mcp", env: { TOKEN: "second" } },
+        },
+        toolNames: ["mcp__first", "mcp__second"],
+      },
+    });
+
+    await waitForSpawn();
+    const spawnOpts = (
+      spawnMock.mock.calls[0] as unknown as [string, string[], { env: Record<string, string> }]
+    )[2];
+    const config = await readFile(join(codexHomeFromEnv(spawnOpts.env), "config.toml"), "utf8");
+    expect(config).toContain("[mcp_servers.first.env]");
+    expect(config).toContain('TOKEN = "first"');
+    expect(config).toContain("[mcp_servers.second.env]");
+    expect(config).toContain('TOKEN = "second"');
+    expect(spawnOpts.env.TOKEN).not.toBe("first");
+    expect(spawnOpts.env.TOKEN).not.toBe("second");
+
+    testState.mockProc.stdout.push("ok");
+    testState.mockProc.stdout.push(null);
+    testState.mockProc.stderr.push(null);
+    testState.mockProc.emit("close", 0);
+    await promise;
+  });
+
+  it("keeps stdio MCP environment names out of the Codex process", async () => {
+    const promise = runCodex({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+      connectorInjection: {
+        mcpServers: {
+          unsafe: {
+            command: "unsafe-mcp",
+            env: { Codex_Home: "/tmp/x", NODE_OPTIONS: "--require attack", Path: "ATTACK" },
           },
-          toolNames: ["mcp__first", "mcp__second"],
         },
-      }),
-    ).rejects.toThrow("conflicting values for env TOKEN");
+        toolNames: ["mcp__unsafe"],
+      },
+    });
 
-    expect(spawnMock).not.toHaveBeenCalled();
+    await waitForSpawn();
+    const spawnOpts = (
+      spawnMock.mock.calls[0] as unknown as [string, string[], { env: Record<string, string> }]
+    )[2];
+    const config = await readFile(join(codexHomeFromEnv(spawnOpts.env), "config.toml"), "utf8");
+    expect(config).toContain('Codex_Home = "/tmp/x"');
+    expect(config).toContain('NODE_OPTIONS = "--require attack"');
+    expect(config).toContain('Path = "ATTACK"');
+    expect(spawnOpts.env.CODEX_HOME).not.toBe("/tmp/x");
+    expect(spawnOpts.env.NODE_OPTIONS).toBe(process.env.NODE_OPTIONS);
+    expect(spawnOpts.env.Path).toBe(process.env.Path);
+
+    testState.mockProc.stdout.push("ok");
+    testState.mockProc.stdout.push(null);
+    testState.mockProc.stderr.push(null);
+    testState.mockProc.emit("close", 0);
+    await promise;
   });
 
-  it("rejects stdio MCP overrides of Codex process environment", async () => {
+  it("allocates collision-free HTTP header secret names", async () => {
+    const promise = runCodex({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+      connectorInjection: {
+        mcpServers: {
+          "foo-bar": {
+            type: "http",
+            url: "https://first.example.com/mcp",
+            headers: { Authorization: "Bearer first" },
+          },
+          foo_bar: {
+            type: "http",
+            url: "https://second.example.com/mcp",
+            headers: { Authorization: "Bearer second" },
+          },
+        },
+        toolNames: ["mcp__foo-bar", "mcp__foo_bar"],
+      },
+    });
+
+    await waitForSpawn();
+    const spawnOpts = (
+      spawnMock.mock.calls[0] as unknown as [string, string[], { env: Record<string, string> }]
+    )[2];
+    const config = await readFile(join(codexHomeFromEnv(spawnOpts.env), "config.toml"), "utf8");
+    expect(config).toContain('Authorization = "ORDINE_MCP_0_0"');
+    expect(config).toContain('Authorization = "ORDINE_MCP_1_0"');
+    expect(spawnOpts.env.ORDINE_MCP_0_0).toBe("Bearer first");
+    expect(spawnOpts.env.ORDINE_MCP_1_0).toBe("Bearer second");
+
+    testState.mockProc.stdout.push("ok");
+    testState.mockProc.stdout.push(null);
+    testState.mockProc.stderr.push(null);
+    testState.mockProc.emit("close", 0);
+    await promise;
+  });
+
+  it("removes the isolated home when progress reporting throws", async () => {
+    const homesBefore = await isolatedCodexHomes();
+
     await expect(
       runCodex({
         systemPrompt: "sys",
         userPrompt: "user",
         cwd: "/tmp",
         connectorInjection: {
-          mcpServers: { unsafe: { command: "unsafe-mcp", env: { CODEX_HOME: "/tmp/x" } } },
-          toolNames: ["mcp__unsafe"],
+          mcpServers: { fs: { command: "fs-mcp" } },
+          toolNames: ["mcp__fs"],
         },
+        onProgress: vi.fn().mockRejectedValue(new Error("progress failed")),
       }),
-    ).rejects.toThrow("cannot override Codex process env CODEX_HOME");
+    ).rejects.toThrow("progress failed");
 
     expect(spawnMock).not.toHaveBeenCalled();
+    expect(await isolatedCodexHomes()).toEqual(homesBefore);
+  });
+
+  it("removes the isolated home when spawning fails", async () => {
+    const promise = runCodex({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+      connectorInjection: {
+        mcpServers: { fs: { command: "fs-mcp" } },
+        toolNames: ["mcp__fs"],
+      },
+    });
+
+    await waitForSpawn();
+    const spawnOpts = (
+      spawnMock.mock.calls[0] as unknown as [string, string[], { env: Record<string, string> }]
+    )[2];
+    const codexHome = codexHomeFromEnv(spawnOpts.env);
+    testState.mockProc.emit("error", new Error("spawn failed"));
+
+    await expect(promise).rejects.toThrow("spawn failed");
+    expect(existsSync(codexHome)).toBe(false);
   });
 
   it("rejects on timeout", async () => {
@@ -264,16 +403,25 @@ describe("runCodex", () => {
       userPrompt: "user",
       cwd: "/tmp",
       timeoutMs: 1000,
+      connectorInjection: {
+        mcpServers: { fs: { command: "fs-mcp" } },
+        toolNames: ["mcp__fs"],
+      },
     });
 
     // Attach the rejection handler before advancing timers
     const rejectPromise = expect(promise).rejects.toThrow(/timed out/);
 
     await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledOnce());
+    const spawnOpts = (
+      spawnMock.mock.calls[0] as unknown as [string, string[], { env: Record<string, string> }]
+    )[2];
+    const codexHome = codexHomeFromEnv(spawnOpts.env);
     await vi.advanceTimersByTimeAsync(1001);
     await rejectPromise;
 
     expect(testState.mockProc.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(existsSync(codexHome)).toBe(false);
 
     vi.useRealTimers();
   });

--- a/packages/agent/src/codex/runCodex.unit.test.ts
+++ b/packages/agent/src/codex/runCodex.unit.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
 import { EventEmitter, Readable, Writable } from "node:stream";
 
 vi.mock("@repo/logger", () => ({
@@ -34,7 +35,11 @@ const createMockProcess = () => {
 
 import { runCodex, CODEX_SANDBOX_MODES, type RunCodexOptions } from "./runCodex";
 
-const tick = () => new Promise((r) => setTimeout(r, 0));
+const waitForSpawn = async () => {
+  while (spawnMock.mock.calls.length === 0) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
 
 describe("runCodex", () => {
   const testState = {
@@ -60,7 +65,7 @@ describe("runCodex", () => {
 
     const promise = runCodex(opts);
 
-    await tick();
+    await waitForSpawn();
     testState.mockProc.stdout.push("Hello from codex");
     testState.mockProc.stdout.push(null);
     testState.mockProc.stderr.push(null);
@@ -95,7 +100,7 @@ describe("runCodex", () => {
       cwd: "/tmp",
     });
 
-    await tick();
+    await waitForSpawn();
     testState.mockProc.stdout.push("result text");
     testState.mockProc.stdout.push(null);
     testState.mockProc.stderr.push(null);
@@ -112,7 +117,7 @@ describe("runCodex", () => {
       cwd: "/tmp",
     });
 
-    await tick();
+    await waitForSpawn();
     testState.mockProc.stdout.push(null);
     testState.mockProc.stderr.push("error details");
     testState.mockProc.stderr.push(null);
@@ -129,7 +134,7 @@ describe("runCodex", () => {
       sandbox: "workspace-write",
     });
 
-    await tick();
+    await waitForSpawn();
     testState.mockProc.stdout.push("ok");
     testState.mockProc.stdout.push(null);
     testState.mockProc.stderr.push(null);
@@ -149,7 +154,7 @@ describe("runCodex", () => {
       model: "o3",
     });
 
-    await tick();
+    await waitForSpawn();
     testState.mockProc.stdout.push("ok");
     testState.mockProc.stdout.push(null);
     testState.mockProc.stderr.push(null);
@@ -184,7 +189,7 @@ describe("runCodex", () => {
       },
     });
 
-    await tick();
+    await waitForSpawn();
     testState.mockProc.stdout.push("ok");
     testState.mockProc.stdout.push(null);
     testState.mockProc.stderr.push(null);
@@ -212,6 +217,43 @@ describe("runCodex", () => {
     );
     expect(headerEnvName).toBeDefined();
     expect(env[headerEnvName!]).toBe("Bearer secret");
+    expect(env.CODEX_HOME).toContain("ordine-codex-home-");
+    expect(existsSync(`${env.CODEX_HOME}/config.toml`)).toBe(false);
+  });
+
+  it("rejects conflicting stdio MCP environment values", async () => {
+    await expect(
+      runCodex({
+        systemPrompt: "sys",
+        userPrompt: "user",
+        cwd: "/tmp",
+        connectorInjection: {
+          mcpServers: {
+            first: { command: "first-mcp", env: { TOKEN: "first" } },
+            second: { command: "second-mcp", env: { TOKEN: "second" } },
+          },
+          toolNames: ["mcp__first", "mcp__second"],
+        },
+      }),
+    ).rejects.toThrow("conflicting values for env TOKEN");
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects stdio MCP overrides of Codex process environment", async () => {
+    await expect(
+      runCodex({
+        systemPrompt: "sys",
+        userPrompt: "user",
+        cwd: "/tmp",
+        connectorInjection: {
+          mcpServers: { unsafe: { command: "unsafe-mcp", env: { CODEX_HOME: "/tmp/x" } } },
+          toolNames: ["mcp__unsafe"],
+        },
+      }),
+    ).rejects.toThrow("cannot override Codex process env CODEX_HOME");
+
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 
   it("rejects on timeout", async () => {
@@ -227,6 +269,7 @@ describe("runCodex", () => {
     // Attach the rejection handler before advancing timers
     const rejectPromise = expect(promise).rejects.toThrow(/timed out/);
 
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledOnce());
     await vi.advanceTimersByTimeAsync(1001);
     await rejectPromise;
 
@@ -252,7 +295,7 @@ describe("runCodex", () => {
       cwd: "/tmp",
     });
 
-    await tick();
+    await waitForSpawn();
     testState.mockProc.stdout.push("ok");
     testState.mockProc.stdout.push(null);
     testState.mockProc.stderr.push(null);

--- a/packages/agent/src/mcp/connectorInjection.ts
+++ b/packages/agent/src/mcp/connectorInjection.ts
@@ -1,0 +1,13 @@
+export type McpServerEntry =
+  | { command: string; args?: string[]; env?: Record<string, string> }
+  | { type: "http"; url: string; headers?: Record<string, string> };
+
+export type McpConnectorInjection = {
+  mcpServers: Record<string, McpServerEntry>;
+  toolNames: readonly string[];
+};
+
+export const hasMcpConnectorInjection = (
+  injection?: McpConnectorInjection | null,
+): injection is McpConnectorInjection =>
+  !!injection && Object.keys(injection.mcpServers).length > 0;

--- a/packages/agent/src/mcp/index.ts
+++ b/packages/agent/src/mcp/index.ts
@@ -1,1 +1,2 @@
 export * from "./mcpStdioClient";
+export * from "./connectorInjection";

--- a/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.test.ts
+++ b/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.test.ts
@@ -92,6 +92,24 @@ describe("executeOperationNode", () => {
     expect(deps.runPrompt).toHaveBeenCalledWith(expect.objectContaining({ prompt: "Do analysis" }));
   });
 
+  it("passes selected tools to prompt operations", async () => {
+    const deps = makeDeps();
+    const op = makeOperation({
+      type: "agent",
+      agentMode: "prompt",
+      prompt: "Do analysis",
+      allowedTools: ["Read", "mcp__github__read_issue"],
+    });
+    const ctx = makeCtx(deps, new Map([["op-id", op]]));
+
+    const result = await executeOperationNode(makeNode({ operationId: "op-id" }), makeInput(), ctx);
+
+    expect(result.outcome).toBe("completed");
+    expect(deps.runPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ allowedTools: ["Read", "mcp__github__read_issue"] }),
+    );
+  });
+
   it("passes structured pipeline and operation runtime context to prompt operations", async () => {
     const deps = makeDeps();
     const op = makeOperation({ type: "agent", agentMode: "prompt", prompt: "Do analysis" });

--- a/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.ts
+++ b/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.ts
@@ -184,6 +184,7 @@ export const executeOperationNode = async (
       agent: agentOverride ?? executor.agent,
       onChunk: handleChunk,
       onProgress,
+      allowedTools: executor.allowedTools,
       extraTools: extraTools.length > 0 ? extraTools : undefined,
       githubToken: input.githubRemote ? ctx.githubToken : undefined,
       outputItems: config.outputs.length > 0 ? config.outputs : undefined,

--- a/packages/pipeline-engine/src/schemas/RunPromptOptionsSchema.ts
+++ b/packages/pipeline-engine/src/schemas/RunPromptOptionsSchema.ts
@@ -12,6 +12,7 @@ export const RunPromptOptionsSchema = z.object({
   agent: AgentRuntimeSchema.optional(),
   apiKey: z.string().optional(),
   model: z.string().optional(),
+  allowedTools: z.array(z.string()).optional(),
   extraTools: z.array(z.string()).optional(),
   githubToken: z.string().optional(),
   outputItems: z.array(OutputItemSchema).optional(),

--- a/packages/services/src/connectorsService/buildClaudeMcpInjection.ts
+++ b/packages/services/src/connectorsService/buildClaudeMcpInjection.ts
@@ -26,9 +26,11 @@ const uniqueServerKey = (base: string, taken: Record<string, unknown>): string =
  */
 export const buildMcpConnectorInjection = (
   connectors: ConnectorLike[],
+  selectedToolNames?: readonly string[],
 ): McpConnectorInjection | null => {
   const mcpServers: Record<string, McpServerEntry> = {};
   const toolNames: string[] = [];
+  const selectedTools = selectedToolNames ? new Set(selectedToolNames) : null;
 
   for (const connector of connectors) {
     if (connector.method !== "mcp") continue;
@@ -37,6 +39,14 @@ export const buildMcpConnectorInjection = (
     if (!isMcpConnectorConfig(config)) continue;
 
     const key = uniqueServerKey(sanitizeServerKey(connector.name), mcpServers);
+    const serverToolPrefix = `mcp__${key}`;
+    const selectedServerTools = selectedTools
+      ? [...selectedTools].filter(
+          (toolName) =>
+            toolName === serverToolPrefix || toolName.startsWith(`${serverToolPrefix}__`),
+        )
+      : null;
+    if (selectedServerTools?.length === 0) continue;
 
     if (config.transport === "stdio") {
       mcpServers[key] = {
@@ -52,11 +62,15 @@ export const buildMcpConnectorInjection = (
       };
     }
 
-    const tools = config.tools ?? [];
-    if (tools.length === 0) {
-      toolNames.push(`mcp__${key}`);
+    if (selectedServerTools) {
+      toolNames.push(...selectedServerTools);
     } else {
-      for (const tool of tools) toolNames.push(`mcp__${key}__${tool.name}`);
+      const tools = config.tools ?? [];
+      if (tools.length === 0) {
+        toolNames.push(serverToolPrefix);
+      } else {
+        for (const tool of tools) toolNames.push(`${serverToolPrefix}__${tool.name}`);
+      }
     }
   }
 

--- a/packages/services/src/connectorsService/buildClaudeMcpInjection.ts
+++ b/packages/services/src/connectorsService/buildClaudeMcpInjection.ts
@@ -1,9 +1,15 @@
 import type { McpConnectorInjection, McpServerEntry } from "@repo/agent";
-import { isMcpConnectorConfig, type ConnectorConfig } from "@repo/schemas";
+import { isMcpConnectorConfig, type ConnectorConfig, type McpConnectorConfig } from "@repo/schemas";
 
 export type ClaudeMcpInjection = McpConnectorInjection;
 
-type ConnectorLike = { name: string; method: string; status: string; config: ConnectorConfig };
+type ConnectorLike = {
+  id: string;
+  name: string;
+  method: string;
+  status: string;
+  config: ConnectorConfig;
+};
 
 /**
  * Server keys keep only [A-Za-z0-9_-]; everything else becomes _
@@ -15,6 +21,26 @@ export const sanitizeServerKey = (name: string): string =>
 /** Dedupe same-named keys: append `_` until unique. */
 const uniqueServerKey = (base: string, taken: Record<string, unknown>): string =>
   base in taken ? uniqueServerKey(`${base}_`, taken) : base;
+
+const selectedMcpToolNames = ({
+  serverKey,
+  config,
+  selectedTools,
+}: {
+  serverKey: string;
+  config: McpConnectorConfig;
+  selectedTools: ReadonlySet<string> | null;
+}): string[] => {
+  const serverToolPrefix = `mcp__${serverKey}`;
+  const availableToolNames =
+    config.tools && config.tools.length > 0
+      ? config.tools.map((tool) => `${serverToolPrefix}__${tool.name}`)
+      : [serverToolPrefix];
+
+  return selectedTools
+    ? availableToolNames.filter((toolName) => selectedTools.has(toolName))
+    : availableToolNames;
+};
 
 /**
  * Assembles method=mcp, status=connected connectors into the claude CLI
@@ -31,22 +57,38 @@ export const buildMcpConnectorInjection = (
   const mcpServers: Record<string, McpServerEntry> = {};
   const toolNames: string[] = [];
   const selectedTools = selectedToolNames ? new Set(selectedToolNames) : null;
+  const selectedToolOwners = new Map<string, string>();
+  const takenServerKeys: Record<string, unknown> = {};
+  const eligibleConnectors = connectors
+    .map((connector) => ({ connector }))
+    .filter(({ connector }) => {
+      if (connector.method !== "mcp") return false;
+      if (connector.status !== "connected") return false;
 
-  for (const connector of connectors) {
-    if (connector.method !== "mcp") continue;
-    if (connector.status !== "connected") continue;
+      return isMcpConnectorConfig(connector.config);
+    })
+    .sort((a, b) => a.connector.id.localeCompare(b.connector.id))
+    .map(({ connector }) => {
+      const key = uniqueServerKey(sanitizeServerKey(connector.name), takenServerKeys);
+      takenServerKeys[key] = true;
+
+      return { connector, key };
+    });
+
+  for (const { connector, key } of eligibleConnectors) {
     const config = connector.config;
     if (!isMcpConnectorConfig(config)) continue;
 
-    const key = uniqueServerKey(sanitizeServerKey(connector.name), mcpServers);
-    const serverToolPrefix = `mcp__${key}`;
-    const selectedServerTools = selectedTools
-      ? [...selectedTools].filter(
-          (toolName) =>
-            toolName === serverToolPrefix || toolName.startsWith(`${serverToolPrefix}__`),
-        )
-      : null;
-    if (selectedServerTools?.length === 0) continue;
+    const selectedServerTools = selectedMcpToolNames({ serverKey: key, config, selectedTools });
+    if (selectedServerTools.length === 0) continue;
+
+    for (const toolName of selectedServerTools) {
+      const existingOwner = selectedToolOwners.get(toolName);
+      if (existingOwner && existingOwner !== key) {
+        throw new Error(`Ambiguous MCP tool selection ${toolName}`);
+      }
+      selectedToolOwners.set(toolName, key);
+    }
 
     if (config.transport === "stdio") {
       mcpServers[key] = {
@@ -62,16 +104,7 @@ export const buildMcpConnectorInjection = (
       };
     }
 
-    if (selectedServerTools) {
-      toolNames.push(...selectedServerTools);
-    } else {
-      const tools = config.tools ?? [];
-      if (tools.length === 0) {
-        toolNames.push(serverToolPrefix);
-      } else {
-        for (const tool of tools) toolNames.push(`${serverToolPrefix}__${tool.name}`);
-      }
-    }
+    toolNames.push(...selectedServerTools);
   }
 
   return Object.keys(mcpServers).length > 0 ? { mcpServers, toolNames } : null;

--- a/packages/services/src/connectorsService/buildClaudeMcpInjection.ts
+++ b/packages/services/src/connectorsService/buildClaudeMcpInjection.ts
@@ -1,18 +1,7 @@
+import type { McpConnectorInjection, McpServerEntry } from "@repo/agent";
 import { isMcpConnectorConfig, type ConnectorConfig } from "@repo/schemas";
 
-export type McpServerEntry =
-  | { command: string; args?: string[]; env?: Record<string, string> }
-  | { type: "http"; url: string; headers?: Record<string, string> };
-
-export type ClaudeMcpInjection = {
-  /** mcpServers map written into the `--mcp-config` file. */
-  mcpServers: Record<string, McpServerEntry>;
-  /**
-   * `mcp__<server>__<tool>` names appended to --allowedTools
-   * (falls back to `mcp__<server>` to allow the whole server when it has no tools).
-   */
-  toolNames: string[];
-};
+export type ClaudeMcpInjection = McpConnectorInjection;
 
 type ConnectorLike = { name: string; method: string; status: string; config: ConnectorConfig };
 
@@ -35,7 +24,9 @@ const uniqueServerKey = (base: string, taken: Record<string, unknown>): string =
  * disconnected ones never reach a run (keeps fake state out of the execution
  * chain).
  */
-export const buildClaudeMcpInjection = (connectors: ConnectorLike[]): ClaudeMcpInjection | null => {
+export const buildMcpConnectorInjection = (
+  connectors: ConnectorLike[],
+): McpConnectorInjection | null => {
   const mcpServers: Record<string, McpServerEntry> = {};
   const toolNames: string[] = [];
 
@@ -71,3 +62,5 @@ export const buildClaudeMcpInjection = (connectors: ConnectorLike[]): ClaudeMcpI
 
   return Object.keys(mcpServers).length > 0 ? { mcpServers, toolNames } : null;
 };
+
+export const buildClaudeMcpInjection = buildMcpConnectorInjection;

--- a/packages/services/src/connectorsService/buildClaudeMcpInjection.unit.test.ts
+++ b/packages/services/src/connectorsService/buildClaudeMcpInjection.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildClaudeMcpInjection, sanitizeServerKey } from "./buildClaudeMcpInjection";
+import { buildMcpConnectorInjection, sanitizeServerKey } from "./buildClaudeMcpInjection";
 
 const connected = (name: string, config: unknown, status = "connected", method = "mcp") =>
   ({ name, method, status, config }) as never;
@@ -11,20 +11,20 @@ describe("sanitizeServerKey", () => {
   });
 });
 
-describe("buildClaudeMcpInjection", () => {
+describe("buildMcpConnectorInjection", () => {
   it("returns null when there are no connected mcp connectors", () => {
-    expect(buildClaudeMcpInjection([])).toBeNull();
+    expect(buildMcpConnectorInjection([])).toBeNull();
     expect(
-      buildClaudeMcpInjection([
+      buildMcpConnectorInjection([
         connected("fs", { transport: "stdio", command: "x" }, "needs_setup"),
       ]),
     ).toBeNull();
-    expect(buildClaudeMcpInjection([connected("legacy", {})])).toBeNull();
+    expect(buildMcpConnectorInjection([connected("legacy", {})])).toBeNull();
   });
 
   it("skips non-mcp connectors even when they look connected", () => {
     expect(
-      buildClaudeMcpInjection([
+      buildMcpConnectorInjection([
         connected("api", { transport: "stdio", command: "x" }, "connected", "direct-api"),
         connected("builtin", { transport: "stdio", command: "y" }, "connected", "built-in"),
       ]),
@@ -32,7 +32,7 @@ describe("buildClaudeMcpInjection", () => {
   });
 
   it("builds stdio server entry + per-tool allow names", () => {
-    const out = buildClaudeMcpInjection([
+    const out = buildMcpConnectorInjection([
       connected("fs", {
         transport: "stdio",
         command: "npx",
@@ -51,7 +51,7 @@ describe("buildClaudeMcpInjection", () => {
   });
 
   it("builds http entry and whole-server allow when no tools discovered", () => {
-    const out = buildClaudeMcpInjection([
+    const out = buildMcpConnectorInjection([
       connected("remote api", { transport: "http", url: "https://x/sse" }),
     ]);
     expect(out!.mcpServers.remote_api).toEqual({ type: "http", url: "https://x/sse" });
@@ -59,7 +59,7 @@ describe("buildClaudeMcpInjection", () => {
   });
 
   it("dedupes server keys with the same sanitized name", () => {
-    const out = buildClaudeMcpInjection([
+    const out = buildMcpConnectorInjection([
       connected("api x", { transport: "stdio", command: "a" }),
       connected("api!x", { transport: "stdio", command: "b" }),
     ]);

--- a/packages/services/src/connectorsService/buildClaudeMcpInjection.unit.test.ts
+++ b/packages/services/src/connectorsService/buildClaudeMcpInjection.unit.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { buildMcpConnectorInjection, sanitizeServerKey } from "./buildClaudeMcpInjection";
 
-const connected = (name: string, config: unknown, status = "connected", method = "mcp") =>
-  ({ name, method, status, config }) as never;
+const connected = (
+  name: string,
+  config: unknown,
+  status = "connected",
+  method = "mcp",
+  id = `connector-${name}`,
+) => ({ id, name, method, status, config }) as never;
 
 describe("sanitizeServerKey", () => {
   it("keeps word chars, replaces the rest", () => {
@@ -87,5 +92,51 @@ describe("buildMcpConnectorInjection", () => {
       mcpServers: { github: { command: "github-mcp" } },
       toolNames: ["mcp__github__read_issue"],
     });
+  });
+
+  it("uses connector id order for stable deduped keys", () => {
+    const connectors = [
+      connected(
+        "api",
+        { transport: "stdio", command: "second-mcp", tools: [{ name: "read" }] },
+        "connected",
+        "mcp",
+        "connector-b",
+      ),
+      connected(
+        "api",
+        { transport: "stdio", command: "first-mcp", tools: [{ name: "read" }] },
+        "connected",
+        "mcp",
+        "connector-a",
+      ),
+    ];
+
+    for (const orderedConnectors of [connectors, [...connectors].reverse()]) {
+      expect(buildMcpConnectorInjection(orderedConnectors, ["mcp__api___read"])).toEqual({
+        mcpServers: { api_: { command: "second-mcp" } },
+        toolNames: ["mcp__api___read"],
+      });
+    }
+  });
+
+  it("fails closed when a selected tool name maps to multiple servers", () => {
+    expect(() =>
+      buildMcpConnectorInjection(
+        [
+          connected("api x", {
+            transport: "stdio",
+            command: "first-mcp",
+            tools: [{ name: "_read" }],
+          }),
+          connected("api!x", {
+            transport: "stdio",
+            command: "second-mcp",
+            tools: [{ name: "read" }],
+          }),
+        ],
+        ["mcp__api_x___read"],
+      ),
+    ).toThrow("Ambiguous MCP tool selection mcp__api_x___read");
   });
 });

--- a/packages/services/src/connectorsService/buildClaudeMcpInjection.unit.test.ts
+++ b/packages/services/src/connectorsService/buildClaudeMcpInjection.unit.test.ts
@@ -65,4 +65,27 @@ describe("buildMcpConnectorInjection", () => {
     ]);
     expect(Object.keys(out!.mcpServers).sort()).toEqual(["api_x", "api_x_"]);
   });
+
+  it("only includes connectors selected for the current run", () => {
+    const out = buildMcpConnectorInjection(
+      [
+        connected("github", {
+          transport: "stdio",
+          command: "github-mcp",
+          tools: [{ name: "create_issue" }, { name: "read_issue" }],
+        }),
+        connected("linear", {
+          transport: "http",
+          url: "https://mcp.linear.app/mcp",
+          tools: [{ name: "create_issue" }],
+        }),
+      ],
+      ["mcp__github__read_issue"],
+    );
+
+    expect(out).toEqual({
+      mcpServers: { github: { command: "github-mcp" } },
+      toolNames: ["mcp__github__read_issue"],
+    });
+  });
 });

--- a/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.ts
+++ b/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.ts
@@ -1,8 +1,14 @@
+import { rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ResultAsync } from "neverthrow";
 import { agentEngine, type AgentInputAttachment } from "@repo/agent-engine";
 import { logger } from "@repo/logger";
 import { TRACE_MARKER, type AgentRuntime, type SshConnection } from "@repo/schemas";
+import type { ClaudeMcpInjection } from "../../connectorsService";
 import { resolveCwd } from "../resolveCwd";
+
+export type ClaudeMcpInjectionProvider = () => Promise<ClaudeMcpInjection | null>;
 
 export interface AgentRunnerOptions {
   agent: AgentRuntime;
@@ -19,7 +25,58 @@ export interface AgentRunnerOptions {
   model?: string;
   githubToken?: string;
   ssh?: SshConnection;
+  getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
 }
+
+type PreparedClaudeMcpInjection = {
+  configPath: string;
+  toolNames: string[];
+};
+
+const writeClaudeMcpConfig = async (
+  injection: ClaudeMcpInjection,
+): Promise<PreparedClaudeMcpInjection> => {
+  const configPath = join(tmpdir(), `ordine-claude-mcp-${crypto.randomUUID()}.json`);
+  await writeFile(
+    configPath,
+    `${JSON.stringify({ mcpServers: injection.mcpServers }, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+
+  return { configPath, toolNames: injection.toolNames };
+};
+
+const prepareClaudeMcpInjection = async ({
+  agent,
+  ssh,
+  getClaudeMcpInjection,
+}: {
+  agent: AgentRuntime;
+  ssh?: SshConnection;
+  getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
+}): Promise<PreparedClaudeMcpInjection | null> => {
+  if (agent !== "claude-code") return null;
+  if (ssh) return null;
+  if (!getClaudeMcpInjection) return null;
+
+  const injection = await getClaudeMcpInjection();
+  if (!injection) return null;
+
+  return writeClaudeMcpConfig(injection);
+};
+
+const cleanupClaudeMcpConfig = async ({
+  configPath,
+  logPrefix,
+}: {
+  configPath: string;
+  logPrefix: string;
+}): Promise<void> => {
+  const cleanup = await ResultAsync.fromPromise(rm(configPath, { force: true }), (error) => error);
+  if (cleanup.isErr()) {
+    logger.warn({ err: cleanup.error, configPath }, `${logPrefix}: failed to remove MCP config`);
+  }
+};
 
 export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
   const {
@@ -36,6 +93,7 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
     apiKey,
     model,
     githubToken,
+    getClaudeMcpInjection,
   } = opts;
 
   logger.info(
@@ -63,8 +121,34 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
   }
   const cwd = cwdResult.value;
 
-  const engineResult = await ResultAsync.fromPromise(
-    agentEngine.run({
+  if (agent === "claude-code" && opts.ssh && getClaudeMcpInjection) {
+    logger.warn({ agent, host: opts.ssh.host }, `${logPrefix}: MCP tools skipped for SSH runtime`);
+    await onProgress?.(`${logPrefix}: MCP tools skipped for SSH runtime`);
+  }
+
+  const mcpInjectionResult = await ResultAsync.fromPromise(
+    prepareClaudeMcpInjection({ agent, ssh: opts.ssh, getClaudeMcpInjection }),
+    (error) => error,
+  );
+  if (mcpInjectionResult.isErr()) {
+    const errMsg =
+      mcpInjectionResult.error instanceof Error
+        ? mcpInjectionResult.error.message
+        : String(mcpInjectionResult.error);
+    logger.error({ err: errMsg, agent }, `${logPrefix}: MCP injection setup failed`);
+    await onProgress?.(`${logPrefix}: MCP injection setup FAILED — ${errMsg}`);
+    throw new Error(`${agent} MCP injection setup failed: ${errMsg}`, {
+      cause: mcpInjectionResult.error,
+    });
+  }
+  const mcpInjection = mcpInjectionResult.value;
+
+  const runWithMcpInjection = (async () => {
+    if (mcpInjection) {
+      await onProgress?.(`${logPrefix}: MCP tools injected — ${mcpInjection.toolNames.join(", ")}`);
+    }
+
+    return agentEngine.run({
       agent,
       mode: "direct",
       systemPrompt,
@@ -79,6 +163,16 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
       model,
       githubToken,
       ssh: opts.ssh,
+      mcpConfigPath: mcpInjection?.configPath,
+      mcpToolNames: mcpInjection?.toolNames,
+    });
+  })();
+
+  const engineResult = await ResultAsync.fromPromise(
+    runWithMcpInjection.finally(async () => {
+      if (mcpInjection) {
+        await cleanupClaudeMcpConfig({ configPath: mcpInjection.configPath, logPrefix });
+      }
     }),
     (error) => error,
   );

--- a/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.ts
+++ b/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.ts
@@ -1,11 +1,14 @@
 import { ResultAsync } from "neverthrow";
-import type { McpConnectorInjection } from "@repo/agent";
-import { agentEngine, type AgentInputAttachment } from "@repo/agent-engine";
+import {
+  agentEngine,
+  type AgentInputAttachment,
+  type McpConnectorInjectionProvider,
+} from "@repo/agent-engine";
 import { logger } from "@repo/logger";
 import { TRACE_MARKER, type AgentRuntime, type SshConnection } from "@repo/schemas";
 import { resolveCwd } from "../resolveCwd";
 
-export type McpConnectorInjectionProvider = () => Promise<McpConnectorInjection | null>;
+export type { McpConnectorInjectionProvider } from "@repo/agent-engine";
 
 export interface AgentRunnerOptions {
   agent: AgentRuntime;
@@ -68,25 +71,6 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
   }
   const cwd = cwdResult.value;
 
-  const connectorInjectionResult = getMcpConnectorInjection
-    ? await ResultAsync.fromPromise(getMcpConnectorInjection(), (error) => error)
-    : null;
-  if (connectorInjectionResult?.isErr()) {
-    const errMsg =
-      connectorInjectionResult.error instanceof Error
-        ? connectorInjectionResult.error.message
-        : String(connectorInjectionResult.error);
-    logger.error({ err: errMsg, agent }, `${logPrefix}: MCP injection setup failed`);
-    await onProgress?.(`${logPrefix}: MCP injection setup FAILED — ${errMsg}`);
-    throw new Error(`${agent} MCP injection setup failed: ${errMsg}`, {
-      cause: connectorInjectionResult.error,
-    });
-  }
-
-  const connectorInjection = connectorInjectionResult?.isOk()
-    ? connectorInjectionResult.value ?? undefined
-    : undefined;
-
   const engineResult = await ResultAsync.fromPromise(
     agentEngine.run({
       agent,
@@ -103,7 +87,7 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
       model,
       githubToken,
       ssh: opts.ssh,
-      connectorInjection,
+      getMcpConnectorInjection,
     }),
     (error) => error,
   );

--- a/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.ts
+++ b/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.ts
@@ -1,14 +1,11 @@
-import { rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { ResultAsync } from "neverthrow";
+import type { McpConnectorInjection } from "@repo/agent";
 import { agentEngine, type AgentInputAttachment } from "@repo/agent-engine";
 import { logger } from "@repo/logger";
 import { TRACE_MARKER, type AgentRuntime, type SshConnection } from "@repo/schemas";
-import type { ClaudeMcpInjection } from "../../connectorsService";
 import { resolveCwd } from "../resolveCwd";
 
-export type ClaudeMcpInjectionProvider = () => Promise<ClaudeMcpInjection | null>;
+export type McpConnectorInjectionProvider = () => Promise<McpConnectorInjection | null>;
 
 export interface AgentRunnerOptions {
   agent: AgentRuntime;
@@ -25,58 +22,8 @@ export interface AgentRunnerOptions {
   model?: string;
   githubToken?: string;
   ssh?: SshConnection;
-  getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
+  getMcpConnectorInjection?: McpConnectorInjectionProvider;
 }
-
-type PreparedClaudeMcpInjection = {
-  configPath: string;
-  toolNames: string[];
-};
-
-const writeClaudeMcpConfig = async (
-  injection: ClaudeMcpInjection,
-): Promise<PreparedClaudeMcpInjection> => {
-  const configPath = join(tmpdir(), `ordine-claude-mcp-${crypto.randomUUID()}.json`);
-  await writeFile(
-    configPath,
-    `${JSON.stringify({ mcpServers: injection.mcpServers }, null, 2)}\n`,
-    { mode: 0o600 },
-  );
-
-  return { configPath, toolNames: injection.toolNames };
-};
-
-const prepareClaudeMcpInjection = async ({
-  agent,
-  ssh,
-  getClaudeMcpInjection,
-}: {
-  agent: AgentRuntime;
-  ssh?: SshConnection;
-  getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
-}): Promise<PreparedClaudeMcpInjection | null> => {
-  if (agent !== "claude-code") return null;
-  if (ssh) return null;
-  if (!getClaudeMcpInjection) return null;
-
-  const injection = await getClaudeMcpInjection();
-  if (!injection) return null;
-
-  return writeClaudeMcpConfig(injection);
-};
-
-const cleanupClaudeMcpConfig = async ({
-  configPath,
-  logPrefix,
-}: {
-  configPath: string;
-  logPrefix: string;
-}): Promise<void> => {
-  const cleanup = await ResultAsync.fromPromise(rm(configPath, { force: true }), (error) => error);
-  if (cleanup.isErr()) {
-    logger.warn({ err: cleanup.error, configPath }, `${logPrefix}: failed to remove MCP config`);
-  }
-};
 
 export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
   const {
@@ -93,7 +40,7 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
     apiKey,
     model,
     githubToken,
-    getClaudeMcpInjection,
+    getMcpConnectorInjection,
   } = opts;
 
   logger.info(
@@ -121,34 +68,27 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
   }
   const cwd = cwdResult.value;
 
-  if (agent === "claude-code" && opts.ssh && getClaudeMcpInjection) {
-    logger.warn({ agent, host: opts.ssh.host }, `${logPrefix}: MCP tools skipped for SSH runtime`);
-    await onProgress?.(`${logPrefix}: MCP tools skipped for SSH runtime`);
-  }
-
-  const mcpInjectionResult = await ResultAsync.fromPromise(
-    prepareClaudeMcpInjection({ agent, ssh: opts.ssh, getClaudeMcpInjection }),
-    (error) => error,
-  );
-  if (mcpInjectionResult.isErr()) {
+  const connectorInjectionResult = getMcpConnectorInjection
+    ? await ResultAsync.fromPromise(getMcpConnectorInjection(), (error) => error)
+    : null;
+  if (connectorInjectionResult?.isErr()) {
     const errMsg =
-      mcpInjectionResult.error instanceof Error
-        ? mcpInjectionResult.error.message
-        : String(mcpInjectionResult.error);
+      connectorInjectionResult.error instanceof Error
+        ? connectorInjectionResult.error.message
+        : String(connectorInjectionResult.error);
     logger.error({ err: errMsg, agent }, `${logPrefix}: MCP injection setup failed`);
     await onProgress?.(`${logPrefix}: MCP injection setup FAILED — ${errMsg}`);
     throw new Error(`${agent} MCP injection setup failed: ${errMsg}`, {
-      cause: mcpInjectionResult.error,
+      cause: connectorInjectionResult.error,
     });
   }
-  const mcpInjection = mcpInjectionResult.value;
 
-  const runWithMcpInjection = (async () => {
-    if (mcpInjection) {
-      await onProgress?.(`${logPrefix}: MCP tools injected — ${mcpInjection.toolNames.join(", ")}`);
-    }
+  const connectorInjection = connectorInjectionResult?.isOk()
+    ? connectorInjectionResult.value ?? undefined
+    : undefined;
 
-    return agentEngine.run({
+  const engineResult = await ResultAsync.fromPromise(
+    agentEngine.run({
       agent,
       mode: "direct",
       systemPrompt,
@@ -163,16 +103,7 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
       model,
       githubToken,
       ssh: opts.ssh,
-      mcpConfigPath: mcpInjection?.configPath,
-      mcpToolNames: mcpInjection?.toolNames,
-    });
-  })();
-
-  const engineResult = await ResultAsync.fromPromise(
-    runWithMcpInjection.finally(async () => {
-      if (mcpInjection) {
-        await cleanupClaudeMcpConfig({ configPath: mcpInjection.configPath, logPrefix });
-      }
+      connectorInjection,
     }),
     (error) => error,
   );

--- a/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.unit.test.ts
@@ -89,95 +89,14 @@ describe("runAgent", () => {
     );
   });
 
-  it("forwards connector MCP injection to agentEngine", async () => {
-    const connectorInjection = {
-      mcpServers: {
-        GitHub: { command: "github-mcp", args: ["--stdio"], env: { GH_TOKEN: "x" } },
-      },
-      toolNames: ["mcp__GitHub__create_issue"],
-    };
-
-    await runAgent({
-      ...baseOpts,
-      getMcpConnectorInjection: async () => connectorInjection,
-    });
-
-    expect(agentEngine.run).toHaveBeenCalledWith(
-      expect.objectContaining({
-        connectorInjection,
-      }),
-    );
-  });
-
-  it("fails when connector MCP injection cannot be prepared", async () => {
-    await expect(
-      runAgent({
-        ...baseOpts,
-        getMcpConnectorInjection: async () => {
-          throw new Error("connector store down");
-        },
-      }),
-    ).rejects.toThrow("connector store down");
-
-    expect(agentEngine.run).not.toHaveBeenCalled();
-  });
-
-  it("skips MCP config when no connected connector can be injected", async () => {
+  it("forwards the connector provider without resolving it", async () => {
     const getMcpConnectorInjection = vi.fn().mockResolvedValue(null);
 
     await runAgent({ ...baseOpts, getMcpConnectorInjection });
 
-    expect(getMcpConnectorInjection).toHaveBeenCalledTimes(1);
+    expect(getMcpConnectorInjection).not.toHaveBeenCalled();
     expect(agentEngine.run).toHaveBeenCalledWith(
-      expect.not.objectContaining({
-        connectorInjection: expect.any(Object),
-      }),
-    );
-  });
-
-  it("leaves SSH connector handling to the selected runtime adapter", async () => {
-    const getMcpConnectorInjection = vi.fn().mockResolvedValue({
-      mcpServers: { GitHub: { command: "github-mcp" } },
-      toolNames: ["mcp__GitHub__create_issue"],
-    });
-    const onProgress = vi.fn();
-
-    await runAgent({
-      ...baseOpts,
-      ssh: { mode: "ssh", host: "remote.example.com", user: "runner" },
-      onProgress,
-      getMcpConnectorInjection,
-    });
-
-    expect(getMcpConnectorInjection).toHaveBeenCalledTimes(1);
-    expect(agentEngine.run).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ssh: { mode: "ssh", host: "remote.example.com", user: "runner" },
-        connectorInjection: {
-          mcpServers: { GitHub: { command: "github-mcp" } },
-          toolNames: ["mcp__GitHub__create_issue"],
-        },
-      }),
-    );
-  });
-
-  it("passes connector MCP injection to non-claude runtimes", async () => {
-    const getMcpConnectorInjection = vi.fn().mockResolvedValue({
-      mcpServers: { GitHub: { command: "github-mcp" } },
-      toolNames: ["mcp__GitHub"],
-    });
-
-    await runAgent({ ...baseOpts, agent: "mastra", getMcpConnectorInjection });
-
-    expect(getMcpConnectorInjection).toHaveBeenCalledTimes(1);
-    expect(agentEngine.run).toHaveBeenCalledWith(
-      expect.objectContaining({
-        agent: "mastra",
-        connectorInjection: {
-          mcpServers: { GitHub: { command: "github-mcp" } },
-          toolNames: ["mcp__GitHub"],
-        },
-      }),
+      expect.objectContaining({ getMcpConnectorInjection }),
     );
   });
 

--- a/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.unit.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { access, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi, beforeEach, afterAll } from "vitest";
@@ -85,6 +86,131 @@ describe("runAgent", () => {
             filename: "diagram.png",
           }),
         ],
+      }),
+    );
+  });
+
+  it("injects connected connector MCP config for claude-code and removes the temp file", async () => {
+    const captured = { configPath: "", configContent: "" };
+
+    vi.mocked(agentEngine.run).mockImplementationOnce(async (opts) => {
+      captured.configPath = opts.mcpConfigPath ?? "";
+      captured.configContent = await readFile(captured.configPath, "utf8");
+
+      return { text: "output", usage: null };
+    });
+
+    const onProgress = vi.fn();
+    await runAgent({
+      ...baseOpts,
+      onProgress,
+      getClaudeMcpInjection: async () => ({
+        mcpServers: {
+          GitHub: { command: "github-mcp", args: ["--stdio"], env: { GH_TOKEN: "x" } },
+        },
+        toolNames: ["mcp__GitHub__create_issue"],
+      }),
+    });
+
+    expect(agentEngine.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mcpConfigPath: captured.configPath,
+        mcpToolNames: ["mcp__GitHub__create_issue"],
+      }),
+    );
+    expect(JSON.parse(captured.configContent)).toEqual({
+      mcpServers: {
+        GitHub: { command: "github-mcp", args: ["--stdio"], env: { GH_TOKEN: "x" } },
+      },
+    });
+    expect(onProgress).toHaveBeenCalledWith("test: MCP tools injected — mcp__GitHub__create_issue");
+    await expect(access(captured.configPath)).rejects.toThrow();
+  });
+
+  it("removes the temp MCP config when progress reporting fails after config creation", async () => {
+    const uuidSpy = vi
+      .spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce(
+        "11111111-1111-4111-8111-111111111111" as ReturnType<typeof crypto.randomUUID>,
+      );
+    const configPath = join(
+      tmpdir(),
+      "ordine-claude-mcp-11111111-1111-4111-8111-111111111111.json",
+    );
+    const onProgress = vi.fn(async (line: string) => {
+      if (line.includes("MCP tools injected")) {
+        throw new Error("progress down");
+      }
+    });
+
+    await expect(
+      runAgent({
+        ...baseOpts,
+        onProgress,
+        getClaudeMcpInjection: async () => ({
+          mcpServers: { GitHub: { command: "github-mcp" } },
+          toolNames: ["mcp__GitHub__create_issue"],
+        }),
+      }),
+    ).rejects.toThrow("progress down");
+
+    expect(agentEngine.run).not.toHaveBeenCalled();
+    await expect(access(configPath)).rejects.toThrow();
+    uuidSpy.mockRestore();
+  });
+
+  it("skips MCP config when no connected connector can be injected", async () => {
+    const getClaudeMcpInjection = vi.fn().mockResolvedValue(null);
+
+    await runAgent({ ...baseOpts, getClaudeMcpInjection });
+
+    expect(getClaudeMcpInjection).toHaveBeenCalledTimes(1);
+    expect(agentEngine.run).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        mcpConfigPath: expect.any(String),
+      }),
+    );
+  });
+
+  it("skips connector MCP injection for SSH-backed claude-code runs", async () => {
+    const getClaudeMcpInjection = vi.fn().mockResolvedValue({
+      mcpServers: { GitHub: { command: "github-mcp" } },
+      toolNames: ["mcp__GitHub__create_issue"],
+    });
+    const onProgress = vi.fn();
+
+    await runAgent({
+      ...baseOpts,
+      ssh: { mode: "ssh", host: "remote.example.com", user: "runner" },
+      onProgress,
+      getClaudeMcpInjection,
+    });
+
+    expect(getClaudeMcpInjection).not.toHaveBeenCalled();
+    expect(onProgress).toHaveBeenCalledWith("test: MCP tools skipped for SSH runtime");
+    expect(agentEngine.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ssh: { mode: "ssh", host: "remote.example.com", user: "runner" },
+        mcpConfigPath: undefined,
+        mcpToolNames: undefined,
+      }),
+    );
+  });
+
+  it("does not read connector MCP config for non-claude runtimes", async () => {
+    const getClaudeMcpInjection = vi.fn().mockResolvedValue({
+      mcpServers: { GitHub: { command: "github-mcp" } },
+      toolNames: ["mcp__GitHub"],
+    });
+
+    await runAgent({ ...baseOpts, agent: "mastra", getClaudeMcpInjection });
+
+    expect(getClaudeMcpInjection).not.toHaveBeenCalled();
+    expect(agentEngine.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: "mastra",
+        mcpConfigPath: undefined,
+        mcpToolNames: undefined,
       }),
     );
   });

--- a/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.unit.test.ts
@@ -1,5 +1,4 @@
 import { mkdtempSync, rmSync } from "node:fs";
-import { access, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi, beforeEach, afterAll } from "vitest";
@@ -90,90 +89,54 @@ describe("runAgent", () => {
     );
   });
 
-  it("injects connected connector MCP config for claude-code and removes the temp file", async () => {
-    const captured = { configPath: "", configContent: "" };
+  it("forwards connector MCP injection to agentEngine", async () => {
+    const connectorInjection = {
+      mcpServers: {
+        GitHub: { command: "github-mcp", args: ["--stdio"], env: { GH_TOKEN: "x" } },
+      },
+      toolNames: ["mcp__GitHub__create_issue"],
+    };
 
-    vi.mocked(agentEngine.run).mockImplementationOnce(async (opts) => {
-      captured.configPath = opts.mcpConfigPath ?? "";
-      captured.configContent = await readFile(captured.configPath, "utf8");
-
-      return { text: "output", usage: null };
-    });
-
-    const onProgress = vi.fn();
     await runAgent({
       ...baseOpts,
-      onProgress,
-      getClaudeMcpInjection: async () => ({
-        mcpServers: {
-          GitHub: { command: "github-mcp", args: ["--stdio"], env: { GH_TOKEN: "x" } },
-        },
-        toolNames: ["mcp__GitHub__create_issue"],
-      }),
+      getMcpConnectorInjection: async () => connectorInjection,
     });
 
     expect(agentEngine.run).toHaveBeenCalledWith(
       expect.objectContaining({
-        mcpConfigPath: captured.configPath,
-        mcpToolNames: ["mcp__GitHub__create_issue"],
+        connectorInjection,
       }),
     );
-    expect(JSON.parse(captured.configContent)).toEqual({
-      mcpServers: {
-        GitHub: { command: "github-mcp", args: ["--stdio"], env: { GH_TOKEN: "x" } },
-      },
-    });
-    expect(onProgress).toHaveBeenCalledWith("test: MCP tools injected — mcp__GitHub__create_issue");
-    await expect(access(captured.configPath)).rejects.toThrow();
   });
 
-  it("removes the temp MCP config when progress reporting fails after config creation", async () => {
-    const uuidSpy = vi
-      .spyOn(crypto, "randomUUID")
-      .mockReturnValueOnce(
-        "11111111-1111-4111-8111-111111111111" as ReturnType<typeof crypto.randomUUID>,
-      );
-    const configPath = join(
-      tmpdir(),
-      "ordine-claude-mcp-11111111-1111-4111-8111-111111111111.json",
-    );
-    const onProgress = vi.fn(async (line: string) => {
-      if (line.includes("MCP tools injected")) {
-        throw new Error("progress down");
-      }
-    });
-
+  it("fails when connector MCP injection cannot be prepared", async () => {
     await expect(
       runAgent({
         ...baseOpts,
-        onProgress,
-        getClaudeMcpInjection: async () => ({
-          mcpServers: { GitHub: { command: "github-mcp" } },
-          toolNames: ["mcp__GitHub__create_issue"],
-        }),
+        getMcpConnectorInjection: async () => {
+          throw new Error("connector store down");
+        },
       }),
-    ).rejects.toThrow("progress down");
+    ).rejects.toThrow("connector store down");
 
     expect(agentEngine.run).not.toHaveBeenCalled();
-    await expect(access(configPath)).rejects.toThrow();
-    uuidSpy.mockRestore();
   });
 
   it("skips MCP config when no connected connector can be injected", async () => {
-    const getClaudeMcpInjection = vi.fn().mockResolvedValue(null);
+    const getMcpConnectorInjection = vi.fn().mockResolvedValue(null);
 
-    await runAgent({ ...baseOpts, getClaudeMcpInjection });
+    await runAgent({ ...baseOpts, getMcpConnectorInjection });
 
-    expect(getClaudeMcpInjection).toHaveBeenCalledTimes(1);
+    expect(getMcpConnectorInjection).toHaveBeenCalledTimes(1);
     expect(agentEngine.run).toHaveBeenCalledWith(
       expect.not.objectContaining({
-        mcpConfigPath: expect.any(String),
+        connectorInjection: expect.any(Object),
       }),
     );
   });
 
-  it("skips connector MCP injection for SSH-backed claude-code runs", async () => {
-    const getClaudeMcpInjection = vi.fn().mockResolvedValue({
+  it("leaves SSH connector handling to the selected runtime adapter", async () => {
+    const getMcpConnectorInjection = vi.fn().mockResolvedValue({
       mcpServers: { GitHub: { command: "github-mcp" } },
       toolNames: ["mcp__GitHub__create_issue"],
     });
@@ -183,34 +146,37 @@ describe("runAgent", () => {
       ...baseOpts,
       ssh: { mode: "ssh", host: "remote.example.com", user: "runner" },
       onProgress,
-      getClaudeMcpInjection,
+      getMcpConnectorInjection,
     });
 
-    expect(getClaudeMcpInjection).not.toHaveBeenCalled();
-    expect(onProgress).toHaveBeenCalledWith("test: MCP tools skipped for SSH runtime");
+    expect(getMcpConnectorInjection).toHaveBeenCalledTimes(1);
     expect(agentEngine.run).toHaveBeenCalledWith(
       expect.objectContaining({
         ssh: { mode: "ssh", host: "remote.example.com", user: "runner" },
-        mcpConfigPath: undefined,
-        mcpToolNames: undefined,
+        connectorInjection: {
+          mcpServers: { GitHub: { command: "github-mcp" } },
+          toolNames: ["mcp__GitHub__create_issue"],
+        },
       }),
     );
   });
 
-  it("does not read connector MCP config for non-claude runtimes", async () => {
-    const getClaudeMcpInjection = vi.fn().mockResolvedValue({
+  it("passes connector MCP injection to non-claude runtimes", async () => {
+    const getMcpConnectorInjection = vi.fn().mockResolvedValue({
       mcpServers: { GitHub: { command: "github-mcp" } },
       toolNames: ["mcp__GitHub"],
     });
 
-    await runAgent({ ...baseOpts, agent: "mastra", getClaudeMcpInjection });
+    await runAgent({ ...baseOpts, agent: "mastra", getMcpConnectorInjection });
 
-    expect(getClaudeMcpInjection).not.toHaveBeenCalled();
+    expect(getMcpConnectorInjection).toHaveBeenCalledTimes(1);
     expect(agentEngine.run).toHaveBeenCalledWith(
       expect.objectContaining({
         agent: "mastra",
-        mcpConfigPath: undefined,
-        mcpToolNames: undefined,
+        connectorInjection: {
+          mcpServers: { GitHub: { command: "github-mcp" } },
+          toolNames: ["mcp__GitHub"],
+        },
       }),
     );
   });

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
@@ -19,8 +19,10 @@ import {
   createSettingsDao,
   createPipelineRunsDao,
   createAgentRuntimesDao,
+  createConnectorsDao,
   type DbConnection,
 } from "@repo/models";
+import { buildClaudeMcpInjection, type ClaudeMcpInjection } from "../../connectorsService";
 
 export class PipelineNotFoundError extends Error {
   constructor(pipelineId: string) {
@@ -57,6 +59,7 @@ export const createPipelineRunnerService = (db: DbConnection) => {
   const agentSpansDao = createAgentSpansDao(db);
   const settingsDao = createSettingsDao(db);
   const agentRuntimesDao = createAgentRuntimesDao(db);
+  const connectorsDao = createConnectorsDao(db);
 
   initObs(jobTracesDao);
   initSpanRecorder({ agentRawExportsDao, agentSpansDao });
@@ -97,12 +100,14 @@ export const createPipelineRunnerService = (db: DbConnection) => {
     model,
     defaultAgent,
     ssh,
+    getClaudeMcpInjection,
   }: {
     jobId: string;
     apiKey?: string;
     model?: string;
     defaultAgent?: AgentRuntime;
     ssh?: SshConnection;
+    getClaudeMcpInjection?: () => Promise<ClaudeMcpInjection | null>;
   }) =>
     pipelineRunnerEngineDeps.build({
       evaluateLoopCondition: loopEvaluatorFactory({ jobId }),
@@ -111,7 +116,20 @@ export const createPipelineRunnerService = (db: DbConnection) => {
       model,
       defaultAgent,
       ssh,
+      getClaudeMcpInjection,
     });
+
+  const buildClaudeMcpInjectionProvider = () => {
+    const cache: { value?: Promise<ClaudeMcpInjection | null> } = {};
+
+    return () => {
+      cache.value ??= connectorsDao
+        .findMany()
+        .then((connectors) => buildClaudeMcpInjection(connectors));
+
+      return cache.value;
+    };
+  };
 
   return {
     startRun: async (opts: {
@@ -182,6 +200,7 @@ export const createPipelineRunnerService = (db: DbConnection) => {
             model: settings.defaultModel,
             defaultAgent: settings.defaultAgentRuntime,
             ssh,
+            getClaudeMcpInjection: buildClaudeMcpInjectionProvider(),
           }),
           runControl: pipelineRunControl.buildForJob(jobId),
           onRunSettled: () => pipelineRunControl.clear(jobId),

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
@@ -23,7 +23,7 @@ import {
   type DbConnection,
 } from "@repo/models";
 import { buildMcpConnectorInjection } from "../../connectorsService";
-import type { McpConnectorInjection } from "@repo/agent";
+import type { McpConnectorInjectionProvider } from "@repo/agent-engine";
 
 export class PipelineNotFoundError extends Error {
   constructor(pipelineId: string) {
@@ -108,7 +108,7 @@ export const createPipelineRunnerService = (db: DbConnection) => {
     model?: string;
     defaultAgent?: AgentRuntime;
     ssh?: SshConnection;
-    getMcpConnectorInjection?: () => Promise<McpConnectorInjection | null>;
+    getMcpConnectorInjection?: McpConnectorInjectionProvider;
   }) =>
     pipelineRunnerEngineDeps.build({
       evaluateLoopCondition: loopEvaluatorFactory({ jobId }),
@@ -121,14 +121,10 @@ export const createPipelineRunnerService = (db: DbConnection) => {
     });
 
   const buildMcpConnectorInjectionProvider = () => {
-    const cache: { value?: Promise<McpConnectorInjection | null> } = {};
+    return async (selectedToolNames: readonly string[]) => {
+      const connectors = await connectorsDao.findMany();
 
-    return () => {
-      cache.value ??= connectorsDao
-        .findMany()
-        .then((connectors) => buildMcpConnectorInjection(connectors));
-
-      return cache.value;
+      return buildMcpConnectorInjection(connectors, selectedToolNames);
     };
   };
 

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
@@ -22,7 +22,8 @@ import {
   createConnectorsDao,
   type DbConnection,
 } from "@repo/models";
-import { buildClaudeMcpInjection, type ClaudeMcpInjection } from "../../connectorsService";
+import { buildMcpConnectorInjection } from "../../connectorsService";
+import type { McpConnectorInjection } from "@repo/agent";
 
 export class PipelineNotFoundError extends Error {
   constructor(pipelineId: string) {
@@ -100,14 +101,14 @@ export const createPipelineRunnerService = (db: DbConnection) => {
     model,
     defaultAgent,
     ssh,
-    getClaudeMcpInjection,
+    getMcpConnectorInjection,
   }: {
     jobId: string;
     apiKey?: string;
     model?: string;
     defaultAgent?: AgentRuntime;
     ssh?: SshConnection;
-    getClaudeMcpInjection?: () => Promise<ClaudeMcpInjection | null>;
+    getMcpConnectorInjection?: () => Promise<McpConnectorInjection | null>;
   }) =>
     pipelineRunnerEngineDeps.build({
       evaluateLoopCondition: loopEvaluatorFactory({ jobId }),
@@ -116,16 +117,16 @@ export const createPipelineRunnerService = (db: DbConnection) => {
       model,
       defaultAgent,
       ssh,
-      getClaudeMcpInjection,
+      getMcpConnectorInjection,
     });
 
-  const buildClaudeMcpInjectionProvider = () => {
-    const cache: { value?: Promise<ClaudeMcpInjection | null> } = {};
+  const buildMcpConnectorInjectionProvider = () => {
+    const cache: { value?: Promise<McpConnectorInjection | null> } = {};
 
     return () => {
       cache.value ??= connectorsDao
         .findMany()
-        .then((connectors) => buildClaudeMcpInjection(connectors));
+        .then((connectors) => buildMcpConnectorInjection(connectors));
 
       return cache.value;
     };
@@ -200,7 +201,7 @@ export const createPipelineRunnerService = (db: DbConnection) => {
             model: settings.defaultModel,
             defaultAgent: settings.defaultAgentRuntime,
             ssh,
-            getClaudeMcpInjection: buildClaudeMcpInjectionProvider(),
+            getMcpConnectorInjection: buildMcpConnectorInjectionProvider(),
           }),
           runControl: pipelineRunControl.buildForJob(jobId),
           onRunSettled: () => pipelineRunControl.clear(jobId),

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
@@ -1,17 +1,37 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { pipelineRunControl } from "../runControl";
 
-const { mockJobsDao, mockConnectorsDao } = vi.hoisted(() => ({
-  mockJobsDao: {
-    findById: vi.fn(),
-    updateStatus: vi.fn().mockResolvedValue(undefined),
-    create: vi.fn().mockResolvedValue(undefined),
-    setNodeStatuses: vi.fn().mockResolvedValue(undefined),
-  },
-  mockConnectorsDao: {
-    findMany: vi.fn().mockResolvedValue([]),
-  },
-}));
+type EngineDepsMock = {
+  runSkill: (opts: unknown) => Promise<void>;
+};
+
+type PipelineRunOptionsMock = {
+  engineDeps: EngineDepsMock;
+};
+
+type EngineDepsBuildOptionsMock = {
+  getMcpConnectorInjection?: (selectedToolNames: readonly string[]) => Promise<unknown>;
+};
+
+const { mockJobsDao, mockConnectorsDao, mockPipelinesDao, mockPipelineRunExecutorRun } = vi.hoisted(
+  () => ({
+    mockJobsDao: {
+      findById: vi.fn(),
+      updateStatus: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn().mockResolvedValue(undefined),
+      setNodeStatuses: vi.fn().mockResolvedValue(undefined),
+    },
+    mockConnectorsDao: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    mockPipelinesDao: {
+      findById: vi.fn(),
+    },
+    mockPipelineRunExecutorRun: vi.fn(async (opts: PipelineRunOptionsMock) => {
+      await opts.engineDeps.runSkill({ allowedTools: ["mcp__github__read_issue"] } as never);
+    }),
+  }),
+);
 
 vi.mock("@repo/obs", () => ({
   initObs: vi.fn(),
@@ -26,16 +46,35 @@ vi.mock("@repo/logger", () => ({
 vi.mock("@repo/models", () => ({
   createAgentsDao: vi.fn(() => ({})),
   createOperationsDao: vi.fn(() => ({})),
-  createPipelinesDao: vi.fn(() => ({ findById: vi.fn() })),
+  createPipelinesDao: vi.fn(() => mockPipelinesDao),
   createJobsDao: vi.fn(() => mockJobsDao),
   createJobTracesDao: vi.fn(() => ({})),
   createSkillsDao: vi.fn(() => ({})),
   createAgentRawExportsDao: vi.fn(() => ({})),
   createAgentSpansDao: vi.fn(() => ({})),
   createSettingsDao: vi.fn(() => ({ get: vi.fn().mockResolvedValue({}) })),
-  createPipelineRunsDao: vi.fn(() => ({})),
+  createPipelineRunsDao: vi.fn(() => ({ create: vi.fn().mockResolvedValue(undefined) })),
   createAgentRuntimesDao: vi.fn(() => ({ findMany: vi.fn().mockResolvedValue([]) })),
   createConnectorsDao: vi.fn(() => mockConnectorsDao),
+}));
+
+vi.mock("../engineDeps", () => ({
+  pipelineRunnerEngineDeps: {
+    build: vi.fn((opts: EngineDepsBuildOptionsMock) => ({
+      runPrompt: vi.fn(),
+      runSkill: vi.fn(async () => {
+        await opts.getMcpConnectorInjection?.(["mcp__github__read_issue"]);
+      }),
+      structuredJsonToMarkdown: vi.fn(),
+      evaluateLoopCondition: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock("../runPipeline", () => ({
+  pipelineRunExecutor: {
+    run: mockPipelineRunExecutorRun,
+  },
 }));
 
 import type { DbConnection } from "@repo/models";
@@ -52,6 +91,14 @@ describe("createPipelineRunnerService run controls", () => {
     vi.clearAllMocks();
     mockJobsDao.updateStatus.mockResolvedValue(undefined);
     mockConnectorsDao.findMany.mockResolvedValue([]);
+    mockPipelinesDao.findById.mockResolvedValue({
+      id: "pipe-1",
+      name: "Pipe",
+      description: "Pipeline description",
+      projectId: null,
+      nodes: [],
+      edges: [],
+    });
   });
 
   it("resumeRun releases a checkpoint waiter while the job status is still running", async () => {
@@ -161,5 +208,16 @@ describe("createPipelineRunnerService run controls", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("DB down");
     }
+  });
+
+  it("builds connector injection from only the tools selected for the run", async () => {
+    const service = makeService();
+
+    const result = await service.startRun({ pipelineId: "pipe-1" });
+    expect(result.isOk()).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockConnectorsDao.findMany).toHaveBeenCalledOnce();
   });
 });

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { pipelineRunControl } from "../runControl";
 
-const { mockJobsDao } = vi.hoisted(() => ({
+const { mockJobsDao, mockConnectorsDao } = vi.hoisted(() => ({
   mockJobsDao: {
     findById: vi.fn(),
     updateStatus: vi.fn().mockResolvedValue(undefined),
     create: vi.fn().mockResolvedValue(undefined),
     setNodeStatuses: vi.fn().mockResolvedValue(undefined),
+  },
+  mockConnectorsDao: {
+    findMany: vi.fn().mockResolvedValue([]),
   },
 }));
 
@@ -32,6 +35,7 @@ vi.mock("@repo/models", () => ({
   createSettingsDao: vi.fn(() => ({ get: vi.fn().mockResolvedValue({}) })),
   createPipelineRunsDao: vi.fn(() => ({})),
   createAgentRuntimesDao: vi.fn(() => ({ findMany: vi.fn().mockResolvedValue([]) })),
+  createConnectorsDao: vi.fn(() => mockConnectorsDao),
 }));
 
 import type { DbConnection } from "@repo/models";
@@ -47,6 +51,7 @@ describe("createPipelineRunnerService run controls", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockJobsDao.updateStatus.mockResolvedValue(undefined);
+    mockConnectorsDao.findMany.mockResolvedValue([]);
   });
 
   it("resumeRun releases a checkpoint waiter while the job status is still running", async () => {
@@ -56,19 +61,19 @@ describe("createPipelineRunnerService run controls", () => {
 
     // The engine suspends on a checkpoint node; the job status stays "running".
     const control = pipelineRunControl.buildForJob(jobId);
-    let released = false;
+    const releaseState = { released: false };
     const waiting = control
       .waitForResume?.({ jobId, nodeId: "n1", reason: "checkpoint" })
       .then(() => {
-        released = true;
+        releaseState.released = true;
       });
-    expect(released).toBe(false);
+    expect(releaseState.released).toBe(false);
 
     const result = await service.resumeRun(jobId);
     await waiting;
 
     expect(result.isOk()).toBe(true);
-    expect(released).toBe(true);
+    expect(releaseState.released).toBe(true);
     expect(mockJobsDao.updateStatus).toHaveBeenCalledWith(jobId, "running", undefined);
 
     pipelineRunControl.clear(jobId);

--- a/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.ts
+++ b/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.ts
@@ -3,6 +3,7 @@ import { skillExecutor } from "../skillExecutor";
 import { structuredOutput } from "../structuredOutput";
 import type { PipelineEngineDeps } from "@repo/pipeline-engine";
 import type { AgentRuntime, SshConnection } from "@repo/schemas";
+import type { ClaudeMcpInjectionProvider } from "../agentRunner/agentRunner";
 import type { LoopEvaluatorFn } from "../loopEvaluator";
 
 export const pipelineRunnerEngineDeps = {
@@ -13,6 +14,7 @@ export const pipelineRunnerEngineDeps = {
     model,
     defaultAgent,
     ssh,
+    getClaudeMcpInjection,
   }: {
     evaluateLoopCondition: LoopEvaluatorFn;
     jobId?: string;
@@ -20,6 +22,7 @@ export const pipelineRunnerEngineDeps = {
     model?: string;
     defaultAgent?: AgentRuntime;
     ssh?: SshConnection;
+    getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
   }): PipelineEngineDeps => ({
     runPrompt: (o) =>
       promptExecutor.run({
@@ -29,6 +32,7 @@ export const pipelineRunnerEngineDeps = {
         apiKey,
         model,
         ssh,
+        getClaudeMcpInjection,
       }),
     runSkill: (o) =>
       skillExecutor.run({
@@ -38,6 +42,7 @@ export const pipelineRunnerEngineDeps = {
         apiKey,
         model,
         ssh,
+        getClaudeMcpInjection,
       }),
     structuredJsonToMarkdown: (content) => structuredOutput.toMarkdown({ content }),
     evaluateLoopCondition,

--- a/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.ts
+++ b/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.ts
@@ -3,7 +3,7 @@ import { skillExecutor } from "../skillExecutor";
 import { structuredOutput } from "../structuredOutput";
 import type { PipelineEngineDeps } from "@repo/pipeline-engine";
 import type { AgentRuntime, SshConnection } from "@repo/schemas";
-import type { ClaudeMcpInjectionProvider } from "../agentRunner/agentRunner";
+import type { McpConnectorInjectionProvider } from "../agentRunner/agentRunner";
 import type { LoopEvaluatorFn } from "../loopEvaluator";
 
 export const pipelineRunnerEngineDeps = {
@@ -14,7 +14,7 @@ export const pipelineRunnerEngineDeps = {
     model,
     defaultAgent,
     ssh,
-    getClaudeMcpInjection,
+    getMcpConnectorInjection,
   }: {
     evaluateLoopCondition: LoopEvaluatorFn;
     jobId?: string;
@@ -22,7 +22,7 @@ export const pipelineRunnerEngineDeps = {
     model?: string;
     defaultAgent?: AgentRuntime;
     ssh?: SshConnection;
-    getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
+    getMcpConnectorInjection?: McpConnectorInjectionProvider;
   }): PipelineEngineDeps => ({
     runPrompt: (o) =>
       promptExecutor.run({
@@ -32,7 +32,7 @@ export const pipelineRunnerEngineDeps = {
         apiKey,
         model,
         ssh,
-        getClaudeMcpInjection,
+        getMcpConnectorInjection,
       }),
     runSkill: (o) =>
       skillExecutor.run({
@@ -42,7 +42,7 @@ export const pipelineRunnerEngineDeps = {
         apiKey,
         model,
         ssh,
-        getClaudeMcpInjection,
+        getMcpConnectorInjection,
       }),
     structuredJsonToMarkdown: (content) => structuredOutput.toMarkdown({ content }),
     evaluateLoopCondition,

--- a/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.unit.test.ts
@@ -132,11 +132,11 @@ describe("pipelineRunnerEngineDeps", () => {
   });
 
   it("passes Claude MCP injection provider to prompt and skill executors", () => {
-    const getClaudeMcpInjection = vi.fn().mockResolvedValue(null);
+    const getMcpConnectorInjection = vi.fn().mockResolvedValue(null);
     const deps = pipelineRunnerEngineDeps.build({
       evaluateLoopCondition,
       jobId: "job-1",
-      getClaudeMcpInjection,
+      getMcpConnectorInjection,
     });
 
     deps.runPrompt({
@@ -152,10 +152,10 @@ describe("pipelineRunnerEngineDeps", () => {
     });
 
     expect(promptExecutor.run).toHaveBeenCalledWith(
-      expect.objectContaining({ getClaudeMcpInjection }),
+      expect.objectContaining({ getMcpConnectorInjection }),
     );
     expect(skillExecutor.run).toHaveBeenCalledWith(
-      expect.objectContaining({ getClaudeMcpInjection }),
+      expect.objectContaining({ getMcpConnectorInjection }),
     );
   });
 });

--- a/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.unit.test.ts
@@ -130,4 +130,32 @@ describe("pipelineRunnerEngineDeps", () => {
       }),
     );
   });
+
+  it("passes Claude MCP injection provider to prompt and skill executors", () => {
+    const getClaudeMcpInjection = vi.fn().mockResolvedValue(null);
+    const deps = pipelineRunnerEngineDeps.build({
+      evaluateLoopCondition,
+      jobId: "job-1",
+      getClaudeMcpInjection,
+    });
+
+    deps.runPrompt({
+      prompt: "publish",
+      inputContent: "content",
+      inputPath: "/tmp/project",
+    });
+    deps.runSkill({
+      skillId: "skill-1",
+      skillDescription: "desc",
+      inputContent: "content",
+      inputPath: "/tmp/project",
+    });
+
+    expect(promptExecutor.run).toHaveBeenCalledWith(
+      expect.objectContaining({ getClaudeMcpInjection }),
+    );
+    expect(skillExecutor.run).toHaveBeenCalledWith(
+      expect.objectContaining({ getClaudeMcpInjection }),
+    );
+  });
 });

--- a/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.ts
+++ b/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.ts
@@ -2,7 +2,7 @@ import { ResultAsync, errAsync } from "neverthrow";
 import { logger } from "@repo/logger";
 import type { OperationRuntimeContext, RunPromptOptions } from "@repo/pipeline-engine";
 import { TRACE_MARKER, type OutputItem, type SshConnection } from "@repo/schemas";
-import { runAgent, type ClaudeMcpInjectionProvider } from "../agentRunner/agentRunner";
+import { runAgent, type McpConnectorInjectionProvider } from "../agentRunner/agentRunner";
 
 export class PromptExecutionError extends Error {
   constructor(
@@ -18,7 +18,7 @@ const PROMPT_AGENT_ID = "prompt-executor";
 
 type PromptExecutorOptions = RunPromptOptions & {
   ssh?: SshConnection;
-  getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
+  getMcpConnectorInjection?: McpConnectorInjectionProvider;
 };
 
 /**
@@ -120,7 +120,7 @@ const run = ({
   outputItems,
   outputDir,
   runtimeContext,
-  getClaudeMcpInjection,
+  getMcpConnectorInjection,
 }: PromptExecutorOptions): ResultAsync<string, PromptExecutionError> => {
   if (!prompt?.trim()) {
     return errAsync(new PromptExecutionError("Prompt text is empty"));
@@ -146,7 +146,7 @@ const run = ({
         model,
         githubToken,
         ssh,
-        getClaudeMcpInjection,
+        getMcpConnectorInjection,
       });
       if (onChunk) await onChunk(raw);
 

--- a/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.ts
+++ b/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.ts
@@ -115,6 +115,7 @@ const run = ({
   apiKey,
   model,
   extraTools,
+  allowedTools,
   githubToken,
   ssh,
   outputItems,
@@ -128,6 +129,7 @@ const run = ({
 
   const outputSection = buildOutputItemsSection(outputItems, outputDir);
   const effectiveInput = outputSection ? `${inputContent}\n${outputSection}` : inputContent;
+  const effectiveAllowedTools = [...new Set([...(allowedTools ?? []), ...(extraTools ?? [])])];
 
   return ResultAsync.fromPromise(
     (async () => {
@@ -139,7 +141,7 @@ const run = ({
         inputPath,
         jobId,
         agentId: PROMPT_AGENT_ID,
-        allowedTools: extraTools ?? [],
+        allowedTools: effectiveAllowedTools,
         onProgress,
         logPrefix: "[LLM] runPrompt",
         apiKey,

--- a/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.ts
+++ b/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.ts
@@ -2,7 +2,7 @@ import { ResultAsync, errAsync } from "neverthrow";
 import { logger } from "@repo/logger";
 import type { OperationRuntimeContext, RunPromptOptions } from "@repo/pipeline-engine";
 import { TRACE_MARKER, type OutputItem, type SshConnection } from "@repo/schemas";
-import { runAgent } from "../agentRunner/agentRunner";
+import { runAgent, type ClaudeMcpInjectionProvider } from "../agentRunner/agentRunner";
 
 export class PromptExecutionError extends Error {
   constructor(
@@ -16,7 +16,10 @@ export class PromptExecutionError extends Error {
 
 const PROMPT_AGENT_ID = "prompt-executor";
 
-type PromptExecutorOptions = RunPromptOptions & { ssh?: SshConnection };
+type PromptExecutorOptions = RunPromptOptions & {
+  ssh?: SshConnection;
+  getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
+};
 
 /**
  * Instruct the executor to emit a structured user-action marker when it cannot
@@ -117,6 +120,7 @@ const run = ({
   outputItems,
   outputDir,
   runtimeContext,
+  getClaudeMcpInjection,
 }: PromptExecutorOptions): ResultAsync<string, PromptExecutionError> => {
   if (!prompt?.trim()) {
     return errAsync(new PromptExecutionError("Prompt text is empty"));
@@ -142,6 +146,7 @@ const run = ({
         model,
         githubToken,
         ssh,
+        getClaudeMcpInjection,
       });
       if (onChunk) await onChunk(raw);
 

--- a/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.unit.test.ts
@@ -161,6 +161,20 @@ describe("promptExecutor", () => {
     expect(callArgs.systemPrompt).toContain("@@USER_ACTION::");
   });
 
+  it("forwards selected MCP tools for prompt operations", async () => {
+    const result = await promptExecutor.run({
+      ...baseOpts,
+      agent: "codex",
+      allowedTools: ["Read", "mcp__github__read_issue"],
+      extraTools: ["Read"],
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(agentEngine.run).toHaveBeenCalledWith(
+      expect.objectContaining({ allowedTools: ["Read", "mcp__github__read_issue"] }),
+    );
+  });
+
   it("returns error for empty prompt", async () => {
     const result = await promptExecutor.run({ ...baseOpts, prompt: "  " });
     expect(result.isErr()).toBe(true);

--- a/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.ts
+++ b/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.ts
@@ -14,7 +14,7 @@ import type {
   RunSkillOptions as EngineRunSkillOptions,
 } from "@repo/pipeline-engine";
 import type { OutputItem, SshConnection } from "@repo/schemas";
-import { runAgent, type ClaudeMcpInjectionProvider } from "../agentRunner/agentRunner";
+import { runAgent, type McpConnectorInjectionProvider } from "../agentRunner/agentRunner";
 
 const CHECK_OUTPUT_EXAMPLE: CheckOutput = {
   type: "check" as const,
@@ -83,7 +83,7 @@ export class SkillExecutionError extends Error {
 type RunSkillExecutorOptions = EngineRunSkillOptions & {
   jobId?: string;
   ssh?: SshConnection;
-  getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
+  getMcpConnectorInjection?: McpConnectorInjectionProvider;
 };
 
 export const DEFAULT_SKILL_SYSTEM_PROMPT = [
@@ -214,7 +214,7 @@ const run = ({
   outputItems,
   outputDir,
   runtimeContext,
-  getClaudeMcpInjection,
+  getMcpConnectorInjection,
 }: RunSkillExecutorOptions): ResultAsync<string, SkillExecutionError> => {
   const effectiveSystemPrompt = systemPrompt ?? DEFAULT_SKILL_SYSTEM_PROMPT;
   const userPrompt = buildSkillUserPrompt({
@@ -250,7 +250,7 @@ const run = ({
         apiKey,
         model,
         ssh,
-        getClaudeMcpInjection,
+        getMcpConnectorInjection,
       });
 
       if (raw.length === 0) {

--- a/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.ts
+++ b/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.ts
@@ -227,11 +227,15 @@ const run = ({
     runtimeContext,
   });
 
-  const parsedCustomTools = customAllowedTools
-    ? ToolNameSchema.array().readonly().safeParse(customAllowedTools)
+  const connectorTools =
+    customAllowedTools?.filter((toolName) => toolName.startsWith("mcp__")) ?? [];
+  const builtInTools = customAllowedTools?.filter((toolName) => !toolName.startsWith("mcp__"));
+  const parsedCustomTools = builtInTools
+    ? ToolNameSchema.array().readonly().safeParse(builtInTools)
     : null;
   const allowedTools =
-    (parsedCustomTools?.success ? parsedCustomTools.data : null) ?? READ_ONLY_TOOLS;
+    (parsedCustomTools?.success ? [...parsedCustomTools.data, ...connectorTools] : null) ??
+    READ_ONLY_TOOLS;
 
   return ResultAsync.fromPromise(
     (async () => {

--- a/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.ts
+++ b/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.ts
@@ -14,7 +14,7 @@ import type {
   RunSkillOptions as EngineRunSkillOptions,
 } from "@repo/pipeline-engine";
 import type { OutputItem, SshConnection } from "@repo/schemas";
-import { runAgent } from "../agentRunner/agentRunner";
+import { runAgent, type ClaudeMcpInjectionProvider } from "../agentRunner/agentRunner";
 
 const CHECK_OUTPUT_EXAMPLE: CheckOutput = {
   type: "check" as const,
@@ -83,6 +83,7 @@ export class SkillExecutionError extends Error {
 type RunSkillExecutorOptions = EngineRunSkillOptions & {
   jobId?: string;
   ssh?: SshConnection;
+  getClaudeMcpInjection?: ClaudeMcpInjectionProvider;
 };
 
 export const DEFAULT_SKILL_SYSTEM_PROMPT = [
@@ -213,6 +214,7 @@ const run = ({
   outputItems,
   outputDir,
   runtimeContext,
+  getClaudeMcpInjection,
 }: RunSkillExecutorOptions): ResultAsync<string, SkillExecutionError> => {
   const effectiveSystemPrompt = systemPrompt ?? DEFAULT_SKILL_SYSTEM_PROMPT;
   const userPrompt = buildSkillUserPrompt({
@@ -248,6 +250,7 @@ const run = ({
         apiKey,
         model,
         ssh,
+        getClaudeMcpInjection,
       });
 
       if (raw.length === 0) {

--- a/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.unit.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi, beforeEach, afterAll } from "vitest";
+import { ToolNameSchema } from "@repo/agent";
 import { agentEngine } from "@repo/agent-engine";
 
 vi.mock("@repo/agent", () => ({
@@ -11,7 +12,9 @@ vi.mock("@repo/agent", () => ({
   CheckOutputSchema: { safeParse: vi.fn().mockReturnValue({ success: true, data: {} }) },
   FixOutputSchema: { safeParse: vi.fn().mockReturnValue({ success: false }) },
   ToolNameSchema: {
-    array: () => ({ readonly: () => ({ safeParse: vi.fn().mockReturnValue({ success: false }) }) }),
+    array: vi.fn(() => ({
+      readonly: () => ({ safeParse: vi.fn().mockReturnValue({ success: false }) }),
+    })),
   },
 }));
 
@@ -115,6 +118,25 @@ describe("skillExecutor", () => {
         jobId: "job-1",
         agentId: "test-skill",
       }),
+    );
+  });
+
+  it("preserves selected MCP tools alongside validated built-in tools", async () => {
+    const safeParse = vi.fn().mockReturnValue({ success: true, data: ["Read"] });
+    vi.mocked(ToolNameSchema.array).mockReturnValue({
+      readonly: () => ({ safeParse }),
+    } as never);
+
+    const result = await skillExecutor.run({
+      ...baseOpts,
+      agent: "codex",
+      allowedTools: ["Read", "mcp__github__read_issue"],
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(safeParse).toHaveBeenCalledWith(["Read"]);
+    expect(agentEngine.run).toHaveBeenCalledWith(
+      expect.objectContaining({ allowedTools: ["Read", "mcp__github__read_issue"] }),
     );
   });
 


### PR DESCRIPTION
中文

# 背景

[COD-248](https://linear.app/code-forge-official/issue/COD-248/featureconnectors为-claude-code-runs-注入已连接-mcp-connector) 先把 Claude Code 的 connector 注入链路打通了，但这只是第一种 runtime adapter。更合理的长期结构是：pipeline runner 只负责决定本次 agent run 可用哪些 connector，具体 runtime adapter 再把这些 connector 翻译成自己的参数/配置。

已调研的方向里，不同 runtime 的接法并不相同：Claude Code 走 `--mcp-config` + `mcp__...`，Codex / Kimi Code / OpenCode / Hermes 也都各自有 MCP 配置入口或其他启动参数；Pi Agent 之类则可能需要明确标记 unsupported 或另做适配。

# 用户故事

作为一个 Ordine 用户<br>我希望 不同 runtime 的 agent run 都能按自己的方式使用已连接的 Connector<br>从而能够 在不改 runner 主逻辑的前提下持续扩展更多 agent runtime

# 功能概览

把 connector injection 的差异收敛到 runtime adapter seam：runner 统一拿到 connected connectors，adapter 负责把它们翻译成该 runtime 的启动参数、MCP 配置或明确的 skip trace。

# 技术说明

## 影响模块

* packages/services 的 pipeline runner / engineDeps / executor 链路
* packages/agent-engine 里的 runtime driver 入口
* 后续各 runtime adapter 实现

## 系统约束

* 不是把 Claude 的 MCP config 硬搬给所有 runtime
* 每个 runtime 只实现自己支持的注入方式
* 不支持的 runtime 必须在 trace 中明确说明 skip 原因
* connector 选择仍然按本次 run 的需要来决定，不默认全量灌入所有已连接 connector

# 核心字段

风险等级：中 —— 涉及多个 runtime adapter 的接口边界和执行参数翻译，范围清楚但改动面比单个 runtime 大。<br>估点：8<br>证据要求：至少把 1 个新 runtime adapter 跑通并补单测；trace 中能看到该 runtime 的 connector 注入或 skip 结果。

# 非目标

* 不回改 [COD-248](https://linear.app/code-forge-official/issue/COD-248/featureconnectors为-claude-code-runs-注入已连接-mcp-connector) 已完成的 Claude Code 注入实现
* 不实现 built-in / direct-api connector 的产品能力
* 不在这票里决定每个 runtime 的具体可用 connector 白名单

# 验收标准

1. pipeline runner 提供统一的 connector 上下文给 runtime adapter
2. 至少 1 个非 Claude runtime 能按自己的方式完成 connector 注入
3. 不支持的 runtime 会输出明确 trace
4. 单测、typecheck、lint 通过

# 参考

父级：无<br>依赖：[COD-248](https://linear.app/code-forge-official/issue/COD-248/featureconnectors为-claude-code-runs-注入已连接-mcp-connector)、[COD-121](https://linear.app/code-forge-official/issue/COD-121/10featureagent-engine-refactor-and-mcp-client-or-agent-引擎重构与-mcp-客户端)<br>阻塞：无<br>相关：[COD-245](https://linear.app/code-forge-official/issue/COD-245/featureconnectors作为自托管用户我希望连接远程-mcp-服务-mcp-http-transport-handshake)、[COD-246](https://linear.app/code-forge-official/issue/COD-246/featureconnectors作为用户我希望用-api-key-直连第三方服务-direct-api-connectors)、[COD-247](https://linear.app/code-forge-official/issue/COD-247/featureconnectors作为用户我希望使用开箱即用的内置连接器-built-in-connectors)

English

# 背景

[COD-248](https://linear.app/code-forge-official/issue/COD-248/featureconnectors为-claude-code-runs-注入已连接-mcp-connector) wires connector injection for Claude Code first, but that is only one runtime adapter. The long-term shape is: the pipeline runner decides which connected connectors are available for a run, and each runtime adapter translates those connectors into its own launch parameters, MCP config, or explicit skip trace.

The researched runtimes do not share the same wiring. Claude Code uses `--mcp-config` plus `mcp__...`; Codex, Kimi Code, OpenCode, and Hermes each have their own MCP configuration or launch entry points, while some runtimes may need to be marked unsupported or adapted separately.

# User Story

As an Ordine user<br>I want each runtime to use connected connectors in its own way<br>so that we can keep extending runtime support without rewriting the runner each time.

# Feature Overview

Move connector injection differences into the runtime adapter seam: the runner provides the connected connectors for a run, and the adapter translates them into launch parameters, MCP config, or an explicit skip trace for that runtime.

# Technical Notes

## Impacted Modules

* pipeline runner / engineDeps / executor chain in packages/services
* runtime driver entry points in packages/agent-engine
* follow-up runtime adapters

## System Constraints

* Do not hard-code Claude's MCP config shape for every runtime
* Each runtime only implements the injection mode it actually supports
* Unsupported runtimes must emit an explicit trace explaining the skip
* Connector selection remains per-run, not a blanket dump of every connected connector

# Core Fields

Risk: Medium — multiple runtime adapter boundaries and parameter translation paths, but the scope is still clear.<br>Estimate: 8<br>Evidence: at least one non-Claude runtime should be wired with tests; trace should show injection or skip behavior.

# Non-Goals

* Do not revert [COD-248](https://linear.app/code-forge-official/issue/COD-248/featureconnectors为-claude-code-runs-注入已连接-mcp-connector)'s Claude Code implementation
* Do not add built-in/direct-api connector product behavior here
* Do not decide each runtime's connector whitelist in this issue

# Acceptance Criteria

1. The pipeline runner passes unified connector context to runtime adapters
2. At least one non-Claude runtime can inject connectors in its own way
3. Unsupported runtimes emit an explicit trace
4. Tests, typecheck, and lint pass

# Reference

Parent: none<br>Depends on: [COD-248](https://linear.app/code-forge-official/issue/COD-248/featureconnectors为-claude-code-runs-注入已连接-mcp-connector), [COD-121](https://linear.app/code-forge-official/issue/COD-121/10featureagent-engine-refactor-and-mcp-client-or-agent-引擎重构与-mcp-客户端)<br>Blocks: none<br>Related: [COD-245](https://linear.app/code-forge-official/issue/COD-245/featureconnectors作为自托管用户我希望连接远程-mcp-服务-mcp-http-transport-handshake), [COD-246](https://linear.app/code-forge-official/issue/COD-246/featureconnectors作为用户我希望用-api-key-直连第三方服务-direct-api-connectors), [COD-247](https://linear.app/code-forge-official/issue/COD-247/featureconnectors作为用户我希望使用开箱即用的内置连接器-built-in-connectors)