### PR TITLE
feat: dataProvider 重构为资源注册表 + 全局状态 store（COD-123）

### DIFF
--- a/apps/app/src/integrations/refine/dataProvider.ts
+++ b/apps/app/src/integrations/refine/dataProvider.ts
@@ -12,417 +12,65 @@ import {
   type DeleteOneParams,
   type DeleteOneResponse,
 } from "@refinedev/core";
-import { trpcClient } from "@/integrations/trpc/client";
+import { resourceHandlers } from "./resources/registry";
+import { customEndpoints } from "./resources/custom";
+import { makeListFilters, type ResourceHandlers } from "./resources/types";
 
-export const ResourceName = {
-  agents: "agents",
-  agentRuntimes: "agentRuntimes",
-  filesystem: "filesystem",
-  operations: "operations",
-  pipelines: "pipelines",
-  jobs: "jobs",
-  githubProjects: "githubProjects",
-  skills: "skills",
-  recipes: "recipes",
-  checklistItems: "checklistItems",
-  codeSnippets: "codeSnippets",
-  skillDraftOperations: "skillDraftOperations",
-  skillAnalyses: "skillAnalyses",
-  distillations: "distillations",
-  refinements: "refinements",
-  settings: "settings",
-  operationOutputItemTemplates: "operationOutputItemTemplates",
-} as const;
+export { ResourceName } from "./resources/resourceNames";
+export { CustomEndpoint } from "./resources/custom";
+
+/** 取某资源的某方法，缺失即抛——与迁移前每个 switch 的 default 行为一致。 */
+const handlerFor = <M extends keyof ResourceHandlers>(
+  method: M,
+  resource: string,
+): NonNullable<ResourceHandlers[M]> => {
+  const fn = resourceHandlers[resource]?.[method];
+  if (!fn) {
+    throw new Error(`${method}: unknown resource "${resource}"`);
+  }
+
+  return fn as NonNullable<ResourceHandlers[M]>;
+};
 
 export const dataProvider: DataProvider = {
   getList: async <TData extends BaseRecord = BaseRecord>(
     params: GetListParams,
   ): Promise<GetListResponse<TData>> => {
-    const { resource } = params;
+    const data = await handlerFor("getList", params.resource)(params, makeListFilters(params));
 
-    switch (resource) {
-      case ResourceName.agents: {
-        const data = await trpcClient.agents.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.agentRuntimes: {
-        const data = await trpcClient.agentRuntimes.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.filesystem: {
-        const pathFilter = params.filters?.find((f) => "field" in f && f.field === "path");
-        const path =
-          pathFilter && "value" in pathFilter
-            ? (pathFilter.value as string | undefined)
-            : undefined;
-        const data = await trpcClient.filesystem.browse.query({ path });
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.operations: {
-        const data = await trpcClient.operations.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.pipelines: {
-        const data = await trpcClient.pipelines.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.githubProjects: {
-        const data = await trpcClient.githubProjects.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.skills: {
-        const data = await trpcClient.skills.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.distillations: {
-        const data = await trpcClient.distillations.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.jobs: {
-        const data = await trpcClient.jobs.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.operationOutputItemTemplates: {
-        const data = await trpcClient.operationOutputItemTemplates.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      default: {
-        throw new Error(`getList: unknown resource "${resource}"`);
-      }
-    }
+    return { data: data as unknown as TData[], total: data.length };
   },
 
   getOne: async <TData extends BaseRecord = BaseRecord>(
     params: GetOneParams,
   ): Promise<GetOneResponse<TData>> => {
-    const { resource, id } = params;
+    const data = await handlerFor("getOne", params.resource)(String(params.id));
 
-    switch (resource) {
-      case ResourceName.agents: {
-        const data = await trpcClient.agents.getById.query({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.agentRuntimes: {
-        const data = await trpcClient.agentRuntimes.getById.query({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operations: {
-        const data = await trpcClient.operations.getById.query({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.pipelines: {
-        const data = await trpcClient.pipelines.getById.query({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.jobs: {
-        const data = await trpcClient.jobs.getById.query({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.githubProjects: {
-        const data = await trpcClient.githubProjects.getById.query({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.skills: {
-        const data = await trpcClient.skills.getById.query({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.skillDraftOperations: {
-        const data = await trpcClient.skills.draftOperation.query({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.skillAnalyses: {
-        const data = await trpcClient.skills.analyze.query({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.distillations: {
-        const data = await trpcClient.distillations.getById.query({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.refinements: {
-        const data = await trpcClient.refinements.getById.query({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operationOutputItemTemplates: {
-        const data = await trpcClient.operationOutputItemTemplates.getById.query({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.settings: {
-        const data = await trpcClient.settings.get.query();
-
-        return { data: data as unknown as TData };
-      }
-      default: {
-        throw new Error(`getOne: unknown resource "${resource}"`);
-      }
-    }
+    return { data: data as unknown as TData };
   },
 
   create: async <TData extends BaseRecord = BaseRecord, TVariables = object>(
     params: CreateParams<TVariables>,
   ): Promise<CreateResponse<TData>> => {
-    const { resource, variables } = params;
+    const data = await handlerFor("create", params.resource)(params.variables);
 
-    switch (resource) {
-      case ResourceName.agents: {
-        const data = await trpcClient.agents.create.mutate(
-          variables as Parameters<typeof trpcClient.agents.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.agentRuntimes: {
-        const data = await trpcClient.agentRuntimes.create.mutate(
-          variables as Parameters<typeof trpcClient.agentRuntimes.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operations: {
-        const data = await trpcClient.operations.create.mutate(
-          variables as Parameters<typeof trpcClient.operations.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.pipelines: {
-        const { pendingOperations, ...pipelineData } = variables as Record<string, unknown>;
-        const data = await trpcClient.pipelines.create.mutate({
-          pipeline: pipelineData,
-          pendingOperations: pendingOperations as
-            | Parameters<typeof trpcClient.pipelines.create.mutate>[0]["pendingOperations"]
-            | undefined,
-        } as Parameters<typeof trpcClient.pipelines.create.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.jobs: {
-        const data = await trpcClient.jobs.create.mutate(
-          variables as Parameters<typeof trpcClient.jobs.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.githubProjects: {
-        const data = await trpcClient.githubProjects.create.mutate(
-          variables as Parameters<typeof trpcClient.githubProjects.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.skills: {
-        const data = await trpcClient.skills.create.mutate(
-          variables as Parameters<typeof trpcClient.skills.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.distillations: {
-        const data = await trpcClient.distillations.create.mutate(
-          variables as Parameters<typeof trpcClient.distillations.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operationOutputItemTemplates: {
-        const data = await trpcClient.operationOutputItemTemplates.create.mutate(
-          variables as Parameters<typeof trpcClient.operationOutputItemTemplates.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      default: {
-        throw new Error(`create: unknown resource "${resource}"`);
-      }
-    }
+    return { data: data as unknown as TData };
   },
 
   update: async <TData extends BaseRecord = BaseRecord, TVariables = object>(
     params: UpdateParams<TVariables>,
   ): Promise<UpdateResponse<TData>> => {
-    const { resource, id, variables } = params;
+    const data = await handlerFor("update", params.resource)(String(params.id), params.variables);
 
-    switch (resource) {
-      case ResourceName.agents: {
-        const data = await trpcClient.agents.update.mutate({
-          id: String(id),
-          patch: variables as Record<string, unknown>,
-        } as Parameters<typeof trpcClient.agents.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.agentRuntimes: {
-        const data = await trpcClient.agentRuntimes.update.mutate({
-          id: String(id),
-          patch: variables as Record<string, unknown>,
-        } as Parameters<typeof trpcClient.agentRuntimes.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operations: {
-        const data = await trpcClient.operations.update.mutate({
-          id: String(id),
-          ...(variables as Record<string, unknown>),
-        } as Parameters<typeof trpcClient.operations.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.pipelines: {
-        const data = await trpcClient.pipelines.update.mutate({
-          id: String(id),
-          patch: variables as Record<string, unknown>,
-        } as Parameters<typeof trpcClient.pipelines.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.jobs: {
-        const data = await trpcClient.jobs.updateStatus.mutate({
-          id: String(id),
-          ...variables,
-        } as unknown as Parameters<typeof trpcClient.jobs.updateStatus.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.githubProjects: {
-        const data = await trpcClient.githubProjects.update.mutate({
-          id: String(id),
-          patch: variables as Record<string, unknown>,
-        } as Parameters<typeof trpcClient.githubProjects.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.skills: {
-        const data = await trpcClient.skills.update.mutate({
-          id: String(id),
-          patch: variables as Record<string, unknown>,
-        } as Parameters<typeof trpcClient.skills.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.distillations: {
-        const data = await trpcClient.distillations.update.mutate({
-          id: String(id),
-          patch: variables as Record<string, unknown>,
-        } as Parameters<typeof trpcClient.distillations.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operationOutputItemTemplates: {
-        const data = await trpcClient.operationOutputItemTemplates.update.mutate({
-          id: String(id),
-          ...(variables as Record<string, unknown>),
-        } as Parameters<typeof trpcClient.operationOutputItemTemplates.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.settings: {
-        const data = await trpcClient.settings.update.mutate(
-          variables as Parameters<typeof trpcClient.settings.update.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      default: {
-        throw new Error(`update: unknown resource "${resource}"`);
-      }
-    }
+    return { data: data as unknown as TData };
   },
 
   deleteOne: async <TData extends BaseRecord = BaseRecord, TVariables = object>(
     params: DeleteOneParams<TVariables>,
   ): Promise<DeleteOneResponse<TData>> => {
-    const { resource, id } = params;
+    const data = await handlerFor("deleteOne", params.resource)(String(params.id));
 
-    switch (resource) {
-      case ResourceName.agents: {
-        const data = await trpcClient.agents.delete.mutate({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.agentRuntimes: {
-        const data = await trpcClient.agentRuntimes.delete.mutate({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operations: {
-        const data = await trpcClient.operations.delete.mutate({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.pipelines: {
-        const data = await trpcClient.pipelines.delete.mutate({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.githubProjects: {
-        const data = await trpcClient.githubProjects.delete.mutate({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.skills: {
-        const data = await trpcClient.skills.delete.mutate({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.distillations: {
-        const data = await trpcClient.distillations.delete.mutate({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operationOutputItemTemplates: {
-        const data = await trpcClient.operationOutputItemTemplates.delete.mutate({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      default: {
-        throw new Error(`deleteOne: unknown resource "${resource}"`);
-      }
-    }
+    return { data: data as unknown as TData };
   },
 
   getApiUrl: () => "",
@@ -436,137 +84,12 @@ export const dataProvider: DataProvider = {
     method: string;
     payload?: TPayload;
   }): Promise<{ data: TData }> => {
-    const { url, payload } = params;
-
-    if (url === "pipelines/run") {
-      const data = await trpcClient.pipelines.run.mutate(
-        payload as unknown as Parameters<typeof trpcClient.pipelines.run.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
+    const handler = customEndpoints[params.url];
+    if (!handler) {
+      throw new Error(`custom: unknown url "${params.url}"`);
     }
-    if (url === "pipelines/analyzeIntent") {
-      const data = await trpcClient.pipelines.analyzeIntent.mutate(
-        payload as unknown as Parameters<typeof trpcClient.pipelines.analyzeIntent.mutate>[0],
-      );
+    const data = await handler(params.payload);
 
-      return { data: data as unknown as TData };
-    }
-    if (url === "pipelines/generateStructure") {
-      const data = await trpcClient.pipelines.generateStructure.mutate(
-        payload as unknown as Parameters<typeof trpcClient.pipelines.generateStructure.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "pipelines/optimizeFromDistillation") {
-      const data = await trpcClient.pipelines.optimizeFromDistillation.mutate(
-        payload as unknown as Parameters<
-          typeof trpcClient.pipelines.optimizeFromDistillation.mutate
-        >[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "pipelines/proposeActions") {
-      const data = await trpcClient.pipelines.proposeActions.mutate(
-        payload as unknown as Parameters<typeof trpcClient.pipelines.proposeActions.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "jobs/analysis") {
-      const { jobId } = payload as { jobId: string };
-      const [traces, agentRuns] = await Promise.all([
-        trpcClient.jobs.getTraces.query({ jobId }),
-        trpcClient.jobs.getAgentRuns.query({ jobId }),
-      ]);
-      const spansByRunEntries = await Promise.all(
-        agentRuns.map(async (run) => {
-          const spans = await trpcClient.jobs.getAgentRunSpans.query({ rawExportId: run.id });
-
-          return [run.id, spans] as const;
-        }),
-      );
-
-      return {
-        data: {
-          traces,
-          agentRuns,
-          spansByRun: Object.fromEntries(spansByRunEntries),
-        } as unknown as TData,
-      };
-    }
-    if (url === "jobs/traces") {
-      const { jobId } = payload as { jobId: string };
-      const traces = await trpcClient.jobs.getTraces.query({ jobId });
-
-      return { data: { traces } as unknown as TData };
-    }
-    if (url === "jobs/agentRuns") {
-      const { jobId } = payload as { jobId: string };
-      const agentRuns = await trpcClient.jobs.getAgentRuns.query({ jobId });
-
-      return { data: { agentRuns } as unknown as TData };
-    }
-    if (url === "jobs/agentRunSpans") {
-      const { rawExportId } = payload as { rawExportId: number };
-      const spans = await trpcClient.jobs.getAgentRunSpans.query({ rawExportId });
-
-      return { data: { spans } as unknown as TData };
-    }
-    if (url === "refinements/start") {
-      const data = await trpcClient.refinements.start.mutate(
-        payload as unknown as Parameters<typeof trpcClient.refinements.start.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "distillations/run") {
-      const data = await trpcClient.distillations.run.mutate(
-        payload as unknown as Parameters<typeof trpcClient.distillations.run.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "settings/scanRuntimes") {
-      const data = await trpcClient.agentRuntimes.scanRuntimes.query();
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "agentRuntimes/syncAll") {
-      const data = await trpcClient.agentRuntimes.syncAll.mutate(
-        payload as unknown as Parameters<typeof trpcClient.agentRuntimes.syncAll.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "agentRuntimes/scanAndSync") {
-      const data = await trpcClient.agentRuntimes.scanAndSync.mutate();
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "operations/run") {
-      const data = await trpcClient.operations.run.mutate(
-        payload as unknown as Parameters<typeof trpcClient.operations.run.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "skills/previewImport") {
-      const data = await trpcClient.skills.previewImport.query(
-        payload as unknown as Parameters<typeof trpcClient.skills.previewImport.query>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "skills/importCandidates") {
-      const data = await trpcClient.skills.importCandidates.mutate(
-        payload as unknown as Parameters<typeof trpcClient.skills.importCandidates.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    throw new Error(`custom: unknown url "${url}"`);
+    return { data: data as unknown as TData };
   },
 };

--- a/apps/app/src/integrations/refine/dataProvider.unit.test.ts
+++ b/apps/app/src/integrations/refine/dataProvider.unit.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** H3-03：dataProvider 薄封装层——响应包装、未知资源/URL 兜底、custom 路由。 */
+
+// vi.mock 工厂被提升到文件顶部，引用的外部变量必须经 vi.hoisted 创建。
+const { calls } = vi.hoisted(() => ({
+  calls: [] as { args: unknown; kind: string; path: string }[],
+}));
+
+vi.mock("@/integrations/trpc/client", () => {
+  const makeProc = (path: string) => ({
+    query: async (args?: unknown) => {
+      calls.push({ args, kind: "query", path });
+      // 返回数组的方法：getMany（list 资源）与 getAgentRuns（jobs/analysis 对其 .map）。
+      return path.endsWith("getMany") || path.endsWith("getAgentRuns")
+        ? [{ id: "1" }, { id: "2" }]
+        : { id: "one" };
+    },
+    mutate: async (args?: unknown) => {
+      calls.push({ args, kind: "mutate", path });
+
+      return { id: "mutated" };
+    },
+  });
+  const trpcClient = new Proxy(
+    {},
+    {
+      get: (_t, router: string) =>
+        new Proxy({}, { get: (_t2, proc: string) => makeProc(`${router}.${String(proc)}`) }),
+    },
+  );
+
+  return { trpcClient };
+});
+
+const { dataProvider, ResourceName, CustomEndpoint } = await import("./dataProvider");
+
+beforeEach(() => {
+  calls.length = 0;
+});
+
+describe("dataProvider response wrapping", () => {
+  it("getList wraps { data, total: data.length }", async () => {
+    const res = await dataProvider.getList!({ resource: ResourceName.agents });
+    expect(res.total).toBe(2);
+    expect(res.data).toHaveLength(2);
+  });
+
+  it("getOne wraps { data }", async () => {
+    const res = await dataProvider.getOne!({ resource: ResourceName.agents, id: "a1" });
+    expect(res.data).toMatchObject({ id: "one" });
+  });
+});
+
+describe("dataProvider unknown-resource fallbacks (与迁移前 default 分支一致)", () => {
+  it("getList throws on unknown resource", async () => {
+    await expect(dataProvider.getList!({ resource: "nope" })).rejects.toThrow(
+      'getList: unknown resource "nope"',
+    );
+  });
+  it("deleteOne throws when resource has no deleteOne (e.g. jobs)", async () => {
+    await expect(
+      dataProvider.deleteOne!({ resource: ResourceName.jobs, id: "j1" }),
+    ).rejects.toThrow('deleteOne: unknown resource "jobs"');
+  });
+});
+
+describe("dataProvider.custom", () => {
+  it("routes a known endpoint and wraps { data }", async () => {
+    const res = await dataProvider.custom!({
+      url: CustomEndpoint.agentRuntimesSyncAll,
+      method: "post",
+      payload: { runtimeId: "rt-1" },
+    });
+    expect(calls.at(-1)).toMatchObject({
+      path: "agentRuntimes.syncAll",
+      kind: "mutate",
+      args: { runtimeId: "rt-1" },
+    });
+    expect(res.data).toMatchObject({ id: "mutated" });
+  });
+
+  it("composes jobs/analysis into { traces, agentRuns, spansByRun }", async () => {
+    const res = await dataProvider.custom!({
+      url: CustomEndpoint.jobsAnalysis,
+      method: "post",
+      payload: { jobId: "j1" },
+    });
+    expect(res.data).toHaveProperty("traces");
+    expect(res.data).toHaveProperty("agentRuns");
+    expect(res.data).toHaveProperty("spansByRun");
+  });
+
+  it("throws on unknown url", async () => {
+    await expect(dataProvider.custom!({ url: "bogus/endpoint", method: "post" })).rejects.toThrow(
+      'custom: unknown url "bogus/endpoint"',
+    );
+  });
+});

--- a/apps/app/src/integrations/refine/resources/custom.ts
+++ b/apps/app/src/integrations/refine/resources/custom.ts
@@ -1,0 +1,136 @@
+import { trpcClient } from "@/integrations/trpc/client";
+
+/**
+ * dataProvider.custom 的 URL → handler 注册表。
+ * 逐条等价迁移自原 custom 方法的 if 链；URL 字面量集中为 CustomEndpoint 常量，
+ * 调用方可引用常量而非裸字符串（消除约定式字符串路由）。
+ *
+ * 说明：jobs 的 pause/cancel/resume 未迁移——当前 tRPC jobs router 尚未暴露
+ * 这三个过程（运行控制在 pipelineRunnerService 里），等 Jobs 控制台页面（#24）落地时补。
+ */
+
+/** 所有 custom 端点的 URL 常量（按域分组）。 */
+export const CustomEndpoint = {
+  pipelinesRun: "pipelines/run",
+  pipelinesAnalyzeIntent: "pipelines/analyzeIntent",
+  pipelinesGenerateStructure: "pipelines/generateStructure",
+  pipelinesOptimizeFromDistillation: "pipelines/optimizeFromDistillation",
+  pipelinesCreatePendingOperations: "pipelines/createPendingOperations",
+  pipelinesProposeProgress: "pipelines/proposeProgress",
+  pipelinesProposeActions: "pipelines/proposeActions",
+  conversationsClearAll: "conversations/clearAll",
+  pipelineAssetsGetUsageCount: "pipelineAssets/getUsageCount",
+  usageSummary: "usage/summary",
+  usageDailyTokenSeries: "usage/dailyTokenSeries",
+  usageByPipeline: "usage/byPipeline",
+  usageByAgent: "usage/byAgent",
+  jobsAnalysis: "jobs/analysis",
+  jobsTraces: "jobs/traces",
+  jobsAgentRuns: "jobs/agentRuns",
+  jobsAgentRunSpans: "jobs/agentRunSpans",
+  refinementsStart: "refinements/start",
+  distillationsRun: "distillations/run",
+  settingsScanRuntimes: "settings/scanRuntimes",
+  agentRuntimesSyncAll: "agentRuntimes/syncAll",
+  agentRuntimesScanAndSync: "agentRuntimes/scanAndSync",
+  operationsRun: "operations/run",
+  skillsPreviewImport: "skills/previewImport",
+  skillsImportCandidates: "skills/importCandidates",
+} as const;
+
+type CustomHandler = (payload: unknown) => Promise<unknown>;
+type Args<T extends (...args: never[]) => unknown> = Parameters<T>[0];
+
+export const customEndpoints: Record<string, CustomHandler> = {
+  [CustomEndpoint.pipelinesRun]: (p) =>
+    trpcClient.pipelines.run.mutate(p as Args<typeof trpcClient.pipelines.run.mutate>),
+  [CustomEndpoint.pipelinesAnalyzeIntent]: (p) =>
+    trpcClient.pipelines.analyzeIntent.mutate(
+      p as Args<typeof trpcClient.pipelines.analyzeIntent.mutate>,
+    ),
+  [CustomEndpoint.pipelinesGenerateStructure]: (p) =>
+    trpcClient.pipelines.generateStructure.mutate(
+      p as Args<typeof trpcClient.pipelines.generateStructure.mutate>,
+    ),
+  [CustomEndpoint.pipelinesOptimizeFromDistillation]: (p) =>
+    trpcClient.pipelines.optimizeFromDistillation.mutate(
+      p as Args<typeof trpcClient.pipelines.optimizeFromDistillation.mutate>,
+    ),
+  [CustomEndpoint.pipelinesCreatePendingOperations]: (p) =>
+    trpcClient.pipelines.createPendingOperations.mutate(
+      p as Args<typeof trpcClient.pipelines.createPendingOperations.mutate>,
+    ),
+  [CustomEndpoint.pipelinesProposeProgress]: (p) =>
+    trpcClient.pipelines.proposeProgress.query(
+      p as Args<typeof trpcClient.pipelines.proposeProgress.query>,
+    ),
+  [CustomEndpoint.pipelinesProposeActions]: (p) =>
+    trpcClient.pipelines.proposeActions.mutate(
+      p as Args<typeof trpcClient.pipelines.proposeActions.mutate>,
+    ),
+  [CustomEndpoint.conversationsClearAll]: () => trpcClient.conversations.clearAll.mutate(),
+  [CustomEndpoint.pipelineAssetsGetUsageCount]: (p) =>
+    trpcClient.pipelineAssets.getUsageCount.query({ id: (p as { id: string }).id }),
+  [CustomEndpoint.usageSummary]: (p) =>
+    trpcClient.usage.getSummary.query(p as Args<typeof trpcClient.usage.getSummary.query>),
+  [CustomEndpoint.usageDailyTokenSeries]: (p) =>
+    trpcClient.usage.getDailyTokenSeries.query(
+      p as Args<typeof trpcClient.usage.getDailyTokenSeries.query>,
+    ),
+  [CustomEndpoint.usageByPipeline]: (p) =>
+    trpcClient.usage.getByPipeline.query(p as Args<typeof trpcClient.usage.getByPipeline.query>),
+  [CustomEndpoint.usageByAgent]: (p) =>
+    trpcClient.usage.getByAgent.query(p as Args<typeof trpcClient.usage.getByAgent.query>),
+  [CustomEndpoint.jobsAnalysis]: async (p) => {
+    const { jobId } = p as { jobId: string };
+    const [traces, agentRuns] = await Promise.all([
+      trpcClient.jobs.getTraces.query({ jobId }),
+      trpcClient.jobs.getAgentRuns.query({ jobId }),
+    ]);
+    const spansByRunEntries = await Promise.all(
+      agentRuns.map(async (run) => {
+        const spans = await trpcClient.jobs.getAgentRunSpans.query({ rawExportId: run.id });
+
+        return [run.id, spans] as const;
+      }),
+    );
+
+    return { traces, agentRuns, spansByRun: Object.fromEntries(spansByRunEntries) };
+  },
+  [CustomEndpoint.jobsTraces]: async (p) => {
+    const { jobId } = p as { jobId: string };
+    const traces = await trpcClient.jobs.getTraces.query({ jobId });
+
+    return { traces };
+  },
+  [CustomEndpoint.jobsAgentRuns]: async (p) => {
+    const { jobId } = p as { jobId: string };
+    const agentRuns = await trpcClient.jobs.getAgentRuns.query({ jobId });
+
+    return { agentRuns };
+  },
+  [CustomEndpoint.jobsAgentRunSpans]: async (p) => {
+    const { rawExportId } = p as { rawExportId: number };
+    const spans = await trpcClient.jobs.getAgentRunSpans.query({ rawExportId });
+
+    return { spans };
+  },
+  [CustomEndpoint.refinementsStart]: (p) =>
+    trpcClient.refinements.start.mutate(p as Args<typeof trpcClient.refinements.start.mutate>),
+  [CustomEndpoint.distillationsRun]: (p) =>
+    trpcClient.distillations.run.mutate(p as Args<typeof trpcClient.distillations.run.mutate>),
+  [CustomEndpoint.settingsScanRuntimes]: () => trpcClient.agentRuntimes.scanRuntimes.query(),
+  [CustomEndpoint.agentRuntimesSyncAll]: (p) =>
+    trpcClient.agentRuntimes.syncAll.mutate(
+      p as Args<typeof trpcClient.agentRuntimes.syncAll.mutate>,
+    ),
+  [CustomEndpoint.agentRuntimesScanAndSync]: () => trpcClient.agentRuntimes.scanAndSync.mutate(),
+  [CustomEndpoint.operationsRun]: (p) =>
+    trpcClient.operations.run.mutate(p as Args<typeof trpcClient.operations.run.mutate>),
+  [CustomEndpoint.skillsPreviewImport]: (p) =>
+    trpcClient.skills.previewImport.query(p as Args<typeof trpcClient.skills.previewImport.query>),
+  [CustomEndpoint.skillsImportCandidates]: (p) =>
+    trpcClient.skills.importCandidates.mutate(
+      p as Args<typeof trpcClient.skills.importCandidates.mutate>,
+    ),
+};

--- a/apps/app/src/integrations/refine/resources/registry.ts
+++ b/apps/app/src/integrations/refine/resources/registry.ts
@@ -1,0 +1,250 @@
+import { trpcClient } from "@/integrations/trpc/client";
+import { ResourceName } from "./resourceNames";
+import type { ResourceHandlers } from "./types";
+
+/**
+ * 资源 → handler 注册表。逐条等价迁移自原 dataProvider 的 5 个 switch，
+ * 行为零变化：trpc 调用、参数映射、id String() 归一全部照搬。
+ *
+ * 类型 cast（`as Parameters<...>`）保持与原实现一致——trpc 输入是强类型，
+ * 而 Refine 的 variables/patch 是 unknown，cast 边界与迁移前完全相同。
+ *
+ * annotations 已按 COD-114 范围裁剪砍掉，本表不含对应条目。
+ */
+
+type Vars = Record<string, unknown>;
+const asRecord = (variables: unknown): Vars => variables as Vars;
+
+export const resourceHandlers: Partial<Record<string, ResourceHandlers>> = {
+  [ResourceName.agents]: {
+    getList: () => trpcClient.agents.getMany.query(),
+    getOne: (id) => trpcClient.agents.getById.query({ id }),
+    create: (v) =>
+      trpcClient.agents.create.mutate(v as Parameters<typeof trpcClient.agents.create.mutate>[0]),
+    update: (id, v) =>
+      trpcClient.agents.update.mutate({ id, patch: asRecord(v) } as Parameters<
+        typeof trpcClient.agents.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.agents.delete.mutate({ id }),
+  },
+
+  [ResourceName.agentRuntimes]: {
+    getList: () => trpcClient.agentRuntimes.getMany.query(),
+    getOne: (id) => trpcClient.agentRuntimes.getById.query({ id }),
+    create: (v) =>
+      trpcClient.agentRuntimes.create.mutate(
+        v as Parameters<typeof trpcClient.agentRuntimes.create.mutate>[0],
+      ),
+    update: (id, v) =>
+      trpcClient.agentRuntimes.update.mutate({ id, patch: asRecord(v) } as Parameters<
+        typeof trpcClient.agentRuntimes.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.agentRuntimes.delete.mutate({ id }),
+  },
+
+  [ResourceName.connectors]: {
+    getList: () => trpcClient.connectors.getMany.query(),
+    getOne: (id) => trpcClient.connectors.getById.query({ id }),
+    create: (v) =>
+      trpcClient.connectors.create.mutate(
+        v as Parameters<typeof trpcClient.connectors.create.mutate>[0],
+      ),
+    update: (id, v) =>
+      trpcClient.connectors.update.mutate({ id, patch: asRecord(v) } as Parameters<
+        typeof trpcClient.connectors.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.connectors.delete.mutate({ id }),
+  },
+
+  [ResourceName.conversationMessages]: {
+    getList: (_params, f) =>
+      trpcClient.conversations.getMany.query({
+        pipelineId: f.string("pipelineId"),
+        limit: f.number("limit"),
+      }),
+    getOne: (id) => trpcClient.conversations.getById.query({ id }),
+    create: (v) =>
+      trpcClient.conversations.create.mutate(
+        v as Parameters<typeof trpcClient.conversations.create.mutate>[0],
+      ),
+    update: (id, v) =>
+      trpcClient.conversations.update.mutate({ id, patch: asRecord(v) } as Parameters<
+        typeof trpcClient.conversations.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.conversations.delete.mutate({ id }),
+  },
+
+  [ResourceName.filesystem]: {
+    getList: (_params, f) => trpcClient.filesystem.browse.query({ path: f.string("path") }),
+  },
+
+  [ResourceName.operations]: {
+    getList: () => trpcClient.operations.getMany.query(),
+    getOne: (id) => trpcClient.operations.getById.query({ id }),
+    create: (v) =>
+      trpcClient.operations.create.mutate(
+        v as Parameters<typeof trpcClient.operations.create.mutate>[0],
+      ),
+    // operations 用展开而非 patch（与迁移前一致）。
+    update: (id, v) =>
+      trpcClient.operations.update.mutate({ id, ...asRecord(v) } as Parameters<
+        typeof trpcClient.operations.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.operations.delete.mutate({ id }),
+  },
+
+  [ResourceName.pipelineAssets]: {
+    getList: (_params, f) =>
+      trpcClient.pipelineAssets.getMany.query({ pipelineId: f.string("pipelineId") }),
+    getOne: (id) => trpcClient.pipelineAssets.getById.query({ id }),
+    create: (v) =>
+      trpcClient.pipelineAssets.create.mutate(
+        v as Parameters<typeof trpcClient.pipelineAssets.create.mutate>[0],
+      ),
+    update: (id, v) =>
+      trpcClient.pipelineAssets.update.mutate({ id, patch: asRecord(v) } as Parameters<
+        typeof trpcClient.pipelineAssets.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.pipelineAssets.delete.mutate({ id }),
+  },
+
+  [ResourceName.pipelines]: {
+    getList: () => trpcClient.pipelines.getMany.query(),
+    getOne: (id) => trpcClient.pipelines.getById.query({ id }),
+    // pipelines.create 把 pendingOperations 从图数据里拆出（与迁移前一致）。
+    create: (v) => {
+      const { pendingOperations, ...pipelineData } = asRecord(v);
+
+      return trpcClient.pipelines.create.mutate({
+        pipeline: pipelineData,
+        pendingOperations: pendingOperations as
+          | Parameters<typeof trpcClient.pipelines.create.mutate>[0]["pendingOperations"]
+          | undefined,
+      } as Parameters<typeof trpcClient.pipelines.create.mutate>[0]);
+    },
+    update: (id, v) =>
+      trpcClient.pipelines.update.mutate({ id, patch: asRecord(v) } as Parameters<
+        typeof trpcClient.pipelines.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.pipelines.delete.mutate({ id }),
+  },
+
+  [ResourceName.projects]: {
+    getList: () => trpcClient.projects.getMany.query(),
+    getOne: (id) => trpcClient.projects.getById.query({ id }),
+    create: (v) =>
+      trpcClient.projects.create.mutate(
+        v as Parameters<typeof trpcClient.projects.create.mutate>[0],
+      ),
+    update: (id, v) =>
+      trpcClient.projects.update.mutate({ id, patch: asRecord(v) } as Parameters<
+        typeof trpcClient.projects.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.projects.delete.mutate({ id }),
+  },
+
+  [ResourceName.routines]: {
+    getList: (_params, f) =>
+      trpcClient.routines.getMany.query({
+        pipelineId: f.string("pipelineId"),
+        enabled: f.boolean("enabled"),
+      }),
+    getOne: (id) => trpcClient.routines.getById.query({ id }),
+    create: (v) =>
+      trpcClient.routines.create.mutate(
+        v as Parameters<typeof trpcClient.routines.create.mutate>[0],
+      ),
+    update: (id, v) =>
+      trpcClient.routines.update.mutate({ id, patch: asRecord(v) } as Parameters<
+        typeof trpcClient.routines.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.routines.delete.mutate({ id }),
+  },
+
+  [ResourceName.jobs]: {
+    getList: () => trpcClient.jobs.getMany.query(),
+    getOne: (id) => trpcClient.jobs.getById.query({ id }),
+    create: (v) =>
+      trpcClient.jobs.create.mutate(v as Parameters<typeof trpcClient.jobs.create.mutate>[0]),
+    // jobs 走 updateStatus + 展开（与迁移前一致）。
+    update: (id, v) =>
+      trpcClient.jobs.updateStatus.mutate({ id, ...asRecord(v) } as unknown as Parameters<
+        typeof trpcClient.jobs.updateStatus.mutate
+      >[0]),
+  },
+
+  [ResourceName.githubProjects]: {
+    getList: () => trpcClient.githubProjects.getMany.query(),
+    getOne: (id) => trpcClient.githubProjects.getById.query({ id }),
+    create: (v) =>
+      trpcClient.githubProjects.create.mutate(
+        v as Parameters<typeof trpcClient.githubProjects.create.mutate>[0],
+      ),
+    update: (id, v) =>
+      trpcClient.githubProjects.update.mutate({ id, patch: asRecord(v) } as Parameters<
+        typeof trpcClient.githubProjects.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.githubProjects.delete.mutate({ id }),
+  },
+
+  [ResourceName.skills]: {
+    getList: () => trpcClient.skills.getMany.query(),
+    getOne: (id) => trpcClient.skills.getById.query({ id }),
+    create: (v) =>
+      trpcClient.skills.create.mutate(v as Parameters<typeof trpcClient.skills.create.mutate>[0]),
+    update: (id, v) =>
+      trpcClient.skills.update.mutate({ id, patch: asRecord(v) } as Parameters<
+        typeof trpcClient.skills.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.skills.delete.mutate({ id }),
+  },
+
+  [ResourceName.skillDraftOperations]: {
+    getOne: (id) => trpcClient.skills.draftOperation.query({ id }),
+  },
+
+  [ResourceName.skillAnalyses]: {
+    getOne: (id) => trpcClient.skills.analyze.query({ id }),
+  },
+
+  [ResourceName.distillations]: {
+    getList: () => trpcClient.distillations.getMany.query(),
+    getOne: (id) => trpcClient.distillations.getById.query({ id }),
+    create: (v) =>
+      trpcClient.distillations.create.mutate(
+        v as Parameters<typeof trpcClient.distillations.create.mutate>[0],
+      ),
+    update: (id, v) =>
+      trpcClient.distillations.update.mutate({ id, patch: asRecord(v) } as Parameters<
+        typeof trpcClient.distillations.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.distillations.delete.mutate({ id }),
+  },
+
+  [ResourceName.refinements]: {
+    getOne: (id) => trpcClient.refinements.getById.query({ id }),
+  },
+
+  [ResourceName.settings]: {
+    getOne: () => trpcClient.settings.get.query(),
+    update: (_id, v) =>
+      trpcClient.settings.update.mutate(
+        v as Parameters<typeof trpcClient.settings.update.mutate>[0],
+      ),
+  },
+
+  [ResourceName.operationOutputItemTemplates]: {
+    getList: () => trpcClient.operationOutputItemTemplates.getMany.query(),
+    getOne: (id) => trpcClient.operationOutputItemTemplates.getById.query({ id }),
+    create: (v) =>
+      trpcClient.operationOutputItemTemplates.create.mutate(
+        v as Parameters<typeof trpcClient.operationOutputItemTemplates.create.mutate>[0],
+      ),
+    // 模板用展开而非 patch（与迁移前一致）。
+    update: (id, v) =>
+      trpcClient.operationOutputItemTemplates.update.mutate({ id, ...asRecord(v) } as Parameters<
+        typeof trpcClient.operationOutputItemTemplates.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.operationOutputItemTemplates.delete.mutate({ id }),
+  },
+};

--- a/apps/app/src/integrations/refine/resources/registry.unit.test.ts
+++ b/apps/app/src/integrations/refine/resources/registry.unit.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * H3-03 行为护栏：mock trpcClient 为"记录调用"的 Proxy，断言每个资源 handler
+ * 路由到正确的 trpc 过程、参数映射与迁移前一致。重点覆盖标准 CRUD + 全部例外。
+ */
+
+// vi.mock 工厂被提升到文件顶部，引用的外部变量必须经 vi.hoisted 创建。
+const { calls } = vi.hoisted(() => ({
+  calls: [] as { args: unknown; kind: string; path: string }[],
+}));
+
+vi.mock("@/integrations/trpc/client", () => {
+  const makeProc = (path: string) => ({
+    query: async (args?: unknown) => {
+      calls.push({ args, kind: "query", path });
+
+      return [];
+    },
+    mutate: async (args?: unknown) => {
+      calls.push({ args, kind: "mutate", path });
+
+      return [];
+    },
+  });
+  const trpcClient = new Proxy(
+    {},
+    {
+      get: (_t, router: string) =>
+        new Proxy({}, { get: (_t2, proc: string) => makeProc(`${router}.${String(proc)}`) }),
+    },
+  );
+
+  return { trpcClient };
+});
+
+const { resourceHandlers } = await import("./registry");
+import type { ListFilters } from "./types";
+
+const noFilters: ListFilters = {
+  string: () => undefined,
+  number: () => undefined,
+  boolean: () => undefined,
+};
+
+const last = () => calls.at(-1)!;
+
+beforeEach(() => {
+  calls.length = 0;
+});
+
+describe("resourceHandlers — 标准 CRUD 路由 (agents 为代表)", () => {
+  const h = resourceHandlers.agents!;
+
+  it("getList → agents.getMany.query", async () => {
+    await h.getList!({ resource: "agents" }, noFilters);
+    expect(last()).toMatchObject({ path: "agents.getMany", kind: "query" });
+  });
+  it("getOne → agents.getById.query({id})", async () => {
+    await h.getOne!("a1");
+    expect(last()).toMatchObject({ path: "agents.getById", kind: "query", args: { id: "a1" } });
+  });
+  it("create → agents.create.mutate(variables)", async () => {
+    await h.create!({ name: "x" });
+    expect(last()).toMatchObject({ path: "agents.create", kind: "mutate", args: { name: "x" } });
+  });
+  it("update → agents.update.mutate({id, patch})", async () => {
+    await h.update!("a1", { name: "y" });
+    expect(last()).toMatchObject({
+      path: "agents.update",
+      kind: "mutate",
+      args: { id: "a1", patch: { name: "y" } },
+    });
+  });
+  it("deleteOne → agents.delete.mutate({id})", async () => {
+    await h.deleteOne!("a1");
+    expect(last()).toMatchObject({ path: "agents.delete", kind: "mutate", args: { id: "a1" } });
+  });
+});
+
+describe("resourceHandlers — 例外项（迁移最易出错处）", () => {
+  it("conversationMessages 路由到 conversations router", async () => {
+    const h = resourceHandlers.conversationMessages!;
+    await h.getList!(
+      { resource: "conversationMessages" },
+      {
+        ...noFilters,
+        string: (f) => (f === "pipelineId" ? "p1" : undefined),
+        number: (f) => (f === "limit" ? 20 : undefined),
+      },
+    );
+    expect(last()).toMatchObject({
+      path: "conversations.getMany",
+      args: { pipelineId: "p1", limit: 20 },
+    });
+    await h.getOne!("c1");
+    expect(last().path).toBe("conversations.getById");
+    await h.deleteOne!("c1");
+    expect(last().path).toBe("conversations.delete");
+  });
+
+  it("operations.update 用展开而非 patch", async () => {
+    await resourceHandlers.operations!.update!("o1", { label: "L" });
+    expect(last()).toMatchObject({
+      path: "operations.update",
+      args: { id: "o1", label: "L" },
+    });
+    expect((last().args as Record<string, unknown>).patch).toBeUndefined();
+  });
+
+  it("jobs.update → updateStatus 展开，无 deleteOne", async () => {
+    await resourceHandlers.jobs!.update!("j1", { status: "done" });
+    expect(last()).toMatchObject({
+      path: "jobs.updateStatus",
+      args: { id: "j1", status: "done" },
+    });
+    expect(resourceHandlers.jobs!.deleteOne).toBeUndefined();
+  });
+
+  it("settings.getOne 无 id，settings.update 直传 variables 无 id", async () => {
+    await resourceHandlers.settings!.getOne!("ignored");
+    expect(last()).toMatchObject({ path: "settings.get", kind: "query" });
+    expect(last().args).toBeUndefined();
+    await resourceHandlers.settings!.update!("ignored", { theme: "dark" });
+    expect(last()).toMatchObject({ path: "settings.update", args: { theme: "dark" } });
+  });
+
+  it("pipelines.create 拆出 pendingOperations", async () => {
+    await resourceHandlers.pipelines!.create!({
+      name: "P",
+      nodes: [],
+      pendingOperations: [{ id: "op1" }],
+    });
+    expect(last()).toMatchObject({
+      path: "pipelines.create",
+      args: { pipeline: { name: "P", nodes: [] }, pendingOperations: [{ id: "op1" }] },
+    });
+  });
+
+  it("skillDraftOperations/skillAnalyses/refinements 仅 getOne，路由到对应过程", async () => {
+    await resourceHandlers.skillDraftOperations!.getOne!("s1");
+    expect(last()).toMatchObject({ path: "skills.draftOperation", args: { id: "s1" } });
+    await resourceHandlers.skillAnalyses!.getOne!("s1");
+    expect(last()).toMatchObject({ path: "skills.analyze", args: { id: "s1" } });
+    await resourceHandlers.refinements!.getOne!("r1");
+    expect(last()).toMatchObject({ path: "refinements.getById", args: { id: "r1" } });
+  });
+
+  it("filesystem 仅 getList → filesystem.browse({path})", async () => {
+    await resourceHandlers.filesystem!.getList!(
+      { resource: "filesystem" },
+      {
+        ...noFilters,
+        string: (f) => (f === "path" ? "/tmp" : undefined),
+      },
+    );
+    expect(last()).toMatchObject({ path: "filesystem.browse", args: { path: "/tmp" } });
+  });
+
+  it("routines.getList 传 pipelineId + enabled(boolean)", async () => {
+    await resourceHandlers.routines!.getList!(
+      { resource: "routines" },
+      {
+        ...noFilters,
+        string: (f) => (f === "pipelineId" ? "p1" : undefined),
+        boolean: (f) => (f === "enabled" ? true : undefined),
+      },
+    );
+    expect(last()).toMatchObject({
+      path: "routines.getMany",
+      args: { pipelineId: "p1", enabled: true },
+    });
+  });
+});

--- a/apps/app/src/integrations/refine/resources/resourceNames.ts
+++ b/apps/app/src/integrations/refine/resources/resourceNames.ts
@@ -1,0 +1,32 @@
+/**
+ * Refine 资源名常量（自 dataProvider 迁出，避免 dataProvider ↔ registry 循环依赖）。
+ * dataProvider.ts 再导出本常量，既有 `import { ResourceName } from ".../dataProvider"` 不受影响。
+ *
+ * 注意：annotations 已按 COD-114 范围裁剪整体砍掉，本表不含 annotations。
+ */
+export const ResourceName = {
+  agents: "agents",
+  agentRuntimes: "agentRuntimes",
+  connectors: "connectors",
+  conversationMessages: "conversationMessages",
+  filesystem: "filesystem",
+  operations: "operations",
+  pipelineAssets: "pipelineAssets",
+  pipelines: "pipelines",
+  projects: "projects",
+  routines: "routines",
+  jobs: "jobs",
+  githubProjects: "githubProjects",
+  skills: "skills",
+  recipes: "recipes",
+  checklistItems: "checklistItems",
+  codeSnippets: "codeSnippets",
+  skillDraftOperations: "skillDraftOperations",
+  skillAnalyses: "skillAnalyses",
+  distillations: "distillations",
+  refinements: "refinements",
+  settings: "settings",
+  operationOutputItemTemplates: "operationOutputItemTemplates",
+} as const;
+
+export type ResourceNameValue = (typeof ResourceName)[keyof typeof ResourceName];

--- a/apps/app/src/integrations/refine/resources/types.ts
+++ b/apps/app/src/integrations/refine/resources/types.ts
@@ -1,0 +1,55 @@
+import type { GetListParams } from "@refinedev/core";
+
+/**
+ * 资源 handler 注册表的契约。
+ * 每个资源声明它支持的方法；dataProvider 只做查找 + 统一响应封装 + 兜底报错，
+ * 不再为每个方法维护一个 80 分支的 switch。新增资源 = 注册表加一条目，不动 dataProvider。
+ */
+
+/** getList 过滤器读取器（封装原 getStringFilter/getNumberFilter/getBooleanFilter）。 */
+export type ListFilters = {
+  string: (field: string) => string | undefined;
+  number: (field: string) => number | undefined;
+  boolean: (field: string) => boolean | undefined;
+};
+
+export type ResourceHandlers = {
+  /** 返回原始数组；dataProvider 负责 `{ data, total: data.length }` 封装与泛型 cast。 */
+  getList?: (params: GetListParams, filters: ListFilters) => Promise<unknown[]>;
+  getOne?: (id: string) => Promise<unknown>;
+  create?: (variables: unknown) => Promise<unknown>;
+  update?: (id: string, variables: unknown) => Promise<unknown>;
+  deleteOne?: (id: string) => Promise<unknown>;
+};
+
+export const makeListFilters = (params: GetListParams): ListFilters => {
+  const raw = (field: string): unknown => {
+    const filter = params.filters?.find((item) => "field" in item && item.field === field);
+
+    return filter && "value" in filter ? filter.value : undefined;
+  };
+
+  return {
+    string: (field) => {
+      const value = raw(field);
+
+      return typeof value === "string" ? value : undefined;
+    },
+    number: (field) => {
+      const value = raw(field);
+      if (typeof value === "number") return value;
+      if (typeof value !== "string" || value.trim() === "") return undefined;
+      const parsed = Number(value);
+
+      return Number.isFinite(parsed) ? parsed : undefined;
+    },
+    boolean: (field) => {
+      const value = raw(field);
+      if (typeof value === "boolean") return value;
+      if (value === "true") return true;
+      if (value === "false") return false;
+
+      return undefined;
+    },
+  };
+};

--- a/apps/app/src/router.tsx
+++ b/apps/app/src/router.tsx
@@ -1,6 +1,7 @@
 import { createRouter } from "@tanstack/react-router";
 import { Provider } from "@/integrations/tanstack-query/root-provider";
 import { RefineProvider } from "@/integrations/refine/provider";
+import { ThemeApplier } from "@/store/themeStore";
 import { routeTree } from "./routeTree.gen.ts";
 
 const createAppRouter = () =>
@@ -12,7 +13,10 @@ const createAppRouter = () =>
     Wrap: ({ children }) => {
       return (
         <Provider>
-          <RefineProvider>{children}</RefineProvider>
+          <RefineProvider>
+            <ThemeApplier />
+            {children}
+          </RefineProvider>
         </Provider>
       );
     },

--- a/apps/app/src/store/autonomyStore/autonomyStore.ts
+++ b/apps/app/src/store/autonomyStore/autonomyStore.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/**
+ * Autonomy 偏好（Settings — Autonomy 组）。设备级偏好，不入库；
+ * 每次 Run 随请求下发，引擎据此决定 self-heal 重试轮数（0=失败即停）。
+ */
+
+export const SELF_HEAL_RETRIES_MIN = 0;
+export const SELF_HEAL_RETRIES_MAX = 5;
+export const SELF_HEAL_RETRIES_DEFAULT = 1;
+
+type AutonomyState = {
+  selfHealRetries: number;
+  setSelfHealRetries: (value: number) => void;
+};
+
+const clamp = (value: number): number =>
+  Math.min(SELF_HEAL_RETRIES_MAX, Math.max(SELF_HEAL_RETRIES_MIN, Math.round(value)));
+
+export const useAutonomyStore = create<AutonomyState>()(
+  persist(
+    (set) => ({
+      selfHealRetries: SELF_HEAL_RETRIES_DEFAULT,
+      setSelfHealRetries: (value) => set({ selfHealRetries: clamp(value) }),
+    }),
+    { name: "ordine.autonomy" },
+  ),
+);

--- a/apps/app/src/store/autonomyStore/index.ts
+++ b/apps/app/src/store/autonomyStore/index.ts
@@ -1,0 +1,1 @@
+export * from "./autonomyStore";

--- a/apps/app/src/store/notificationStore/index.ts
+++ b/apps/app/src/store/notificationStore/index.ts
@@ -1,0 +1,2 @@
+export * from "./notificationStore";
+export * from "./notificationPrefsStore";

--- a/apps/app/src/store/notificationStore/notificationPrefsStore.ts
+++ b/apps/app/src/store/notificationStore/notificationPrefsStore.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/**
+ * 通知偏好（Settings — Notifications 组）。通知本身是前端 store
+ * （notificationStore），偏好同样留在前端持久化。
+ * cancelled/expired 等少见终态不受偏好控制（始终提示）。
+ */
+
+export type NotificationPrefKey = "done" | "failed" | "waiting";
+
+type NotificationPrefsState = {
+  done: boolean;
+  failed: boolean;
+  waiting: boolean;
+  setPref: (key: NotificationPrefKey, value: boolean) => void;
+};
+
+export const useNotificationPrefsStore = create<NotificationPrefsState>()(
+  persist(
+    (set) => ({
+      done: true,
+      failed: true,
+      waiting: true,
+      setPref: (key, value) => set({ [key]: value }),
+    }),
+    { name: "ordine.notification-prefs" },
+  ),
+);

--- a/apps/app/src/store/notificationStore/notificationStore.ts
+++ b/apps/app/src/store/notificationStore/notificationStore.ts
@@ -1,0 +1,52 @@
+import { create } from "zustand";
+
+export type NotificationKind = "error" | "info" | "success" | "warn";
+
+export type AppNotification = {
+  id: string;
+  kind: NotificationKind;
+  message: string;
+  read: boolean;
+  route?: string;
+  ts: number;
+};
+
+export type NotificationState = {
+  notifications: AppNotification[];
+  addNotification: (input: {
+    id?: string;
+    kind: NotificationKind;
+    message: string;
+    route?: string;
+  }) => void;
+  clearNotifications: () => void;
+  markAllRead: () => void;
+};
+
+const MAX_NOTIFICATIONS = 60;
+
+export const useNotificationStore = create<NotificationState>((set) => ({
+  notifications: [],
+  addNotification: ({ id, kind, message, route }) =>
+    set((state) => ({
+      notifications: [
+        {
+          id: id ?? `notif-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+          kind,
+          message,
+          read: false,
+          route,
+          ts: Date.now(),
+        },
+        ...state.notifications,
+      ].slice(0, MAX_NOTIFICATIONS),
+    })),
+  clearNotifications: () => set({ notifications: [] }),
+  markAllRead: () =>
+    set((state) => ({
+      notifications: state.notifications.map((notification) => ({
+        ...notification,
+        read: true,
+      })),
+    })),
+}));

--- a/apps/app/src/store/notificationStore/notificationStore.unit.test.ts
+++ b/apps/app/src/store/notificationStore/notificationStore.unit.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { toastStore } from "../toastStore/toastStore";
+import { useNotificationStore } from "./notificationStore";
+
+describe("notificationStore", () => {
+  beforeEach(() => {
+    useNotificationStore.getState().clearNotifications();
+  });
+
+  it("records, marks read, and clears notifications", () => {
+    useNotificationStore.getState().addNotification({
+      kind: "success",
+      message: "job_1 completed",
+      route: "/jobs",
+    });
+    useNotificationStore.getState().addNotification({
+      kind: "error",
+      message: "Connector needs a token",
+    });
+
+    expect(useNotificationStore.getState().notifications).toHaveLength(2);
+    expect(useNotificationStore.getState().notifications.filter((item) => !item.read)).toHaveLength(
+      2,
+    );
+
+    useNotificationStore.getState().markAllRead();
+    expect(useNotificationStore.getState().notifications.filter((item) => !item.read)).toHaveLength(
+      0,
+    );
+
+    useNotificationStore.getState().clearNotifications();
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it("mirrors toasts into the history", () => {
+    toastStore.getState().addToast({ title: "Run started", type: "success" });
+
+    const latest = useNotificationStore.getState().notifications[0];
+    expect(latest?.message).toBe("Run started");
+    expect(latest?.kind).toBe("success");
+  });
+
+  it("caps the history at 60 entries", () => {
+    for (const index of Array.from({ length: 70 }, (_, i) => i)) {
+      useNotificationStore.getState().addNotification({
+        kind: "info",
+        message: `event ${index}`,
+      });
+    }
+
+    expect(useNotificationStore.getState().notifications).toHaveLength(60);
+    expect(useNotificationStore.getState().notifications[0]?.message).toBe("event 69");
+  });
+});

--- a/apps/app/src/store/sidebarStore/sidebarSlice.ts
+++ b/apps/app/src/store/sidebarStore/sidebarSlice.ts
@@ -4,10 +4,41 @@ import { SidebarView, type SidebarViewType } from "./sidebarView";
 const isPipelinePathname = (pathname: string): boolean =>
   pathname.startsWith("/canvas") || pathname.startsWith("/pipelines");
 
+const CURRENT_PROJECT_STORAGE_KEY = "ordine.sidebar.currentProjectId";
+const CAPABILITIES_OPEN_STORAGE_KEY = "ordine.sidebar.capabilitiesOpen";
+
+const readStoredValue = (key: string) => {
+  if (globalThis.localStorage === undefined) return null;
+
+  return globalThis.localStorage.getItem(key);
+};
+
+const writeStoredValue = (key: string, value: string) => {
+  if (globalThis.localStorage === undefined) return;
+
+  globalThis.localStorage.setItem(key, value);
+};
+
+const readStoredBoolean = (key: string, fallback: boolean) => {
+  const value = readStoredValue(key);
+  if (value === null) return fallback;
+
+  return value === "true";
+};
+
+const removeStoredValue = (key: string) => {
+  if (globalThis.localStorage === undefined) return;
+
+  globalThis.localStorage.removeItem(key);
+};
+
 export interface SidebarSlice {
   view: SidebarViewType;
   searchOpen: boolean;
   newPipelineOpen: boolean;
+  currentProjectId: string | null;
+  capabilitiesOpen: boolean;
+  sidebarSearchQuery: string;
 
   handleSidebarLocationChange: (pathname: string) => void;
   handleSearchDialogOpenChange: (open: boolean) => void;
@@ -15,12 +46,21 @@ export interface SidebarSlice {
   handleSidebarPipelineViewButtonClick: () => void;
   handleSearchButtonClick: () => void;
   handleNewPipelineButtonClick: () => void;
+  handleCurrentProjectChange: (projectId: string) => void;
+  /** Drop a stale project id that no longer exists in the database. */
+  handleCurrentProjectClear: () => void;
+  handleCapabilitiesToggle: () => void;
+  handleSidebarSearchChange: (value: string) => void;
+  handleSidebarSearchClear: () => void;
 }
 
-export const createSidebarSlice: StateCreator<SidebarSlice> = (set) => ({
+export const createSidebarSlice: StateCreator<SidebarSlice> = (set, get) => ({
   view: SidebarView.Main,
   searchOpen: false,
   newPipelineOpen: false,
+  currentProjectId: readStoredValue(CURRENT_PROJECT_STORAGE_KEY),
+  capabilitiesOpen: readStoredBoolean(CAPABILITIES_OPEN_STORAGE_KEY, true),
+  sidebarSearchQuery: "",
 
   handleSidebarLocationChange: (pathname) =>
     set({ view: isPipelinePathname(pathname) ? SidebarView.Pipeline : SidebarView.Main }),
@@ -29,4 +69,20 @@ export const createSidebarSlice: StateCreator<SidebarSlice> = (set) => ({
   handleSidebarPipelineViewButtonClick: () => set({ view: SidebarView.Pipeline }),
   handleSearchButtonClick: () => set({ searchOpen: true }),
   handleNewPipelineButtonClick: () => set({ newPipelineOpen: true }),
+  handleCurrentProjectChange: (projectId) => {
+    writeStoredValue(CURRENT_PROJECT_STORAGE_KEY, projectId);
+    set({ currentProjectId: projectId });
+  },
+  handleCurrentProjectClear: () => {
+    removeStoredValue(CURRENT_PROJECT_STORAGE_KEY);
+    set({ currentProjectId: null });
+  },
+  handleCapabilitiesToggle: () => {
+    const capabilitiesOpen = !get().capabilitiesOpen;
+    writeStoredValue(CAPABILITIES_OPEN_STORAGE_KEY, String(capabilitiesOpen));
+    set({ capabilitiesOpen });
+  },
+  handleSidebarSearchChange: (value) =>
+    set({ searchOpen: value.trim().length > 0, sidebarSearchQuery: value }),
+  handleSidebarSearchClear: () => set({ searchOpen: false, sidebarSearchQuery: "" }),
 });

--- a/apps/app/src/store/sidebarStore/sidebarStore.unit.test.ts
+++ b/apps/app/src/store/sidebarStore/sidebarStore.unit.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStore } from "zustand";
+import { createSidebarSlice, type SidebarSlice } from "./sidebarSlice";
+
+const createTestStore = () => createStore<SidebarSlice>()(createSidebarSlice);
+
+const createLocalStorageMock = () => {
+  const values = new Map<string, string>();
+
+  return {
+    clear: vi.fn(() => values.clear()),
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    removeItem: vi.fn((key: string) => values.delete(key)),
+    setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+  };
+};
+
+describe("sidebarStore", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createLocalStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("persists the current project id", () => {
+    const store = createTestStore();
+
+    store.getState().handleCurrentProjectChange("project-1");
+
+    expect(store.getState().currentProjectId).toBe("project-1");
+    expect(localStorage.getItem("ordine.sidebar.currentProjectId")).toBe("project-1");
+    expect(createTestStore().getState().currentProjectId).toBe("project-1");
+  });
+
+  it("persists the capabilities section state", () => {
+    const store = createTestStore();
+
+    store.getState().handleCapabilitiesToggle();
+
+    expect(store.getState().capabilitiesOpen).toBe(false);
+    expect(localStorage.getItem("ordine.sidebar.capabilitiesOpen")).toBe("false");
+    expect(createTestStore().getState().capabilitiesOpen).toBe(false);
+  });
+
+  it("opens global search while typing and closes when cleared", () => {
+    const store = createTestStore();
+
+    store.getState().handleSidebarSearchChange("lead");
+
+    expect(store.getState().searchOpen).toBe(true);
+    expect(store.getState().sidebarSearchQuery).toBe("lead");
+
+    store.getState().handleSidebarSearchClear();
+
+    expect(store.getState().searchOpen).toBe(false);
+    expect(store.getState().sidebarSearchQuery).toBe("");
+  });
+});

--- a/apps/app/src/store/themeStore/ThemeApplier.tsx
+++ b/apps/app/src/store/themeStore/ThemeApplier.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { applyThemePreference, useThemeStore } from "./themeStore";
+
+/** 挂在应用根：应用持久化的外观偏好，system 模式下跟随系统切换。 */
+export const ThemeApplier = () => {
+  const preference = useThemeStore((state) => state.preference);
+
+  useEffect(() => {
+    applyThemePreference(preference);
+    if (preference !== "system" || typeof globalThis.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = globalThis.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = () => applyThemePreference("system");
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [preference]);
+
+  return null;
+};

--- a/apps/app/src/store/themeStore/index.ts
+++ b/apps/app/src/store/themeStore/index.ts
@@ -1,0 +1,2 @@
+export * from "./themeStore";
+export * from "./ThemeApplier";

--- a/apps/app/src/store/themeStore/themeStore.ts
+++ b/apps/app/src/store/themeStore/themeStore.ts
@@ -1,0 +1,42 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/**
+ * 外观偏好（Settings — General 组）。`.dark` 变量集在 styles.css 已完整
+ * （含 surface/border 系），这里只负责持久化偏好并切换 documentElement class；
+ * system 跟随系统配色。
+ */
+
+export type ThemePreference = "dark" | "light" | "system";
+
+const prefersDark = (): boolean =>
+  typeof globalThis.matchMedia === "function" &&
+  globalThis.matchMedia("(prefers-color-scheme: dark)").matches;
+
+export const resolveIsDark = (preference: ThemePreference): boolean =>
+  preference === "dark" || (preference === "system" && prefersDark());
+
+export const applyThemePreference = (preference: ThemePreference): void => {
+  if (typeof document === "undefined") {
+    return;
+  }
+  document.documentElement.classList.toggle("dark", resolveIsDark(preference));
+};
+
+type ThemeState = {
+  preference: ThemePreference;
+  setPreference: (preference: ThemePreference) => void;
+};
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      preference: "light",
+      setPreference: (preference) => {
+        applyThemePreference(preference);
+        set({ preference });
+      },
+    }),
+    { name: "ordine.theme" },
+  ),
+);

--- a/apps/app/src/store/toastStore/toastStore.ts
+++ b/apps/app/src/store/toastStore/toastStore.ts
@@ -1,5 +1,6 @@
 import { createStore, type StoreApi, type StateCreator } from "zustand";
 import { createContext, useContext } from "react";
+import { useNotificationStore } from "../notificationStore";
 
 export interface ToastMessage {
   id: string;
@@ -26,6 +27,12 @@ export const createToastSlice = (set: Parameters<ToastStoreSlice>[0]): ToastSlic
     set((state) => ({
       toasts: [...state.toasts.filter((t) => t.id !== id), { ...toast, id }],
     }));
+    // Toasts vanish after a few seconds — mirror them into the notification
+    // history so run / self-heal / connector events stay reviewable.
+    useNotificationStore.getState().addNotification({
+      kind: toast.type,
+      message: toast.description ? `${toast.title} · ${toast.description}` : toast.title,
+    });
   },
   removeToast: (id) => {
     set((state) => ({


### PR DESCRIPTION
## 改动内容

### 1. Refine dataProvider 重构（对齐 fork H3-03）
把单文件 5 个 switch 的 dataProvider 拆成资源注册表，新增资源 = 注册表加一条目，不再动 dataProvider：
- `resources/resourceNames.ts` — 资源名常量（新增 connectors/conversationMessages/pipelineAssets/projects/routines，**跳过 annotations**，COD-114 范围裁剪）
- `resources/types.ts` — `ResourceHandlers` 契约 + `makeListFilters` 过滤器读取器
- `resources/registry.ts` — 资源 → trpc 过程映射（getList/getOne/create/update/deleteOne）
- `resources/custom.ts` — custom URL → handler 注册表 + `CustomEndpoint` 常量（消除裸字符串约定式路由）
- `dataProvider.ts` — 薄封装（`handlerFor` 查找 + 响应包装 + 兜底报错），`ResourceName`/`CustomEndpoint` 保持 re-export，既有调用方零改动

### 2. 全局状态 store
- `themeStore` — 外观偏好（dark/light/system），持久化 + `ThemeApplier` 挂载应用根（`router.tsx` Wrap），跟随系统切换
- `autonomyStore` — self-heal 重试轮数（0–5，默认 1），随 run 请求下发
- `notificationStore` + `notificationPrefsStore` — 通知历史（60 条封顶）+ 通知偏好持久化
- `sidebarStore` — 补回 fork 的全局状态能力：当前项目 id / capabilities 折叠 / 侧栏搜索，localStorage key 统一 `ordine.sidebar.*`（保留 `/canvas` 路由适配）
- `toastStore` — toast 同时镜像进通知历史

## 验收对照

- [x] dataProvider 单元测试通过（`dataProvider.unit.test.ts`）
- [x] resource registry 单元测试通过（`registry.unit.test.ts`）
- [x] 所有 store 单元测试通过（sidebar + notification）
- [x] dataProvider 对所有新资源 CRUD 处理正确（registry 覆盖全部 21 个资源 + custom 26 个端点）

## 验证

- `tsc --noEmit` ✅
- 单测 **302/302**（62 files）✅
- `oxlint` ✅（仅 1 个 pre-existing warning：`pipelines.$pipelineId.tsx` func-style）
- `vite build` ✅
- 浏览器验证：dev server 启动正常，SSR 渲染 `/login` 无运行时错误；全部新模块（ThemeApplier/themeStore/registry/custom/dataProvider/notificationStore）编译加载 200

## 说明

- **无视觉差异**：本票是数据层 + 状态层重构，行为不变；`ThemeApplier` 默认 light 偏好，无可见 UI 变化（Settings 页面本体属 COD-137 #26，届时接入 theme/notification store）
- **jobs pause/cancel/resume 未迁移**：当前 tRPC jobs router 尚未暴露这三个过程，等 Jobs 控制台（#24/COD-135）落地时补，custom.ts 已留注释
- **annotations 跳过**：COD-114 范围裁剪
