### PR TITLE
feat: add unified data provider and app stores (COD-123)

### DIFF
--- a/apps/app/src/components/AppLayout.tsx
+++ b/apps/app/src/components/AppLayout.tsx
@@ -1,23 +1,37 @@
 import { SidebarInset, SidebarProvider } from "@repo/ui/sidebar";
 import { AppSidebar } from "./AppSidebar";
 import { ToastContainer } from "./ToastContainer";
-import { ToastStoreProvider } from "@/store/toastStore";
+import { toastStore, ToastStoreProvider } from "@/store/toastStore";
 import { SidebarStoreProvider } from "@/store/sidebarStore";
 import { SearchPipelineDialog } from "./SearchPipelineDialog";
 import { NewPipelineDialog } from "./NewPipelineDialog";
+import { AutonomyStoreProvider } from "@repo/views/store/autonomyStore";
+import {
+  NotificationStoreProvider,
+  ToastNotificationBridge,
+} from "@repo/views/store/notificationStore";
+import { ThemeApplier, ThemeStoreProvider } from "@repo/views/store/themeStore";
 
 export const AppLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <ToastStoreProvider>
-      <SidebarStoreProvider>
-        <SidebarProvider>
-          <AppSidebar />
-          <SidebarInset>{children}</SidebarInset>
-          <ToastContainer />
-          <SearchPipelineDialog />
-          <NewPipelineDialog />
-        </SidebarProvider>
-      </SidebarStoreProvider>
-    </ToastStoreProvider>
+    <ThemeStoreProvider>
+      <NotificationStoreProvider>
+        <AutonomyStoreProvider>
+          <ToastStoreProvider>
+            <SidebarStoreProvider>
+              <ThemeApplier />
+              <ToastNotificationBridge toastStore={toastStore} />
+              <SidebarProvider>
+                <AppSidebar />
+                <SidebarInset>{children}</SidebarInset>
+                <ToastContainer />
+                <SearchPipelineDialog />
+                <NewPipelineDialog />
+              </SidebarProvider>
+            </SidebarStoreProvider>
+          </ToastStoreProvider>
+        </AutonomyStoreProvider>
+      </NotificationStoreProvider>
+    </ThemeStoreProvider>
   );
 };

--- a/apps/app/src/integrations/refine/dataProvider.ts
+++ b/apps/app/src/integrations/refine/dataProvider.ts
@@ -1,432 +1,66 @@
 import {
-  type DataProvider,
   type BaseRecord,
+  type CreateParams,
+  type CreateResponse,
+  type DataProvider,
+  type DeleteOneParams,
+  type DeleteOneResponse,
   type GetListParams,
   type GetListResponse,
   type GetOneParams,
   type GetOneResponse,
-  type CreateParams,
-  type CreateResponse,
   type UpdateParams,
   type UpdateResponse,
-  type DeleteOneParams,
-  type DeleteOneResponse,
 } from "@refinedev/core";
-import { trpcClient } from "@/integrations/trpc/client";
+import { customEndpoints } from "./resources/custom";
+import { resourceHandlers } from "./resources/registry";
+import { makeListFilters, type ResourceHandlers } from "./resources/types";
 
-export const ResourceName = {
-  agents: "agents",
-  agentRuntimes: "agentRuntimes",
-  filesystem: "filesystem",
-  operations: "operations",
-  pipelines: "pipelines",
-  jobs: "jobs",
-  githubProjects: "githubProjects",
-  skills: "skills",
-  recipes: "recipes",
-  checklistItems: "checklistItems",
-  codeSnippets: "codeSnippets",
-  skillDraftOperations: "skillDraftOperations",
-  skillAnalyses: "skillAnalyses",
-  distillations: "distillations",
-  refinements: "refinements",
-  settings: "settings",
-  operationOutputItemTemplates: "operationOutputItemTemplates",
-} as const;
+export { CustomEndpoint } from "./resources/custom";
+export { ResourceName } from "./resources/resourceNames";
+
+const handlerFor = <Method extends keyof ResourceHandlers>(
+  method: Method,
+  resource: string,
+): NonNullable<ResourceHandlers[Method]> => {
+  const handler = resourceHandlers[resource]?.[method];
+  if (!handler) throw new Error(`${method}: unknown resource "${resource}"`);
+
+  return handler as NonNullable<ResourceHandlers[Method]>;
+};
 
 export const dataProvider: DataProvider = {
   getList: async <TData extends BaseRecord = BaseRecord>(
     params: GetListParams,
   ): Promise<GetListResponse<TData>> => {
-    const { resource } = params;
+    const data = await handlerFor("getList", params.resource)(params, makeListFilters(params));
 
-    switch (resource) {
-      case ResourceName.agents: {
-        const data = await trpcClient.agents.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.agentRuntimes: {
-        const data = await trpcClient.agentRuntimes.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.filesystem: {
-        const pathFilter = params.filters?.find((f) => "field" in f && f.field === "path");
-        const path =
-          pathFilter && "value" in pathFilter
-            ? (pathFilter.value as string | undefined)
-            : undefined;
-        const data = await trpcClient.filesystem.browse.query({ path });
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.operations: {
-        const data = await trpcClient.operations.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.pipelines: {
-        const data = await trpcClient.pipelines.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.githubProjects: {
-        const data = await trpcClient.githubProjects.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.skills: {
-        const data = await trpcClient.skills.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.distillations: {
-        const data = await trpcClient.distillations.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.jobs: {
-        const data = await trpcClient.jobs.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      case ResourceName.operationOutputItemTemplates: {
-        const data = await trpcClient.operationOutputItemTemplates.getMany.query();
-
-        return { data: data as unknown as TData[], total: data.length };
-      }
-      default: {
-        throw new Error(`getList: unknown resource "${resource}"`);
-      }
-    }
+    return { data: data as TData[], total: data.length };
   },
-
   getOne: async <TData extends BaseRecord = BaseRecord>(
     params: GetOneParams,
-  ): Promise<GetOneResponse<TData>> => {
-    const { resource, id } = params;
-
-    switch (resource) {
-      case ResourceName.agents: {
-        const data = await trpcClient.agents.getById.query({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.agentRuntimes: {
-        const data = await trpcClient.agentRuntimes.getById.query({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operations: {
-        const data = await trpcClient.operations.getById.query({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.pipelines: {
-        const data = await trpcClient.pipelines.getById.query({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.jobs: {
-        const data = await trpcClient.jobs.getById.query({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.githubProjects: {
-        const data = await trpcClient.githubProjects.getById.query({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.skills: {
-        const data = await trpcClient.skills.getById.query({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.skillDraftOperations: {
-        const data = await trpcClient.skills.draftOperation.query({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.skillAnalyses: {
-        const data = await trpcClient.skills.analyze.query({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.distillations: {
-        const data = await trpcClient.distillations.getById.query({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.refinements: {
-        const data = await trpcClient.refinements.getById.query({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operationOutputItemTemplates: {
-        const data = await trpcClient.operationOutputItemTemplates.getById.query({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.settings: {
-        const data = await trpcClient.settings.get.query();
-
-        return { data: data as unknown as TData };
-      }
-      default: {
-        throw new Error(`getOne: unknown resource "${resource}"`);
-      }
-    }
-  },
-
+  ): Promise<GetOneResponse<TData>> => ({
+    data: (await handlerFor("getOne", params.resource)(String(params.id))) as TData,
+  }),
   create: async <TData extends BaseRecord = BaseRecord, TVariables = object>(
     params: CreateParams<TVariables>,
-  ): Promise<CreateResponse<TData>> => {
-    const { resource, variables } = params;
-
-    switch (resource) {
-      case ResourceName.agents: {
-        const data = await trpcClient.agents.create.mutate(
-          variables as Parameters<typeof trpcClient.agents.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.agentRuntimes: {
-        const data = await trpcClient.agentRuntimes.create.mutate(
-          variables as Parameters<typeof trpcClient.agentRuntimes.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operations: {
-        const data = await trpcClient.operations.create.mutate(
-          variables as Parameters<typeof trpcClient.operations.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.pipelines: {
-        const { pendingOperations, ...pipelineData } = variables as Record<string, unknown>;
-        const data = await trpcClient.pipelines.create.mutate({
-          pipeline: pipelineData,
-          pendingOperations: pendingOperations as
-            | Parameters<typeof trpcClient.pipelines.create.mutate>[0]["pendingOperations"]
-            | undefined,
-        } as Parameters<typeof trpcClient.pipelines.create.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.jobs: {
-        const data = await trpcClient.jobs.create.mutate(
-          variables as Parameters<typeof trpcClient.jobs.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.githubProjects: {
-        const data = await trpcClient.githubProjects.create.mutate(
-          variables as Parameters<typeof trpcClient.githubProjects.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.skills: {
-        const data = await trpcClient.skills.create.mutate(
-          variables as Parameters<typeof trpcClient.skills.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.distillations: {
-        const data = await trpcClient.distillations.create.mutate(
-          variables as Parameters<typeof trpcClient.distillations.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operationOutputItemTemplates: {
-        const data = await trpcClient.operationOutputItemTemplates.create.mutate(
-          variables as Parameters<typeof trpcClient.operationOutputItemTemplates.create.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      default: {
-        throw new Error(`create: unknown resource "${resource}"`);
-      }
-    }
-  },
-
+  ): Promise<CreateResponse<TData>> => ({
+    data: (await handlerFor("create", params.resource)(params.variables)) as TData,
+  }),
   update: async <TData extends BaseRecord = BaseRecord, TVariables = object>(
     params: UpdateParams<TVariables>,
-  ): Promise<UpdateResponse<TData>> => {
-    const { resource, id, variables } = params;
-
-    switch (resource) {
-      case ResourceName.agents: {
-        const data = await trpcClient.agents.update.mutate({
-          id: String(id),
-          patch: variables as Record<string, unknown>,
-        } as Parameters<typeof trpcClient.agents.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.agentRuntimes: {
-        const data = await trpcClient.agentRuntimes.update.mutate({
-          id: String(id),
-          patch: variables as Record<string, unknown>,
-        } as Parameters<typeof trpcClient.agentRuntimes.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operations: {
-        const data = await trpcClient.operations.update.mutate({
-          id: String(id),
-          ...(variables as Record<string, unknown>),
-        } as Parameters<typeof trpcClient.operations.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.pipelines: {
-        const data = await trpcClient.pipelines.update.mutate({
-          id: String(id),
-          patch: variables as Record<string, unknown>,
-        } as Parameters<typeof trpcClient.pipelines.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.jobs: {
-        const data = await trpcClient.jobs.updateStatus.mutate({
-          id: String(id),
-          ...variables,
-        } as unknown as Parameters<typeof trpcClient.jobs.updateStatus.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.githubProjects: {
-        const data = await trpcClient.githubProjects.update.mutate({
-          id: String(id),
-          patch: variables as Record<string, unknown>,
-        } as Parameters<typeof trpcClient.githubProjects.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.skills: {
-        const data = await trpcClient.skills.update.mutate({
-          id: String(id),
-          patch: variables as Record<string, unknown>,
-        } as Parameters<typeof trpcClient.skills.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.distillations: {
-        const data = await trpcClient.distillations.update.mutate({
-          id: String(id),
-          patch: variables as Record<string, unknown>,
-        } as Parameters<typeof trpcClient.distillations.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operationOutputItemTemplates: {
-        const data = await trpcClient.operationOutputItemTemplates.update.mutate({
-          id: String(id),
-          ...(variables as Record<string, unknown>),
-        } as Parameters<typeof trpcClient.operationOutputItemTemplates.update.mutate>[0]);
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.settings: {
-        const data = await trpcClient.settings.update.mutate(
-          variables as Parameters<typeof trpcClient.settings.update.mutate>[0],
-        );
-
-        return { data: data as unknown as TData };
-      }
-      default: {
-        throw new Error(`update: unknown resource "${resource}"`);
-      }
-    }
-  },
-
+  ): Promise<UpdateResponse<TData>> => ({
+    data: (await handlerFor("update", params.resource)(
+      String(params.id),
+      params.variables,
+    )) as TData,
+  }),
   deleteOne: async <TData extends BaseRecord = BaseRecord, TVariables = object>(
     params: DeleteOneParams<TVariables>,
-  ): Promise<DeleteOneResponse<TData>> => {
-    const { resource, id } = params;
-
-    switch (resource) {
-      case ResourceName.agents: {
-        const data = await trpcClient.agents.delete.mutate({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.agentRuntimes: {
-        const data = await trpcClient.agentRuntimes.delete.mutate({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operations: {
-        const data = await trpcClient.operations.delete.mutate({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.pipelines: {
-        const data = await trpcClient.pipelines.delete.mutate({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.githubProjects: {
-        const data = await trpcClient.githubProjects.delete.mutate({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.skills: {
-        const data = await trpcClient.skills.delete.mutate({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.distillations: {
-        const data = await trpcClient.distillations.delete.mutate({ id: String(id) });
-
-        return { data: data as unknown as TData };
-      }
-      case ResourceName.operationOutputItemTemplates: {
-        const data = await trpcClient.operationOutputItemTemplates.delete.mutate({
-          id: String(id),
-        });
-
-        return { data: data as unknown as TData };
-      }
-      default: {
-        throw new Error(`deleteOne: unknown resource "${resource}"`);
-      }
-    }
-  },
-
+  ): Promise<DeleteOneResponse<TData>> => ({
+    data: (await handlerFor("deleteOne", params.resource)(String(params.id))) as TData,
+  }),
   getApiUrl: () => "",
-
   custom: async <
     TData extends BaseRecord = BaseRecord,
     _TQuery = unknown,
@@ -436,137 +70,9 @@ export const dataProvider: DataProvider = {
     method: string;
     payload?: TPayload;
   }): Promise<{ data: TData }> => {
-    const { url, payload } = params;
+    const handler = customEndpoints[params.url];
+    if (!handler) throw new Error(`custom: unknown url "${params.url}"`);
 
-    if (url === "pipelines/run") {
-      const data = await trpcClient.pipelines.run.mutate(
-        payload as unknown as Parameters<typeof trpcClient.pipelines.run.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "pipelines/analyzeIntent") {
-      const data = await trpcClient.pipelines.analyzeIntent.mutate(
-        payload as unknown as Parameters<typeof trpcClient.pipelines.analyzeIntent.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "pipelines/generateStructure") {
-      const data = await trpcClient.pipelines.generateStructure.mutate(
-        payload as unknown as Parameters<typeof trpcClient.pipelines.generateStructure.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "pipelines/optimizeFromDistillation") {
-      const data = await trpcClient.pipelines.optimizeFromDistillation.mutate(
-        payload as unknown as Parameters<
-          typeof trpcClient.pipelines.optimizeFromDistillation.mutate
-        >[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "pipelines/proposeActions") {
-      const data = await trpcClient.pipelines.proposeActions.mutate(
-        payload as unknown as Parameters<typeof trpcClient.pipelines.proposeActions.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "jobs/analysis") {
-      const { jobId } = payload as { jobId: string };
-      const [traces, agentRuns] = await Promise.all([
-        trpcClient.jobs.getTraces.query({ jobId }),
-        trpcClient.jobs.getAgentRuns.query({ jobId }),
-      ]);
-      const spansByRunEntries = await Promise.all(
-        agentRuns.map(async (run) => {
-          const spans = await trpcClient.jobs.getAgentRunSpans.query({ rawExportId: run.id });
-
-          return [run.id, spans] as const;
-        }),
-      );
-
-      return {
-        data: {
-          traces,
-          agentRuns,
-          spansByRun: Object.fromEntries(spansByRunEntries),
-        } as unknown as TData,
-      };
-    }
-    if (url === "jobs/traces") {
-      const { jobId } = payload as { jobId: string };
-      const traces = await trpcClient.jobs.getTraces.query({ jobId });
-
-      return { data: { traces } as unknown as TData };
-    }
-    if (url === "jobs/agentRuns") {
-      const { jobId } = payload as { jobId: string };
-      const agentRuns = await trpcClient.jobs.getAgentRuns.query({ jobId });
-
-      return { data: { agentRuns } as unknown as TData };
-    }
-    if (url === "jobs/agentRunSpans") {
-      const { rawExportId } = payload as { rawExportId: number };
-      const spans = await trpcClient.jobs.getAgentRunSpans.query({ rawExportId });
-
-      return { data: { spans } as unknown as TData };
-    }
-    if (url === "refinements/start") {
-      const data = await trpcClient.refinements.start.mutate(
-        payload as unknown as Parameters<typeof trpcClient.refinements.start.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "distillations/run") {
-      const data = await trpcClient.distillations.run.mutate(
-        payload as unknown as Parameters<typeof trpcClient.distillations.run.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "settings/scanRuntimes") {
-      const data = await trpcClient.agentRuntimes.scanRuntimes.query();
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "agentRuntimes/syncAll") {
-      const data = await trpcClient.agentRuntimes.syncAll.mutate(
-        payload as unknown as Parameters<typeof trpcClient.agentRuntimes.syncAll.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "agentRuntimes/scanAndSync") {
-      const data = await trpcClient.agentRuntimes.scanAndSync.mutate();
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "operations/run") {
-      const data = await trpcClient.operations.run.mutate(
-        payload as unknown as Parameters<typeof trpcClient.operations.run.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "skills/previewImport") {
-      const data = await trpcClient.skills.previewImport.query(
-        payload as unknown as Parameters<typeof trpcClient.skills.previewImport.query>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    if (url === "skills/importCandidates") {
-      const data = await trpcClient.skills.importCandidates.mutate(
-        payload as unknown as Parameters<typeof trpcClient.skills.importCandidates.mutate>[0],
-      );
-
-      return { data: data as unknown as TData };
-    }
-    throw new Error(`custom: unknown url "${url}"`);
+    return { data: (await handler(params.payload)) as TData };
   },
 };

--- a/apps/app/src/integrations/refine/dataProvider.unit.test.ts
+++ b/apps/app/src/integrations/refine/dataProvider.unit.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { calls } = vi.hoisted(() => ({
+  calls: [] as Array<{ args: unknown; kind: "query" | "mutate"; path: string }>,
+}));
+
+vi.mock("@/integrations/trpc/client", () => {
+  const makeProcedure = (path: string) => ({
+    query: async (args?: unknown) => {
+      calls.push({ args, kind: "query", path });
+
+      return path.endsWith("getMany") || path.endsWith("browse")
+        ? [{ id: "1" }, { id: "2" }]
+        : { id: "one" };
+    },
+    mutate: async (args?: unknown) => {
+      calls.push({ args, kind: "mutate", path });
+
+      return { id: "mutated" };
+    },
+  });
+  const trpcClient = new Proxy(
+    {},
+    {
+      get: (_target, router: string) =>
+        new Proxy(
+          {},
+          { get: (_innerTarget, procedure: string) => makeProcedure(`${router}.${procedure}`) },
+        ),
+    },
+  );
+
+  return { trpcClient };
+});
+
+const { CustomEndpoint, ResourceName, dataProvider } = await import("./dataProvider");
+
+beforeEach(() => {
+  calls.length = 0;
+});
+
+describe("dataProvider resource registry", () => {
+  it("wraps standard resource responses", async () => {
+    const list = await dataProvider.getList!({ resource: ResourceName.agents });
+    const one = await dataProvider.getOne!({ resource: ResourceName.projects, id: 7 });
+
+    expect(list).toMatchObject({ total: 2 });
+    expect(one.data).toEqual({ id: "one" });
+    expect(calls.at(-1)).toMatchObject({ path: "projects.getById", args: { id: "7" } });
+  });
+
+  it("converts list filters for COD-122 resources", async () => {
+    await dataProvider.getList!({
+      resource: ResourceName.routines,
+      filters: [
+        { field: "pipelineId", operator: "eq", value: "pipeline-1" },
+        { field: "enabled", operator: "eq", value: "true" },
+      ],
+    });
+    await dataProvider.getList!({
+      resource: ResourceName.conversationMessages,
+      filters: [
+        { field: "pipelineId", operator: "eq", value: "pipeline-1" },
+        { field: "limit", operator: "eq", value: "20" },
+      ],
+    });
+
+    expect(calls).toEqual([
+      {
+        path: "routines.getMany",
+        kind: "query",
+        args: { pipelineId: "pipeline-1", enabled: true },
+      },
+      {
+        path: "conversations.getMany",
+        kind: "query",
+        args: { pipelineId: "pipeline-1", limit: 20 },
+      },
+    ]);
+  });
+
+  it("throws when a resource does not implement the requested method", async () => {
+    await expect(
+      dataProvider.deleteOne!({ resource: ResourceName.jobs, id: "job-1" }),
+    ).rejects.toThrow('deleteOne: unknown resource "jobs"');
+    await expect(dataProvider.getList!({ resource: "unknown" })).rejects.toThrow(
+      'getList: unknown resource "unknown"',
+    );
+  });
+});
+
+describe("dataProvider custom registry", () => {
+  it("routes COD-122 actions through named endpoints", async () => {
+    const response = await dataProvider.custom!({
+      url: CustomEndpoint.routinesRunNow,
+      method: "post",
+      payload: { id: "routine-1" },
+    });
+
+    expect(response.data).toEqual({ id: "mutated" });
+    expect(calls.at(-1)).toEqual({
+      path: "routines.runNow",
+      kind: "mutate",
+      args: { id: "routine-1" },
+    });
+  });
+
+  it("throws for unknown custom urls", async () => {
+    await expect(dataProvider.custom!({ url: "unknown", method: "post" })).rejects.toThrow(
+      'custom: unknown url "unknown"',
+    );
+  });
+});

--- a/apps/app/src/integrations/refine/resources/custom.ts
+++ b/apps/app/src/integrations/refine/resources/custom.ts
@@ -1,0 +1,141 @@
+import { trpcClient } from "@/integrations/trpc/client";
+
+export const CustomEndpoint = {
+  pipelinesRun: "pipelines/run",
+  pipelinesAnalyzeIntent: "pipelines/analyzeIntent",
+  pipelinesGenerateStructure: "pipelines/generateStructure",
+  pipelinesOptimizeFromDistillation: "pipelines/optimizeFromDistillation",
+  pipelinesProposeActions: "pipelines/proposeActions",
+  connectorsConnect: "connectors/connect",
+  conversationsClearAll: "conversations/clearAll",
+  pipelineAssetsGetUsageCount: "pipelineAssets/getUsageCount",
+  pipelineAssetsIncrementRunStats: "pipelineAssets/incrementRunStats",
+  pipelineAssetsDistillFromPipeline: "pipelineAssets/distillFromPipeline",
+  routinesRunNow: "routines/runNow",
+  usageSummary: "usage/summary",
+  usageDailyTokenSeries: "usage/dailyTokenSeries",
+  usageByPipeline: "usage/byPipeline",
+  usageByAgent: "usage/byAgent",
+  jobsAnalysis: "jobs/analysis",
+  jobsTraces: "jobs/traces",
+  jobsAgentRuns: "jobs/agentRuns",
+  jobsAgentRunSpans: "jobs/agentRunSpans",
+  refinementsStart: "refinements/start",
+  distillationsRun: "distillations/run",
+  settingsScanRuntimes: "settings/scanRuntimes",
+  agentRuntimesSyncAll: "agentRuntimes/syncAll",
+  agentRuntimesScanAndSync: "agentRuntimes/scanAndSync",
+  operationsRun: "operations/run",
+  skillsPreviewImport: "skills/previewImport",
+  skillsImportCandidates: "skills/importCandidates",
+} as const;
+
+type CustomHandler = (payload: unknown) => Promise<unknown>;
+type Input<T extends (...args: never[]) => unknown> = Parameters<T>[0];
+
+export const customEndpoints: Record<string, CustomHandler> = {
+  [CustomEndpoint.pipelinesRun]: (payload) =>
+    trpcClient.pipelines.run.mutate(payload as Input<typeof trpcClient.pipelines.run.mutate>),
+  [CustomEndpoint.pipelinesAnalyzeIntent]: (payload) =>
+    trpcClient.pipelines.analyzeIntent.mutate(
+      payload as Input<typeof trpcClient.pipelines.analyzeIntent.mutate>,
+    ),
+  [CustomEndpoint.pipelinesGenerateStructure]: (payload) =>
+    trpcClient.pipelines.generateStructure.mutate(
+      payload as Input<typeof trpcClient.pipelines.generateStructure.mutate>,
+    ),
+  [CustomEndpoint.pipelinesOptimizeFromDistillation]: (payload) =>
+    trpcClient.pipelines.optimizeFromDistillation.mutate(
+      payload as Input<typeof trpcClient.pipelines.optimizeFromDistillation.mutate>,
+    ),
+  [CustomEndpoint.pipelinesProposeActions]: (payload) =>
+    trpcClient.pipelines.proposeActions.mutate(
+      payload as Input<typeof trpcClient.pipelines.proposeActions.mutate>,
+    ),
+  [CustomEndpoint.connectorsConnect]: (payload) =>
+    trpcClient.connectors.connect.mutate(
+      payload as Input<typeof trpcClient.connectors.connect.mutate>,
+    ),
+  [CustomEndpoint.conversationsClearAll]: () => trpcClient.conversations.clearAll.mutate(),
+  [CustomEndpoint.pipelineAssetsGetUsageCount]: (payload) =>
+    trpcClient.pipelineAssets.getUsageCount.query(
+      payload as Input<typeof trpcClient.pipelineAssets.getUsageCount.query>,
+    ),
+  [CustomEndpoint.pipelineAssetsIncrementRunStats]: (payload) =>
+    trpcClient.pipelineAssets.incrementRunStats.mutate(
+      payload as Input<typeof trpcClient.pipelineAssets.incrementRunStats.mutate>,
+    ),
+  [CustomEndpoint.pipelineAssetsDistillFromPipeline]: (payload) =>
+    trpcClient.pipelineAssets.distillFromPipeline.mutate(
+      payload as Input<typeof trpcClient.pipelineAssets.distillFromPipeline.mutate>,
+    ),
+  [CustomEndpoint.routinesRunNow]: (payload) =>
+    trpcClient.routines.runNow.mutate(payload as Input<typeof trpcClient.routines.runNow.mutate>),
+  [CustomEndpoint.usageSummary]: (payload) =>
+    trpcClient.usage.getSummary.query(payload as Input<typeof trpcClient.usage.getSummary.query>),
+  [CustomEndpoint.usageDailyTokenSeries]: (payload) =>
+    trpcClient.usage.getDailyTokenSeries.query(
+      payload as Input<typeof trpcClient.usage.getDailyTokenSeries.query>,
+    ),
+  [CustomEndpoint.usageByPipeline]: (payload) =>
+    trpcClient.usage.getByPipeline.query(
+      payload as Input<typeof trpcClient.usage.getByPipeline.query>,
+    ),
+  [CustomEndpoint.usageByAgent]: (payload) =>
+    trpcClient.usage.getByAgent.query(payload as Input<typeof trpcClient.usage.getByAgent.query>),
+  [CustomEndpoint.jobsAnalysis]: async (payload) => {
+    const { jobId } = payload as { jobId: string };
+    const [traces, agentRuns] = await Promise.all([
+      trpcClient.jobs.getTraces.query({ jobId }),
+      trpcClient.jobs.getAgentRuns.query({ jobId }),
+    ]);
+    const spansByRunEntries = await Promise.all(
+      agentRuns.map(async (run) => {
+        const spans = await trpcClient.jobs.getAgentRunSpans.query({ rawExportId: run.id });
+
+        return [run.id, spans] as const;
+      }),
+    );
+
+    return { traces, agentRuns, spansByRun: Object.fromEntries(spansByRunEntries) };
+  },
+  [CustomEndpoint.jobsTraces]: async (payload) => {
+    const { jobId } = payload as { jobId: string };
+
+    return { traces: await trpcClient.jobs.getTraces.query({ jobId }) };
+  },
+  [CustomEndpoint.jobsAgentRuns]: async (payload) => {
+    const { jobId } = payload as { jobId: string };
+
+    return { agentRuns: await trpcClient.jobs.getAgentRuns.query({ jobId }) };
+  },
+  [CustomEndpoint.jobsAgentRunSpans]: async (payload) => {
+    const { rawExportId } = payload as { rawExportId: number };
+
+    return { spans: await trpcClient.jobs.getAgentRunSpans.query({ rawExportId }) };
+  },
+  [CustomEndpoint.refinementsStart]: (payload) =>
+    trpcClient.refinements.start.mutate(
+      payload as Input<typeof trpcClient.refinements.start.mutate>,
+    ),
+  [CustomEndpoint.distillationsRun]: (payload) =>
+    trpcClient.distillations.run.mutate(
+      payload as Input<typeof trpcClient.distillations.run.mutate>,
+    ),
+  [CustomEndpoint.settingsScanRuntimes]: () => trpcClient.agentRuntimes.scanRuntimes.query(),
+  [CustomEndpoint.agentRuntimesSyncAll]: (payload) =>
+    trpcClient.agentRuntimes.syncAll.mutate(
+      payload as Input<typeof trpcClient.agentRuntimes.syncAll.mutate>,
+    ),
+  [CustomEndpoint.agentRuntimesScanAndSync]: () => trpcClient.agentRuntimes.scanAndSync.mutate(),
+  [CustomEndpoint.operationsRun]: (payload) =>
+    trpcClient.operations.run.mutate(payload as Input<typeof trpcClient.operations.run.mutate>),
+  [CustomEndpoint.skillsPreviewImport]: (payload) =>
+    trpcClient.skills.previewImport.query(
+      payload as Input<typeof trpcClient.skills.previewImport.query>,
+    ),
+  [CustomEndpoint.skillsImportCandidates]: (payload) =>
+    trpcClient.skills.importCandidates.mutate(
+      payload as Input<typeof trpcClient.skills.importCandidates.mutate>,
+    ),
+};

--- a/apps/app/src/integrations/refine/resources/registry.ts
+++ b/apps/app/src/integrations/refine/resources/registry.ts
@@ -1,0 +1,226 @@
+import { trpcClient } from "@/integrations/trpc/client";
+import { ResourceName } from "./resourceNames";
+import type { ResourceHandlers } from "./types";
+
+type Variables = Record<string, unknown>;
+const asRecord = (variables: unknown): Variables => variables as Variables;
+
+export const resourceHandlers: Partial<Record<string, ResourceHandlers>> = {
+  [ResourceName.agents]: {
+    getList: () => trpcClient.agents.getMany.query(),
+    getOne: (id) => trpcClient.agents.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.agents.create.mutate(
+        variables as Parameters<typeof trpcClient.agents.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.agents.update.mutate({ id, patch: asRecord(variables) } as Parameters<
+        typeof trpcClient.agents.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.agents.delete.mutate({ id }),
+  },
+  [ResourceName.agentRuntimes]: {
+    getList: () => trpcClient.agentRuntimes.getMany.query(),
+    getOne: (id) => trpcClient.agentRuntimes.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.agentRuntimes.create.mutate(
+        variables as Parameters<typeof trpcClient.agentRuntimes.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.agentRuntimes.update.mutate({ id, patch: asRecord(variables) } as Parameters<
+        typeof trpcClient.agentRuntimes.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.agentRuntimes.delete.mutate({ id }),
+  },
+  [ResourceName.connectors]: {
+    getList: () => trpcClient.connectors.getMany.query(),
+    getOne: (id) => trpcClient.connectors.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.connectors.create.mutate(
+        variables as Parameters<typeof trpcClient.connectors.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.connectors.update.mutate({ id, patch: asRecord(variables) } as Parameters<
+        typeof trpcClient.connectors.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.connectors.delete.mutate({ id }),
+  },
+  [ResourceName.conversationMessages]: {
+    getList: (_params, filters) =>
+      trpcClient.conversations.getMany.query({
+        pipelineId: filters.string("pipelineId"),
+        limit: filters.number("limit"),
+      }),
+    getOne: (id) => trpcClient.conversations.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.conversations.create.mutate(
+        variables as Parameters<typeof trpcClient.conversations.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.conversations.update.mutate({ id, patch: asRecord(variables) } as Parameters<
+        typeof trpcClient.conversations.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.conversations.delete.mutate({ id }),
+  },
+  [ResourceName.filesystem]: {
+    getList: (_params, filters) =>
+      trpcClient.filesystem.browse.query({ path: filters.string("path") }),
+  },
+  [ResourceName.operations]: {
+    getList: () => trpcClient.operations.getMany.query(),
+    getOne: (id) => trpcClient.operations.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.operations.create.mutate(
+        variables as Parameters<typeof trpcClient.operations.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.operations.update.mutate({ id, ...asRecord(variables) } as Parameters<
+        typeof trpcClient.operations.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.operations.delete.mutate({ id }),
+  },
+  [ResourceName.pipelineAssets]: {
+    getList: (_params, filters) =>
+      trpcClient.pipelineAssets.getMany.query({ pipelineId: filters.string("pipelineId") }),
+    getOne: (id) => trpcClient.pipelineAssets.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.pipelineAssets.create.mutate(
+        variables as Parameters<typeof trpcClient.pipelineAssets.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.pipelineAssets.update.mutate({ id, patch: asRecord(variables) } as Parameters<
+        typeof trpcClient.pipelineAssets.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.pipelineAssets.delete.mutate({ id }),
+  },
+  [ResourceName.pipelines]: {
+    getList: () => trpcClient.pipelines.getMany.query(),
+    getOne: (id) => trpcClient.pipelines.getById.query({ id }),
+    create: (variables) => {
+      const { pendingOperations, ...pipelineData } = asRecord(variables);
+
+      return trpcClient.pipelines.create.mutate({
+        pipeline: pipelineData,
+        pendingOperations: pendingOperations as
+          | Parameters<typeof trpcClient.pipelines.create.mutate>[0]["pendingOperations"]
+          | undefined,
+      } as Parameters<typeof trpcClient.pipelines.create.mutate>[0]);
+    },
+    update: (id, variables) =>
+      trpcClient.pipelines.update.mutate({ id, patch: asRecord(variables) } as Parameters<
+        typeof trpcClient.pipelines.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.pipelines.delete.mutate({ id }),
+  },
+  [ResourceName.projects]: {
+    getList: () => trpcClient.projects.getMany.query(),
+    getOne: (id) => trpcClient.projects.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.projects.create.mutate(
+        variables as Parameters<typeof trpcClient.projects.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.projects.update.mutate({ id, patch: asRecord(variables) } as Parameters<
+        typeof trpcClient.projects.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.projects.delete.mutate({ id }),
+  },
+  [ResourceName.routines]: {
+    getList: (_params, filters) =>
+      trpcClient.routines.getMany.query({
+        pipelineId: filters.string("pipelineId"),
+        enabled: filters.boolean("enabled"),
+      }),
+    getOne: (id) => trpcClient.routines.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.routines.create.mutate(
+        variables as Parameters<typeof trpcClient.routines.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.routines.update.mutate({ id, patch: asRecord(variables) } as Parameters<
+        typeof trpcClient.routines.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.routines.delete.mutate({ id }),
+  },
+  [ResourceName.jobs]: {
+    getList: () => trpcClient.jobs.getMany.query(),
+    getOne: (id) => trpcClient.jobs.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.jobs.create.mutate(
+        variables as Parameters<typeof trpcClient.jobs.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.jobs.updateStatus.mutate({ id, ...asRecord(variables) } as unknown as Parameters<
+        typeof trpcClient.jobs.updateStatus.mutate
+      >[0]),
+  },
+  [ResourceName.githubProjects]: {
+    getList: () => trpcClient.githubProjects.getMany.query(),
+    getOne: (id) => trpcClient.githubProjects.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.githubProjects.create.mutate(
+        variables as Parameters<typeof trpcClient.githubProjects.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.githubProjects.update.mutate({ id, patch: asRecord(variables) } as Parameters<
+        typeof trpcClient.githubProjects.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.githubProjects.delete.mutate({ id }),
+  },
+  [ResourceName.skills]: {
+    getList: () => trpcClient.skills.getMany.query(),
+    getOne: (id) => trpcClient.skills.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.skills.create.mutate(
+        variables as Parameters<typeof trpcClient.skills.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.skills.update.mutate({ id, patch: asRecord(variables) } as Parameters<
+        typeof trpcClient.skills.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.skills.delete.mutate({ id }),
+  },
+  [ResourceName.skillDraftOperations]: {
+    getOne: (id) => trpcClient.skills.draftOperation.query({ id }),
+  },
+  [ResourceName.skillAnalyses]: {
+    getOne: (id) => trpcClient.skills.analyze.query({ id }),
+  },
+  [ResourceName.distillations]: {
+    getList: () => trpcClient.distillations.getMany.query(),
+    getOne: (id) => trpcClient.distillations.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.distillations.create.mutate(
+        variables as Parameters<typeof trpcClient.distillations.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.distillations.update.mutate({ id, patch: asRecord(variables) } as Parameters<
+        typeof trpcClient.distillations.update.mutate
+      >[0]),
+    deleteOne: (id) => trpcClient.distillations.delete.mutate({ id }),
+  },
+  [ResourceName.refinements]: {
+    getOne: (id) => trpcClient.refinements.getById.query({ id }),
+  },
+  [ResourceName.settings]: {
+    getOne: () => trpcClient.settings.get.query(),
+    update: (_id, variables) =>
+      trpcClient.settings.update.mutate(
+        variables as Parameters<typeof trpcClient.settings.update.mutate>[0],
+      ),
+  },
+  [ResourceName.operationOutputItemTemplates]: {
+    getList: () => trpcClient.operationOutputItemTemplates.getMany.query(),
+    getOne: (id) => trpcClient.operationOutputItemTemplates.getById.query({ id }),
+    create: (variables) =>
+      trpcClient.operationOutputItemTemplates.create.mutate(
+        variables as Parameters<typeof trpcClient.operationOutputItemTemplates.create.mutate>[0],
+      ),
+    update: (id, variables) =>
+      trpcClient.operationOutputItemTemplates.update.mutate({
+        id,
+        ...asRecord(variables),
+      } as Parameters<typeof trpcClient.operationOutputItemTemplates.update.mutate>[0]),
+    deleteOne: (id) => trpcClient.operationOutputItemTemplates.delete.mutate({ id }),
+  },
+};

--- a/apps/app/src/integrations/refine/resources/registry.unit.test.ts
+++ b/apps/app/src/integrations/refine/resources/registry.unit.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ListFilters } from "./types";
+
+const { calls } = vi.hoisted(() => ({
+  calls: [] as Array<{ args: unknown; kind: "query" | "mutate"; path: string }>,
+}));
+
+vi.mock("@/integrations/trpc/client", () => {
+  const makeProcedure = (path: string) => ({
+    query: async (args?: unknown) => {
+      calls.push({ args, kind: "query", path });
+
+      return [];
+    },
+    mutate: async (args?: unknown) => {
+      calls.push({ args, kind: "mutate", path });
+
+      return { id: "result" };
+    },
+  });
+  const trpcClient = new Proxy(
+    {},
+    {
+      get: (_target, router: string) =>
+        new Proxy(
+          {},
+          { get: (_innerTarget, procedure: string) => makeProcedure(`${router}.${procedure}`) },
+        ),
+    },
+  );
+
+  return { trpcClient };
+});
+
+const { resourceHandlers } = await import("./registry");
+
+const noFilters: ListFilters = {
+  boolean: () => undefined,
+  number: () => undefined,
+  string: () => undefined,
+};
+
+const latestCall = () => calls.at(-1);
+
+beforeEach(() => {
+  calls.length = 0;
+});
+
+describe("COD-122 resource registry", () => {
+  it.each([
+    ["connectors", "connectors"],
+    ["conversationMessages", "conversations"],
+    ["pipelineAssets", "pipelineAssets"],
+    ["projects", "projects"],
+    ["routines", "routines"],
+  ] as const)("routes %s CRUD through the %s router", async (resource, router) => {
+    const handler = resourceHandlers[resource]!;
+
+    await handler.getOne!("item-1");
+    expect(latestCall()).toEqual({
+      args: { id: "item-1" },
+      kind: "query",
+      path: `${router}.getById`,
+    });
+
+    await handler.create!({ name: "created" });
+    expect(latestCall()).toEqual({
+      args: { name: "created" },
+      kind: "mutate",
+      path: `${router}.create`,
+    });
+
+    await handler.update!("item-1", { name: "updated" });
+    expect(latestCall()).toEqual({
+      args: { id: "item-1", patch: { name: "updated" } },
+      kind: "mutate",
+      path: `${router}.update`,
+    });
+
+    await handler.deleteOne!("item-1");
+    expect(latestCall()).toEqual({
+      args: { id: "item-1" },
+      kind: "mutate",
+      path: `${router}.delete`,
+    });
+  });
+
+  it("maps conversation, asset, and routine list filters", async () => {
+    const filters: ListFilters = {
+      boolean: (field) => (field === "enabled" ? false : undefined),
+      number: (field) => (field === "limit" ? 25 : undefined),
+      string: (field) => (field === "pipelineId" ? "pipeline-1" : undefined),
+    };
+
+    await resourceHandlers.conversationMessages!.getList!(
+      { resource: "conversationMessages" },
+      filters,
+    );
+    await resourceHandlers.pipelineAssets!.getList!({ resource: "pipelineAssets" }, filters);
+    await resourceHandlers.routines!.getList!({ resource: "routines" }, filters);
+
+    expect(calls).toEqual([
+      {
+        args: { limit: 25, pipelineId: "pipeline-1" },
+        kind: "query",
+        path: "conversations.getMany",
+      },
+      {
+        args: { pipelineId: "pipeline-1" },
+        kind: "query",
+        path: "pipelineAssets.getMany",
+      },
+      {
+        args: { enabled: false, pipelineId: "pipeline-1" },
+        kind: "query",
+        path: "routines.getMany",
+      },
+    ]);
+  });
+});
+
+describe("legacy resource mapping guards", () => {
+  it("keeps pipeline pending operations outside the pipeline payload", async () => {
+    await resourceHandlers.pipelines!.create!({
+      name: "Pipeline",
+      pendingOperations: [{ id: "operation-1" }],
+    });
+
+    expect(latestCall()).toEqual({
+      args: {
+        pendingOperations: [{ id: "operation-1" }],
+        pipeline: { name: "Pipeline" },
+      },
+      kind: "mutate",
+      path: "pipelines.create",
+    });
+  });
+
+  it("keeps exceptional operation, filesystem, and settings shapes", async () => {
+    await resourceHandlers.operations!.update!("operation-1", { label: "Updated" });
+    expect(latestCall()?.args).toEqual({ id: "operation-1", label: "Updated" });
+
+    await resourceHandlers.filesystem!.getList!({ resource: "filesystem" }, noFilters);
+    expect(latestCall()).toMatchObject({ args: { path: undefined }, path: "filesystem.browse" });
+
+    await resourceHandlers.settings!.update!("ignored", { language: "zh" });
+    expect(latestCall()).toMatchObject({
+      args: { language: "zh" },
+      path: "settings.update",
+    });
+  });
+});

--- a/apps/app/src/integrations/refine/resources/resourceNames.ts
+++ b/apps/app/src/integrations/refine/resources/resourceNames.ts
@@ -1,0 +1,26 @@
+export const ResourceName = {
+  agents: "agents",
+  agentRuntimes: "agentRuntimes",
+  connectors: "connectors",
+  conversationMessages: "conversationMessages",
+  filesystem: "filesystem",
+  operations: "operations",
+  pipelineAssets: "pipelineAssets",
+  pipelines: "pipelines",
+  projects: "projects",
+  routines: "routines",
+  jobs: "jobs",
+  githubProjects: "githubProjects",
+  skills: "skills",
+  recipes: "recipes",
+  checklistItems: "checklistItems",
+  codeSnippets: "codeSnippets",
+  skillDraftOperations: "skillDraftOperations",
+  skillAnalyses: "skillAnalyses",
+  distillations: "distillations",
+  refinements: "refinements",
+  settings: "settings",
+  operationOutputItemTemplates: "operationOutputItemTemplates",
+} as const;
+
+export type ResourceNameValue = (typeof ResourceName)[keyof typeof ResourceName];

--- a/apps/app/src/integrations/refine/resources/types.ts
+++ b/apps/app/src/integrations/refine/resources/types.ts
@@ -1,0 +1,47 @@
+import type { GetListParams } from "@refinedev/core";
+
+export type ListFilters = {
+  string: (field: string) => string | undefined;
+  number: (field: string) => number | undefined;
+  boolean: (field: string) => boolean | undefined;
+};
+
+export type ResourceHandlers = {
+  getList?: (params: GetListParams, filters: ListFilters) => Promise<unknown[]>;
+  getOne?: (id: string) => Promise<unknown>;
+  create?: (variables: unknown) => Promise<unknown>;
+  update?: (id: string, variables: unknown) => Promise<unknown>;
+  deleteOne?: (id: string) => Promise<unknown>;
+};
+
+export const makeListFilters = (params: GetListParams): ListFilters => {
+  const raw = (field: string): unknown => {
+    const filter = params.filters?.find((item) => "field" in item && item.field === field);
+
+    return filter && "value" in filter ? filter.value : undefined;
+  };
+
+  return {
+    string: (field) => {
+      const value = raw(field);
+
+      return typeof value === "string" ? value : undefined;
+    },
+    number: (field) => {
+      const value = raw(field);
+      if (typeof value === "number") return value;
+      if (typeof value !== "string" || value.trim() === "") return undefined;
+      const parsed = Number(value);
+
+      return Number.isFinite(parsed) ? parsed : undefined;
+    },
+    boolean: (field) => {
+      const value = raw(field);
+      if (typeof value === "boolean") return value;
+      if (value === "true") return true;
+      if (value === "false") return false;
+
+      return undefined;
+    },
+  };
+};

--- a/apps/app/src/integrations/trpc/router.unit.test.ts
+++ b/apps/app/src/integrations/trpc/router.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ok } from "neverthrow";
+import { err, ok } from "neverthrow";
 
 vi.hoisted(() => {
   process.env.BETTER_AUTH_SECRET = "test-secret";
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   pipelineAssetsGetAll: vi.fn(),
   pipelineAssetsGetUsageCount: vi.fn(),
   projectsGetAll: vi.fn(),
+  routinesGetByPipelineId: vi.fn(),
   routinesGetAll: vi.fn(),
   routinesRunNow: vi.fn(),
   usageGetDailyTokenSeries: vi.fn(),
@@ -46,6 +47,7 @@ vi.mock("./services", () => ({
   refinementsService: {},
   routinesService: {
     getAll: mocks.routinesGetAll,
+    getByPipelineId: mocks.routinesGetByPipelineId,
     runNow: mocks.routinesRunNow,
   },
   settingsService: {},
@@ -80,6 +82,7 @@ beforeEach(() => {
   mocks.pipelineAssetsGetUsageCount.mockResolvedValue(ok({ assetId: "asset-1", count: 1 }));
   mocks.projectsGetAll.mockResolvedValue(ok([]));
   mocks.routinesGetAll.mockResolvedValue([]);
+  mocks.routinesGetByPipelineId.mockResolvedValue([]);
   mocks.routinesRunNow.mockResolvedValue(ok({ jobId: "job-1" }));
   mocks.usageGetDailyTokenSeries.mockResolvedValue(ok([]));
 });
@@ -87,6 +90,7 @@ beforeEach(() => {
 describe("domain tRPC routers", () => {
   it("exposes the newly added service procedures", async () => {
     const caller = domainRouter.createCaller({ session: null });
+    const authedCaller = domainRouter.createCaller({ session: { user: { id: "user-1" } } });
 
     await expect(caller.connectors.getMany()).resolves.toEqual([]);
     await expect(caller.conversations.getMany()).resolves.toEqual([]);
@@ -96,7 +100,7 @@ describe("domain tRPC routers", () => {
     await expect(caller.routines.runNow({ id: "routine-1" })).resolves.toEqual({
       jobId: "job-1",
     });
-    await expect(caller.connectors.connect({ id: "connector-1" })).resolves.toEqual({
+    await expect(authedCaller.connectors.connect({ id: "connector-1" })).resolves.toEqual({
       id: "connector-1",
     });
     await expect(caller.conversations.clearAll()).resolves.toEqual({ cleared: true });
@@ -110,5 +114,46 @@ describe("domain tRPC routers", () => {
         to: new Date("2026-07-31T00:00:00.000Z"),
       }),
     ).resolves.toEqual([]);
+  });
+
+  it("requires a session for connector mutations", async () => {
+    const caller = domainRouter.createCaller({ session: null });
+
+    await expect(caller.connectors.connect({ id: "connector-1" })).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    expect(mocks.connectorsConnect).not.toHaveBeenCalled();
+  });
+
+  it("filters pipeline routines by enabled status", async () => {
+    mocks.routinesGetByPipelineId.mockResolvedValue([
+      { id: "enabled", enabled: true },
+      { id: "disabled", enabled: false },
+    ]);
+    const caller = domainRouter.createCaller({ session: null });
+
+    await expect(caller.routines.getMany({ pipelineId: "p1", enabled: true })).resolves.toEqual([
+      { id: "enabled", enabled: true },
+    ]);
+  });
+
+  it("maps missing routine runs to NOT_FOUND", async () => {
+    const notFound = new Error("Routine:missing not found");
+    notFound.name = "NotFoundError";
+    mocks.routinesRunNow.mockResolvedValue(err(notFound));
+    const caller = domainRouter.createCaller({ session: null });
+
+    await expect(caller.routines.runNow({ id: "missing" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("rejects conversation limit without a pipelineId", async () => {
+    const caller = domainRouter.createCaller({ session: null });
+
+    await expect(caller.conversations.getMany({ limit: 1 })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+    expect(mocks.conversationsGetAll).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/integrations/trpc/routers/connectors.ts
+++ b/apps/app/src/integrations/trpc/routers/connectors.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { z } from "zod/v4";
 import { CreateConnectorSchema, UpdateConnectorSchema } from "@repo/schemas";
-import { publicProcedure, router } from "../init";
+import { authedProcedure, publicProcedure, router } from "../init";
 import { connectorsService } from "../services";
 import { unwrapResult } from "./result";
 
@@ -16,21 +16,21 @@ export const connectorsRouter = router({
     .input(z.object({ id: z.string() }))
     .query(async ({ input }) => unwrapResult(await connectorsService.getById(input.id))),
 
-  create: publicProcedure
+  create: authedProcedure
     .input(CreateConnectorRouteSchema)
     .mutation(async ({ input }) => unwrapResult(await connectorsService.create(input))),
 
-  update: publicProcedure
+  update: authedProcedure
     .input(z.object({ id: z.string(), patch: UpdateConnectorSchema }))
     .mutation(async ({ input }) =>
       unwrapResult(await connectorsService.update(input.id, input.patch)),
     ),
 
-  connect: publicProcedure
+  connect: authedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ input }) => unwrapResult(await connectorsService.connect(input.id))),
 
-  delete: publicProcedure
+  delete: authedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ input }) => unwrapResult(await connectorsService.delete(input.id))),
 });

--- a/apps/app/src/integrations/trpc/routers/conversations.ts
+++ b/apps/app/src/integrations/trpc/routers/conversations.ts
@@ -17,6 +17,10 @@ export const conversationsRouter = router({
           pipelineId: z.string().optional(),
           limit: z.number().int().positive().optional(),
         })
+        .refine(({ limit, pipelineId }) => limit === undefined || pipelineId !== undefined, {
+          message: "limit requires pipelineId",
+          path: ["limit"],
+        })
         .optional(),
     )
     .query(async ({ input }) => {

--- a/apps/app/src/integrations/trpc/routers/routines.ts
+++ b/apps/app/src/integrations/trpc/routers/routines.ts
@@ -27,7 +27,9 @@ export const routinesRouter = router({
           ? await routinesService.getEnabled()
           : await routinesService.getAll();
 
-      return input?.enabled === false ? routines.filter((routine) => !routine.enabled) : routines;
+      return input?.enabled === undefined
+        ? routines
+        : routines.filter((routine) => routine.enabled === input.enabled);
     }),
 
   getById: publicProcedure.input(z.object({ id: z.string() })).query(async ({ input }) => {

--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -1008,6 +1008,22 @@
     "language": "Language",
     "selectLanguage": "Select language",
     "timezone": "Timezone",
+    "general": {
+      "appearance": {
+        "title": "Appearance",
+        "description": "Choose how Ordine looks on this device.",
+        "light": "Light",
+        "dark": "Dark",
+        "system": "System"
+      },
+      "notifications": {
+        "title": "Notifications",
+        "description": "Choose which run status changes are recorded and shown.",
+        "done": "Run completed",
+        "failed": "Run failed",
+        "waiting": "Run needs attention"
+      }
+    },
     "appearance": {
       "dark": "Dark",
       "hint": "Applies immediately and is remembered on this device.",
@@ -1016,6 +1032,7 @@
       "system": "System"
     },
     "sections": {
+      "general": "General",
       "profile": "Profile",
       "notifications": "Notifications",
       "appearance": "Appearance",

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -1008,6 +1008,22 @@
     "language": "语言",
     "selectLanguage": "选择语言",
     "timezone": "时区",
+    "general": {
+      "appearance": {
+        "title": "外观",
+        "description": "选择 Ordine 在此设备上的显示方式。",
+        "light": "浅色",
+        "dark": "深色",
+        "system": "跟随系统"
+      },
+      "notifications": {
+        "title": "通知",
+        "description": "选择需要记录和显示的运行状态变化。",
+        "done": "运行完成",
+        "failed": "运行失败",
+        "waiting": "运行需要处理"
+      }
+    },
     "appearance": {
       "dark": "深色",
       "hint": "立即生效，并在本设备记住该选择。",
@@ -1016,6 +1032,7 @@
       "system": "跟随系统"
     },
     "sections": {
+      "general": "通用",
       "profile": "个人信息",
       "notifications": "通知",
       "appearance": "外观",

--- a/apps/desktop-app/package.json
+++ b/apps/desktop-app/package.json
@@ -13,7 +13,8 @@
     "bundle-server": "bun run scripts/bundle-server.ts",
     "lint": "oxlint --config ./.oxlintrc.json src/",
     "format": "oxfmt --config node_modules/@repo/oxc-formatter-config/oxfmt.json --write src/",
-    "format:check": "oxfmt --config node_modules/@repo/oxc-formatter-config/oxfmt.json --check src/"
+    "format:check": "oxfmt --config node_modules/@repo/oxc-formatter-config/oxfmt.json --check src/",
+    "test": "vitest run"
   },
   "dependencies": {
     "@refinedev/core": "^5.0.12",
@@ -45,6 +46,7 @@
     "@vitejs/plugin-react": "^4.5.2",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^4.1.6"
   }
 }

--- a/apps/desktop-app/src/integrations/refine/dataProvider.ts
+++ b/apps/desktop-app/src/integrations/refine/dataProvider.ts
@@ -47,14 +47,31 @@ type CustomRequest = {
   url: string;
   method: string;
   body?: unknown;
+  transform?: (data: unknown) => unknown;
 };
 
 const payloadRecord = (payload: unknown) => (payload ?? {}) as Record<string, unknown>;
+
+const payloadWithout = (payload: unknown, ...fields: string[]) => {
+  const body = { ...payloadRecord(payload) };
+  for (const field of fields) delete body[field];
+
+  return body;
+};
 
 const requiredPayloadString = (payload: unknown, field: string) => {
   const value = payloadRecord(payload)[field];
   if (typeof value !== "string" || value.length === 0) {
     throw new Error(`Custom request requires payload.${field}`);
+  }
+
+  return value;
+};
+
+const requiredPayloadNumber = (payload: unknown, field: string) => {
+  const value = payloadRecord(payload)[field];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError(`Custom request requires numeric payload.${field}`);
   }
 
   return value;
@@ -73,6 +90,38 @@ const resolveCustomRequest = (url: string, method: string, payload: unknown): Cu
   if (url.startsWith("http")) return { url, method, body: payload };
 
   switch (url) {
+    case "pipelines/run": {
+      const id = requiredPayloadString(payload, "id");
+
+      return {
+        url: `${DESKTOP_API_BASE}/pipelines/${id}/run`,
+        method: "POST",
+        body: payloadWithout(payload, "id"),
+      };
+    }
+    case "pipelines/analyzeIntent": {
+      return {
+        url: `${DESKTOP_API_BASE}/pipelines/analyze-intent`,
+        method: "POST",
+        body: payloadRecord(payload),
+      };
+    }
+    case "pipelines/generateStructure": {
+      return {
+        url: `${DESKTOP_API_BASE}/pipelines/generate-structure`,
+        method: "POST",
+        body: payloadRecord(payload),
+      };
+    }
+    case "pipelines/proposeActions": {
+      const id = requiredPayloadString(payload, "id");
+
+      return {
+        url: `${DESKTOP_API_BASE}/pipelines/${id}/propose-actions`,
+        method: "POST",
+        body: payloadWithout(payload, "id"),
+      };
+    }
     case "connectors/connect": {
       return {
         url: `${DESKTOP_API_BASE}/connectors/${requiredPayloadString(payload, "id")}/connect`,
@@ -119,8 +168,56 @@ const resolveCustomRequest = (url: string, method: string, payload: unknown): Cu
     case "usage/byAgent": {
       return usageRequest("by-agent", payload);
     }
+    case "jobs/traces": {
+      return {
+        url: `${DESKTOP_API_BASE}/jobs/${requiredPayloadString(payload, "jobId")}/traces`,
+        method: "GET",
+        transform: (traces) => ({ traces }),
+      };
+    }
+    case "jobs/agentRuns": {
+      return {
+        url: `${DESKTOP_API_BASE}/jobs/${requiredPayloadString(payload, "jobId")}/agent-runs`,
+        method: "GET",
+        transform: (agentRuns) => ({ agentRuns }),
+      };
+    }
+    case "jobs/agentRunSpans": {
+      const jobId = requiredPayloadString(payload, "jobId");
+      const rawExportId = requiredPayloadNumber(payload, "rawExportId");
+
+      return {
+        url: `${DESKTOP_API_BASE}/jobs/${jobId}/agent-runs/${rawExportId}/spans`,
+        method: "GET",
+        transform: (spans) => ({ spans }),
+      };
+    }
+    case "distillations/run": {
+      return {
+        url: `${DESKTOP_API_BASE}/distillations/${requiredPayloadString(payload, "id")}/run`,
+        method: "POST",
+      };
+    }
+    case "operations/run": {
+      const operationId = requiredPayloadString(payload, "operationId");
+
+      return {
+        url: `${DESKTOP_API_BASE}/operations/${operationId}/run`,
+        method: "POST",
+        body: payloadWithout(payload, "operationId"),
+      };
+    }
+    case "pipelines/optimizeFromDistillation":
+    case "refinements/start":
+    case "settings/scanRuntimes":
+    case "agentRuntimes/syncAll":
+    case "agentRuntimes/scanAndSync":
+    case "skills/previewImport":
+    case "skills/importCandidates": {
+      throw new Error(`Unsupported Desktop custom endpoint "${url}"`);
+    }
     default: {
-      return { url: `${DESKTOP_API_BASE}/${url}`, method, body: payload };
+      throw new Error(`Unknown Desktop custom endpoint "${url}"`);
     }
   }
 };
@@ -133,7 +230,8 @@ const LIST_FILTERS: Partial<Record<string, string[]>> = {
 };
 
 const getListUrl = (params: GetListParams) => {
-  const url = new URL(`${DESKTOP_API_BASE}/${getPath(params.resource)}`);
+  const path = params.resource === "filesystem" ? "filesystem/browse" : getPath(params.resource);
+  const url = new URL(`${DESKTOP_API_BASE}/${path}`);
   const allowedFields = LIST_FILTERS[params.resource] ?? [];
   for (const filter of params.filters ?? []) {
     if (!("field" in filter) || !("value" in filter) || !allowedFields.includes(filter.field)) {
@@ -145,6 +243,45 @@ const getListUrl = (params: GetListParams) => {
   }
 
   return url.toString();
+};
+
+const executeCustomRequest = async (request: CustomRequest) => {
+  const hasBody = request.body !== undefined;
+  const response = await desktopRequest(request.url, {
+    method: request.method,
+    headers: hasBody ? { "Content-Type": "application/json" } : undefined,
+    body: hasBody ? JSON.stringify(request.body) : undefined,
+  });
+  if (!response.ok) {
+    throw new Error(`Custom request failed: ${request.method} ${request.url} ${response.status}`);
+  }
+
+  const data = response.status === 204 ? {} : await response.json();
+
+  return request.transform ? request.transform(data) : data;
+};
+
+const executeJobAnalysis = async (payload: unknown) => {
+  const jobId = requiredPayloadString(payload, "jobId");
+  const [tracesResult, agentRunsResult] = await Promise.all([
+    executeCustomRequest(resolveCustomRequest("jobs/traces", "GET", { jobId })),
+    executeCustomRequest(resolveCustomRequest("jobs/agentRuns", "GET", { jobId })),
+  ]);
+  const traces = payloadRecord(tracesResult).traces;
+  const agentRunsValue = payloadRecord(agentRunsResult).agentRuns;
+  const agentRuns = Array.isArray(agentRunsValue) ? agentRunsValue : [];
+  const spansByRunEntries = await Promise.all(
+    agentRuns.map(async (run) => {
+      const rawExportId = requiredPayloadNumber(run, "id");
+      const result = await executeCustomRequest(
+        resolveCustomRequest("jobs/agentRunSpans", "GET", { jobId, rawExportId }),
+      );
+
+      return [rawExportId, payloadRecord(result).spans] as const;
+    }),
+  );
+
+  return { traces, agentRuns, spansByRun: Object.fromEntries(spansByRunEntries) };
 };
 
 export const dataProvider: DataProvider = {
@@ -239,17 +376,12 @@ export const dataProvider: DataProvider = {
     params: CustomParams,
   ): Promise<CustomResponse<TData>> => {
     const { url, method = "get", payload } = params;
-    const request = resolveCustomRequest(url, method.toUpperCase(), payload);
-
-    const response = await desktopRequest(request.url, {
-      method: request.method,
-      headers: request.body ? { "Content-Type": "application/json" } : undefined,
-      body: request.body ? JSON.stringify(request.body) : undefined,
-    });
-    if (!response.ok) {
-      throw new Error(`Custom request failed: ${request.method} ${request.url} ${response.status}`);
+    if (url === "jobs/analysis") {
+      return { data: (await executeJobAnalysis(payload)) as unknown as TData };
     }
-    const data = response.status === 204 ? ({} as TData) : ((await response.json()) as TData);
+
+    const request = resolveCustomRequest(url, method.toUpperCase(), payload);
+    const data = (await executeCustomRequest(request)) as TData;
 
     return { data };
   },

--- a/apps/desktop-app/src/integrations/refine/dataProvider.ts
+++ b/apps/desktop-app/src/integrations/refine/dataProvider.ts
@@ -19,9 +19,14 @@ import { DESKTOP_API_BASE, desktopRequest } from "../platform";
 const RESOURCE_PATH: Record<string, string> = {
   agents: "agents",
   agentRuntimes: "agents/runtimes",
+  connectors: "connectors",
+  conversationMessages: "conversations",
   filesystem: "filesystem",
   operations: "operations",
+  pipelineAssets: "pipeline-assets",
   pipelines: "pipelines",
+  projects: "projects",
+  routines: "routines",
   jobs: "jobs",
   githubProjects: "github-projects",
   skills: "skills",
@@ -31,18 +36,124 @@ const RESOURCE_PATH: Record<string, string> = {
   operationOutputItemTemplates: "operation-output-item-templates",
 };
 
-const getPath = (resource: string) => RESOURCE_PATH[resource] ?? resource;
+const getPath = (resource: string) => {
+  const path = RESOURCE_PATH[resource];
+  if (!path) throw new Error(`Unknown resource "${resource}"`);
+
+  return path;
+};
+
+type CustomRequest = {
+  url: string;
+  method: string;
+  body?: unknown;
+};
+
+const payloadRecord = (payload: unknown) => (payload ?? {}) as Record<string, unknown>;
+
+const requiredPayloadString = (payload: unknown, field: string) => {
+  const value = payloadRecord(payload)[field];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Custom request requires payload.${field}`);
+  }
+
+  return value;
+};
+
+const usageRequest = (path: string, payload: unknown): CustomRequest => {
+  const values = payloadRecord(payload);
+  const url = new URL(`${DESKTOP_API_BASE}/usage/${path}`);
+  if (values.from !== undefined) url.searchParams.set("from", String(values.from));
+  if (values.to !== undefined) url.searchParams.set("to", String(values.to));
+
+  return { url: url.toString(), method: "GET" };
+};
+
+const resolveCustomRequest = (url: string, method: string, payload: unknown): CustomRequest => {
+  if (url.startsWith("http")) return { url, method, body: payload };
+
+  switch (url) {
+    case "connectors/connect": {
+      return {
+        url: `${DESKTOP_API_BASE}/connectors/${requiredPayloadString(payload, "id")}/connect`,
+        method: "POST",
+      };
+    }
+    case "conversations/clearAll": {
+      return { url: `${DESKTOP_API_BASE}/conversations`, method: "DELETE" };
+    }
+    case "pipelineAssets/getUsageCount": {
+      return {
+        url: `${DESKTOP_API_BASE}/pipeline-assets/${requiredPayloadString(payload, "id")}/usage-count`,
+        method: "GET",
+      };
+    }
+    case "pipelineAssets/incrementRunStats": {
+      return {
+        url: `${DESKTOP_API_BASE}/pipeline-assets/${requiredPayloadString(payload, "id")}/increment-run-stats`,
+        method: "POST",
+        body: payloadRecord(payload).stats,
+      };
+    }
+    case "pipelineAssets/distillFromPipeline": {
+      return {
+        url: `${DESKTOP_API_BASE}/pipeline-assets/distill/${requiredPayloadString(payload, "pipelineId")}`,
+        method: "POST",
+      };
+    }
+    case "routines/runNow": {
+      return {
+        url: `${DESKTOP_API_BASE}/routines/${requiredPayloadString(payload, "id")}/run-now`,
+        method: "POST",
+      };
+    }
+    case "usage/summary": {
+      return usageRequest("summary", payload);
+    }
+    case "usage/dailyTokenSeries": {
+      return usageRequest("daily-token-series", payload);
+    }
+    case "usage/byPipeline": {
+      return usageRequest("by-pipeline", payload);
+    }
+    case "usage/byAgent": {
+      return usageRequest("by-agent", payload);
+    }
+    default: {
+      return { url: `${DESKTOP_API_BASE}/${url}`, method, body: payload };
+    }
+  }
+};
+
+const LIST_FILTERS: Partial<Record<string, string[]>> = {
+  conversationMessages: ["pipelineId", "limit"],
+  filesystem: ["path"],
+  pipelineAssets: ["pipelineId"],
+  routines: ["pipelineId", "enabled"],
+};
+
+const getListUrl = (params: GetListParams) => {
+  const url = new URL(`${DESKTOP_API_BASE}/${getPath(params.resource)}`);
+  const allowedFields = LIST_FILTERS[params.resource] ?? [];
+  for (const filter of params.filters ?? []) {
+    if (!("field" in filter) || !("value" in filter) || !allowedFields.includes(filter.field)) {
+      continue;
+    }
+    if (filter.value !== undefined && filter.value !== null) {
+      url.searchParams.set(filter.field, String(filter.value));
+    }
+  }
+
+  return url.toString();
+};
 
 export const dataProvider: DataProvider = {
   getList: async <TData extends BaseRecord = BaseRecord>(
     params: GetListParams,
   ): Promise<GetListResponse<TData>> => {
-    const { resource } = params;
-    const path = getPath(resource);
-
-    const response = await desktopRequest(`${DESKTOP_API_BASE}/${path}`);
+    const response = await desktopRequest(getListUrl(params));
     if (!response.ok) {
-      return { data: [] as TData[], total: 0 };
+      throw new Error(`Failed to list ${params.resource}: ${response.status}`);
     }
     const data = (await response.json()) as TData[];
 
@@ -114,7 +225,10 @@ export const dataProvider: DataProvider = {
     if (!response.ok) {
       throw new Error(`Failed to delete ${resource}/${id}: ${response.status}`);
     }
-    const data = (await response.json()) as TData;
+    const data =
+      response.status === 204
+        ? ({ id: String(id) } as unknown as TData)
+        : ((await response.json()) as TData);
 
     return { data };
   },
@@ -125,19 +239,17 @@ export const dataProvider: DataProvider = {
     params: CustomParams,
   ): Promise<CustomResponse<TData>> => {
     const { url, method = "get", payload } = params;
-    const fetchUrl = url.startsWith("http") ? url : `${DESKTOP_API_BASE}/${url}`;
+    const request = resolveCustomRequest(url, method.toUpperCase(), payload);
 
-    const response = await desktopRequest(fetchUrl, {
-      method: method.toUpperCase(),
-      headers: payload ? { "Content-Type": "application/json" } : undefined,
-      body: payload ? JSON.stringify(payload) : undefined,
+    const response = await desktopRequest(request.url, {
+      method: request.method,
+      headers: request.body ? { "Content-Type": "application/json" } : undefined,
+      body: request.body ? JSON.stringify(request.body) : undefined,
     });
     if (!response.ok) {
-      throw new Error(
-        `Custom request failed: ${method.toUpperCase()} ${fetchUrl} ${response.status}`,
-      );
+      throw new Error(`Custom request failed: ${request.method} ${request.url} ${response.status}`);
     }
-    const data = (await response.json()) as TData;
+    const data = response.status === 204 ? ({} as TData) : ((await response.json()) as TData);
 
     return { data };
   },

--- a/apps/desktop-app/src/integrations/refine/dataProvider.unit.test.ts
+++ b/apps/desktop-app/src/integrations/refine/dataProvider.unit.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { desktopRequest } = vi.hoisted(() => ({
+  desktopRequest: vi.fn(),
+}));
+
+vi.mock("../platform", () => ({
+  DESKTOP_API_BASE: "http://desktop.test/api",
+  desktopRequest,
+}));
+
+const { dataProvider } = await import("./dataProvider");
+
+const jsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), {
+    headers: { "Content-Type": "application/json" },
+    status,
+  });
+
+beforeEach(() => {
+  desktopRequest.mockReset();
+  desktopRequest.mockResolvedValue(jsonResponse([]));
+});
+
+describe("desktop dataProvider", () => {
+  it("uses registered resource paths and only forwards supported list filters", async () => {
+    await dataProvider.getList!({
+      resource: "conversationMessages",
+      filters: [
+        { field: "pipelineId", operator: "eq", value: "pipeline-1" },
+        { field: "limit", operator: "eq", value: 20 },
+        { field: "ignored", operator: "eq", value: "value" },
+      ],
+    });
+
+    expect(desktopRequest).toHaveBeenCalledWith(
+      "http://desktop.test/api/conversations?pipelineId=pipeline-1&limit=20",
+    );
+  });
+
+  it("rejects unknown resources and list failures explicitly", async () => {
+    await expect(dataProvider.getList!({ resource: "unknown" })).rejects.toThrow(
+      'Unknown resource "unknown"',
+    );
+    expect(desktopRequest).not.toHaveBeenCalled();
+
+    desktopRequest.mockResolvedValueOnce(new Response(null, { status: 503 }));
+    await expect(dataProvider.getList!({ resource: "projects" })).rejects.toThrow(
+      "Failed to list projects: 503",
+    );
+  });
+
+  it("maps custom resource actions and rejects payloads missing required identifiers", async () => {
+    desktopRequest.mockResolvedValueOnce(jsonResponse({ jobId: "job-1" }));
+    await dataProvider.custom!({
+      url: "routines/runNow",
+      method: "post",
+      payload: { id: "routine-1" },
+    });
+
+    expect(desktopRequest).toHaveBeenCalledWith(
+      "http://desktop.test/api/routines/routine-1/run-now",
+      {
+        method: "POST",
+        headers: undefined,
+        body: undefined,
+      },
+    );
+
+    await expect(
+      dataProvider.custom!({
+        url: "pipelineAssets/getUsageCount",
+        method: "get",
+        payload: {},
+      }),
+    ).rejects.toThrow("Custom request requires payload.id");
+  });
+
+  it("does not parse 204 responses as JSON", async () => {
+    desktopRequest.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await expect(
+      dataProvider.deleteOne!({ resource: "projects", id: "project-1" }),
+    ).resolves.toEqual({
+      data: { id: "project-1" },
+    });
+
+    desktopRequest.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await expect(
+      dataProvider.custom!({ url: "conversations/clearAll", method: "delete" }),
+    ).resolves.toEqual({ data: {} });
+  });
+});

--- a/apps/desktop-app/src/integrations/refine/dataProvider.unit.test.ts
+++ b/apps/desktop-app/src/integrations/refine/dataProvider.unit.test.ts
@@ -19,7 +19,7 @@ const jsonResponse = (data: unknown, status = 200) =>
 
 beforeEach(() => {
   desktopRequest.mockReset();
-  desktopRequest.mockResolvedValue(jsonResponse([]));
+  desktopRequest.mockImplementation(() => Promise.resolve(jsonResponse([])));
 });
 
 describe("desktop dataProvider", () => {
@@ -36,6 +36,15 @@ describe("desktop dataProvider", () => {
     expect(desktopRequest).toHaveBeenCalledWith(
       "http://desktop.test/api/conversations?pipelineId=pipeline-1&limit=20",
     );
+
+    await dataProvider.getList!({
+      resource: "filesystem",
+      filters: [{ field: "path", operator: "eq", value: "/workspace/project" }],
+    });
+
+    expect(desktopRequest).toHaveBeenLastCalledWith(
+      "http://desktop.test/api/filesystem/browse?path=%2Fworkspace%2Fproject",
+    );
   });
 
   it("rejects unknown resources and list failures explicitly", async () => {
@@ -50,23 +59,174 @@ describe("desktop dataProvider", () => {
     );
   });
 
-  it("maps custom resource actions and rejects payloads missing required identifiers", async () => {
-    desktopRequest.mockResolvedValueOnce(jsonResponse({ jobId: "job-1" }));
-    await dataProvider.custom!({
-      url: "routines/runNow",
-      method: "post",
+  it.each([
+    {
+      endpoint: "pipelines/run",
+      payload: { id: "pipeline-1", inputPath: "/input" },
+      request: [
+        "http://desktop.test/api/pipelines/pipeline-1/run",
+        "POST",
+        { inputPath: "/input" },
+      ],
+    },
+    {
+      endpoint: "pipelines/analyzeIntent",
+      payload: { name: "Pipeline", description: "Description" },
+      request: [
+        "http://desktop.test/api/pipelines/analyze-intent",
+        "POST",
+        { name: "Pipeline", description: "Description" },
+      ],
+    },
+    {
+      endpoint: "pipelines/generateStructure",
+      payload: { name: "Pipeline", description: "Description" },
+      request: [
+        "http://desktop.test/api/pipelines/generate-structure",
+        "POST",
+        { name: "Pipeline", description: "Description" },
+      ],
+    },
+    {
+      endpoint: "pipelines/proposeActions",
+      payload: { id: "pipeline-1", message: "Update", snapshot: { nodes: [], edges: [] } },
+      request: [
+        "http://desktop.test/api/pipelines/pipeline-1/propose-actions",
+        "POST",
+        { message: "Update", snapshot: { nodes: [], edges: [] } },
+      ],
+    },
+    {
+      endpoint: "connectors/connect",
+      payload: { id: "connector-1" },
+      request: ["http://desktop.test/api/connectors/connector-1/connect", "POST"],
+    },
+    {
+      endpoint: "conversations/clearAll",
+      request: ["http://desktop.test/api/conversations", "DELETE"],
+    },
+    {
+      endpoint: "pipelineAssets/getUsageCount",
+      payload: { id: "asset-1" },
+      request: ["http://desktop.test/api/pipeline-assets/asset-1/usage-count", "GET"],
+    },
+    {
+      endpoint: "pipelineAssets/incrementRunStats",
+      payload: { id: "asset-1", stats: { success: true, durationMs: 12 } },
+      request: [
+        "http://desktop.test/api/pipeline-assets/asset-1/increment-run-stats",
+        "POST",
+        { success: true, durationMs: 12 },
+      ],
+    },
+    {
+      endpoint: "pipelineAssets/distillFromPipeline",
+      payload: { pipelineId: "pipeline-1" },
+      request: ["http://desktop.test/api/pipeline-assets/distill/pipeline-1", "POST"],
+    },
+    {
+      endpoint: "routines/runNow",
       payload: { id: "routine-1" },
+      request: ["http://desktop.test/api/routines/routine-1/run-now", "POST"],
+    },
+    {
+      endpoint: "usage/summary",
+      payload: { from: "2026-08-01", to: "2026-08-04" },
+      request: ["http://desktop.test/api/usage/summary?from=2026-08-01&to=2026-08-04", "GET"],
+    },
+    {
+      endpoint: "usage/dailyTokenSeries",
+      request: ["http://desktop.test/api/usage/daily-token-series", "GET"],
+    },
+    {
+      endpoint: "usage/byPipeline",
+      request: ["http://desktop.test/api/usage/by-pipeline", "GET"],
+    },
+    {
+      endpoint: "usage/byAgent",
+      request: ["http://desktop.test/api/usage/by-agent", "GET"],
+    },
+    {
+      endpoint: "jobs/traces",
+      payload: { jobId: "job-1" },
+      request: ["http://desktop.test/api/jobs/job-1/traces", "GET"],
+    },
+    {
+      endpoint: "jobs/agentRuns",
+      payload: { jobId: "job-1" },
+      request: ["http://desktop.test/api/jobs/job-1/agent-runs", "GET"],
+    },
+    {
+      endpoint: "jobs/agentRunSpans",
+      payload: { jobId: "job-1", rawExportId: 42 },
+      request: ["http://desktop.test/api/jobs/job-1/agent-runs/42/spans", "GET"],
+    },
+    {
+      endpoint: "distillations/run",
+      payload: { id: "distillation-1" },
+      request: ["http://desktop.test/api/distillations/distillation-1/run", "POST"],
+    },
+    {
+      endpoint: "operations/run",
+      payload: { operationId: "operation-1", inputContent: "content" },
+      request: [
+        "http://desktop.test/api/operations/operation-1/run",
+        "POST",
+        { inputContent: "content" },
+      ],
+    },
+  ])("maps the REST-backed $endpoint custom endpoint", async ({ endpoint, payload, request }) => {
+    await dataProvider.custom!({ url: endpoint, method: "post", payload });
+
+    const [url, method, body] = request;
+    expect(desktopRequest).toHaveBeenCalledWith(url, {
+      method,
+      headers: body === undefined ? undefined : { "Content-Type": "application/json" },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  });
+
+  it("preserves the Web provider response shapes for job details", async () => {
+    desktopRequest.mockResolvedValueOnce(jsonResponse([{ id: "trace-1" }]));
+    await expect(
+      dataProvider.custom!({
+        url: "jobs/traces",
+        method: "get",
+        payload: { jobId: "job-1" },
+      }),
+    ).resolves.toEqual({ data: { traces: [{ id: "trace-1" }] } });
+
+    desktopRequest
+      .mockResolvedValueOnce(jsonResponse([{ id: "trace-1" }]))
+      .mockResolvedValueOnce(jsonResponse([{ id: 42, agentId: "agent-1" }]))
+      .mockResolvedValueOnce(jsonResponse([{ id: "span-1" }]));
+    await expect(
+      dataProvider.custom!({
+        url: "jobs/analysis",
+        method: "get",
+        payload: { jobId: "job-1" },
+      }),
+    ).resolves.toEqual({
+      data: {
+        traces: [{ id: "trace-1" }],
+        agentRuns: [{ id: 42, agentId: "agent-1" }],
+        spansByRun: { 42: [{ id: "span-1" }] },
+      },
     });
 
-    expect(desktopRequest).toHaveBeenCalledWith(
-      "http://desktop.test/api/routines/routine-1/run-now",
-      {
-        method: "POST",
-        headers: undefined,
-        body: undefined,
-      },
+    expect(desktopRequest).toHaveBeenNthCalledWith(2, "http://desktop.test/api/jobs/job-1/traces", {
+      method: "GET",
+      headers: undefined,
+      body: undefined,
+    });
+    expect(desktopRequest).toHaveBeenNthCalledWith(
+      4,
+      "http://desktop.test/api/jobs/job-1/agent-runs/42/spans",
+      { method: "GET", headers: undefined, body: undefined },
     );
+  });
 
+  it("rejects invalid and unsupported custom endpoint contracts before requesting", async () => {
     await expect(
       dataProvider.custom!({
         url: "pipelineAssets/getUsageCount",
@@ -74,6 +234,33 @@ describe("desktop dataProvider", () => {
         payload: {},
       }),
     ).rejects.toThrow("Custom request requires payload.id");
+
+    await expect(
+      dataProvider.custom!({
+        url: "jobs/agentRunSpans",
+        method: "get",
+        payload: { jobId: "job-1", rawExportId: "42" },
+      }),
+    ).rejects.toThrow("Custom request requires numeric payload.rawExportId");
+
+    for (const endpoint of [
+      "pipelines/optimizeFromDistillation",
+      "refinements/start",
+      "settings/scanRuntimes",
+      "agentRuntimes/syncAll",
+      "agentRuntimes/scanAndSync",
+      "skills/previewImport",
+      "skills/importCandidates",
+    ]) {
+      await expect(dataProvider.custom!({ url: endpoint, method: "post" })).rejects.toThrow(
+        `Unsupported Desktop custom endpoint "${endpoint}"`,
+      );
+    }
+
+    await expect(dataProvider.custom!({ url: "unknown/action", method: "post" })).rejects.toThrow(
+      'Unknown Desktop custom endpoint "unknown/action"',
+    );
+    expect(desktopRequest).not.toHaveBeenCalled();
   });
 
   it("does not parse 204 responses as JSON", async () => {

--- a/apps/desktop-app/src/locales/en.json
+++ b/apps/desktop-app/src/locales/en.json
@@ -715,8 +715,25 @@
     "language": "Language",
     "selectLanguage": "Select language",
     "timezone": "Timezone",
+    "general": {
+      "appearance": {
+        "title": "Appearance",
+        "description": "Choose how Ordine looks on this device.",
+        "light": "Light",
+        "dark": "Dark",
+        "system": "System"
+      },
+      "notifications": {
+        "title": "Notifications",
+        "description": "Choose which run status changes are recorded and shown.",
+        "done": "Run completed",
+        "failed": "Run failed",
+        "waiting": "Run needs attention"
+      }
+    },
     "appearance": "Appearance",
     "sections": {
+      "general": "General",
       "profile": "Profile",
       "notifications": "Notifications",
       "appearance": "Appearance",

--- a/apps/desktop-app/src/locales/zh.json
+++ b/apps/desktop-app/src/locales/zh.json
@@ -715,8 +715,25 @@
     "language": "语言",
     "selectLanguage": "选择语言",
     "timezone": "时区",
+    "general": {
+      "appearance": {
+        "title": "外观",
+        "description": "选择 Ordine 在此设备上的显示方式。",
+        "light": "浅色",
+        "dark": "深色",
+        "system": "跟随系统"
+      },
+      "notifications": {
+        "title": "通知",
+        "description": "选择需要记录和显示的运行状态变化。",
+        "done": "运行完成",
+        "failed": "运行失败",
+        "waiting": "运行需要处理"
+      }
+    },
     "appearance": "外观",
     "sections": {
+      "general": "通用",
       "profile": "个人信息",
       "notifications": "通知",
       "appearance": "外观",

--- a/apps/server/src/integrations/auth/agentApiAuth.ts
+++ b/apps/server/src/integrations/auth/agentApiAuth.ts
@@ -1,13 +1,11 @@
 import { timingSafeEqual } from "node:crypto";
+import type { MiddlewareHandler } from "hono";
 import { getEnv } from "../env";
 
 const parseBearerToken = (value: string | undefined) =>
   value?.startsWith("Bearer ") ? value.slice("Bearer ".length) : "";
 
-export const isValidAgentApiToken = (
-  value: string | undefined,
-  expectedToken: string,
-) => {
+export const isValidAgentApiToken = (value: string | undefined, expectedToken: string) => {
   const expected = Buffer.from(expectedToken);
   const actual = Buffer.from(parseBearerToken(value));
 
@@ -20,10 +18,23 @@ export const getAgentApiAuthState = (headers: Headers) => {
   return {
     configured: Boolean(ORDINE_AGENT_API_TOKEN),
     authenticated: ORDINE_AGENT_API_TOKEN
-      ? isValidAgentApiToken(
-          headers.get("authorization") ?? undefined,
-          ORDINE_AGENT_API_TOKEN,
-        )
+      ? isValidAgentApiToken(headers.get("authorization") ?? undefined, ORDINE_AGENT_API_TOKEN)
       : false,
   };
+};
+
+export const agentApiAuthMiddleware: MiddlewareHandler = async (c, next) => {
+  const env = getEnv();
+  // Desktop mode is already protected by the app-wide desktop token middleware.
+  if (env.DESKTOP_MODE) return next();
+
+  const authState = getAgentApiAuthState(c.req.raw.headers);
+  if (!authState.configured) {
+    return c.json({ error: "Agent API authentication is not configured" }, 500);
+  }
+  if (!authState.authenticated) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  return next();
 };

--- a/apps/server/src/routes/connectors.ts
+++ b/apps/server/src/routes/connectors.ts
@@ -2,10 +2,13 @@ import { randomUUID } from "node:crypto";
 import { Hono } from "hono";
 import { z } from "zod/v4";
 import { CreateConnectorSchema, UpdateConnectorSchema } from "@repo/schemas";
+import { agentApiAuthMiddleware } from "../integrations/auth";
 import { connectorsService } from "../services.js";
 import { resultJson, resultNoContent, validateJson, validationErrorJson } from "./result.js";
 
 export const connectorsRoutes = new Hono();
+
+connectorsRoutes.use("*", agentApiAuthMiddleware);
 
 const CreateConnectorRouteSchema = CreateConnectorSchema.extend({
   id: z.string().default(() => randomUUID()),

--- a/apps/server/src/routes/conversations.ts
+++ b/apps/server/src/routes/conversations.ts
@@ -7,10 +7,15 @@ import { resultJson, resultNoContent, validateJson, validationErrorJson } from "
 
 export const conversationsRoutes = new Hono();
 
-const listQuerySchema = z.object({
-  pipelineId: z.string().optional(),
-  limit: z.coerce.number().int().positive().optional(),
-});
+const listQuerySchema = z
+  .object({
+    pipelineId: z.string().optional(),
+    limit: z.coerce.number().int().positive().optional(),
+  })
+  .refine(({ limit, pipelineId }) => limit === undefined || pipelineId !== undefined, {
+    message: "limit requires pipelineId",
+    path: ["limit"],
+  });
 
 const CreateConversationMessageRouteSchema = CreateConversationMessageSchema.extend({
   id: z.string().default(() => randomUUID()),

--- a/apps/server/src/routes/pipelines.ts
+++ b/apps/server/src/routes/pipelines.ts
@@ -1,13 +1,13 @@
 import { Hono } from "hono";
 import { ResultAsync } from "neverthrow";
 import { z } from "zod/v4";
-import { ConversationAttachmentSchema, PipelineGraphSnapshotSchema } from "@repo/schemas";
+import { PipelineGraphSnapshotSchema, ProposeAttachmentSchema } from "@repo/schemas";
 import { pipelinesService, pipelineRunnerService } from "../services.js";
 
 export const pipelinesRoutes = new Hono();
 
 const proposeActionsBodySchema = z.object({
-  attachments: z.array(ConversationAttachmentSchema).optional(),
+  attachments: z.array(ProposeAttachmentSchema).optional(),
   diagnostics: z.array(z.string()).optional(),
   failedProposal: z.unknown().optional(),
   snapshot: PipelineGraphSnapshotSchema,

--- a/apps/server/src/routes/routines.ts
+++ b/apps/server/src/routes/routines.ts
@@ -30,7 +30,9 @@ routinesRoutes.get("/", async (c) => {
       : await routinesService.getAll();
 
   const filtered =
-    parsed.data.enabled === "false" ? routines.filter((routine) => !routine.enabled) : routines;
+    parsed.data.enabled === undefined
+      ? routines
+      : routines.filter((routine) => routine.enabled === (parsed.data.enabled === "true"));
 
   return c.json(filtered);
 });

--- a/apps/server/tests/domainRoutes.test.ts
+++ b/apps/server/tests/domainRoutes.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ok } from "neverthrow";
+import { err, ok } from "neverthrow";
+
+vi.hoisted(() => {
+  process.env.ORDINE_AGENT_API_TOKEN = "test-agent-api-token-that-is-long-enough";
+});
 
 const mocks = vi.hoisted(() => ({
   connectorsConnect: vi.fn(),
@@ -9,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   pipelineAssetsGetAll: vi.fn(),
   pipelineAssetsGetUsageCount: vi.fn(),
   projectsGetAll: vi.fn(),
+  routinesGetByPipelineId: vi.fn(),
   routinesGetAll: vi.fn(),
   routinesRunNow: vi.fn(),
   usageGetDailyTokenSeries: vi.fn(),
@@ -40,6 +45,7 @@ vi.mock("../src/services.js", () => ({
   projectsService: { getAll: mocks.projectsGetAll },
   routinesService: {
     getAll: mocks.routinesGetAll,
+    getByPipelineId: mocks.routinesGetByPipelineId,
     runNow: mocks.routinesRunNow,
   },
   skillsService: {},
@@ -61,6 +67,7 @@ beforeEach(() => {
   mocks.pipelineAssetsGetUsageCount.mockResolvedValue(ok({ assetId: "asset-1", count: 1 }));
   mocks.projectsGetAll.mockResolvedValue(ok([]));
   mocks.routinesGetAll.mockResolvedValue([]);
+  mocks.routinesGetByPipelineId.mockResolvedValue([]);
   mocks.routinesRunNow.mockResolvedValue(ok({ jobId: "job-1" }));
   mocks.usageGetDailyTokenSeries.mockResolvedValue(ok([]));
   mocks.usageGetSummary.mockResolvedValue(ok({ runCount: 0, totalTokens: 0 }));
@@ -74,7 +81,9 @@ describe("domain REST routes", () => {
     ["/api/projects", mocks.projectsGetAll],
     ["/api/routines", mocks.routinesGetAll],
   ])("registers GET %s", async (path, serviceCall) => {
-    const response = await app.request(path);
+    const response = await app.request(path, {
+      headers: path === "/api/connectors" ? authorizedHeaders : undefined,
+    });
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual([]);
@@ -91,9 +100,33 @@ describe("domain REST routes", () => {
     expect(mocks.routinesRunNow).toHaveBeenCalledWith("routine-1");
   });
 
+  it("maps a missing routine run to 404", async () => {
+    const notFound = new Error("Routine:missing not found");
+    notFound.name = "NotFoundError";
+    mocks.routinesRunNow.mockResolvedValue(err(notFound));
+
+    const response = await app.request("/api/routines/missing/run-now", { method: "POST" });
+
+    expect(response.status).toBe(404);
+    expect(mocks.routinesRunNow).toHaveBeenCalledWith("missing");
+  });
+
+  it("filters pipeline routines by enabled status", async () => {
+    mocks.routinesGetByPipelineId.mockResolvedValue([
+      { id: "enabled", enabled: true },
+      { id: "disabled", enabled: false },
+    ]);
+
+    const response = await app.request("/api/routines?pipelineId=p1&enabled=true");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([{ id: "enabled", enabled: true }]);
+  });
+
   it("exposes current connector and conversation actions", async () => {
     const connectResponse = await app.request("/api/connectors/connector-1/connect", {
       method: "POST",
+      headers: authorizedHeaders,
     });
     const clearResponse = await app.request("/api/conversations", { method: "DELETE" });
 
@@ -102,6 +135,22 @@ describe("domain REST routes", () => {
     expect(clearResponse.status).toBe(204);
     expect(mocks.connectorsConnect).toHaveBeenCalledWith("connector-1");
     expect(mocks.conversationsClearAll).toHaveBeenCalledOnce();
+  });
+
+  it("rejects unauthenticated connector access before spawning a connector", async () => {
+    const response = await app.request("/api/connectors/connector-1/connect", {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(401);
+    expect(mocks.connectorsConnect).not.toHaveBeenCalled();
+  });
+
+  it("rejects limit without pipelineId instead of silently ignoring it", async () => {
+    const response = await app.request("/api/conversations?limit=1");
+
+    expect(response.status).toBe(400);
+    expect(mocks.conversationsGetAll).not.toHaveBeenCalled();
   });
 
   it("returns pipeline asset usage counts", async () => {
@@ -125,3 +174,7 @@ describe("domain REST routes", () => {
     expect(mocks.usageGetDailyTokenSeries).toHaveBeenCalledOnce();
   });
 });
+
+const authorizedHeaders = {
+  Authorization: "Bearer test-agent-api-token-that-is-long-enough",
+};

--- a/apps/server/tests/routes/pipelines.test.ts
+++ b/apps/server/tests/routes/pipelines.test.ts
@@ -97,4 +97,31 @@ describe("pipelinesRoutes propose-actions", () => {
       runtimeId: "runtime-codex",
     });
   });
+
+  it("preserves attachment content when forwarding propose-actions", async () => {
+    mocks.proposeActions.mockResolvedValue({ proposal: null, diagnostics: [] });
+    const attachment = {
+      name: "context.txt",
+      type: "text/plain",
+      content: "full attachment body",
+    };
+
+    const response = await makeApp().request("/pipelines/p1/propose-actions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        attachments: [attachment],
+        snapshot: { nodes: [], edges: [] },
+        message: "use this context",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.proposeActions).toHaveBeenCalledWith({
+      pipelineId: "p1",
+      attachments: [attachment],
+      snapshot: { nodes: [], edges: [] },
+      message: "use this context",
+    });
+  });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -190,6 +190,7 @@
         "tailwindcss": "^4.2.2",
         "typescript": "^5.8.3",
         "vite": "^6.3.5",
+        "vitest": "^4.1.6",
       },
     },
     "apps/docs": {

--- a/packages/schemas/src/routine/RoutineSchema.ts
+++ b/packages/schemas/src/routine/RoutineSchema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { isValidCronExpression } from "@repo/utils";
+import { isValidCronExpression } from "@repo/utils/cron";
 
 interface RoutineScheduleShape {
   cronExpression?: string | null | undefined;

--- a/packages/services/src/routinesService/createRoutinesService.ts
+++ b/packages/services/src/routinesService/createRoutinesService.ts
@@ -3,6 +3,7 @@ import { createRoutinesDao, type DbConnection } from "@repo/models";
 import { mapWithMeta, withMeta } from "@repo/schemas";
 import { getNextCronRunAt, toStringInputs } from "@repo/utils";
 import type { RoutineStartRun } from "../routineSchedulerService/routineScheduler";
+import { NotFoundError } from "../serviceErrors";
 
 // Disabled routines never have a pending occurrence; enabled routines get the
 // next occurrence of their cron expression (null when the expression is
@@ -46,7 +47,7 @@ export const createRoutinesService = (
     },
     update: async (id: string, patch: Parameters<typeof dao.update>[1]) => {
       const existing = await dao.findById(id);
-      if (!existing) return err(new Error(`Routine not found: ${id}`));
+      if (!existing) return err(new NotFoundError("Routine", id));
 
       // The enabled/cron cross-check lives here (not in UpdateRoutineSchema)
       // because it needs the stored routine: a pure { enabled: true } patch is
@@ -63,14 +64,14 @@ export const createRoutinesService = (
       const effectivePatch = scheduleTouched ? { ...patch, nextRunAt: schedule.value } : patch;
 
       const updated = await dao.update(id, effectivePatch);
-      if (!updated) return err(new Error(`Routine not found: ${id}`));
+      if (!updated) return err(new NotFoundError("Routine", id));
 
       return ok(withMeta(updated));
     },
     delete: (id: string) => dao.delete(id),
     runNow: async (id: string): Promise<Result<{ jobId: string }, Error>> => {
       const routine = await dao.findById(id);
-      if (!routine) return err(new Error(`Routine not found: ${id}`));
+      if (!routine) return err(new NotFoundError("Routine", id));
 
       const result = await deps.startRun({
         inputs: toStringInputs(routine.inputConfig),

--- a/packages/services/src/routinesService/createRoutinesService.unit.test.ts
+++ b/packages/services/src/routinesService/createRoutinesService.unit.test.ts
@@ -1,5 +1,6 @@
 import { err, ok } from "neverthrow";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NotFoundError } from "../serviceErrors";
 
 const now = new Date("2026-06-10T09:00:00.000Z");
 const storedRoutine = {
@@ -190,6 +191,7 @@ describe("createRoutinesService", () => {
     const svc = makeService();
     const result = await svc.runNow("missing");
     expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError);
     expect(startRun).not.toHaveBeenCalled();
   });
 });

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./cron": "./src/cron.ts"
   },
   "scripts": {
     "check-types": "tsc --noEmit",

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -39,7 +39,10 @@
     "./auth": "./src/auth/index.ts",
     "./constants": "./src/constants.ts",
     "./store/sidebarStore": "./src/store/sidebarStore/index.ts",
-    "./store/toastStore": "./src/store/toastStore/index.ts"
+    "./store/toastStore": "./src/store/toastStore/index.ts",
+    "./store/themeStore": "./src/store/themeStore/index.ts",
+    "./store/notificationStore": "./src/store/notificationStore/index.ts",
+    "./store/autonomyStore": "./src/store/autonomyStore/index.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/views/src/components/AppLayout.tsx
+++ b/packages/views/src/components/AppLayout.tsx
@@ -1,21 +1,32 @@
 import { SidebarInset, SidebarProvider } from "@repo/ui/sidebar";
 import { AppSidebar } from "./AppSidebar";
 import { ToastContainer } from "./ToastContainer";
-import { ToastStoreProvider } from "../store/toastStore";
+import { toastStore, ToastStoreProvider } from "../store/toastStore";
 import { SidebarStoreProvider } from "../store/sidebarStore";
+import { AutonomyStoreProvider } from "../store/autonomyStore";
+import { NotificationStoreProvider, ToastNotificationBridge } from "../store/notificationStore";
+import { ThemeApplier, ThemeStoreProvider } from "../store/themeStore";
 import { SearchPipelineDialog } from "./SearchPipelineDialog";
 
 export const AppLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <ToastStoreProvider>
-      <SidebarStoreProvider>
-        <SidebarProvider>
-          <AppSidebar />
-          <SidebarInset>{children}</SidebarInset>
-          <ToastContainer />
-          <SearchPipelineDialog />
-        </SidebarProvider>
-      </SidebarStoreProvider>
-    </ToastStoreProvider>
+    <ThemeStoreProvider>
+      <NotificationStoreProvider>
+        <AutonomyStoreProvider>
+          <ToastStoreProvider>
+            <SidebarStoreProvider>
+              <ThemeApplier />
+              <ToastNotificationBridge toastStore={toastStore} />
+              <SidebarProvider>
+                <AppSidebar />
+                <SidebarInset>{children}</SidebarInset>
+                <ToastContainer />
+                <SearchPipelineDialog />
+              </SidebarProvider>
+            </SidebarStoreProvider>
+          </ToastStoreProvider>
+        </AutonomyStoreProvider>
+      </NotificationStoreProvider>
+    </ThemeStoreProvider>
   );
 };

--- a/packages/views/src/pages/JobDetailPage/AgentRunsPanel/AgentRunCard.tsx
+++ b/packages/views/src/pages/JobDetailPage/AgentRunsPanel/AgentRunCard.tsx
@@ -19,10 +19,11 @@ import { SpanRow } from "./SpanRow";
 import { formatDuration, formatTokens } from "./agentRunsHelpers";
 
 interface AgentRunCardProps {
+  jobId: string;
   run: AgentRawExport;
 }
 
-export const AgentRunCard = ({ run }: AgentRunCardProps) => {
+export const AgentRunCard = ({ jobId, run }: AgentRunCardProps) => {
   const [expanded, setExpanded] = useState(false);
   const [rawExpanded, setRawExpanded] = useState(false);
   const handleToggleRawButtonClick = () => setRawExpanded((prev) => !prev);
@@ -32,7 +33,7 @@ export const AgentRunCard = ({ run }: AgentRunCardProps) => {
   const { result: spansResult } = useCustom<{ spans: AgentSpan[] }>({
     url: "jobs/agentRunSpans",
     method: "get",
-    config: { payload: { rawExportId: run.id } },
+    config: { payload: { jobId, rawExportId: run.id } },
     queryOptions: { enabled: expanded },
   });
   const spans = spansResult.data?.spans ?? [];

--- a/packages/views/src/pages/JobDetailPage/AgentRunsPanel/AgentRunsPanel.tsx
+++ b/packages/views/src/pages/JobDetailPage/AgentRunsPanel/AgentRunsPanel.tsx
@@ -46,7 +46,7 @@ export const AgentRunsPanel = ({ jobId }: AgentRunsPanelProps) => {
       ) : (
         <div className="p-3 space-y-2">
           {runs.map((run) => (
-            <AgentRunCard key={run.id} run={run} />
+            <AgentRunCard key={run.id} jobId={jobId} run={run} />
           ))}
         </div>
       )}

--- a/packages/views/src/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/views/src/pages/SettingsPage/SettingsPage.tsx
@@ -5,7 +5,9 @@ import { SettingsPageContent } from "./SettingsPageContent";
 const STORAGE_KEY = "ordine_settings_v1";
 
 const loadInitialSettings = (): Partial<AppSettings> | undefined => {
-  const raw = localStorage.getItem(STORAGE_KEY);
+  if (typeof globalThis.localStorage === "undefined") return undefined;
+
+  const raw = globalThis.localStorage.getItem(STORAGE_KEY);
   if (!raw) return undefined;
   const result = safeJsonParse<Partial<AppSettings>>(raw);
 

--- a/packages/views/src/pages/SettingsPage/SettingsPageContent/SettingsPageContent.tsx
+++ b/packages/views/src/pages/SettingsPage/SettingsPageContent/SettingsPageContent.tsx
@@ -1,23 +1,28 @@
 import { useState } from "react";
-import { Globe, Code, ChevronRight, Settings } from "lucide-react";
+import { Globe, Code, ChevronRight, Settings, SlidersHorizontal } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@repo/ui/button";
 import { cn } from "@repo/ui/lib/utils";
 import { PageHeader } from "../../../components/PageHeader";
-import { DeveloperSection, LanguageSection } from "../sections";
+import { DeveloperSection, GeneralSection, LanguageSection } from "../sections";
 
-type Section = "language" | "developer";
+type Section = "general" | "language" | "developer";
 
 const SECTION_ICONS: Record<Section, React.FC<{ className?: string }>> = {
+  general: SlidersHorizontal,
   language: Globe,
   developer: Code,
 };
 
-const SECTION_IDS: Section[] = ["language", ...(import.meta.env.DEV ? ["developer" as const] : [])];
+const SECTION_IDS: Section[] = [
+  "general",
+  "language",
+  ...(import.meta.env.DEV ? ["developer" as const] : []),
+];
 
 export const SettingsPageContent = () => {
   const { t } = useTranslation();
-  const [active, setActive] = useState<Section>("language");
+  const [active, setActive] = useState<Section>("general");
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -55,6 +60,7 @@ export const SettingsPageContent = () => {
 
         <div className="flex-1 overflow-y-auto p-8">
           <div className="mx-auto max-w-lg space-y-6">
+            {active === "general" && <GeneralSection />}
             {active === "language" && <LanguageSection />}
             {active === "developer" && <DeveloperSection />}
           </div>

--- a/packages/views/src/pages/SettingsPage/SettingsPageContent/SettingsPageContent.unit.test.tsx
+++ b/packages/views/src/pages/SettingsPage/SettingsPageContent/SettingsPageContent.unit.test.tsx
@@ -4,6 +4,7 @@ import { SettingsPageContent } from "./SettingsPageContent";
 
 vi.mock("../sections", () => ({
   DeveloperSection: () => <div>DeveloperSection</div>,
+  GeneralSection: () => <div>GeneralSection</div>,
   LanguageSection: () => <div>LanguageSection</div>,
 }));
 
@@ -16,10 +17,11 @@ describe("SettingsPageContent", () => {
   it("renders navigation sidebar items", () => {
     render(<SettingsPageContent />);
     expect(screen.getByText("语言与地区")).toBeTruthy();
+    expect(screen.getByText("通用")).toBeTruthy();
   });
 
-  it("renders LanguageSection by default", () => {
+  it("renders GeneralSection by default", () => {
     render(<SettingsPageContent />);
-    expect(screen.getByText("LanguageSection")).toBeTruthy();
+    expect(screen.getByText("GeneralSection")).toBeTruthy();
   });
 });

--- a/packages/views/src/pages/SettingsPage/Toggle/Toggle.tsx
+++ b/packages/views/src/pages/SettingsPage/Toggle/Toggle.tsx
@@ -13,10 +13,14 @@ export const Toggle = ({ enabled, onToggle, label }: ToggleProps) => {
     <div className="flex items-center justify-between rounded-lg border bg-muted/50 px-4 py-3">
       <span className="text-sm">{label}</span>
       <button
+        aria-checked={enabled}
+        aria-label={label}
         className={cn(
           "relative h-5 w-9 rounded-full transition-colors",
           enabled ? "bg-primary" : "bg-input",
         )}
+        role="switch"
+        type="button"
         onClick={handleToggle}
       >
         <span

--- a/packages/views/src/pages/SettingsPage/_store/settingsPageMetaSlice.ts
+++ b/packages/views/src/pages/SettingsPage/_store/settingsPageMetaSlice.ts
@@ -31,7 +31,7 @@ export const createSettingsPageMetaSlice: StateCreator<
       resetSaved: _resetSaved,
       ...settings
     } = get();
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(settings));
     set({ saved: true });
   },
 

--- a/packages/views/src/pages/SettingsPage/_store/settingsPageMetaSlice.ts
+++ b/packages/views/src/pages/SettingsPage/_store/settingsPageMetaSlice.ts
@@ -24,6 +24,8 @@ export const createSettingsPageMetaSlice: StateCreator<
     })),
 
   save: () => {
+    if (typeof globalThis.localStorage === "undefined") return;
+
     const {
       saved: _saved,
       updateSection: _updateSection,
@@ -31,7 +33,7 @@ export const createSettingsPageMetaSlice: StateCreator<
       resetSaved: _resetSaved,
       ...settings
     } = get();
-    globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(settings));
+    globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
     set({ saved: true });
   },
 

--- a/packages/views/src/pages/SettingsPage/_store/settingsStore.unit.test.ts
+++ b/packages/views/src/pages/SettingsPage/_store/settingsStore.unit.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSettingsPageStore } from "./settingsPageStore";
 
 describe("settingsPageStore", () => {
@@ -6,6 +6,10 @@ describe("settingsPageStore", () => {
 
   beforeEach(() => {
     ctx.store = createSettingsPageStore();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("is initialized with default settings", () => {
@@ -23,6 +27,15 @@ describe("settingsPageStore", () => {
     ctx.store!.getState().updateSection("language", { language: "en" });
     ctx.store!.getState().save();
     expect(ctx.store!.getState().saved).toBe(true);
+  });
+
+  it("does not mark settings as saved when storage is unavailable", () => {
+    vi.stubGlobal("localStorage", undefined);
+    const store = createSettingsPageStore();
+
+    store.getState().save();
+
+    expect(store.getState().saved).toBe(false);
   });
 
   it("loads initial settings from provided values", () => {

--- a/packages/views/src/pages/SettingsPage/sections/GeneralSection/GeneralSection.tsx
+++ b/packages/views/src/pages/SettingsPage/sections/GeneralSection/GeneralSection.tsx
@@ -1,0 +1,86 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import { Button } from "@repo/ui/button";
+import { cn } from "@repo/ui/lib/utils";
+import {
+  useNotificationStore,
+  type NotificationPreference,
+} from "../../../../store/notificationStore";
+import { useThemeStore, type ThemePreference } from "../../../../store/themeStore";
+import { SectionHeader } from "../../SectionHeader";
+import { Toggle } from "../../Toggle";
+
+const THEMES: Array<{ value: ThemePreference; icon: typeof Sun }> = [
+  { value: "light", icon: Sun },
+  { value: "dark", icon: Moon },
+  { value: "system", icon: Monitor },
+];
+
+const NOTIFICATION_PREFERENCES: NotificationPreference[] = ["done", "failed", "waiting"];
+
+export const GeneralSection = () => {
+  const { t } = useTranslation();
+  const themeStore = useThemeStore();
+  const preference = useStore(themeStore, (state) => state.preference);
+  const setPreference = useStore(themeStore, (state) => state.setPreference);
+  const notificationStore = useNotificationStore();
+  const notificationPreferences = useStore(notificationStore, (state) => state.preferences);
+  const setNotificationPreference = useStore(notificationStore, (state) => state.setPreference);
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <SectionHeader
+          description={t("settings.general.appearance.description")}
+          title={t("settings.general.appearance.title")}
+        />
+        <div
+          aria-label={t("settings.general.appearance.title")}
+          className="grid grid-cols-3 gap-2"
+          role="group"
+        >
+          {THEMES.map(({ value, icon: Icon }) => {
+            const handleThemeClick = () => setPreference(value);
+
+            return (
+              <Button
+                key={value}
+                aria-pressed={preference === value}
+                className={cn("h-10 gap-2", preference === value && "border-primary")}
+                type="button"
+                variant={preference === value ? "secondary" : "outline"}
+                onClick={handleThemeClick}
+              >
+                <Icon className="h-4 w-4" />
+                {t(`settings.general.appearance.${value}`)}
+              </Button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section>
+        <SectionHeader
+          description={t("settings.general.notifications.description")}
+          title={t("settings.general.notifications.title")}
+        />
+        <div className="space-y-2">
+          {NOTIFICATION_PREFERENCES.map((item) => {
+            const handleNotificationToggle = () =>
+              setNotificationPreference(item, !notificationPreferences[item]);
+
+            return (
+              <Toggle
+                key={item}
+                enabled={notificationPreferences[item]}
+                label={t(`settings.general.notifications.${item}`)}
+                onToggle={handleNotificationToggle}
+              />
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/packages/views/src/pages/SettingsPage/sections/GeneralSection/GeneralSection.unit.test.tsx
+++ b/packages/views/src/pages/SettingsPage/sections/GeneralSection/GeneralSection.unit.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { NotificationStoreProvider } from "../../../../store/notificationStore";
+import { ThemeStoreProvider } from "../../../../store/themeStore";
+import { GeneralSection } from "./GeneralSection";
+
+const renderSection = () =>
+  render(
+    <ThemeStoreProvider>
+      <NotificationStoreProvider>
+        <GeneralSection />
+      </NotificationStoreProvider>
+    </ThemeStoreProvider>,
+  );
+
+describe("GeneralSection", () => {
+  it("changes theme and notification preferences", async () => {
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(screen.getByRole("button", { name: "深色" }));
+    expect(screen.getByRole("button", { name: "深色" })).toHaveAttribute("aria-pressed", "true");
+
+    const waiting = screen.getByRole("switch", { name: "运行需要处理" });
+    expect(waiting).toHaveAttribute("aria-checked", "true");
+    await user.click(waiting);
+    expect(waiting).toHaveAttribute("aria-checked", "false");
+  });
+});

--- a/packages/views/src/pages/SettingsPage/sections/GeneralSection/index.ts
+++ b/packages/views/src/pages/SettingsPage/sections/GeneralSection/index.ts
@@ -1,0 +1,1 @@
+export * from "./GeneralSection";

--- a/packages/views/src/pages/SettingsPage/sections/index.ts
+++ b/packages/views/src/pages/SettingsPage/sections/index.ts
@@ -1,2 +1,3 @@
 export * from "./DeveloperSection";
+export * from "./GeneralSection";
 export * from "./LanguageSection";

--- a/packages/views/src/store/autonomyStore/AutonomyProvider.tsx
+++ b/packages/views/src/store/autonomyStore/AutonomyProvider.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+import { useInit } from "../../hooks/useInit";
+import { AutonomyStoreContext, createAutonomyStore } from "./autonomyStore";
+
+export const AutonomyStoreProvider = ({ children }: { children: ReactNode }) => {
+  const store = useInit(createAutonomyStore);
+
+  return <AutonomyStoreContext.Provider value={store}>{children}</AutonomyStoreContext.Provider>;
+};

--- a/packages/views/src/store/autonomyStore/autonomyStore.ts
+++ b/packages/views/src/store/autonomyStore/autonomyStore.ts
@@ -1,0 +1,37 @@
+import { createContext, useContext } from "react";
+import { createStore, type StoreApi } from "zustand";
+import { persist } from "zustand/middleware";
+
+export const SELF_HEAL_RETRIES_MIN = 0;
+export const SELF_HEAL_RETRIES_MAX = 5;
+export const SELF_HEAL_RETRIES_DEFAULT = 1;
+
+export interface AutonomyState {
+  selfHealRetries: number;
+  setSelfHealRetries: (value: number) => void;
+}
+
+export type AutonomyStore = StoreApi<AutonomyState>;
+const clampRetries = (value: number) =>
+  Math.min(SELF_HEAL_RETRIES_MAX, Math.max(SELF_HEAL_RETRIES_MIN, Math.round(value)));
+
+export const createAutonomyStore = (): AutonomyStore =>
+  createStore<AutonomyState>()(
+    persist(
+      (set) => ({
+        selfHealRetries: SELF_HEAL_RETRIES_DEFAULT,
+        setSelfHealRetries: (value) => set({ selfHealRetries: clampRetries(value) }),
+      }),
+      { name: "ordine.autonomy" },
+    ),
+  );
+
+export const autonomyStore = createAutonomyStore();
+export const AutonomyStoreContext = createContext<AutonomyStore | null>(null);
+
+export const useAutonomyStore = () => {
+  const store = useContext(AutonomyStoreContext);
+  if (!store) throw new Error("useAutonomyStore must be used within AutonomyStoreProvider");
+
+  return store;
+};

--- a/packages/views/src/store/autonomyStore/autonomyStore.ts
+++ b/packages/views/src/store/autonomyStore/autonomyStore.ts
@@ -26,7 +26,6 @@ export const createAutonomyStore = (): AutonomyStore =>
     ),
   );
 
-export const autonomyStore = createAutonomyStore();
 export const AutonomyStoreContext = createContext<AutonomyStore | null>(null);
 
 export const useAutonomyStore = () => {

--- a/packages/views/src/store/autonomyStore/autonomyStore.unit.test.ts
+++ b/packages/views/src/store/autonomyStore/autonomyStore.unit.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAutonomyStore,
+  SELF_HEAL_RETRIES_DEFAULT,
+  SELF_HEAL_RETRIES_MAX,
+  SELF_HEAL_RETRIES_MIN,
+} from "./autonomyStore";
+
+describe("autonomyStore", () => {
+  it("uses the safe default and clamps retry updates", () => {
+    const store = createAutonomyStore();
+    expect(store.getState().selfHealRetries).toBe(SELF_HEAL_RETRIES_DEFAULT);
+
+    store.getState().setSelfHealRetries(99);
+    expect(store.getState().selfHealRetries).toBe(SELF_HEAL_RETRIES_MAX);
+
+    store.getState().setSelfHealRetries(-3);
+    expect(store.getState().selfHealRetries).toBe(SELF_HEAL_RETRIES_MIN);
+
+    store.getState().setSelfHealRetries(2.6);
+    expect(store.getState().selfHealRetries).toBe(3);
+  });
+});

--- a/packages/views/src/store/autonomyStore/index.ts
+++ b/packages/views/src/store/autonomyStore/index.ts
@@ -1,0 +1,2 @@
+export * from "./autonomyStore";
+export * from "./AutonomyProvider";

--- a/packages/views/src/store/notificationStore/NotificationProvider.tsx
+++ b/packages/views/src/store/notificationStore/NotificationProvider.tsx
@@ -1,0 +1,51 @@
+import { useEffect, type ReactNode } from "react";
+import { useInit } from "../../hooks/useInit";
+import {
+  createNotificationStore,
+  NotificationStoreContext,
+  useNotificationStore,
+} from "./notificationStore";
+
+type ToastSnapshot = {
+  toasts: Array<{
+    id: string;
+    type: "success" | "error";
+    title: string;
+    description?: string;
+  }>;
+};
+
+export const ToastNotificationBridge = <State extends ToastSnapshot>({
+  toastStore,
+}: {
+  toastStore: {
+    subscribe: (listener: (state: State, previousState: State) => void) => () => void;
+  };
+}) => {
+  const notifications = useNotificationStore();
+
+  useEffect(
+    () =>
+      toastStore.subscribe((state, previousState) => {
+        const previousIds = new Set(previousState.toasts.map((toast) => toast.id));
+        for (const toast of state.toasts.filter((item) => !previousIds.has(item.id))) {
+          notifications.getState().addNotification({
+            id: `toast-${toast.id}`,
+            kind: toast.type,
+            message: toast.description ? `${toast.title}: ${toast.description}` : toast.title,
+          });
+        }
+      }),
+    [notifications, toastStore],
+  );
+
+  return null;
+};
+
+export const NotificationStoreProvider = ({ children }: { children: ReactNode }) => {
+  const store = useInit(createNotificationStore);
+
+  return (
+    <NotificationStoreContext.Provider value={store}>{children}</NotificationStoreContext.Provider>
+  );
+};

--- a/packages/views/src/store/notificationStore/index.ts
+++ b/packages/views/src/store/notificationStore/index.ts
@@ -1,0 +1,2 @@
+export * from "./notificationStore";
+export * from "./NotificationProvider";

--- a/packages/views/src/store/notificationStore/notificationStore.ts
+++ b/packages/views/src/store/notificationStore/notificationStore.ts
@@ -1,0 +1,78 @@
+import { createContext, useContext } from "react";
+import { createStore, type StoreApi } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type NotificationPreference = "done" | "failed" | "waiting";
+export type NotificationKind = "error" | "info" | "success" | "warning";
+
+export interface AppNotification {
+  id: string;
+  kind: NotificationKind;
+  message: string;
+  read: boolean;
+  route?: string;
+  timestamp: number;
+}
+
+export interface NotificationState {
+  preferences: Record<NotificationPreference, boolean>;
+  notifications: AppNotification[];
+  setPreference: (preference: NotificationPreference, enabled: boolean) => void;
+  addNotification: (
+    input: Omit<AppNotification, "id" | "read" | "timestamp"> & { id?: string },
+  ) => void;
+  markAllRead: () => void;
+  clearNotifications: () => void;
+}
+
+export type NotificationStore = StoreApi<NotificationState>;
+const MAX_NOTIFICATIONS = 60;
+
+export const createNotificationStore = (): NotificationStore =>
+  createStore<NotificationState>()(
+    persist(
+      (set) => ({
+        preferences: { done: true, failed: true, waiting: true },
+        notifications: [],
+        setPreference: (preference, enabled) =>
+          set((state) => ({
+            preferences: { ...state.preferences, [preference]: enabled },
+          })),
+        addNotification: ({ id, kind, message, route }) =>
+          set((state) => ({
+            notifications: [
+              {
+                id: id ?? `notification-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+                kind,
+                message,
+                read: false,
+                route,
+                timestamp: Date.now(),
+              },
+              ...state.notifications.filter((notification) => notification.id !== id),
+            ].slice(0, MAX_NOTIFICATIONS),
+          })),
+        markAllRead: () =>
+          set((state) => ({
+            notifications: state.notifications.map((notification) => ({
+              ...notification,
+              read: true,
+            })),
+          })),
+        clearNotifications: () => set({ notifications: [] }),
+      }),
+      { name: "ordine.notifications" },
+    ),
+  );
+
+export const notificationStore = createNotificationStore();
+export const NotificationStoreContext = createContext<NotificationStore | null>(null);
+
+export const useNotificationStore = () => {
+  const store = useContext(NotificationStoreContext);
+  if (!store) {
+    throw new Error("useNotificationStore must be used within NotificationStoreProvider");
+  }
+
+  return store;
+};

--- a/packages/views/src/store/notificationStore/notificationStore.ts
+++ b/packages/views/src/store/notificationStore/notificationStore.ts
@@ -65,7 +65,6 @@ export const createNotificationStore = (): NotificationStore =>
     ),
   );
 
-export const notificationStore = createNotificationStore();
 export const NotificationStoreContext = createContext<NotificationStore | null>(null);
 
 export const useNotificationStore = () => {

--- a/packages/views/src/store/notificationStore/notificationStore.unit.test.ts
+++ b/packages/views/src/store/notificationStore/notificationStore.unit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { createNotificationStore } from "./notificationStore";
+
+describe("notificationStore", () => {
+  it("updates preferences without changing the others", () => {
+    const store = createNotificationStore();
+
+    store.getState().setPreference("waiting", false);
+
+    expect(store.getState().preferences).toEqual({ done: true, failed: true, waiting: false });
+  });
+
+  it("records, marks read, clears, and caps notification history", () => {
+    const store = createNotificationStore();
+    for (const index of Array.from({ length: 70 }, (_, itemIndex) => itemIndex)) {
+      store.getState().addNotification({ kind: "info", message: `event ${index}` });
+    }
+
+    expect(store.getState().notifications).toHaveLength(60);
+    expect(store.getState().notifications[0]?.message).toBe("event 69");
+
+    store.getState().markAllRead();
+    expect(store.getState().notifications.every((notification) => notification.read)).toBe(true);
+
+    store.getState().clearNotifications();
+    expect(store.getState().notifications).toEqual([]);
+  });
+});

--- a/packages/views/src/store/sidebarStore/sidebarSlice.ts
+++ b/packages/views/src/store/sidebarStore/sidebarSlice.ts
@@ -4,10 +4,27 @@ import { SidebarView, type SidebarViewType } from "./sidebarView";
 const isPipelinePathname = (pathname: string): boolean =>
   pathname.startsWith("/canvas") || pathname.startsWith("/pipelines");
 
+const CAPABILITIES_OPEN_STORAGE_KEY = "ordine.sidebar.capabilitiesOpen";
+
+const readStoredCapabilitiesOpen = () => {
+  if (globalThis.localStorage === undefined) return true;
+
+  const value = globalThis.localStorage.getItem(CAPABILITIES_OPEN_STORAGE_KEY);
+
+  return value === null ? true : value === "true";
+};
+
+const writeStoredCapabilitiesOpen = (value: boolean) => {
+  if (globalThis.localStorage === undefined) return;
+
+  globalThis.localStorage.setItem(CAPABILITIES_OPEN_STORAGE_KEY, String(value));
+};
+
 export interface SidebarSlice {
   view: SidebarViewType;
   searchOpen: boolean;
   newPipelineOpen: boolean;
+  capabilitiesOpen: boolean;
 
   handleSidebarLocationChange: (pathname: string) => void;
   handleSearchDialogOpenChange: (open: boolean) => void;
@@ -15,12 +32,14 @@ export interface SidebarSlice {
   handleSidebarPipelineViewButtonClick: () => void;
   handleSearchButtonClick: () => void;
   handleNewPipelineButtonClick: () => void;
+  handleCapabilitiesToggle: () => void;
 }
 
-export const createSidebarSlice: StateCreator<SidebarSlice> = (set) => ({
+export const createSidebarSlice: StateCreator<SidebarSlice> = (set, get) => ({
   view: SidebarView.Main,
   searchOpen: false,
   newPipelineOpen: false,
+  capabilitiesOpen: readStoredCapabilitiesOpen(),
 
   handleSidebarLocationChange: (pathname) =>
     set({ view: isPipelinePathname(pathname) ? SidebarView.Pipeline : SidebarView.Main }),
@@ -29,4 +48,9 @@ export const createSidebarSlice: StateCreator<SidebarSlice> = (set) => ({
   handleSidebarPipelineViewButtonClick: () => set({ view: SidebarView.Pipeline }),
   handleSearchButtonClick: () => set({ searchOpen: true }),
   handleNewPipelineButtonClick: () => set({ newPipelineOpen: true }),
+  handleCapabilitiesToggle: () => {
+    const capabilitiesOpen = !get().capabilitiesOpen;
+    writeStoredCapabilitiesOpen(capabilitiesOpen);
+    set({ capabilitiesOpen });
+  },
 });

--- a/packages/views/src/store/sidebarStore/sidebarStore.unit.test.ts
+++ b/packages/views/src/store/sidebarStore/sidebarStore.unit.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { createSidebarStore } from "./sidebarStore";
+import { SidebarView } from "./sidebarView";
+
+describe("sidebarStore", () => {
+  it("selects a view from the current route", () => {
+    const store = createSidebarStore();
+
+    store.getState().handleSidebarLocationChange("/canvas/pipeline-1");
+    expect(store.getState().view).toBe(SidebarView.Pipeline);
+
+    store.getState().handleSidebarLocationChange("/jobs");
+    expect(store.getState().view).toBe(SidebarView.Main);
+  });
+
+  it("controls sidebar dialogs", () => {
+    const store = createSidebarStore();
+
+    store.getState().handleSearchButtonClick();
+    store.getState().handleNewPipelineButtonClick();
+    expect(store.getState()).toMatchObject({ searchOpen: true, newPipelineOpen: true });
+
+    store.getState().handleSearchDialogOpenChange(false);
+    expect(store.getState().searchOpen).toBe(false);
+  });
+});

--- a/packages/views/src/store/sidebarStore/sidebarStore.unit.test.ts
+++ b/packages/views/src/store/sidebarStore/sidebarStore.unit.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSidebarStore } from "./sidebarStore";
 import { SidebarView } from "./sidebarView";
 
 describe("sidebarStore", () => {
+  beforeEach(() => {
+    const values = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key: string) => values.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("selects a view from the current route", () => {
     const store = createSidebarStore();
 
@@ -22,5 +34,16 @@ describe("sidebarStore", () => {
 
     store.getState().handleSearchDialogOpenChange(false);
     expect(store.getState().searchOpen).toBe(false);
+  });
+
+  it("persists the capabilities section state", () => {
+    const store = createSidebarStore();
+
+    expect(store.getState().capabilitiesOpen).toBe(true);
+    store.getState().handleCapabilitiesToggle();
+
+    expect(store.getState().capabilitiesOpen).toBe(false);
+    expect(localStorage.getItem("ordine.sidebar.capabilitiesOpen")).toBe("false");
+    expect(createSidebarStore().getState().capabilitiesOpen).toBe(false);
   });
 });

--- a/packages/views/src/store/themeStore/ThemeProvider.tsx
+++ b/packages/views/src/store/themeStore/ThemeProvider.tsx
@@ -1,0 +1,45 @@
+import { useEffect, type ReactNode } from "react";
+import { useStore } from "zustand";
+import { useInit } from "../../hooks/useInit";
+import {
+  createThemeStore,
+  ThemeStoreContext,
+  useThemeStore,
+  type ThemePreference,
+} from "./themeStore";
+
+export const resolveIsDark = (preference: ThemePreference) =>
+  preference === "dark" ||
+  (preference === "system" &&
+    typeof globalThis.matchMedia === "function" &&
+    globalThis.matchMedia("(prefers-color-scheme: dark)").matches);
+
+const applyTheme = (preference: ThemePreference) => {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.toggle("dark", resolveIsDark(preference));
+  }
+};
+
+export const ThemeApplier = () => {
+  const store = useThemeStore();
+  const preference = useStore(store, (state) => state.preference);
+
+  useEffect(() => {
+    applyTheme(preference);
+    if (preference !== "system" || typeof globalThis.matchMedia !== "function") return;
+
+    const mediaQuery = globalThis.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = () => applyTheme("system");
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [preference]);
+
+  return null;
+};
+
+export const ThemeStoreProvider = ({ children }: { children: ReactNode }) => {
+  const store = useInit(createThemeStore);
+
+  return <ThemeStoreContext.Provider value={store}>{children}</ThemeStoreContext.Provider>;
+};

--- a/packages/views/src/store/themeStore/index.ts
+++ b/packages/views/src/store/themeStore/index.ts
@@ -1,0 +1,2 @@
+export * from "./themeStore";
+export * from "./ThemeProvider";

--- a/packages/views/src/store/themeStore/themeStore.ts
+++ b/packages/views/src/store/themeStore/themeStore.ts
@@ -22,7 +22,6 @@ export const createThemeStore = (): ThemeStore =>
     ),
   );
 
-export const themeStore = createThemeStore();
 export const ThemeStoreContext = createContext<ThemeStore | null>(null);
 
 export const useThemeStore = () => {

--- a/packages/views/src/store/themeStore/themeStore.ts
+++ b/packages/views/src/store/themeStore/themeStore.ts
@@ -1,0 +1,33 @@
+import { createContext, useContext } from "react";
+import { createStore, type StoreApi } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type ThemePreference = "light" | "dark" | "system";
+
+export interface ThemeState {
+  preference: ThemePreference;
+  setPreference: (preference: ThemePreference) => void;
+}
+
+export type ThemeStore = StoreApi<ThemeState>;
+
+export const createThemeStore = (): ThemeStore =>
+  createStore<ThemeState>()(
+    persist(
+      (set) => ({
+        preference: "system",
+        setPreference: (preference) => set({ preference }),
+      }),
+      { name: "ordine.theme" },
+    ),
+  );
+
+export const themeStore = createThemeStore();
+export const ThemeStoreContext = createContext<ThemeStore | null>(null);
+
+export const useThemeStore = () => {
+  const store = useContext(ThemeStoreContext);
+  if (!store) throw new Error("useThemeStore must be used within ThemeStoreProvider");
+
+  return store;
+};

--- a/packages/views/src/store/themeStore/themeStore.unit.test.ts
+++ b/packages/views/src/store/themeStore/themeStore.unit.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { createThemeStore } from "./themeStore";
+import { resolveIsDark } from "./ThemeProvider";
+
+describe("themeStore", () => {
+  it("stores an explicit theme preference", () => {
+    const store = createThemeStore();
+
+    store.getState().setPreference("dark");
+
+    expect(store.getState().preference).toBe("dark");
+  });
+
+  it("resolves system theme from matchMedia", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: true })),
+    );
+
+    expect(resolveIsDark("system")).toBe(true);
+    expect(resolveIsDark("light")).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
## Summary
- refactor the Web Refine data provider into resource and custom-endpoint registries covering the COD-122 resources
- align the Desktop data provider with REST paths, filters, explicit failures, payload validation, and 204 responses
- add persisted theme, notification, autonomy, and sidebar store coverage and wire shared providers into both app layouts
- make Settings General the default tab with theme and notification controls plus Web/Desktop i18n
- include the PR #136 follow-up fixes for connector authorization, proposal attachments, routine filtering and not-found handling, and conversation query validation

## Validation
- 187 test files and 1,095 tests passed across app, desktop, server, services, views, and schemas
- type checks passed for app, server, services, views, schemas, and utils
- Web and Desktop production builds passed
- lint passed with only two pre-existing Desktop warnings
- changed-file format checks and `git diff --check` passed
- independent Terra acceptance review completed with no remaining blockers

Linear: https://linear.app/code-forge-official/issue/COD-123/12featurestore-data-provider-and-app-state-or-store%E6%95%B0%E6%8D%AE%E5%B1%82%E4%B8%8E%E5%BA%94%E7%94%A8%E7%8A%B6%E6%80%81
