### PR TITLE
ci: 添加 Codex 自动 PR Review

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,109 @@
+name: Codex PR Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: >-
+      github.repository == 'forge-town/ordine' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      final_message: ${{ steps.codex.outputs.final-message }}
+    steps:
+      - name: Check out pull request merge commit
+        uses: actions/checkout@v5
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch pull request refs
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch --no-tags origin \
+            "$PR_BASE_REF" \
+            "+refs/pull/$PR_NUMBER/head"
+
+      - name: Run Codex review
+        id: codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          model: gpt-5.6-sol
+          effort: high
+          sandbox: read-only
+          safety-strategy: drop-sudo
+          prompt: |
+            Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            Review only changes introduced between these commits:
+            - Base: ${{ github.event.pull_request.base.sha }}
+            - Head: ${{ github.event.pull_request.head.sha }}
+
+            Focus on concrete correctness bugs, security vulnerabilities,
+            regressions, race conditions, data loss, and missing tests for risky
+            behavior. Ignore style-only preferences and pre-existing problems.
+
+            For every finding, include severity, file path, line number or the
+            smallest relevant line range, why it is a real problem, and a
+            concise fix. If there are no actionable findings, say so clearly.
+            Keep the review concise and do not modify files.
+
+  publish:
+    needs: review
+    if: needs.review.outputs.final_message != ''
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Publish or update Codex review
+        uses: actions/github-script@v7
+        env:
+          CODEX_REVIEW: ${{ needs.review.outputs.final_message }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const marker = '<!-- codex-auto-review -->';
+            const body = `${marker}\n## Codex review\n\n${process.env.CODEX_REVIEW}`;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                per_page: 100,
+              },
+            );
+            const previous = comments.find(
+              (comment) =>
+                comment.user?.login === 'github-actions[bot]' &&
+                comment.body?.includes(marker),
+            );
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## 变更\n- PR 创建、重新打开、转为 ready 或推送新提交时自动运行 Codex Review\n- 使用 gpt-5.6-sol/high，仅读 sandbox + drop-sudo\n- Review 与评论回写拆成两个 job，降低密钥暴露风险\n- 同一 PR 更新已有 Codex 评论，避免重复刷屏\n\n## 配置要求\n合并后需在 forge-town/ordine 的 Actions secrets 中添加 `OPENAI_API_KEY`。\n\n## 验证\n- `actionlint .github/workflows/codex-review.yml`\n- YAML parse\n- `git diff --check`