### PR TITLE
feat(canvas): 增加画布状态管理核心（COD-126）

### DIFF
--- a/apps/app/src/pages/WorkspacePage/canvas/_store/canvasStore.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/canvasStore.tsx
@@ -1,0 +1,66 @@
+import { createContext, createElement, useContext, useRef, type ReactNode } from "react";
+import { useStore } from "zustand";
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { createDecisionSlice, type DecisionSlice } from "./decisionSlice";
+import { createGraphSlice, type GraphSlice } from "./graphSlice";
+import { createHistorySlice, type HistorySlice } from "./historySlice";
+import { createPanelSlice, type PanelSlice } from "./panelSlice";
+import { createProposalSlice, type ProposalSlice } from "./proposalSlice";
+import { createRunSlice, type RunSlice } from "./runSlice";
+import { createSelectionSlice, type SelectionSlice } from "./selectionSlice";
+import type { CanvasEdge, CanvasNode } from "./canvasTypes";
+
+export type CanvasStoreState = DecisionSlice &
+  GraphSlice &
+  HistorySlice &
+  PanelSlice &
+  ProposalSlice &
+  RunSlice &
+  SelectionSlice;
+
+export type CanvasStore = StoreApi<CanvasStoreState>;
+
+type CanvasStoreInitialState = {
+  edges?: CanvasEdge[];
+  nodes?: CanvasNode[];
+};
+
+export const createCanvasStore = (initialState: CanvasStoreInitialState = {}): CanvasStore =>
+  createStore<CanvasStoreState>()((set, get, store) => ({
+    ...createGraphSlice<CanvasStoreState>(initialState)(set, get, store),
+    ...createHistorySlice<CanvasStoreState>()(set, get, store),
+    ...createPanelSlice<CanvasStoreState>()(set, get, store),
+    ...createRunSlice<CanvasStoreState>()(set, get, store),
+    ...createSelectionSlice<CanvasStoreState>()(set, get, store),
+    ...createProposalSlice<CanvasStoreState>()(set, get, store),
+    ...createDecisionSlice<CanvasStoreState>()(set, get, store),
+  }));
+
+export const CanvasStoreContext = createContext<CanvasStore | null>(null);
+
+export const CanvasStoreProvider = ({
+  children,
+  edges,
+  nodes,
+}: {
+  children: ReactNode;
+  edges?: CanvasEdge[];
+  nodes?: CanvasNode[];
+}) => {
+  const storeRef = useRef<CanvasStore | null>(null);
+
+  if (!storeRef.current) {
+    storeRef.current = createCanvasStore({ edges, nodes });
+  }
+
+  return createElement(CanvasStoreContext.Provider, { value: storeRef.current }, children);
+};
+
+export const useCanvasStore = <T,>(selector: (state: CanvasStoreState) => T): T => {
+  const store = useContext(CanvasStoreContext);
+  if (!store) {
+    throw new Error("useCanvasStore must be used within CanvasStoreProvider");
+  }
+
+  return useStore(store, selector);
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/canvasTypes.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/canvasTypes.ts
@@ -1,0 +1,81 @@
+import type { Edge, Node } from "@xyflow/react";
+import type {
+  BuiltinNodeType,
+  PipelineEdgeData,
+  PipelineGraphSnapshot,
+  PipelineNodeData,
+} from "@repo/schemas";
+
+export type CanvasNode = Node<PipelineNodeData, BuiltinNodeType>;
+export type CanvasEdge = Edge<PipelineEdgeData>;
+
+type CanvasSnapshot = {
+  nodes: CanvasNode[];
+  edges: CanvasEdge[];
+};
+
+type SnapshotNode = PipelineGraphSnapshot["nodes"][number];
+type SnapshotEdge = PipelineGraphSnapshot["edges"][number];
+
+const isAncestor = (
+  ancestorId: string,
+  node: CanvasNode,
+  nodeById: ReadonlyMap<string, CanvasNode>,
+): boolean => {
+  const visited = new Set<string>();
+  const cursor = { parentId: node.parentId };
+
+  while (cursor.parentId) {
+    if (cursor.parentId === ancestorId) {
+      return true;
+    }
+    if (visited.has(cursor.parentId)) {
+      return false;
+    }
+
+    visited.add(cursor.parentId);
+    cursor.parentId = nodeById.get(cursor.parentId)?.parentId;
+  }
+
+  return false;
+};
+
+export const sortParentBeforeChildren = (nodes: readonly CanvasNode[]): CanvasNode[] => {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const originalIndex = new Map(nodes.map((node, index) => [node.id, index]));
+
+  return [...nodes].sort((a, b) => {
+    if (isAncestor(a.id, b, nodeById)) {
+      return -1;
+    }
+    if (isAncestor(b.id, a, nodeById)) {
+      return 1;
+    }
+
+    return (originalIndex.get(a.id) ?? 0) - (originalIndex.get(b.id) ?? 0);
+  });
+};
+
+export const fromPipelineSnapshot = (snapshot: PipelineGraphSnapshot): CanvasSnapshot => ({
+  nodes: sortParentBeforeChildren(
+    snapshot.nodes.map(
+      (node): CanvasNode => ({
+        ...node,
+      }),
+    ),
+  ),
+  edges: snapshot.edges.map(
+    (edge): CanvasEdge => ({
+      ...edge,
+    }),
+  ),
+});
+
+export const toPipelineSnapshot = (snapshot: CanvasSnapshot): PipelineGraphSnapshot => ({
+  nodes: sortParentBeforeChildren(snapshot.nodes).map((node) => {
+    return { ...node } as SnapshotNode;
+  }),
+  edges: snapshot.edges.map((edge) => {
+    return { ...edge } as SnapshotEdge;
+  }),
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/canvasTypes.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/canvasTypes.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { PipelineGraphSnapshot } from "@repo/schemas";
+import {
+  fromPipelineSnapshot,
+  sortParentBeforeChildren,
+  toPipelineSnapshot,
+  type CanvasNode,
+} from "./canvasTypes";
+
+const makeFileNode = (id: string, parentId?: string): CanvasNode => ({
+  id,
+  type: "file",
+  parentId,
+  extent: parentId ? "parent" : undefined,
+  position: { x: 0, y: 0 },
+  data: {
+    label: id,
+    nodeType: "file",
+    filePath: `/tmp/${id}.txt`,
+  },
+});
+
+describe("canvasTypes", () => {
+  it("round-trips a pipeline snapshot without dropping canvas fields", () => {
+    const parent = makeFileNode("parent");
+    const child = {
+      ...makeFileNode("child", "parent"),
+      measured: { width: 240, height: 120 },
+    };
+    const snapshot: PipelineGraphSnapshot = {
+      nodes: [child, parent],
+      edges: [
+        {
+          id: "edge-parent-child",
+          source: "parent",
+          target: "child",
+          sourceHandle: "out",
+          targetHandle: "in",
+          type: "semantic",
+          animated: true,
+          data: { label: "Parent to child" },
+        },
+      ],
+    };
+
+    const canvas = fromPipelineSnapshot(snapshot);
+    const nextSnapshot = toPipelineSnapshot(canvas);
+
+    expect(nextSnapshot.nodes.map((node) => node.id)).toEqual(["parent", "child"]);
+    expect(nextSnapshot.nodes.find((node) => node.id === "child")).toEqual(child);
+    expect(nextSnapshot.edges).toEqual(snapshot.edges);
+  });
+
+  it("sorts every ancestor before its children", () => {
+    const unrelated = makeFileNode("unrelated");
+    const grandchild = makeFileNode("grandchild", "child");
+    const child = makeFileNode("child", "parent");
+    const parent = makeFileNode("parent");
+
+    const sorted = sortParentBeforeChildren([unrelated, grandchild, child, parent]);
+
+    expect(sorted.map((node) => node.id)).toEqual(["unrelated", "parent", "child", "grandchild"]);
+  });
+
+  it("keeps unrelated nodes in their original order", () => {
+    const first = makeFileNode("first");
+    const second = makeFileNode("second");
+    const third = makeFileNode("third");
+
+    const sorted = sortParentBeforeChildren([first, second, third]);
+
+    expect(sorted).toEqual([first, second, third]);
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/decisionSlice.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/decisionSlice.ts
@@ -1,0 +1,57 @@
+import type { StateCreator } from "zustand";
+import type { DecisionSelectMode } from "@repo/schemas";
+
+/**
+ * 人类决策的「选中候选」状态，按决策节点 id 归档（支持多个决策节点并行等待）。
+ * 选择动作只改本地状态；落地由 DecisionBoard 经 tRPC jobs.resolveDecision 触发。
+ * 不设默认勾选（施工手册红线：禁止伪造人类决策）。
+ */
+export type DecisionSlice = {
+  decisionSelections: Record<string, string[]>;
+  toggleDecisionCandidate: (
+    decisionId: string,
+    candidateId: string,
+    mode: DecisionSelectMode,
+  ) => void;
+  clearDecisionSelection: (decisionId: string) => void;
+};
+
+const nextSelection = (
+  current: string[],
+  candidateId: string,
+  mode: DecisionSelectMode,
+): string[] => {
+  if (mode === "single") {
+    return current[0] === candidateId ? [] : [candidateId];
+  }
+
+  return current.includes(candidateId)
+    ? current.filter((id) => id !== candidateId)
+    : [...current, candidateId];
+};
+
+export const createDecisionSlice =
+  <T extends DecisionSlice>(): StateCreator<T, [], [], DecisionSlice> =>
+  (set) => ({
+    decisionSelections: {},
+    toggleDecisionCandidate: (decisionId, candidateId, mode) =>
+      set(
+        (state) =>
+          ({
+            decisionSelections: {
+              ...state.decisionSelections,
+              [decisionId]: nextSelection(
+                state.decisionSelections[decisionId] ?? [],
+                candidateId,
+                mode,
+              ),
+            },
+          }) as unknown as Partial<T>,
+      ),
+    clearDecisionSelection: (decisionId) =>
+      set((state) => {
+        const { [decisionId]: _removed, ...rest } = state.decisionSelections;
+
+        return { decisionSelections: rest } as unknown as Partial<T>;
+      }),
+  });

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/decisionSlice.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/decisionSlice.unit.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { createCanvasStore } from "./canvasStore";
+
+describe("decisionSlice", () => {
+  it("starts with no selection (no fabricated default)", () => {
+    const store = createCanvasStore();
+    expect(store.getState().decisionSelections).toEqual({});
+  });
+
+  it("single mode keeps at most one candidate and toggles off on re-pick", () => {
+    const store = createCanvasStore();
+    const { toggleDecisionCandidate } = store.getState();
+
+    toggleDecisionCandidate("d1", "a", "single");
+    expect(store.getState().decisionSelections.d1).toEqual(["a"]);
+
+    toggleDecisionCandidate("d1", "b", "single");
+    expect(store.getState().decisionSelections.d1).toEqual(["b"]);
+
+    toggleDecisionCandidate("d1", "b", "single");
+    expect(store.getState().decisionSelections.d1).toEqual([]);
+  });
+
+  it("multi mode accumulates and removes candidates", () => {
+    const store = createCanvasStore();
+    const { toggleDecisionCandidate } = store.getState();
+
+    toggleDecisionCandidate("d1", "a", "multi");
+    toggleDecisionCandidate("d1", "b", "multi");
+    expect(store.getState().decisionSelections.d1).toEqual(["a", "b"]);
+
+    toggleDecisionCandidate("d1", "a", "multi");
+    expect(store.getState().decisionSelections.d1).toEqual(["b"]);
+  });
+
+  it("clears a decision's selection without touching others", () => {
+    const store = createCanvasStore();
+    const { toggleDecisionCandidate, clearDecisionSelection } = store.getState();
+
+    toggleDecisionCandidate("d1", "a", "multi");
+    toggleDecisionCandidate("d2", "x", "multi");
+    clearDecisionSelection("d1");
+
+    expect(store.getState().decisionSelections.d1).toBeUndefined();
+    expect(store.getState().decisionSelections.d2).toEqual(["x"]);
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/derivePhase.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/derivePhase.ts
@@ -1,0 +1,39 @@
+import type { JobStatus, WorkspacePhase } from "@repo/schemas";
+import type { CanvasNode } from "./canvasTypes";
+
+type PipelineJob = {
+  status: JobStatus;
+};
+
+export type DerivePhaseInput = {
+  activeJob?: PipelineJob | null;
+  graphDirtySinceLatestJob?: boolean;
+  latestJob?: PipelineJob | null;
+  nodes: readonly CanvasNode[];
+  pendingProposal?: unknown | null;
+};
+
+const ACTIVE_JOB_STATUSES = new Set<JobStatus>(["queued", "running"]);
+
+export const derivePhase = ({
+  activeJob,
+  graphDirtySinceLatestJob = false,
+  latestJob,
+  nodes,
+  pendingProposal,
+}: DerivePhaseInput): WorkspacePhase => {
+  if (pendingProposal) {
+    return "proposal";
+  }
+  if (activeJob && ACTIVE_JOB_STATUSES.has(activeJob.status)) {
+    return "running";
+  }
+  if (nodes.length === 0) {
+    return "empty";
+  }
+  if (latestJob?.status === "done" && !graphDirtySinceLatestJob) {
+    return "done";
+  }
+
+  return "applied";
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/derivePhase.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/derivePhase.unit.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { derivePhase } from "./derivePhase";
+import type { CanvasNode } from "./canvasTypes";
+
+const node: CanvasNode = {
+  id: "node-1",
+  type: "file",
+  position: { x: 0, y: 0 },
+  data: {
+    label: "File",
+    nodeType: "file",
+    filePath: "/tmp/file.txt",
+  },
+};
+
+describe("derivePhase", () => {
+  it("returns proposal when a pending proposal exists", () => {
+    expect(
+      derivePhase({
+        activeJob: { status: "running" },
+        nodes: [],
+        pendingProposal: { actions: [] },
+      }),
+    ).toBe("proposal");
+  });
+
+  it("returns running for an active queued job", () => {
+    expect(derivePhase({ activeJob: { status: "queued" }, nodes: [node] })).toBe("running");
+  });
+
+  it("returns running for an active running job", () => {
+    expect(derivePhase({ activeJob: { status: "running" }, nodes: [node] })).toBe("running");
+  });
+
+  it("returns empty when the graph has no nodes", () => {
+    expect(derivePhase({ nodes: [], latestJob: { status: "done" } })).toBe("empty");
+  });
+
+  it("returns done when the latest job completed and the graph has not changed", () => {
+    expect(
+      derivePhase({
+        graphDirtySinceLatestJob: false,
+        latestJob: { status: "done" },
+        nodes: [node],
+      }),
+    ).toBe("done");
+  });
+
+  it("returns applied when a completed graph changed after the latest job", () => {
+    expect(
+      derivePhase({
+        graphDirtySinceLatestJob: true,
+        latestJob: { status: "done" },
+        nodes: [node],
+      }),
+    ).toBe("applied");
+  });
+
+  it("returns applied for any non-empty graph without a completed clean job", () => {
+    expect(derivePhase({ nodes: [node], latestJob: { status: "failed" } })).toBe("applied");
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/graphSlice.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/graphSlice.ts
@@ -1,0 +1,560 @@
+import {
+  addEdge,
+  applyEdgeChanges,
+  applyNodeChanges,
+  type Connection,
+  type EdgeChange,
+  type NodeChange,
+} from "@xyflow/react";
+import type { StateCreator } from "zustand";
+import type { BuiltinNodeType, CompoundNodeData, PipelineEdgeData } from "@repo/schemas";
+import { ConnectionRuleSchema } from "@repo/pipeline-engine/schemas";
+import { makeDefaultNodeData } from "../utils/makeDefaultNodeData";
+import { sortParentBeforeChildren, type CanvasEdge, type CanvasNode } from "./canvasTypes";
+
+const DUPLICATE_OFFSET = { x: 40, y: 40 } as const;
+const COMPOUND_PAD = 40;
+const COMPOUND_HEADER = 36;
+const DEFAULT_NODE_WIDTH = 240;
+const DEFAULT_NODE_HEIGHT = 120;
+
+export type AddCatalogNodeInput = {
+  data?: CanvasNode["data"];
+  id?: string;
+  label?: string;
+  position: CanvasNode["position"];
+  type: BuiltinNodeType;
+};
+
+export type ComposeNodesOptions = {
+  id?: string;
+  label?: string;
+};
+
+export type VisibleGraph = {
+  edges: CanvasEdge[];
+  nodes: CanvasNode[];
+};
+
+export type GraphSlice = {
+  drillStack: string[];
+  edges: CanvasEdge[];
+  nodes: CanvasNode[];
+  addNode: (node: CanvasNode, childNodes?: CanvasNode[]) => void;
+  addNodeFromCatalog: (input: AddCatalogNodeInput) => CanvasNode;
+  composeNodes: (nodeIds: string[], options?: ComposeNodesOptions) => CanvasNode | null;
+  deleteEdge: (edgeId: string) => void;
+  deleteNode: (nodeId: string) => void;
+  deleteSelected: (ids: string[]) => void;
+  duplicateNode: (nodeId: string, id?: string) => CanvasNode | null;
+  getVisibleGraph: () => VisibleGraph;
+  handleConnect: (connection: Connection) => void;
+  handleEdgesChange: (changes: EdgeChange<CanvasEdge>[]) => void;
+  handleNodesChange: (changes: NodeChange<CanvasNode>[]) => void;
+  popDrillStack: () => void;
+  pushDrillStack: (nodeId: string) => void;
+  setDrillStack: (stack: string[]) => void;
+  ungroupCompound: (compoundId: string) => void;
+  updateEdgeData: (edgeId: string, data: Partial<PipelineEdgeData>) => void;
+  updateNodeData: (nodeId: string, data: Partial<CanvasNode["data"]>) => void;
+};
+
+type GraphSliceInitialState = {
+  edges?: CanvasEdge[];
+  nodes?: CanvasNode[];
+};
+
+const createId = (prefix: string): string => `${prefix}-${globalThis.crypto.randomUUID()}`;
+
+const hasValidConnectionRule = (source: CanvasNode, target: CanvasNode): boolean =>
+  ConnectionRuleSchema.safeParse({
+    sourceType: source.type,
+    targetType: target.type,
+  }).success;
+
+const makeEdge = (connection: Connection): CanvasEdge => ({
+  ...connection,
+  id: `e-${connection.source}-${connection.target}-${globalThis.crypto.randomUUID()}`,
+  type: "semantic",
+  animated: false,
+  data: { label: "" },
+});
+
+const makeCompoundNode = (
+  selectedNodes: CanvasNode[],
+  childEdges: CanvasEdge[],
+  boundaryEdges: CanvasEdge[],
+  options?: ComposeNodesOptions,
+): CanvasNode => {
+  const minX = Math.min(...selectedNodes.map((node) => node.position.x));
+  const minY = Math.min(...selectedNodes.map((node) => node.position.y));
+  const maxX = Math.max(...selectedNodes.map((node) => node.position.x + DEFAULT_NODE_WIDTH));
+  const maxY = Math.max(...selectedNodes.map((node) => node.position.y + DEFAULT_NODE_HEIGHT));
+  const label = options?.label?.trim() || undefined;
+
+  return {
+    id: options?.id ?? createId("compound"),
+    type: "compound",
+    position: { x: minX - COMPOUND_PAD, y: minY - COMPOUND_PAD - COMPOUND_HEADER },
+    style: {
+      width: maxX - minX + COMPOUND_PAD * 2,
+      height: maxY - minY + COMPOUND_PAD * 2 + COMPOUND_HEADER,
+    },
+    data: {
+      ...(makeDefaultNodeData("compound", { label }) as CompoundNodeData),
+      boundaryEdges,
+      childEdges,
+      childNodeIds: selectedNodes.map((node) => node.id),
+    },
+  };
+};
+
+const isCompoundNode = (
+  node: CanvasNode | undefined,
+): node is CanvasNode & {
+  data: CompoundNodeData;
+} => node?.type === "compound";
+
+const detachCompoundChild = (node: CanvasNode): CanvasNode => ({
+  ...node,
+  extent: undefined,
+  parentId: undefined,
+});
+
+const boundaryEdgeRewireId = (
+  compoundId: string,
+  childNodeIds: readonly string[],
+  edge: CanvasEdge,
+): string => {
+  const childIdSet = new Set(childNodeIds);
+  const source = childIdSet.has(edge.source) ? compoundId : edge.source;
+  const target = childIdSet.has(edge.target) ? compoundId : edge.target;
+
+  return `e-${source}-${target}-${edge.id}`;
+};
+
+const removeEdgeReferencesFromCompound = (
+  node: CanvasNode,
+  removedEdgeIds: ReadonlySet<string>,
+): CanvasNode => {
+  if (!isCompoundNode(node) || removedEdgeIds.size === 0) {
+    return node;
+  }
+
+  return {
+    ...node,
+    data: {
+      ...node.data,
+      boundaryEdges: (node.data.boundaryEdges ?? []).filter(
+        (edge) =>
+          !removedEdgeIds.has(edge.id) &&
+          !removedEdgeIds.has(boundaryEdgeRewireId(node.id, node.data.childNodeIds, edge)),
+      ),
+      childEdges: (node.data.childEdges ?? []).filter((edge) => !removedEdgeIds.has(edge.id)),
+    },
+  };
+};
+
+const getRewiredEdgeIdsForRemovedChildren = (
+  nodes: readonly CanvasNode[],
+  removedNodeIds: ReadonlySet<string>,
+): Set<string> =>
+  new Set(
+    nodes
+      .filter(isCompoundNode)
+      .flatMap((compound) =>
+        (compound.data.boundaryEdges ?? [])
+          .filter((edge) => removedNodeIds.has(edge.source) || removedNodeIds.has(edge.target))
+          .map((edge) => boundaryEdgeRewireId(compound.id, compound.data.childNodeIds, edge)),
+      ),
+  );
+
+const removeNodeReferencesFromCompound = (
+  node: CanvasNode,
+  removedIds: ReadonlySet<string>,
+): CanvasNode => {
+  if (!isCompoundNode(node)) {
+    return node;
+  }
+
+  const withoutRemovedEdges = (edges: readonly CanvasEdge[] | undefined): CanvasEdge[] =>
+    (edges ?? []).filter((edge) => !removedIds.has(edge.source) && !removedIds.has(edge.target));
+
+  return {
+    ...node,
+    data: {
+      ...node.data,
+      boundaryEdges: withoutRemovedEdges(node.data.boundaryEdges),
+      childEdges: withoutRemovedEdges(node.data.childEdges),
+      childNodeIds: node.data.childNodeIds.filter((id) => !removedIds.has(id)),
+    },
+  };
+};
+
+export const createGraphSlice =
+  <T extends GraphSlice = GraphSlice>(
+    initialState: GraphSliceInitialState = {},
+  ): StateCreator<T, [], [], GraphSlice> =>
+  (set, get) => {
+    const castGraphState = (state: Partial<GraphSlice>) => state as unknown as Partial<T>;
+
+    return {
+      drillStack: [],
+      edges: initialState.edges ?? [],
+      nodes: sortParentBeforeChildren(initialState.nodes ?? []),
+      addNode: (node, childNodes = []) =>
+        set((state) =>
+          castGraphState({
+            nodes: sortParentBeforeChildren([...state.nodes, node, ...childNodes]),
+          }),
+        ),
+      addNodeFromCatalog: (input) => {
+        const node: CanvasNode = {
+          id: input.id ?? createId(input.type),
+          type: input.type,
+          position: input.position,
+          data: input.data ?? makeDefaultNodeData(input.type, { label: input.label }),
+        };
+        get().addNode(node);
+
+        return node;
+      },
+      composeNodes: (nodeIds, options) => {
+        const state = get();
+        const selectedIdSet = new Set(nodeIds);
+        const selectedNodes = state.nodes.filter(
+          (node) => selectedIdSet.has(node.id) && !node.parentId && node.type !== "compound",
+        );
+
+        if (selectedNodes.length < 2 || selectedNodes.length !== selectedIdSet.size) {
+          return null;
+        }
+
+        const childEdges = state.edges.filter(
+          (edge) => selectedIdSet.has(edge.source) && selectedIdSet.has(edge.target),
+        );
+        const boundaryEdges = state.edges.filter(
+          (edge) => selectedIdSet.has(edge.source) !== selectedIdSet.has(edge.target),
+        );
+        const compound = makeCompoundNode(selectedNodes, childEdges, boundaryEdges, options);
+        const rewiredEdges: CanvasEdge[] = [];
+        const untouchedEdges: CanvasEdge[] = [];
+
+        for (const edge of state.edges) {
+          const sourceSelected = selectedIdSet.has(edge.source);
+          const targetSelected = selectedIdSet.has(edge.target);
+
+          if (sourceSelected && targetSelected) {
+            continue;
+          }
+
+          if (sourceSelected !== targetSelected) {
+            const source = sourceSelected ? compound.id : edge.source;
+            const target = targetSelected ? compound.id : edge.target;
+            rewiredEdges.push({
+              ...edge,
+              id: `e-${source}-${target}-${edge.id}`,
+              source,
+              sourceHandle: sourceSelected ? null : edge.sourceHandle,
+              target,
+              targetHandle: targetSelected ? null : edge.targetHandle,
+            });
+            continue;
+          }
+
+          untouchedEdges.push(edge);
+        }
+
+        set((current) =>
+          castGraphState({
+            edges: [...untouchedEdges, ...rewiredEdges],
+            nodes: sortParentBeforeChildren([
+              ...current.nodes.map((node) =>
+                selectedIdSet.has(node.id)
+                  ? {
+                      ...node,
+                      extent: "parent" as const,
+                      parentId: compound.id,
+                      position: {
+                        x: node.position.x - compound.position.x,
+                        y: node.position.y - compound.position.y,
+                      },
+                    }
+                  : node,
+              ),
+              compound,
+            ]),
+          }),
+        );
+
+        return compound;
+      },
+      deleteEdge: (edgeId) =>
+        set((state) =>
+          castGraphState({
+            edges: state.edges.filter((edge) => edge.id !== edgeId),
+            nodes: state.nodes.map((node) =>
+              removeEdgeReferencesFromCompound(node, new Set([edgeId])),
+            ),
+          }),
+        ),
+      deleteNode: (nodeId) =>
+        set((state) => {
+          const compound = state.nodes.find((node) => node.id === nodeId);
+          const removedIds = new Set([nodeId]);
+          const removedRewiredEdgeIds = getRewiredEdgeIdsForRemovedChildren(
+            state.nodes,
+            removedIds,
+          );
+          const restoredEdges = isCompoundNode(compound)
+            ? [...(compound.data.childEdges ?? []), ...(compound.data.boundaryEdges ?? [])]
+            : [];
+
+          return castGraphState({
+            drillStack: state.drillStack.filter((id) => id !== nodeId),
+            edges: [
+              ...state.edges.filter(
+                (edge) =>
+                  edge.source !== nodeId &&
+                  edge.target !== nodeId &&
+                  !removedRewiredEdgeIds.has(edge.id),
+              ),
+              ...restoredEdges,
+            ],
+            nodes: state.nodes
+              .filter((node) => node.id !== nodeId)
+              .map((node) =>
+                node.parentId === nodeId
+                  ? {
+                      ...node,
+                      extent: undefined,
+                      parentId: undefined,
+                      position: {
+                        x: node.position.x + (compound?.position.x ?? 0),
+                        y: node.position.y + (compound?.position.y ?? 0),
+                      },
+                    }
+                  : removeNodeReferencesFromCompound(node, removedIds),
+              ),
+          });
+        }),
+      deleteSelected: (ids) => {
+        const selectedIdSet = new Set(ids);
+        if (selectedIdSet.size === 0) {
+          return;
+        }
+
+        set((state) => {
+          const removedCompounds = state.nodes
+            .filter(isCompoundNode)
+            .filter((node) => selectedIdSet.has(node.id));
+          const compoundById = new Map(removedCompounds.map((node) => [node.id, node]));
+          const removedRewiredEdgeIds = getRewiredEdgeIdsForRemovedChildren(
+            state.nodes,
+            selectedIdSet,
+          );
+          const restoredEdges = removedCompounds.flatMap((compound) => [
+            ...(compound.data.childEdges ?? []).map((edge) => ({ edge, rewiredId: null })),
+            ...(compound.data.boundaryEdges ?? []).map((edge) => ({
+              edge,
+              rewiredId: boundaryEdgeRewireId(compound.id, compound.data.childNodeIds, edge),
+            })),
+          ]);
+
+          return castGraphState({
+            drillStack: state.drillStack.filter((id) => !selectedIdSet.has(id)),
+            edges: [
+              ...state.edges.filter(
+                (edge) =>
+                  !selectedIdSet.has(edge.id) &&
+                  !selectedIdSet.has(edge.source) &&
+                  !selectedIdSet.has(edge.target) &&
+                  !removedRewiredEdgeIds.has(edge.id),
+              ),
+              ...restoredEdges
+                .filter(
+                  ({ edge, rewiredId }) =>
+                    !selectedIdSet.has(edge.id) &&
+                    !selectedIdSet.has(edge.source) &&
+                    !selectedIdSet.has(edge.target) &&
+                    (!rewiredId || !selectedIdSet.has(rewiredId)),
+                )
+                .map(({ edge }) => edge),
+            ],
+            nodes: state.nodes
+              .filter((node) => !selectedIdSet.has(node.id))
+              .map((node) =>
+                node.parentId && selectedIdSet.has(node.parentId)
+                  ? {
+                      ...node,
+                      extent: undefined,
+                      parentId: undefined,
+                      position: {
+                        x: node.position.x + (compoundById.get(node.parentId)?.position.x ?? 0),
+                        y: node.position.y + (compoundById.get(node.parentId)?.position.y ?? 0),
+                      },
+                    }
+                  : removeEdgeReferencesFromCompound(
+                      removeNodeReferencesFromCompound(node, selectedIdSet),
+                      selectedIdSet,
+                    ),
+              ),
+          });
+        });
+      },
+      duplicateNode: (nodeId, id) => {
+        const source = get().nodes.find((node) => node.id === nodeId);
+        if (!source || source.type === "compound") {
+          return null;
+        }
+
+        const node: CanvasNode = {
+          ...source,
+          id: id ?? createId(source.type),
+          position: {
+            x: source.position.x + DUPLICATE_OFFSET.x,
+            y: source.position.y + DUPLICATE_OFFSET.y,
+          },
+          selected: false,
+          data: { ...source.data },
+        };
+        get().addNode(node);
+
+        return node;
+      },
+      getVisibleGraph: () => {
+        const state = get();
+        const activeCompoundId = state.drillStack.at(-1);
+        const activeCompound = state.nodes.find((node) => node.id === activeCompoundId);
+
+        if (!isCompoundNode(activeCompound)) {
+          return { edges: state.edges, nodes: state.nodes };
+        }
+
+        const childIdSet = new Set(activeCompound.data.childNodeIds);
+
+        return {
+          edges: (activeCompound.data.childEdges ?? []).map(
+            (edge): CanvasEdge => ({
+              ...edge,
+              animated: false,
+              type: "semantic",
+            }),
+          ),
+          nodes: state.nodes.filter((node) => childIdSet.has(node.id)).map(detachCompoundChild),
+        };
+      },
+      handleConnect: (connection) => {
+        const source = get().nodes.find((node) => node.id === connection.source);
+        const target = get().nodes.find((node) => node.id === connection.target);
+
+        if (!source || !target || !hasValidConnectionRule(source, target)) {
+          return;
+        }
+
+        set((state) =>
+          castGraphState({
+            edges: addEdge(makeEdge(connection), state.edges),
+          }),
+        );
+      },
+      handleEdgesChange: (changes) =>
+        set((state) => {
+          const removedEdgeIds = new Set(
+            changes.filter((change) => change.type === "remove").map((change) => change.id),
+          );
+
+          return castGraphState({
+            edges: applyEdgeChanges(changes, state.edges),
+            nodes: state.nodes.map((node) =>
+              removeEdgeReferencesFromCompound(node, removedEdgeIds),
+            ),
+          });
+        }),
+      handleNodesChange: (changes) =>
+        set((state) =>
+          castGraphState({
+            nodes: sortParentBeforeChildren(applyNodeChanges(changes, state.nodes)),
+          }),
+        ),
+      popDrillStack: () =>
+        set((state) =>
+          castGraphState({
+            drillStack: state.drillStack.slice(0, -1),
+          }),
+        ),
+      pushDrillStack: (nodeId) =>
+        set((state) =>
+          castGraphState({
+            drillStack: [...state.drillStack, nodeId],
+          }),
+        ),
+      setDrillStack: (stack) => set(castGraphState({ drillStack: [...stack] })),
+      ungroupCompound: (compoundId) => {
+        const state = get();
+        const compound = state.nodes.find((node) => node.id === compoundId);
+
+        if (!isCompoundNode(compound)) {
+          return;
+        }
+
+        const childIdSet = new Set(compound.data.childNodeIds);
+        const childEdges = compound.data.childEdges ?? [];
+        const boundaryEdges = compound.data.boundaryEdges ?? [];
+
+        set((current) =>
+          castGraphState({
+            drillStack: current.drillStack.filter((id) => id !== compoundId),
+            edges: [
+              ...current.edges.filter(
+                (edge) => edge.source !== compoundId && edge.target !== compoundId,
+              ),
+              ...childEdges,
+              ...boundaryEdges,
+            ],
+            nodes: current.nodes
+              .filter((node) => node.id !== compoundId)
+              .map((node) =>
+                childIdSet.has(node.id)
+                  ? {
+                      ...node,
+                      extent: undefined,
+                      parentId: undefined,
+                      position: {
+                        x: node.position.x + compound.position.x,
+                        y: node.position.y + compound.position.y,
+                      },
+                    }
+                  : node,
+              ),
+          }),
+        );
+      },
+      updateEdgeData: (edgeId, data) =>
+        set((state) =>
+          castGraphState({
+            edges: state.edges.map((edge) =>
+              edge.id === edgeId
+                ? {
+                    ...edge,
+                    data: { label: "", ...edge.data, ...data },
+                  }
+                : edge,
+            ),
+          }),
+        ),
+      updateNodeData: (nodeId, data) =>
+        set((state) =>
+          castGraphState({
+            nodes: state.nodes.map((node) =>
+              node.id === nodeId
+                ? ({
+                    ...node,
+                    data: { ...node.data, ...data } as CanvasNode["data"],
+                  } as CanvasNode)
+                : node,
+            ),
+          }),
+        ),
+    };
+  };

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/graphSlice.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/graphSlice.unit.test.ts
@@ -1,0 +1,349 @@
+import { createStore } from "zustand/vanilla";
+import { describe, expect, it } from "vitest";
+import type { CompoundNodeData } from "@repo/schemas";
+import { createGraphSlice, type GraphSlice } from "./graphSlice";
+import type { CanvasEdge, CanvasNode } from "./canvasTypes";
+
+const makeFileNode = (id: string, x = 0, y = 0): CanvasNode => ({
+  id,
+  type: "file",
+  position: { x, y },
+  data: {
+    label: id,
+    nodeType: "file",
+    filePath: `/tmp/${id}.txt`,
+  },
+});
+
+const makeOperationNode = (id: string, x = 0, y = 0): CanvasNode => ({
+  id,
+  type: "operation",
+  position: { x, y },
+  data: {
+    label: id,
+    nodeType: "operation",
+    operationId: id,
+    operationName: id,
+    status: "idle",
+  },
+});
+
+const makeOutputNode = (id: string, x = 0, y = 0): CanvasNode => ({
+  id,
+  type: "output-local-path",
+  position: { x, y },
+  data: {
+    label: id,
+    nodeType: "output-local-path",
+    localPath: `/tmp/${id}`,
+  },
+});
+
+const makeEdge = (id: string, source: string, target: string): CanvasEdge => ({
+  id,
+  source,
+  target,
+  type: "semantic",
+  animated: true,
+  data: { label: id },
+});
+
+const createGraphStore = (nodes: CanvasNode[] = [], edges: CanvasEdge[] = []) =>
+  createStore<GraphSlice>()(createGraphSlice({ edges, nodes }));
+
+describe("graphSlice", () => {
+  it("adds valid connections and rejects invalid node type pairs", () => {
+    const store = createGraphStore([
+      makeFileNode("file"),
+      makeOperationNode("operation"),
+      makeOutputNode("output"),
+    ]);
+
+    store.getState().handleConnect({
+      source: "file",
+      sourceHandle: null,
+      target: "operation",
+      targetHandle: null,
+    });
+    store.getState().handleConnect({
+      source: "output",
+      sourceHandle: null,
+      target: "operation",
+      targetHandle: null,
+    });
+
+    expect(store.getState().edges).toHaveLength(1);
+    expect(store.getState().edges[0]).toMatchObject({
+      source: "file",
+      target: "operation",
+      type: "semantic",
+      animated: false,
+    });
+  });
+
+  it("creates catalog nodes, duplicates them, and deletes connected edges", () => {
+    const store = createGraphStore(
+      [makeFileNode("file"), makeOperationNode("operation")],
+      [makeEdge("edge-file-operation", "file", "operation")],
+    );
+
+    const catalogNode = store.getState().addNodeFromCatalog({
+      id: "folder",
+      position: { x: 10, y: 20 },
+      type: "folder",
+    });
+    const duplicate = store.getState().duplicateNode("folder", "folder-copy");
+    store.getState().deleteNode("file");
+
+    expect(catalogNode.data).toMatchObject({ label: "Folder", nodeType: "folder" });
+    expect(duplicate?.position).toEqual({ x: 50, y: 60 });
+    expect(store.getState().edges).toEqual([]);
+    expect(store.getState().nodes.map((node) => node.id)).toEqual([
+      "operation",
+      "folder",
+      "folder-copy",
+    ]);
+  });
+
+  it("composes selected nodes into a compound node and rewires boundary edges", () => {
+    const store = createGraphStore(
+      [
+        makeFileNode("outside-in", -240, 0),
+        makeFileNode("node-a", 0, 0),
+        makeFileNode("node-b", 260, 0),
+        makeFileNode("outside-out", 560, 0),
+      ],
+      [
+        makeEdge("edge-in", "outside-in", "node-a"),
+        makeEdge("edge-internal", "node-a", "node-b"),
+        makeEdge("edge-out", "node-b", "outside-out"),
+      ],
+    );
+
+    const compound = store
+      .getState()
+      .composeNodes(["node-a", "node-b"], { id: "compound-1", label: "Review pair" });
+    const state = store.getState();
+    const compoundData = compound?.data as CompoundNodeData | undefined;
+
+    expect(compoundData?.label).toBe("Review pair");
+    expect(compoundData?.childNodeIds).toEqual(["node-a", "node-b"]);
+    expect(compoundData?.childEdges).toEqual([
+      expect.objectContaining({ id: "edge-internal", source: "node-a", target: "node-b" }),
+    ]);
+    expect(compoundData?.boundaryEdges).toEqual([
+      expect.objectContaining({ id: "edge-in", source: "outside-in", target: "node-a" }),
+      expect.objectContaining({ id: "edge-out", source: "node-b", target: "outside-out" }),
+    ]);
+    expect(state.nodes.map((node) => node.id)).toEqual(
+      expect.arrayContaining(["outside-in", "outside-out", "compound-1", "node-a", "node-b"]),
+    );
+    expect(state.nodes.findIndex((node) => node.id === "compound-1")).toBeLessThan(
+      state.nodes.findIndex((node) => node.id === "node-a"),
+    );
+    expect(state.nodes.find((node) => node.id === "node-a")?.parentId).toBe("compound-1");
+    expect(state.edges).toEqual([
+      expect.objectContaining({ id: "e-outside-in-compound-1-edge-in" }),
+      expect.objectContaining({ id: "e-compound-1-outside-out-edge-out" }),
+    ]);
+  });
+
+  it("returns compound children and child edges for the active drill stack", () => {
+    const store = createGraphStore(
+      [makeFileNode("node-a", 0, 0), makeFileNode("node-b", 260, 0)],
+      [makeEdge("edge-internal", "node-a", "node-b")],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    store.getState().pushDrillStack("compound-1");
+
+    const visible = store.getState().getVisibleGraph();
+
+    expect(visible.nodes.map((node) => [node.id, node.parentId])).toEqual([
+      ["node-a", undefined],
+      ["node-b", undefined],
+    ]);
+    expect(visible.edges).toEqual([
+      expect.objectContaining({
+        id: "edge-internal",
+        source: "node-a",
+        target: "node-b",
+        type: "semantic",
+        animated: false,
+      }),
+    ]);
+  });
+
+  it("ungroups a compound node and restores internal and boundary edges", () => {
+    const store = createGraphStore(
+      [
+        makeFileNode("outside-in", -240, 0),
+        makeFileNode("node-a", 0, 0),
+        makeFileNode("node-b", 260, 0),
+        makeFileNode("outside-out", 560, 0),
+      ],
+      [
+        makeEdge("edge-in", "outside-in", "node-a"),
+        makeEdge("edge-internal", "node-a", "node-b"),
+        makeEdge("edge-out", "node-b", "outside-out"),
+      ],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    store.getState().pushDrillStack("compound-1");
+    store.getState().ungroupCompound("compound-1");
+
+    expect(store.getState().drillStack).toEqual([]);
+    expect(store.getState().nodes.map((node) => node.id)).toEqual([
+      "outside-in",
+      "node-a",
+      "node-b",
+      "outside-out",
+    ]);
+    expect(store.getState().nodes.every((node) => node.parentId === undefined)).toBe(true);
+    expect(store.getState().edges).toEqual([
+      expect.objectContaining({ id: "edge-internal", source: "node-a", target: "node-b" }),
+      expect.objectContaining({ id: "edge-in", source: "outside-in", target: "node-a" }),
+      expect.objectContaining({ id: "edge-out", source: "node-b", target: "outside-out" }),
+    ]);
+  });
+
+  it("does not restore a deleted rewired boundary edge when ungrouping", () => {
+    const store = createGraphStore(
+      [makeFileNode("outside", -240, 0), makeFileNode("node-a"), makeFileNode("node-b", 260, 0)],
+      [makeEdge("edge-boundary", "outside", "node-a"), makeEdge("edge-child", "node-a", "node-b")],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    store.getState().deleteEdge("e-outside-compound-1-edge-boundary");
+    store.getState().ungroupCompound("compound-1");
+
+    expect(store.getState().edges.map((edge) => edge.id)).toEqual(["edge-child"]);
+  });
+
+  it("syncs xyflow edge removals into compound metadata", () => {
+    const store = createGraphStore(
+      [makeFileNode("outside", -240, 0), makeFileNode("node-a"), makeFileNode("node-b", 260, 0)],
+      [makeEdge("edge-boundary", "outside", "node-a"), makeEdge("edge-child", "node-a", "node-b")],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    store
+      .getState()
+      .handleEdgesChange([{ id: "e-outside-compound-1-edge-boundary", type: "remove" }]);
+    store.getState().ungroupCompound("compound-1");
+
+    expect(store.getState().edges.map((edge) => edge.id)).toEqual(["edge-child"]);
+  });
+
+  it("restores compound children and their edges when deleting the compound", () => {
+    const store = createGraphStore(
+      [makeFileNode("outside", -240, 0), makeFileNode("node-a"), makeFileNode("node-b", 260, 0)],
+      [makeEdge("edge-boundary", "outside", "node-a"), makeEdge("edge-child", "node-a", "node-b")],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    store.getState().deleteNode("compound-1");
+
+    expect(store.getState().nodes.every((node) => node.parentId === undefined)).toBe(true);
+    expect(store.getState().nodes.find((node) => node.id === "node-a")?.position).toEqual({
+      x: 0,
+      y: 0,
+    });
+    expect(store.getState().edges.map((edge) => edge.id)).toEqual(["edge-child", "edge-boundary"]);
+  });
+
+  it("restores compound children while respecting other selected deletions", () => {
+    const store = createGraphStore(
+      [makeFileNode("outside", -240, 0), makeFileNode("node-a"), makeFileNode("node-b", 260, 0)],
+      [makeEdge("edge-boundary", "outside", "node-a"), makeEdge("edge-child", "node-a", "node-b")],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    store.getState().deleteSelected(["compound-1", "node-a"]);
+
+    expect(store.getState().nodes.map((node) => node.id)).toEqual(["outside", "node-b"]);
+    expect(store.getState().nodes.find((node) => node.id === "node-b")?.parentId).toBeUndefined();
+    expect(store.getState().edges).toEqual([]);
+  });
+
+  it("does not restore a selected rewired edge when deleting its compound", () => {
+    const store = createGraphStore(
+      [makeFileNode("outside", -240, 0), makeFileNode("node-a"), makeFileNode("node-b", 260, 0)],
+      [makeEdge("edge-boundary", "outside", "node-a"), makeEdge("edge-child", "node-a", "node-b")],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    store.getState().deleteSelected(["compound-1", "e-outside-compound-1-edge-boundary"]);
+
+    expect(store.getState().edges.map((edge) => edge.id)).toEqual(["edge-child"]);
+  });
+
+  it("removes deleted child references from compound metadata", () => {
+    const store = createGraphStore(
+      [makeFileNode("outside", -240, 0), makeFileNode("node-a"), makeFileNode("node-b", 260, 0)],
+      [makeEdge("edge-boundary", "outside", "node-a"), makeEdge("edge-child", "node-a", "node-b")],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    store.getState().deleteNode("node-a");
+
+    const compound = store.getState().nodes.find((node) => node.id === "compound-1");
+    const data = compound?.data as CompoundNodeData | undefined;
+    expect(data?.childNodeIds).toEqual(["node-b"]);
+    expect(data?.childEdges).toEqual([]);
+    expect(data?.boundaryEdges).toEqual([]);
+    expect(store.getState().edges).toEqual([]);
+  });
+
+  it("removes rewired edges when compound children are deleted consecutively", () => {
+    const store = createGraphStore(
+      [
+        makeFileNode("outside", -240, 0),
+        makeFileNode("node-a"),
+        makeFileNode("node-b", 260, 0),
+        makeFileNode("node-c", 520, 0),
+      ],
+      [makeEdge("edge-a", "outside", "node-a"), makeEdge("edge-b", "outside", "node-b")],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b", "node-c"], { id: "compound-1" });
+    store.getState().deleteNode("node-a");
+    store.getState().deleteNode("node-b");
+
+    expect(store.getState().edges).toEqual([]);
+  });
+
+  it("does not duplicate compound nodes or recompose existing children", () => {
+    const store = createGraphStore(
+      [makeFileNode("node-a"), makeFileNode("node-b", 260, 0), makeFileNode("node-c", 520, 0)],
+      [],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+
+    expect(store.getState().duplicateNode("compound-1", "compound-copy")).toBeNull();
+    expect(store.getState().composeNodes(["node-a", "node-c"], { id: "compound-2" })).toBeNull();
+  });
+
+  it("rejects a mixed compose selection containing an existing compound child", () => {
+    const store = createGraphStore(
+      [
+        makeFileNode("node-a"),
+        makeFileNode("node-b", 260, 0),
+        makeFileNode("node-c", 520, 0),
+        makeFileNode("node-d", 780, 0),
+      ],
+      [],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    expect(
+      store.getState().composeNodes(["node-a", "node-c", "node-d"], { id: "compound-2" }),
+    ).toBeNull();
+    expect(store.getState().nodes.find((node) => node.id === "node-a")?.parentId).toBe(
+      "compound-1",
+    );
+    expect(store.getState().nodes.some((node) => node.id === "compound-2")).toBe(false);
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/historySlice.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/historySlice.ts
@@ -1,0 +1,121 @@
+import type { StateCreator } from "zustand";
+import { sortParentBeforeChildren, type CanvasEdge, type CanvasNode } from "./canvasTypes";
+
+type GraphSnapshot = {
+  edges: CanvasEdge[];
+  nodes: CanvasNode[];
+};
+
+type HistoryGraphState = {
+  edges: CanvasEdge[];
+  nodes: CanvasNode[];
+};
+
+export type HistorySlice = {
+  canRedo: boolean;
+  canUndo: boolean;
+  historyFuture: GraphSnapshot[];
+  historyPast: GraphSnapshot[];
+  clearHistory: () => void;
+  recordHistory: (previous: GraphSnapshot) => void;
+  redo: () => void;
+  undo: () => void;
+};
+
+const MAX_HISTORY = 100;
+
+const cloneSnapshot = (snapshot: GraphSnapshot): GraphSnapshot => ({
+  edges: snapshot.edges.map((edge) => ({
+    ...edge,
+    data: edge.data ? { ...edge.data } : edge.data,
+  })),
+  nodes: sortParentBeforeChildren(
+    snapshot.nodes.map((node) => ({ ...node, data: { ...node.data } })),
+  ),
+});
+
+const hasGraphChanged = (a: GraphSnapshot, b: GraphSnapshot): boolean =>
+  JSON.stringify(a) !== JSON.stringify(b);
+
+export const createHistorySlice =
+  <T extends HistoryGraphState & HistorySlice>(): StateCreator<T, [], [], HistorySlice> =>
+  (set, get) => {
+    const castHistoryState = (state: Partial<HistorySlice & HistoryGraphState>) =>
+      state as unknown as Partial<T>;
+
+    return {
+      canRedo: false,
+      canUndo: false,
+      historyFuture: [],
+      historyPast: [],
+      clearHistory: () =>
+        set(
+          castHistoryState({
+            canRedo: false,
+            canUndo: false,
+            historyFuture: [],
+            historyPast: [],
+          }),
+        ),
+      recordHistory: (previous) => {
+        const current = { edges: get().edges, nodes: get().nodes };
+
+        if (!hasGraphChanged(previous, current)) {
+          return;
+        }
+
+        set((state) => {
+          const historyPast = [...state.historyPast, cloneSnapshot(previous)].slice(-MAX_HISTORY);
+
+          return castHistoryState({
+            canRedo: false,
+            canUndo: historyPast.length > 0,
+            historyFuture: [],
+            historyPast,
+          });
+        });
+      },
+      redo: () =>
+        set((state) => {
+          const next = state.historyFuture[0];
+          if (!next) {
+            return castHistoryState({});
+          }
+
+          const historyFuture = state.historyFuture.slice(1);
+          const historyPast = [
+            ...state.historyPast,
+            cloneSnapshot({ edges: state.edges, nodes: state.nodes }),
+          ].slice(-MAX_HISTORY);
+
+          return castHistoryState({
+            ...cloneSnapshot(next),
+            canRedo: historyFuture.length > 0,
+            canUndo: historyPast.length > 0,
+            historyFuture,
+            historyPast,
+          });
+        }),
+      undo: () =>
+        set((state) => {
+          const previous = state.historyPast.at(-1);
+          if (!previous) {
+            return castHistoryState({});
+          }
+
+          const historyPast = state.historyPast.slice(0, -1);
+          const historyFuture = [
+            cloneSnapshot({ edges: state.edges, nodes: state.nodes }),
+            ...state.historyFuture,
+          ];
+
+          return castHistoryState({
+            ...cloneSnapshot(previous),
+            canRedo: historyFuture.length > 0,
+            canUndo: historyPast.length > 0,
+            historyFuture,
+            historyPast,
+          });
+        }),
+    };
+  };

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/historySlice.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/historySlice.unit.test.ts
@@ -1,0 +1,62 @@
+import { createStore } from "zustand/vanilla";
+import { describe, expect, it } from "vitest";
+import { createHistorySlice, type HistorySlice } from "./historySlice";
+import type { CanvasEdge, CanvasNode } from "./canvasTypes";
+
+type TestStoreState = HistorySlice & {
+  edges: CanvasEdge[];
+  nodes: CanvasNode[];
+};
+
+const makeNode = (id: string): CanvasNode => ({
+  data: {
+    label: id,
+    nodeType: "file",
+    filePath: `${id}.ts`,
+  },
+  id,
+  position: { x: 0, y: 0 },
+  type: "file",
+});
+
+const makeStore = () =>
+  createStore<TestStoreState>()((set, get, store) => ({
+    edges: [],
+    nodes: [makeNode("node-a")],
+    ...createHistorySlice<TestStoreState>()(set, get, store),
+  }));
+
+describe("historySlice", () => {
+  it("undoes and redoes graph snapshots", () => {
+    const store = makeStore();
+    const previous = {
+      edges: store.getState().edges,
+      nodes: store.getState().nodes,
+    };
+
+    store.setState({ nodes: [...store.getState().nodes, makeNode("node-b")] });
+    store.getState().recordHistory(previous);
+
+    expect(store.getState().canUndo).toBe(true);
+    expect(store.getState().nodes.map((node) => node.id)).toEqual(["node-a", "node-b"]);
+
+    store.getState().undo();
+    expect(store.getState().nodes.map((node) => node.id)).toEqual(["node-a"]);
+    expect(store.getState().canRedo).toBe(true);
+
+    store.getState().redo();
+    expect(store.getState().nodes.map((node) => node.id)).toEqual(["node-a", "node-b"]);
+  });
+
+  it("skips unchanged snapshots", () => {
+    const store = makeStore();
+
+    store.getState().recordHistory({
+      edges: store.getState().edges,
+      nodes: store.getState().nodes,
+    });
+
+    expect(store.getState().historyPast).toEqual([]);
+    expect(store.getState().canUndo).toBe(false);
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/panelSlice.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/panelSlice.ts
@@ -1,0 +1,73 @@
+import type { StateCreator } from "zustand";
+
+export type CanvasTool = "hand" | "select";
+
+export type PanelSlice = {
+  annotatingId: string | null;
+  askNodeId: string | null;
+  canvasTool: CanvasTool;
+  compPanelOpen: boolean;
+  composingNodeIds: string[] | null;
+  configNodeId: string | null;
+  inspectEdgeId: string | null;
+  viewingAnnId: string | null;
+  closePanels: () => void;
+  openEdgeInspector: (edgeId: string) => void;
+  openNodeConfig: (nodeId: string) => void;
+  setAnnotatingId: (id: string | null) => void;
+  setAskNodeId: (id: string | null) => void;
+  setCanvasTool: (tool: CanvasTool) => void;
+  setCompPanelOpen: (open: boolean) => void;
+  setComposingNodeIds: (ids: string[] | null) => void;
+  setConfigNodeId: (id: string | null) => void;
+  setInspectEdgeId: (id: string | null) => void;
+  setViewingAnnId: (id: string | null) => void;
+  toggleCompPanelOpen: () => void;
+};
+
+export const createPanelSlice =
+  <T extends PanelSlice>(): StateCreator<T, [], [], PanelSlice> =>
+  (set) => ({
+    annotatingId: null,
+    askNodeId: null,
+    canvasTool: "select",
+    compPanelOpen: false,
+    composingNodeIds: null,
+    configNodeId: null,
+    inspectEdgeId: null,
+    viewingAnnId: null,
+    closePanels: () =>
+      set({
+        annotatingId: null,
+        askNodeId: null,
+        composingNodeIds: null,
+        configNodeId: null,
+        inspectEdgeId: null,
+        viewingAnnId: null,
+      } as Partial<T>),
+    openEdgeInspector: (edgeId) =>
+      set({
+        configNodeId: null,
+        inspectEdgeId: edgeId,
+      } as Partial<T>),
+    openNodeConfig: (nodeId) =>
+      set({
+        configNodeId: nodeId,
+        inspectEdgeId: null,
+      } as Partial<T>),
+    setAnnotatingId: (id) => set({ annotatingId: id } as Partial<T>),
+    setAskNodeId: (id) => set({ askNodeId: id } as Partial<T>),
+    setCanvasTool: (tool) => set({ canvasTool: tool } as Partial<T>),
+    setCompPanelOpen: (open) => set({ compPanelOpen: open } as Partial<T>),
+    setComposingNodeIds: (ids) => set({ composingNodeIds: ids ? [...ids] : null } as Partial<T>),
+    setConfigNodeId: (id) => set({ configNodeId: id } as Partial<T>),
+    setInspectEdgeId: (id) => set({ inspectEdgeId: id } as Partial<T>),
+    setViewingAnnId: (id) => set({ viewingAnnId: id } as Partial<T>),
+    toggleCompPanelOpen: () =>
+      set(
+        (state) =>
+          ({
+            compPanelOpen: !state.compPanelOpen,
+          }) as Partial<T>,
+      ),
+  });

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/proposalSlice.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/proposalSlice.ts
@@ -1,0 +1,144 @@
+import type { StateCreator } from "zustand";
+import { applyPipelineActions } from "@repo/pipeline-engine/actions";
+import type { PipelineActionDiagnostic, PipelineActionProposal } from "@repo/schemas";
+import type { PanelSlice } from "./panelSlice";
+import type { SelectionSlice } from "./selectionSlice";
+import {
+  fromPipelineSnapshot,
+  toPipelineSnapshot,
+  type CanvasEdge,
+  type CanvasNode,
+} from "./canvasTypes";
+
+type ProposalGraphState = {
+  edges: CanvasEdge[];
+  nodes: CanvasNode[];
+};
+
+export type ProposalPreviewDiff = "new" | "modified" | "reuse";
+
+export type ProposalPreview = {
+  diffById: Record<string, ProposalPreviewDiff>;
+  edges: CanvasEdge[];
+  newEdgeIds: string[];
+  nodes: CanvasNode[];
+};
+
+export type ProposalSlice = {
+  pendingProposal: PipelineActionProposal | null;
+  proposalDiagnostics: PipelineActionDiagnostic[] | null;
+  proposalPreview: ProposalPreview | null;
+  applyPendingProposal: () => boolean;
+  applyProposal: (proposal: PipelineActionProposal) => boolean;
+  clearPendingProposal: () => void;
+  rejectProposal: () => void;
+  setPendingProposal: (
+    proposal: PipelineActionProposal | null,
+    diagnostics?: PipelineActionDiagnostic[] | null,
+  ) => void;
+};
+
+/**
+ * Dry-runs the proposal against the current graph so the canvas can render a
+ * ghost preview (prototype canvas.jsx preview phase: new / edited / reused
+ * badges) before the user approves. Returns null when actions cannot apply.
+ */
+const computeProposalPreview = (
+  nodes: CanvasNode[],
+  edges: CanvasEdge[],
+  proposal: PipelineActionProposal,
+): ProposalPreview | null => {
+  const result = applyPipelineActions(toPipelineSnapshot({ edges, nodes }), proposal.actions);
+
+  if (result.isErr()) {
+    return null;
+  }
+
+  const next = fromPipelineSnapshot(result.value);
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const edgeIds = new Set(edges.map((edge) => edge.id));
+  const diffById: Record<string, ProposalPreviewDiff> = {};
+
+  for (const node of next.nodes) {
+    const current = nodeById.get(node.id);
+    diffById[node.id] = current
+      ? JSON.stringify(current.data) === JSON.stringify(node.data)
+        ? "reuse"
+        : "modified"
+      : "new";
+  }
+
+  return {
+    diffById,
+    edges: next.edges,
+    newEdgeIds: next.edges.filter((edge) => !edgeIds.has(edge.id)).map((edge) => edge.id),
+    nodes: next.nodes,
+  };
+};
+
+type ProposalStoreState = PanelSlice & ProposalGraphState & ProposalSlice & SelectionSlice;
+
+const clearProposalInteractionState = {
+  configNodeId: null,
+  inspectEdgeId: null,
+  pendingProposal: null,
+  proposalDiagnostics: null,
+  proposalPreview: null,
+  selectedEdgeId: null,
+  selectedIds: [],
+  selectedNodeId: null,
+} satisfies Partial<ProposalStoreState>;
+
+export const createProposalSlice =
+  <T extends ProposalStoreState>(): StateCreator<T, [], [], ProposalSlice> =>
+  (set, get) => ({
+    pendingProposal: null,
+    proposalDiagnostics: null,
+    proposalPreview: null,
+    applyPendingProposal: () => {
+      const proposal = get().pendingProposal;
+
+      return proposal ? get().applyProposal(proposal) : false;
+    },
+    applyProposal: (proposal) => {
+      const result = applyPipelineActions(
+        toPipelineSnapshot({
+          edges: get().edges,
+          nodes: get().nodes,
+        }),
+        proposal.actions,
+      );
+
+      if (result.isErr()) {
+        set({
+          proposalDiagnostics: result.error,
+        } as unknown as Partial<T>);
+
+        return false;
+      }
+
+      const next = fromPipelineSnapshot(result.value);
+      set({
+        ...clearProposalInteractionState,
+        edges: next.edges,
+        nodes: next.nodes,
+      } as unknown as Partial<T>);
+
+      return true;
+    },
+    clearPendingProposal: () =>
+      set({
+        pendingProposal: null,
+        proposalDiagnostics: null,
+        proposalPreview: null,
+      } as unknown as Partial<T>),
+    rejectProposal: () => get().clearPendingProposal(),
+    setPendingProposal: (proposal, diagnostics = null) =>
+      set({
+        pendingProposal: proposal,
+        proposalDiagnostics: diagnostics,
+        proposalPreview: proposal
+          ? computeProposalPreview(get().nodes, get().edges, proposal)
+          : null,
+      } as unknown as Partial<T>),
+  });

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/proposalSlice.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/proposalSlice.unit.test.ts
@@ -1,0 +1,142 @@
+import { createStore } from "zustand/vanilla";
+import { describe, expect, it } from "vitest";
+import type { PipelineActionProposal } from "@repo/schemas";
+import { createGraphSlice, type GraphSlice } from "./graphSlice";
+import { createPanelSlice, type PanelSlice } from "./panelSlice";
+import { createProposalSlice, type ProposalSlice } from "./proposalSlice";
+import { createSelectionSlice, type SelectionSlice } from "./selectionSlice";
+import type { CanvasEdge, CanvasNode } from "./canvasTypes";
+
+type TestStoreState = GraphSlice & PanelSlice & ProposalSlice & SelectionSlice;
+
+const makeNode = (id: string): CanvasNode => ({
+  id,
+  type: "operation",
+  position: { x: 0, y: 0 },
+  data: {
+    label: id,
+    nodeType: "operation",
+    operationId: `op-${id}`,
+    operationName: id,
+    status: "idle",
+  },
+});
+
+const makeEdge = (id: string, source: string, target: string): CanvasEdge => ({
+  id,
+  source,
+  target,
+  data: { label: id },
+});
+
+const createTestStore = () =>
+  createStore<TestStoreState>()((set, get, store) => ({
+    ...createGraphSlice({
+      edges: [makeEdge("edge-a", "node-a", "node-b")],
+      nodes: [makeNode("node-a"), makeNode("node-b")],
+    })(set, get, store),
+    ...createPanelSlice<TestStoreState>()(set, get, store),
+    ...createSelectionSlice<TestStoreState>()(set, get, store),
+    ...createProposalSlice<TestStoreState>()(set, get, store),
+  }));
+
+const removeNodeProposal = (nodeId: string): PipelineActionProposal => ({
+  summary: `Remove ${nodeId}`,
+  actions: [{ type: "removeNode", nodeId }],
+});
+
+describe("proposalSlice", () => {
+  it("applies the pending proposal and clears interaction state", () => {
+    const store = createTestStore();
+    const proposal = removeNodeProposal("node-a");
+
+    store.getState().setPendingProposal(proposal);
+    store.getState().selectNode("node-a");
+    store.getState().openNodeConfig("node-a");
+
+    const applied = store.getState().applyPendingProposal();
+
+    expect(applied).toBe(true);
+    expect(store.getState().nodes.map((node) => node.id)).toEqual(["node-b"]);
+    expect(store.getState().edges).toEqual([]);
+    expect(store.getState().pendingProposal).toBeNull();
+    expect(store.getState().proposalDiagnostics).toBeNull();
+    expect(store.getState().selectedIds).toEqual([]);
+    expect(store.getState().configNodeId).toBeNull();
+  });
+
+  it("keeps the graph and exposes diagnostics when a proposal fails", () => {
+    const store = createTestStore();
+    const proposal = removeNodeProposal("missing-node");
+
+    store.getState().setPendingProposal(proposal);
+    const applied = store.getState().applyPendingProposal();
+
+    expect(applied).toBe(false);
+    expect(store.getState().nodes.map((node) => node.id)).toEqual(["node-a", "node-b"]);
+    expect(store.getState().edges).toHaveLength(1);
+    expect(store.getState().pendingProposal).toEqual(proposal);
+    expect(store.getState().proposalDiagnostics).toEqual([
+      expect.objectContaining({
+        actionIndex: 0,
+        code: "NODE_NOT_FOUND",
+        severity: "error",
+      }),
+    ]);
+  });
+
+  it("rejects and clears a pending proposal", () => {
+    const store = createTestStore();
+
+    store
+      .getState()
+      .setPendingProposal(removeNodeProposal("node-a"), [
+        { actionIndex: 0, code: "NODE_NOT_FOUND", message: "missing", severity: "error" },
+      ]);
+    store.getState().rejectProposal();
+
+    expect(store.getState().pendingProposal).toBeNull();
+    expect(store.getState().proposalDiagnostics).toBeNull();
+    expect(store.getState().proposalPreview).toBeNull();
+  });
+
+  it("computes a canvas preview with diff badges when a proposal arrives", () => {
+    const store = createTestStore();
+    const proposal: PipelineActionProposal = {
+      summary: "Add node-c after node-b",
+      actions: [
+        { type: "addNode", node: makeNode("node-c") },
+        { type: "addEdge", edge: makeEdge("edge-b", "node-b", "node-c") },
+      ],
+    };
+
+    store.getState().setPendingProposal(proposal);
+
+    const preview = store.getState().proposalPreview;
+    expect(preview).not.toBeNull();
+    expect(preview?.nodes.map((node) => node.id)).toEqual(["node-a", "node-b", "node-c"]);
+    expect(preview?.diffById).toEqual({ "node-a": "reuse", "node-b": "reuse", "node-c": "new" });
+    expect(preview?.newEdgeIds).toEqual(["edge-b"]);
+    expect(store.getState().nodes.map((node) => node.id)).toEqual(["node-a", "node-b"]);
+  });
+
+  it("leaves the preview null when proposal actions cannot apply", () => {
+    const store = createTestStore();
+
+    store.getState().setPendingProposal(removeNodeProposal("missing-node"));
+
+    expect(store.getState().pendingProposal).not.toBeNull();
+    expect(store.getState().proposalPreview).toBeNull();
+  });
+
+  it("clears the preview after the proposal is applied", () => {
+    const store = createTestStore();
+
+    store.getState().setPendingProposal(removeNodeProposal("node-a"));
+    expect(store.getState().proposalPreview).not.toBeNull();
+
+    store.getState().applyPendingProposal();
+
+    expect(store.getState().proposalPreview).toBeNull();
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/runSlice.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/runSlice.ts
@@ -1,0 +1,150 @@
+import type { StateCreator } from "zustand";
+import {
+  normalizeNodeRunStatus,
+  type Job,
+  type JobTrace,
+  type NodeArtifact,
+  type NodeRunStatus,
+} from "@repo/schemas";
+
+type RawNodeRunStatuses = Record<string, NodeRunStatus | string>;
+
+export type CheckpointWaitState = {
+  jobId: string;
+  nodeId: string;
+};
+
+export type RunSlice = {
+  activeJob: Job | null;
+  activeJobId: string | null;
+  checkpointWait: CheckpointWaitState | null;
+  latestJob: Job | null;
+  nodeArtifacts: Record<string, NodeArtifact>;
+  nodeLlmContent: Record<string, string>;
+  nodeRunStatuses: Record<string, NodeRunStatus>;
+  runTraces: JobTrace[];
+  runningNodeId: string | null;
+  applyJobSnapshot: (job: Job | null) => void;
+  applyNodeArtifact: (nodeId: string, artifact: NodeArtifact) => void;
+  applyNodeLlmContent: (nodeId: string, content: string) => void;
+  beginRun: (jobId: string) => void;
+  clearRunState: () => void;
+  markNodeFailed: (nodeId: string) => void;
+  markNodeRunning: (nodeId: string) => void;
+  markNodeSkipped: (nodeId: string) => void;
+  markNodeSucceeded: (nodeId: string) => void;
+  setNodeRunStatuses: (statuses: RawNodeRunStatuses) => void;
+  setRunTraces: (traces: JobTrace[]) => void;
+};
+
+const LIVE_JOB_STATUSES = new Set<Job["status"]>(["queued", "running"]);
+const ACTIVE_NODE_STATUSES = new Set<NodeRunStatus>(["queued", "running", "retrying"]);
+
+const normalizeNodeRunStatuses = (
+  statuses: RawNodeRunStatuses | null | undefined,
+): Record<string, NodeRunStatus> =>
+  Object.fromEntries(
+    Object.entries(statuses ?? {}).map(([nodeId, status]) => [
+      nodeId,
+      normalizeNodeRunStatus(status),
+    ]),
+  );
+
+const getActiveRunNodeId = (statuses: Record<string, NodeRunStatus>): string | null =>
+  Object.entries(statuses).find(([, status]) => ACTIVE_NODE_STATUSES.has(status))?.[0] ?? null;
+
+const getCheckpointWait = (
+  activeJobId: string | null,
+  statuses: Record<string, NodeRunStatus>,
+): CheckpointWaitState | null => {
+  const nodeId =
+    Object.entries(statuses).find(([, status]) => status === "waitingForUser")?.[0] ?? null;
+
+  return activeJobId && nodeId ? { jobId: activeJobId, nodeId } : null;
+};
+
+export const createRunSlice =
+  <T extends RunSlice>(): StateCreator<T, [], [], RunSlice> =>
+  (set, get) => ({
+    activeJob: null,
+    activeJobId: null,
+    checkpointWait: null,
+    latestJob: null,
+    nodeArtifacts: {},
+    nodeLlmContent: {},
+    nodeRunStatuses: {},
+    runTraces: [],
+    runningNodeId: null,
+    applyJobSnapshot: (job) => {
+      if (!job) {
+        return;
+      }
+
+      const statuses = normalizeNodeRunStatuses(job.nodeStatuses);
+      const activeJobId = LIVE_JOB_STATUSES.has(job.status) ? job.id : null;
+
+      set({
+        activeJob: activeJobId ? job : null,
+        activeJobId,
+        checkpointWait: getCheckpointWait(activeJobId, statuses),
+        latestJob: job,
+        nodeRunStatuses: statuses,
+        runningNodeId: getActiveRunNodeId(statuses),
+      } as unknown as Partial<T>);
+    },
+    beginRun: (jobId) =>
+      set({
+        activeJobId: jobId,
+        checkpointWait: null,
+        nodeArtifacts: {},
+        nodeRunStatuses: {},
+        runTraces: [],
+        runningNodeId: null,
+      } as unknown as Partial<T>),
+    applyNodeArtifact: (nodeId, artifact) =>
+      set(
+        (state) =>
+          ({
+            nodeArtifacts: { ...state.nodeArtifacts, [nodeId]: artifact },
+          }) as unknown as Partial<T>,
+      ),
+    applyNodeLlmContent: (nodeId, content) =>
+      set(
+        (state) =>
+          ({
+            nodeLlmContent: { ...state.nodeLlmContent, [nodeId]: content },
+          }) as unknown as Partial<T>,
+      ),
+    clearRunState: () =>
+      set({
+        activeJob: null,
+        activeJobId: null,
+        checkpointWait: null,
+        nodeArtifacts: {},
+        nodeLlmContent: {},
+        nodeRunStatuses: {},
+        runTraces: [],
+        runningNodeId: null,
+      } as unknown as Partial<T>),
+    markNodeFailed: (nodeId) =>
+      get().setNodeRunStatuses({ ...get().nodeRunStatuses, [nodeId]: "failed" }),
+    markNodeRunning: (nodeId) =>
+      get().setNodeRunStatuses({ ...get().nodeRunStatuses, [nodeId]: "running" }),
+    markNodeSkipped: (nodeId) =>
+      get().setNodeRunStatuses({ ...get().nodeRunStatuses, [nodeId]: "skipped" }),
+    markNodeSucceeded: (nodeId) =>
+      get().setNodeRunStatuses({ ...get().nodeRunStatuses, [nodeId]: "done" }),
+    setNodeRunStatuses: (statuses) => {
+      const nodeRunStatuses = normalizeNodeRunStatuses(statuses);
+
+      set(
+        (state) =>
+          ({
+            checkpointWait: getCheckpointWait(state.activeJobId, nodeRunStatuses),
+            nodeRunStatuses,
+            runningNodeId: getActiveRunNodeId(nodeRunStatuses),
+          }) as unknown as Partial<T>,
+      );
+    },
+    setRunTraces: (traces) => set({ runTraces: [...traces] } as unknown as Partial<T>),
+  });

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/runSlice.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/runSlice.unit.test.ts
@@ -1,0 +1,128 @@
+import { createStore } from "zustand/vanilla";
+import { describe, expect, it } from "vitest";
+import type { Job, JobTrace } from "@repo/schemas";
+import { createRunSlice, type RunSlice } from "./runSlice";
+
+const createRunStore = () => createStore<RunSlice>()(createRunSlice<RunSlice>());
+
+const makeJob = (patch: Partial<Job>): Job => ({
+  id: "job-1",
+  title: "Pipeline run",
+  type: "pipeline_run",
+  status: "running",
+  parentJobId: null,
+  pipelineId: "pipeline-1",
+  projectId: null,
+  nodeStatuses: null,
+  error: null,
+  startedAt: new Date("2026-06-11T00:00:00Z"),
+  finishedAt: null,
+  ...patch,
+});
+
+const trace: JobTrace = {
+  id: 1,
+  jobId: "job-1",
+  level: "info",
+  message: "Started",
+  createdAt: new Date("2026-06-11T00:00:00Z"),
+};
+
+describe("runSlice", () => {
+  it("applies a live job snapshot and normalizes legacy node statuses", () => {
+    const store = createRunStore();
+
+    store.getState().applyJobSnapshot(
+      makeJob({
+        nodeStatuses: {
+          input: "done",
+          operation: "running",
+        },
+      }),
+    );
+    store.getState().setNodeRunStatuses({ ...store.getState().nodeRunStatuses, input: "pass" });
+
+    expect(store.getState().activeJobId).toBe("job-1");
+    expect(store.getState().latestJob?.id).toBe("job-1");
+    expect(store.getState().nodeRunStatuses).toEqual({
+      input: "done",
+      operation: "running",
+    });
+    expect(store.getState().runningNodeId).toBe("operation");
+  });
+
+  it("keeps completed jobs as latest but clears the active job", () => {
+    const store = createRunStore();
+
+    store.getState().applyJobSnapshot(
+      makeJob({
+        finishedAt: new Date("2026-06-11T00:01:00Z"),
+        status: "done",
+      }),
+    );
+
+    expect(store.getState().activeJob).toBeNull();
+    expect(store.getState().activeJobId).toBeNull();
+    expect(store.getState().latestJob?.status).toBe("done");
+  });
+
+  it("derives checkpoint waiting state from waitingForUser node status", () => {
+    const store = createRunStore();
+
+    store.getState().applyJobSnapshot(
+      makeJob({
+        nodeStatuses: {
+          checkpoint: "waitingForUser",
+        },
+      }),
+    );
+
+    expect(store.getState().checkpointWait).toEqual({
+      jobId: "job-1",
+      nodeId: "checkpoint",
+    });
+  });
+
+  it("marks nodes through the run status helpers", () => {
+    const store = createRunStore();
+
+    store.getState().markNodeRunning("operation");
+    expect(store.getState().runningNodeId).toBe("operation");
+
+    store.getState().markNodeSucceeded("operation");
+    store.getState().markNodeFailed("output");
+    store.getState().markNodeSkipped("optional");
+
+    expect(store.getState().nodeRunStatuses).toEqual({
+      operation: "done",
+      optional: "skipped",
+      output: "failed",
+    });
+    expect(store.getState().runningNodeId).toBeNull();
+  });
+
+  it("begins a run by marking the job id and resetting stale state", () => {
+    const store = createRunStore();
+
+    store.getState().markNodeFailed("operation");
+    store.getState().setRunTraces([trace]);
+    store.getState().beginRun("job-9");
+
+    expect(store.getState().activeJobId).toBe("job-9");
+    expect(store.getState().nodeRunStatuses).toEqual({});
+    expect(store.getState().runTraces).toEqual([]);
+    expect(store.getState().checkpointWait).toBeNull();
+  });
+
+  it("stores traces, node content, and clears run state", () => {
+    const store = createRunStore();
+
+    store.getState().setRunTraces([trace]);
+    store.getState().applyNodeLlmContent("operation", "result text");
+    store.getState().clearRunState();
+
+    expect(store.getState().runTraces).toEqual([]);
+    expect(store.getState().nodeLlmContent).toEqual({});
+    expect(store.getState().nodeRunStatuses).toEqual({});
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/selectionPanelSlice.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/selectionPanelSlice.unit.test.ts
@@ -1,0 +1,149 @@
+import { createStore } from "zustand/vanilla";
+import { describe, expect, it } from "vitest";
+import { createGraphSlice, type GraphSlice } from "./graphSlice";
+import { createPanelSlice, type PanelSlice } from "./panelSlice";
+import { createSelectionSlice, type SelectionSlice } from "./selectionSlice";
+import type { CanvasEdge, CanvasNode } from "./canvasTypes";
+
+type TestStoreState = GraphSlice & PanelSlice & SelectionSlice;
+
+const makeNode = (id: string): CanvasNode => ({
+  id,
+  type: "file",
+  position: { x: 0, y: 0 },
+  data: {
+    label: `Node ${id}`,
+    nodeType: "file",
+    filePath: `/tmp/${id}.txt`,
+  },
+});
+
+const edge: CanvasEdge = {
+  id: "edge-a",
+  source: "node-a",
+  target: "node-b",
+  type: "semantic",
+  data: { label: "Edge A" },
+};
+
+const createTestStore = () =>
+  createStore<TestStoreState>()((set, get, store) => ({
+    ...createGraphSlice({ edges: [edge], nodes: [makeNode("node-a"), makeNode("node-b")] })(
+      set,
+      get,
+      store,
+    ),
+    ...createPanelSlice<TestStoreState>()(set, get, store),
+    ...createSelectionSlice<TestStoreState>()(set, get, store),
+  }));
+
+describe("selection and panel slices", () => {
+  it("selects nodes and edges with replace, add, and toggle modes", () => {
+    const store = createTestStore();
+
+    store.getState().selectNode("node-a");
+    store.getState().selectNode("node-b", "add");
+    store.getState().selectNode("node-a", "toggle");
+    store.getState().selectEdge("edge-a", "add");
+
+    expect(store.getState().selectedNodeId).toBe("node-b");
+    expect(store.getState().selectedEdgeId).toBe("edge-a");
+    expect(store.getState().selectedIds).toEqual(["node-b", "edge-a"]);
+  });
+
+  it("builds structured refs for the current selection", () => {
+    const store = createTestStore();
+
+    store.getState().setSelectedIds(["node-a", "edge-a"]);
+
+    expect(store.getState().selectedNodeId).toBe("node-a");
+    expect(store.getState().selectedEdgeId).toBe("edge-a");
+
+    expect(store.getState().getSelectedRefs()).toEqual([
+      {
+        baseId: "node-a",
+        id: "node-a",
+        kind: "file",
+        label: "Node node-a",
+        path: [],
+        type: "node",
+      },
+      {
+        baseId: "edge-a",
+        id: "edge-a",
+        kind: "semantic",
+        label: "Edge A",
+        path: [],
+        type: "edge",
+      },
+    ]);
+  });
+
+  it("prefixes refs with the drill path inside a compound", () => {
+    const store = createTestStore();
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1", label: "Review" });
+    store.getState().pushDrillStack("compound-1");
+    store.getState().setSelectedIds(["node-a"]);
+
+    expect(store.getState().getSelectedRefs()).toEqual([
+      {
+        baseId: "node-a",
+        id: "compound-1/node-a",
+        kind: "file",
+        label: "Review / Node node-a",
+        path: ["compound-1"],
+        type: "node",
+      },
+    ]);
+  });
+
+  it("keeps state identity when the selection content is unchanged", () => {
+    const store = createTestStore();
+
+    store.getState().setSelectedIds(["node-a"]);
+    const first = store.getState().selectedIds;
+    store.getState().setSelectedIds(["node-a"]);
+
+    expect(store.getState().selectedIds).toBe(first);
+  });
+
+  it("clears the selection", () => {
+    const store = createTestStore();
+
+    store.getState().setSelectedIds(["node-a", "edge-a"]);
+    store.getState().clearSelection();
+
+    expect(store.getState().selectedEdgeId).toBeNull();
+    expect(store.getState().selectedNodeId).toBeNull();
+    expect(store.getState().selectedIds).toEqual([]);
+  });
+
+  it("opens mutually exclusive config and edge inspector panels", () => {
+    const store = createTestStore();
+
+    store.getState().openNodeConfig("node-a");
+    expect(store.getState().configNodeId).toBe("node-a");
+    expect(store.getState().inspectEdgeId).toBeNull();
+
+    store.getState().openEdgeInspector("edge-a");
+    expect(store.getState().configNodeId).toBeNull();
+    expect(store.getState().inspectEdgeId).toBe("edge-a");
+  });
+
+  it("updates lightweight panel state", () => {
+    const store = createTestStore();
+
+    store.getState().setAnnotatingId("node-a");
+    store.getState().setViewingAnnId("ann-a");
+    store.getState().setComposingNodeIds(["node-a", "node-b"]);
+    store.getState().setCompPanelOpen(false);
+    store.getState().toggleCompPanelOpen();
+    store.getState().closePanels();
+
+    expect(store.getState().annotatingId).toBeNull();
+    expect(store.getState().viewingAnnId).toBeNull();
+    expect(store.getState().composingNodeIds).toBeNull();
+    expect(store.getState().compPanelOpen).toBe(true);
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/selectionSlice.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/selectionSlice.ts
@@ -1,0 +1,172 @@
+import type { StateCreator } from "zustand";
+import type { WorkspaceCanvasRef } from "@repo/schemas";
+import type { CanvasEdge, CanvasNode } from "./canvasTypes";
+
+export type SelectionMode = "add" | "replace" | "toggle";
+
+type SelectionGraphState = {
+  drillStack: string[];
+  edges: CanvasEdge[];
+  nodes: CanvasNode[];
+};
+
+export type SelectionSlice = {
+  clearSelection: () => void;
+  getSelectedRefs: () => WorkspaceCanvasRef[];
+  selectEdge: (edgeId: string | null, mode?: SelectionMode) => void;
+  selectNode: (nodeId: string | null, mode?: SelectionMode) => void;
+  selectedEdgeId: string | null;
+  selectedIds: string[];
+  selectedNodeId: string | null;
+  setSelectedIds: (ids: string[]) => void;
+};
+
+const getNextSelectedIds = (
+  currentIds: readonly string[],
+  id: string | null,
+  mode: SelectionMode,
+): string[] => {
+  if (!id) {
+    return [];
+  }
+  if (mode === "replace") {
+    return [id];
+  }
+  if (mode === "add") {
+    return currentIds.includes(id) ? [...currentIds] : [...currentIds, id];
+  }
+
+  return currentIds.includes(id)
+    ? currentIds.filter((selectedId) => selectedId !== id)
+    : [...currentIds, id];
+};
+
+const refId = (drillStack: readonly string[], baseId: string): string =>
+  drillStack.length > 0 ? [...drillStack, baseId].join("/") : baseId;
+
+const drillLabelPrefix = (drillStack: readonly string[], nodes: readonly CanvasNode[]): string => {
+  if (drillStack.length === 0) {
+    return "";
+  }
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const labels = drillStack.map((id) => nodeById.get(id)?.data.label ?? id);
+
+  return `${labels.join(" / ")} / `;
+};
+
+const toSelectedRefs = (
+  selectedIds: readonly string[],
+  nodes: readonly CanvasNode[],
+  edges: readonly CanvasEdge[],
+  drillStack: readonly string[],
+): WorkspaceCanvasRef[] => {
+  const prefix = drillLabelPrefix(drillStack, nodes);
+  const path = [...drillStack];
+  const nodeRefs = nodes
+    .filter((node) => selectedIds.includes(node.id))
+    .map(
+      (node): WorkspaceCanvasRef => ({
+        baseId: node.id,
+        id: refId(drillStack, node.id),
+        kind: node.type ?? "node",
+        label: `${prefix}${node.data.label}`,
+        path,
+        type: "node",
+      }),
+    );
+  const edgeRefs = edges
+    .filter((edge) => selectedIds.includes(edge.id))
+    .map(
+      (edge): WorkspaceCanvasRef => ({
+        baseId: edge.id,
+        id: refId(drillStack, edge.id),
+        kind: "semantic",
+        label: `${prefix}${edge.data?.label || `${edge.source} → ${edge.target}`}`,
+        path,
+        type: "edge",
+      }),
+    );
+
+  return [...nodeRefs, ...edgeRefs];
+};
+
+const getPrimarySelection = (
+  selectedIds: readonly string[],
+  nodes: readonly CanvasNode[],
+  edges: readonly CanvasEdge[],
+): Pick<SelectionSlice, "selectedEdgeId" | "selectedNodeId"> => ({
+  selectedEdgeId:
+    [...selectedIds].reverse().find((id) => edges.some((edge) => edge.id === id)) ?? null,
+  selectedNodeId:
+    [...selectedIds].reverse().find((id) => nodes.some((node) => node.id === id)) ?? null,
+});
+
+export const createSelectionSlice =
+  <T extends SelectionGraphState & SelectionSlice>(): StateCreator<T, [], [], SelectionSlice> =>
+  (set, get) => {
+    const castSelectionState = (state: Partial<SelectionSlice>) => state as unknown as Partial<T>;
+
+    return {
+      selectedEdgeId: null,
+      selectedIds: [],
+      selectedNodeId: null,
+      clearSelection: () =>
+        set(
+          castSelectionState({
+            selectedEdgeId: null,
+            selectedIds: [],
+            selectedNodeId: null,
+          }),
+        ),
+      getSelectedRefs: () => {
+        const state = get();
+        const childEdges = state.nodes.flatMap((node) =>
+          node.type === "compound"
+            ? ((node.data as { childEdges?: CanvasEdge[] }).childEdges ?? [])
+            : [],
+        );
+
+        return toSelectedRefs(
+          state.selectedIds,
+          state.nodes,
+          [...state.edges, ...childEdges],
+          state.drillStack,
+        );
+      },
+      selectEdge: (edgeId, mode = "replace") =>
+        set((state) => {
+          const selectedIds = getNextSelectedIds(state.selectedIds, edgeId, mode);
+
+          return {
+            ...getPrimarySelection(selectedIds, state.nodes, state.edges),
+            selectedIds,
+          } as unknown as Partial<T>;
+        }),
+      selectNode: (nodeId, mode = "replace") =>
+        set((state) => {
+          const selectedIds = getNextSelectedIds(state.selectedIds, nodeId, mode);
+
+          return {
+            ...getPrimarySelection(selectedIds, state.nodes, state.edges),
+            selectedIds,
+          } as unknown as Partial<T>;
+        }),
+      setSelectedIds: (ids) =>
+        set((state) => {
+          // xyflow's selection listener fires on every render with a fresh
+          // array — bail out when the content is unchanged, otherwise the
+          // store update re-renders the flow and loops forever.
+          if (
+            state.selectedIds.length === ids.length &&
+            state.selectedIds.every((id, index) => id === ids[index])
+          ) {
+            return castSelectionState({});
+          }
+
+          return castSelectionState({
+            ...getPrimarySelection(ids, state.nodes, state.edges),
+            selectedIds: [...ids],
+          });
+        }),
+    };
+  };

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/selectors.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/selectors.ts
@@ -1,0 +1,17 @@
+import type { NodeRunStatus } from "@repo/schemas";
+import type { CanvasStoreState } from "./canvasStore";
+
+export type NodeRunState = {
+  dimmed: boolean;
+  runStatus: NodeRunStatus | undefined;
+};
+
+export const selectNodeRunState =
+  (nodeId: string) =>
+  (state: CanvasStoreState): NodeRunState => {
+    const runStatus = state.nodeRunStatuses[nodeId];
+    const dimmed =
+      state.runningNodeId !== null && state.runningNodeId !== nodeId && runStatus !== "running";
+
+    return { dimmed, runStatus };
+  };

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/selectors.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/selectors.unit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { createCanvasStore } from "./canvasStore";
+import { selectNodeRunState } from "./selectors";
+
+describe("canvas selectors", () => {
+  it("returns the selected node run status", () => {
+    const store = createCanvasStore();
+    store.getState().setNodeRunStatuses({ "node-a": "done" });
+
+    expect(selectNodeRunState("node-a")(store.getState())).toEqual({
+      dimmed: false,
+      runStatus: "done",
+    });
+  });
+
+  it("dims inactive nodes while another node is running", () => {
+    const store = createCanvasStore();
+    store.getState().markNodeRunning("node-a");
+
+    expect(selectNodeRunState("node-b")(store.getState())).toEqual({
+      dimmed: true,
+      runStatus: undefined,
+    });
+  });
+
+  it("does not dim a node whose own status is running", () => {
+    const store = createCanvasStore();
+    store.getState().markNodeRunning("node-a");
+    store.getState().setNodeRunStatuses({ "node-b": "running" });
+
+    expect(selectNodeRunState("node-b")(store.getState())).toEqual({
+      dimmed: false,
+      runStatus: "running",
+    });
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/utils/makeDefaultNodeData.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/utils/makeDefaultNodeData.ts
@@ -1,0 +1,90 @@
+import type { BuiltinNodeType, PipelineNodeData } from "@repo/schemas";
+
+export const makeDefaultNodeData = (
+  type: BuiltinNodeType,
+  options?: { label?: string },
+): PipelineNodeData => {
+  switch (type) {
+    case "operation": {
+      return {
+        label: options?.label ?? "Operation",
+        nodeType: "operation",
+        operationId: "",
+        operationName: "",
+        status: "idle",
+        config: {},
+      };
+    }
+    case "file": {
+      return {
+        label: options?.label ?? "Code file",
+        nodeType: "file",
+        filePath: "",
+        language: "typescript",
+        description: "",
+      };
+    }
+    case "folder": {
+      return {
+        label: options?.label ?? "Folder",
+        nodeType: "folder",
+        folderPath: "",
+        description: "",
+      };
+    }
+    case "github-project": {
+      return {
+        label: options?.label ?? "GitHub project",
+        nodeType: "github-project",
+        owner: "",
+        repo: "",
+        branch: "main",
+        description: "",
+      };
+    }
+    case "output-project-path": {
+      return {
+        label: options?.label ?? "Project output",
+        nodeType: "output-project-path",
+        projectId: "",
+        path: "",
+        description: "",
+      };
+    }
+    case "output-local-path": {
+      return {
+        label: options?.label ?? "Local output",
+        nodeType: "output-local-path",
+        localPath: "",
+        description: "",
+      };
+    }
+    case "compound": {
+      return {
+        label: options?.label ?? "Compound node",
+        nodeType: "compound",
+        compoundKind: "custom",
+        boundaryEdges: [],
+        childNodeIds: [],
+        childEdges: [],
+        description: "",
+      };
+    }
+    case "prompt": {
+      return {
+        label: options?.label ?? "Prompt",
+        nodeType: "prompt",
+        prompt: "",
+        description: "",
+      };
+    }
+    case "decision": {
+      return {
+        label: options?.label ?? "Decision",
+        nodeType: "decision",
+        selectMode: "single",
+        description: "",
+      };
+    }
+  }
+};

--- a/packages/schemas/src/pipeline/node-data/CompoundNodeDataSchema.ts
+++ b/packages/schemas/src/pipeline/node-data/CompoundNodeDataSchema.ts
@@ -35,7 +35,7 @@ export const DelegationConfigSchema = z.object({
 export type DelegationConfig = z.infer<typeof DelegationConfigSchema>;
 
 /**
- * `compoundKind` / `childEdges` are optional until downstream consumers are
+ * `compoundKind` / `childEdges` / `boundaryEdges` are optional until downstream consumers are
  * migrated to produce the new shape. Keeping them optional avoids breaking
  * existing compound constructors and stories that still emit the legacy
  * `{ label, nodeType, childNodeIds }` shape.
@@ -44,6 +44,7 @@ export const CompoundNodeDataSchema = z.object({
   label: z.string(),
   nodeType: z.literal("compound"),
   compoundKind: CompoundKindSchema.optional(),
+  boundaryEdges: z.array(PipelineEdgeSchema).optional(),
   childNodeIds: z.array(z.string()),
   childEdges: z.array(PipelineEdgeSchema).optional(),
   description: z.string().optional(),

--- a/packages/schemas/src/pipeline/node-data/CompoundNodeDataSchema.unit.test.ts
+++ b/packages/schemas/src/pipeline/node-data/CompoundNodeDataSchema.unit.test.ts
@@ -19,10 +19,12 @@ describe("CompoundNodeDataSchema backward compatibility", () => {
       nodeType: "compound",
       compoundKind: "verify",
       childNodeIds: ["v0", "vg", "vc", "vgate", "vout"],
+      boundaryEdges: [{ id: "vin", source: "input", target: "v0", data: { label: "input" } }],
       childEdges: [{ id: "ve0", source: "v0", target: "vg", data: { label: "candidate" } }],
       verifyConfig: { maxRounds: 3, criteria: "All answers must cite the source text." },
     });
     expect(parsed.compoundKind).toBe("verify");
+    expect(parsed.boundaryEdges).toHaveLength(1);
     expect(parsed.childEdges).toHaveLength(1);
     expect(parsed.verifyConfig?.maxRounds).toBe(3);
   });


### PR DESCRIPTION
## PR 做了什么

- 新增 Workspace Canvas 的 Zustand store 与 graph、selection、proposal、run、history、panel、decision 7 个 slice
- 新增 editing → proposing → running → reviewing 阶段推导与派生 selectors
- 补齐 compound 组合、解组、删除和边界连线元数据，并扩展 CompoundNodeDataSchema
- 新增状态层与 schema 单元测试

## Review 发现什么

独立 Claude review 发现 compound 解组会恢复已删除的 boundary edge、删除 compound 会丢失子节点连线、selection 主选项不一致，以及混合 compose 和组合删除的边缘路径。

## 我怎么解决

- 删除边时同步清理 compound 的 childEdges 和 boundaryEdges 元数据
- 删除或解组 compound 时正确还原未删除的内部边、边界边和子节点绝对坐标
- 删除 child 时清理对应的顶层 rewired edge
- 统一 primary selection 推导；拒绝 compound duplicate 与跨父级混合 compose
- 为上述路径补充回归测试；最终独立复审结论为无阻塞问题

## 验证结果

- `bun run --cwd apps/app compile`：通过
- `bun run --cwd apps/app lint`：通过，仅有 develop 已存在的 func-style warning
- Canvas state tests：9 files / 52 tests passed
- Compound schema tests：1 file / 3 tests passed
- 浏览器验证：本地 `/canvas` 返回 200，并按未登录状态正常跳转 `/login`，清空后无 console error
- 根目录 `bun run quality`：17/18 tasks 通过；唯一失败是既有 `CanvasSettingsDrawer` 测试，当前 develop 工作区可独立复现（输入期望完整字符串但只收到首字符），与本 PR 文件无交集

Linear: COD-126