### PR TITLE
fix(canvas): 修复 PR #140 状态层审查问题

### DIFF
--- a/apps/app/src/pages/WorkspacePage/canvas/_store/canvasTypes.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/canvasTypes.ts
@@ -17,43 +17,64 @@ type CanvasSnapshot = {
 type SnapshotNode = PipelineGraphSnapshot["nodes"][number];
 type SnapshotEdge = PipelineGraphSnapshot["edges"][number];
 
-const isAncestor = (
-  ancestorId: string,
-  node: CanvasNode,
-  nodeById: ReadonlyMap<string, CanvasNode>,
-): boolean => {
-  const visited = new Set<string>();
-  const cursor = { parentId: node.parentId };
-
-  while (cursor.parentId) {
-    if (cursor.parentId === ancestorId) {
-      return true;
-    }
-    if (visited.has(cursor.parentId)) {
-      return false;
-    }
-
-    visited.add(cursor.parentId);
-    cursor.parentId = nodeById.get(cursor.parentId)?.parentId;
-  }
-
-  return false;
-};
-
 export const sortParentBeforeChildren = (nodes: readonly CanvasNode[]): CanvasNode[] => {
   const nodeById = new Map(nodes.map((node) => [node.id, node]));
   const originalIndex = new Map(nodes.map((node, index) => [node.id, index]));
+  const childrenByParent = new Map<string, CanvasNode[]>();
 
-  return [...nodes].sort((a, b) => {
-    if (isAncestor(a.id, b, nodeById)) {
-      return -1;
+  for (const node of nodes) {
+    if (!node.parentId || !nodeById.has(node.parentId)) {
+      continue;
     }
-    if (isAncestor(b.id, a, nodeById)) {
-      return 1;
+    const children = childrenByParent.get(node.parentId) ?? [];
+    children.push(node);
+    childrenByParent.set(node.parentId, children);
+  }
+
+  const sorted: CanvasNode[] = [];
+  const visited = new Set<string>();
+  const treeIndexById = new Map<string, number>();
+  const getTreeIndex = (node: CanvasNode, visiting = new Set<string>()): number => {
+    const cached = treeIndexById.get(node.id);
+    if (cached !== undefined) {
+      return cached;
+    }
+    if (visiting.has(node.id)) {
+      return originalIndex.get(node.id) ?? 0;
     }
 
-    return (originalIndex.get(a.id) ?? 0) - (originalIndex.get(b.id) ?? 0);
-  });
+    visiting.add(node.id);
+    const index = Math.min(
+      originalIndex.get(node.id) ?? 0,
+      ...(childrenByParent.get(node.id) ?? []).map((child) => getTreeIndex(child, visiting)),
+    );
+    visiting.delete(node.id);
+    treeIndexById.set(node.id, index);
+
+    return index;
+  };
+  const visit = (node: CanvasNode) => {
+    if (visited.has(node.id)) {
+      return;
+    }
+    visited.add(node.id);
+    sorted.push(node);
+    for (const child of childrenByParent.get(node.id) ?? []) {
+      visit(child);
+    }
+  };
+
+  const roots = nodes
+    .filter((node) => !node.parentId || !nodeById.has(node.parentId))
+    .sort((a, b) => getTreeIndex(a) - getTreeIndex(b));
+  for (const node of roots) {
+    visit(node);
+  }
+  for (const node of nodes) {
+    visit(node);
+  }
+
+  return sorted;
 };
 
 export const fromPipelineSnapshot = (snapshot: PipelineGraphSnapshot): CanvasSnapshot => ({

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/derivePhase.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/derivePhase.ts
@@ -13,7 +13,7 @@ export type DerivePhaseInput = {
   pendingProposal?: unknown | null;
 };
 
-const ACTIVE_JOB_STATUSES = new Set<JobStatus>(["queued", "running"]);
+const ACTIVE_JOB_STATUSES = new Set<JobStatus>(["paused", "queued", "running"]);
 
 export const derivePhase = ({
   activeJob,

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/derivePhase.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/derivePhase.unit.test.ts
@@ -32,6 +32,10 @@ describe("derivePhase", () => {
     expect(derivePhase({ activeJob: { status: "running" }, nodes: [node] })).toBe("running");
   });
 
+  it("returns running for an active paused job", () => {
+    expect(derivePhase({ activeJob: { status: "paused" }, nodes: [node] })).toBe("running");
+  });
+
   it("returns empty when the graph has no nodes", () => {
     expect(derivePhase({ nodes: [], latestJob: { status: "done" } })).toBe("empty");
   });

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/graphSlice.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/graphSlice.ts
@@ -64,6 +64,15 @@ type GraphSliceInitialState = {
   nodes?: CanvasNode[];
 };
 
+type GraphSnapshot = {
+  edges: CanvasEdge[];
+  nodes: CanvasNode[];
+};
+
+type OptionalGraphHistory = {
+  recordHistory?: (previous: GraphSnapshot) => void;
+};
+
 const createId = (prefix: string): string => `${prefix}-${globalThis.crypto.randomUUID()}`;
 
 const hasValidConnectionRule = (source: CanvasNode, target: CanvasNode): boolean =>
@@ -133,6 +142,36 @@ const boundaryEdgeRewireId = (
   return `e-${source}-${target}-${edge.id}`;
 };
 
+const withEdgeData = (edge: CanvasEdge, data: Partial<PipelineEdgeData>): CanvasEdge => ({
+  ...edge,
+  data: { label: "", ...edge.data, ...data },
+});
+
+const updateStoredCompoundEdge = (
+  node: CanvasNode,
+  edgeId: string,
+  data: Partial<PipelineEdgeData>,
+): CanvasNode => {
+  if (!isCompoundNode(node)) {
+    return node;
+  }
+
+  return {
+    ...node,
+    data: {
+      ...node.data,
+      boundaryEdges: (node.data.boundaryEdges ?? []).map((edge) =>
+        boundaryEdgeRewireId(node.id, node.data.childNodeIds, edge) === edgeId
+          ? withEdgeData(edge, data)
+          : edge,
+      ),
+      childEdges: (node.data.childEdges ?? []).map((edge) =>
+        edge.id === edgeId ? withEdgeData(edge, data) : edge,
+      ),
+    },
+  };
+};
+
 const removeEdgeReferencesFromCompound = (
   node: CanvasNode,
   removedEdgeIds: ReadonlySet<string>,
@@ -192,22 +231,28 @@ const removeNodeReferencesFromCompound = (
 };
 
 export const createGraphSlice =
-  <T extends GraphSlice = GraphSlice>(
+  <T extends GraphSlice & OptionalGraphHistory = GraphSlice>(
     initialState: GraphSliceInitialState = {},
   ): StateCreator<T, [], [], GraphSlice> =>
   (set, get) => {
     const castGraphState = (state: Partial<GraphSlice>) => state as unknown as Partial<T>;
+    const getGraphSnapshot = (): GraphSnapshot => ({ edges: get().edges, nodes: get().nodes });
+    const recordGraphChange = (previous: GraphSnapshot) => get().recordHistory?.(previous);
+    const dragHistory = { start: null as GraphSnapshot | null };
 
     return {
       drillStack: [],
       edges: initialState.edges ?? [],
       nodes: sortParentBeforeChildren(initialState.nodes ?? []),
-      addNode: (node, childNodes = []) =>
+      addNode: (node, childNodes = []) => {
+        const previous = getGraphSnapshot();
         set((state) =>
           castGraphState({
             nodes: sortParentBeforeChildren([...state.nodes, node, ...childNodes]),
           }),
-        ),
+        );
+        recordGraphChange(previous);
+      },
       addNodeFromCatalog: (input) => {
         const node: CanvasNode = {
           id: input.id ?? createId(input.type),
@@ -230,6 +275,7 @@ export const createGraphSlice =
           return null;
         }
 
+        const previous = getGraphSnapshot();
         const childEdges = state.edges.filter(
           (edge) => selectedIdSet.has(edge.source) && selectedIdSet.has(edge.target),
         );
@@ -286,10 +332,12 @@ export const createGraphSlice =
             ]),
           }),
         );
+        recordGraphChange(previous);
 
         return compound;
       },
-      deleteEdge: (edgeId) =>
+      deleteEdge: (edgeId) => {
+        const previous = getGraphSnapshot();
         set((state) =>
           castGraphState({
             edges: state.edges.filter((edge) => edge.id !== edgeId),
@@ -297,8 +345,11 @@ export const createGraphSlice =
               removeEdgeReferencesFromCompound(node, new Set([edgeId])),
             ),
           }),
-        ),
-      deleteNode: (nodeId) =>
+        );
+        recordGraphChange(previous);
+      },
+      deleteNode: (nodeId) => {
+        const previous = getGraphSnapshot();
         set((state) => {
           const compound = state.nodes.find((node) => node.id === nodeId);
           const removedIds = new Set([nodeId]);
@@ -337,13 +388,16 @@ export const createGraphSlice =
                   : removeNodeReferencesFromCompound(node, removedIds),
               ),
           });
-        }),
+        });
+        recordGraphChange(previous);
+      },
       deleteSelected: (ids) => {
         const selectedIdSet = new Set(ids);
         if (selectedIdSet.size === 0) {
           return;
         }
 
+        const previous = getGraphSnapshot();
         set((state) => {
           const removedCompounds = state.nodes
             .filter(isCompoundNode)
@@ -401,6 +455,7 @@ export const createGraphSlice =
               ),
           });
         });
+        recordGraphChange(previous);
       },
       duplicateNode: (nodeId, id) => {
         const source = get().nodes.find((node) => node.id === nodeId);
@@ -452,14 +507,60 @@ export const createGraphSlice =
           return;
         }
 
-        set((state) =>
-          castGraphState({
-            edges: addEdge(makeEdge(connection), state.edges),
-          }),
-        );
-      },
-      handleEdgesChange: (changes) =>
+        const previous = getGraphSnapshot();
+        const edge = makeEdge(connection);
         set((state) => {
+          const activeCompoundId = state.drillStack.at(-1);
+          const activeCompound = state.nodes.find((node) => node.id === activeCompoundId);
+          const activeChildIds = isCompoundNode(activeCompound)
+            ? new Set(activeCompound.data.childNodeIds)
+            : null;
+
+          if (
+            isCompoundNode(activeCompound) &&
+            activeChildIds?.has(connection.source) &&
+            activeChildIds.has(connection.target)
+          ) {
+            return castGraphState({
+              nodes: state.nodes.map((node) =>
+                node.id === activeCompound.id
+                  ? {
+                      ...node,
+                      data: {
+                        ...activeCompound.data,
+                        childEdges: addEdge(edge, activeCompound.data.childEdges ?? []),
+                      },
+                    }
+                  : node,
+              ),
+            });
+          }
+
+          return castGraphState({ edges: addEdge(edge, state.edges) });
+        });
+        recordGraphChange(previous);
+      },
+      handleEdgesChange: (changes) => {
+        const previous = getGraphSnapshot();
+        set((state) => {
+          const activeCompoundId = state.drillStack.at(-1);
+          const activeCompound = state.nodes.find((node) => node.id === activeCompoundId);
+          if (isCompoundNode(activeCompound)) {
+            return castGraphState({
+              nodes: state.nodes.map((node) =>
+                node.id === activeCompound.id
+                  ? {
+                      ...node,
+                      data: {
+                        ...activeCompound.data,
+                        childEdges: applyEdgeChanges(changes, activeCompound.data.childEdges ?? []),
+                      },
+                    }
+                  : node,
+              ),
+            });
+          }
+
           const removedEdgeIds = new Set(
             changes.filter((change) => change.type === "remove").map((change) => change.id),
           );
@@ -470,13 +571,53 @@ export const createGraphSlice =
               removeEdgeReferencesFromCompound(node, removedEdgeIds),
             ),
           });
-        }),
-      handleNodesChange: (changes) =>
+        });
+        if (changes.some((change) => change.type !== "select")) {
+          recordGraphChange(previous);
+        }
+      },
+      handleNodesChange: (changes) => {
+        const removedNodeIds = changes
+          .filter((change) => change.type === "remove")
+          .map((change) => change.id);
+        if (removedNodeIds.length > 0) {
+          get().deleteSelected(removedNodeIds);
+          const remainingChanges = changes.filter((change) => change.type !== "remove");
+          if (remainingChanges.length > 0) {
+            get().handleNodesChange(remainingChanges);
+          }
+
+          return;
+        }
+
+        const continuesDrag = changes.some(
+          (change) => change.type === "position" && change.dragging === true,
+        );
+        const endsDrag = changes.some(
+          (change) => change.type === "position" && change.dragging === false,
+        );
+        const shouldRecord = changes.some(
+          (change) => change.type !== "select" && change.type !== "dimensions",
+        );
+        const previous = continuesDrag
+          ? null
+          : (endsDrag && dragHistory.start) || (shouldRecord ? getGraphSnapshot() : null);
+        if (continuesDrag) {
+          dragHistory.start ??= getGraphSnapshot();
+        }
+        if (endsDrag) {
+          dragHistory.start = null;
+        }
+
         set((state) =>
           castGraphState({
             nodes: sortParentBeforeChildren(applyNodeChanges(changes, state.nodes)),
           }),
-        ),
+        );
+        if (previous) {
+          recordGraphChange(previous);
+        }
+      },
       popDrillStack: () =>
         set((state) =>
           castGraphState({
@@ -498,6 +639,7 @@ export const createGraphSlice =
           return;
         }
 
+        const previous = getGraphSnapshot();
         const childIdSet = new Set(compound.data.childNodeIds);
         const childEdges = compound.data.childEdges ?? [];
         const boundaryEdges = compound.data.boundaryEdges ?? [];
@@ -529,21 +671,22 @@ export const createGraphSlice =
               ),
           }),
         );
+        recordGraphChange(previous);
       },
-      updateEdgeData: (edgeId, data) =>
+      updateEdgeData: (edgeId, data) => {
+        const previous = getGraphSnapshot();
         set((state) =>
           castGraphState({
             edges: state.edges.map((edge) =>
-              edge.id === edgeId
-                ? {
-                    ...edge,
-                    data: { label: "", ...edge.data, ...data },
-                  }
-                : edge,
+              edge.id === edgeId ? withEdgeData(edge, data) : edge,
             ),
+            nodes: state.nodes.map((node) => updateStoredCompoundEdge(node, edgeId, data)),
           }),
-        ),
-      updateNodeData: (nodeId, data) =>
+        );
+        recordGraphChange(previous);
+      },
+      updateNodeData: (nodeId, data) => {
+        const previous = getGraphSnapshot();
         set((state) =>
           castGraphState({
             nodes: state.nodes.map((node) =>
@@ -555,6 +698,8 @@ export const createGraphSlice =
                 : node,
             ),
           }),
-        ),
+        );
+        recordGraphChange(previous);
+      },
     };
   };

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/graphSlice.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/graphSlice.unit.test.ts
@@ -174,6 +174,24 @@ describe("graphSlice", () => {
     ]);
   });
 
+  it("stores new connections in the active compound while drilled in", () => {
+    const store = createGraphStore([makeFileNode("node-a"), makeOperationNode("node-b", 260, 0)]);
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    store.getState().pushDrillStack("compound-1");
+    store.getState().handleConnect({
+      source: "node-a",
+      sourceHandle: null,
+      target: "node-b",
+      targetHandle: null,
+    });
+
+    expect(store.getState().edges).toEqual([]);
+    expect(store.getState().getVisibleGraph().edges).toEqual([
+      expect.objectContaining({ source: "node-a", target: "node-b" }),
+    ]);
+  });
+
   it("ungroups a compound node and restores internal and boundary edges", () => {
     const store = createGraphStore(
       [
@@ -251,6 +269,36 @@ describe("graphSlice", () => {
       y: 0,
     });
     expect(store.getState().edges.map((edge) => edge.id)).toEqual(["edge-child", "edge-boundary"]);
+  });
+
+  it("routes xyflow compound removals through compound cleanup", () => {
+    const store = createGraphStore(
+      [makeFileNode("outside", -240, 0), makeFileNode("node-a"), makeFileNode("node-b", 260, 0)],
+      [makeEdge("edge-boundary", "outside", "node-a"), makeEdge("edge-child", "node-a", "node-b")],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    store.getState().handleNodesChange([{ id: "compound-1", type: "remove" }]);
+
+    expect(store.getState().nodes.every((node) => node.parentId === undefined)).toBe(true);
+    expect(store.getState().edges.map((edge) => edge.id)).toEqual(["edge-child", "edge-boundary"]);
+  });
+
+  it("syncs rewired boundary edge edits back to the original edge", () => {
+    const store = createGraphStore(
+      [makeFileNode("outside", -240, 0), makeFileNode("node-a"), makeFileNode("node-b", 260, 0)],
+      [makeEdge("edge-boundary", "outside", "node-a")],
+    );
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    store
+      .getState()
+      .updateEdgeData("e-outside-compound-1-edge-boundary", { label: "Updated boundary" });
+    store.getState().ungroupCompound("compound-1");
+
+    expect(store.getState().edges).toEqual([
+      expect.objectContaining({ id: "edge-boundary", data: { label: "Updated boundary" } }),
+    ]);
   });
 
   it("restores compound children while respecting other selected deletions", () => {

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/historySlice.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/historySlice.unit.test.ts
@@ -1,5 +1,6 @@
 import { createStore } from "zustand/vanilla";
 import { describe, expect, it } from "vitest";
+import { createGraphSlice, type GraphSlice } from "./graphSlice";
 import { createHistorySlice, type HistorySlice } from "./historySlice";
 import type { CanvasEdge, CanvasNode } from "./canvasTypes";
 
@@ -24,6 +25,14 @@ const makeStore = () =>
     edges: [],
     nodes: [makeNode("node-a")],
     ...createHistorySlice<TestStoreState>()(set, get, store),
+  }));
+
+type GraphHistoryStoreState = GraphSlice & HistorySlice;
+
+const makeGraphHistoryStore = () =>
+  createStore<GraphHistoryStoreState>()((set, get, store) => ({
+    ...createGraphSlice<GraphHistoryStoreState>({ nodes: [makeNode("node-a")] })(set, get, store),
+    ...createHistorySlice<GraphHistoryStoreState>()(set, get, store),
   }));
 
 describe("historySlice", () => {
@@ -58,5 +67,39 @@ describe("historySlice", () => {
 
     expect(store.getState().historyPast).toEqual([]);
     expect(store.getState().canUndo).toBe(false);
+  });
+
+  it("records graph actions so they can be undone", () => {
+    const store = makeGraphHistoryStore();
+
+    store.getState().addNode(makeNode("node-b"));
+    expect(store.getState().canUndo).toBe(true);
+
+    store.getState().undo();
+    expect(store.getState().nodes.map((node) => node.id)).toEqual(["node-a"]);
+  });
+
+  it("records a drag interaction as one history entry", () => {
+    const store = makeGraphHistoryStore();
+
+    store
+      .getState()
+      .handleNodesChange([
+        { id: "node-a", type: "position", position: { x: 10, y: 0 }, dragging: true },
+      ]);
+    store
+      .getState()
+      .handleNodesChange([
+        { id: "node-a", type: "position", position: { x: 20, y: 0 }, dragging: true },
+      ]);
+    store
+      .getState()
+      .handleNodesChange([
+        { id: "node-a", type: "position", position: { x: 30, y: 0 }, dragging: false },
+      ]);
+
+    expect(store.getState().historyPast).toHaveLength(1);
+    store.getState().undo();
+    expect(store.getState().nodes[0]?.position).toEqual({ x: 0, y: 0 });
   });
 });

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/runSlice.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/runSlice.ts
@@ -37,7 +37,7 @@ export type RunSlice = {
   setRunTraces: (traces: JobTrace[]) => void;
 };
 
-const LIVE_JOB_STATUSES = new Set<Job["status"]>(["queued", "running"]);
+const LIVE_JOB_STATUSES = new Set<Job["status"]>(["paused", "queued", "running"]);
 const ACTIVE_NODE_STATUSES = new Set<NodeRunStatus>(["queued", "running", "retrying"]);
 
 const normalizeNodeRunStatuses = (
@@ -97,6 +97,7 @@ export const createRunSlice =
         activeJobId: jobId,
         checkpointWait: null,
         nodeArtifacts: {},
+        nodeLlmContent: {},
         nodeRunStatuses: {},
         runTraces: [],
         runningNodeId: null,

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/runSlice.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/runSlice.unit.test.ts
@@ -66,6 +66,15 @@ describe("runSlice", () => {
     expect(store.getState().latestJob?.status).toBe("done");
   });
 
+  it("keeps paused jobs active so they can be resumed", () => {
+    const store = createRunStore();
+
+    store.getState().applyJobSnapshot(makeJob({ status: "paused" }));
+
+    expect(store.getState().activeJobId).toBe("job-1");
+    expect(store.getState().activeJob?.status).toBe("paused");
+  });
+
   it("derives checkpoint waiting state from waitingForUser node status", () => {
     const store = createRunStore();
 
@@ -105,11 +114,13 @@ describe("runSlice", () => {
     const store = createRunStore();
 
     store.getState().markNodeFailed("operation");
+    store.getState().applyNodeLlmContent("operation", "stale result");
     store.getState().setRunTraces([trace]);
     store.getState().beginRun("job-9");
 
     expect(store.getState().activeJobId).toBe("job-9");
     expect(store.getState().nodeRunStatuses).toEqual({});
+    expect(store.getState().nodeLlmContent).toEqual({});
     expect(store.getState().runTraces).toEqual([]);
     expect(store.getState().checkpointWait).toBeNull();
   });

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/selectionPanelSlice.unit.test.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/selectionPanelSlice.unit.test.ts
@@ -98,6 +98,19 @@ describe("selection and panel slices", () => {
     ]);
   });
 
+  it("uses an internal edge as the primary selection while drilled in", () => {
+    const store = createTestStore();
+
+    store.getState().composeNodes(["node-a", "node-b"], { id: "compound-1" });
+    store.getState().pushDrillStack("compound-1");
+    store.getState().setSelectedIds(["edge-a"]);
+
+    expect(store.getState().selectedEdgeId).toBe("edge-a");
+    expect(store.getState().getSelectedRefs()).toEqual([
+      expect.objectContaining({ baseId: "edge-a", id: "compound-1/edge-a", type: "edge" }),
+    ]);
+  });
+
   it("keeps state identity when the selection content is unchanged", () => {
     const store = createTestStore();
 

--- a/apps/app/src/pages/WorkspacePage/canvas/_store/selectionSlice.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/_store/selectionSlice.ts
@@ -101,6 +101,16 @@ const getPrimarySelection = (
     [...selectedIds].reverse().find((id) => nodes.some((node) => node.id === id)) ?? null,
 });
 
+const getSelectableEdges = (
+  nodes: readonly CanvasNode[],
+  edges: readonly CanvasEdge[],
+): CanvasEdge[] => [
+  ...edges,
+  ...nodes.flatMap((node) =>
+    node.type === "compound" ? ((node.data as { childEdges?: CanvasEdge[] }).childEdges ?? []) : [],
+  ),
+];
+
 export const createSelectionSlice =
   <T extends SelectionGraphState & SelectionSlice>(): StateCreator<T, [], [], SelectionSlice> =>
   (set, get) => {
@@ -120,16 +130,11 @@ export const createSelectionSlice =
         ),
       getSelectedRefs: () => {
         const state = get();
-        const childEdges = state.nodes.flatMap((node) =>
-          node.type === "compound"
-            ? ((node.data as { childEdges?: CanvasEdge[] }).childEdges ?? [])
-            : [],
-        );
 
         return toSelectedRefs(
           state.selectedIds,
           state.nodes,
-          [...state.edges, ...childEdges],
+          getSelectableEdges(state.nodes, state.edges),
           state.drillStack,
         );
       },
@@ -138,7 +143,11 @@ export const createSelectionSlice =
           const selectedIds = getNextSelectedIds(state.selectedIds, edgeId, mode);
 
           return {
-            ...getPrimarySelection(selectedIds, state.nodes, state.edges),
+            ...getPrimarySelection(
+              selectedIds,
+              state.nodes,
+              getSelectableEdges(state.nodes, state.edges),
+            ),
             selectedIds,
           } as unknown as Partial<T>;
         }),
@@ -147,7 +156,11 @@ export const createSelectionSlice =
           const selectedIds = getNextSelectedIds(state.selectedIds, nodeId, mode);
 
           return {
-            ...getPrimarySelection(selectedIds, state.nodes, state.edges),
+            ...getPrimarySelection(
+              selectedIds,
+              state.nodes,
+              getSelectableEdges(state.nodes, state.edges),
+            ),
             selectedIds,
           } as unknown as Partial<T>;
         }),
@@ -164,7 +177,7 @@ export const createSelectionSlice =
           }
 
           return castSelectionState({
-            ...getPrimarySelection(ids, state.nodes, state.edges),
+            ...getPrimarySelection(ids, state.nodes, getSelectableEdges(state.nodes, state.edges)),
             selectedIds: [...ids],
           });
         }),


### PR DESCRIPTION
## 背景

回补 woodfish 在 PR #140 合并后补充 review 中指出的 8 个画布状态层问题。

## 修复内容

### P1

- 使用稳定的父节点优先拓扑排序，保证任意层级父节点先于子节点
- 将图变更接入 undo/redo 历史，并将连续拖拽合并为单条历史记录
- 将 React Flow 节点 remove 事件路由到 compound 清理逻辑，避免悬空 parentId 和边引用
- 下钻视图中的新连线写入当前 compound 的 childEdges

### P2

- 将 paused 统一视为可恢复的活动运行态
- 同步更新重连边与 compound 保存的 boundaryEdges 原始边数据
- 主选中查询覆盖 compound 内部边
- beginRun 时清空上一轮 nodeLlmContent

## 验证

- bun run --cwd apps/app test：74 个测试文件、363 个测试全部通过
- bun run --cwd apps/app check-types：通过
- bun run --cwd apps/app lint：通过，仅保留一条与本次无关的既有 warning
- git diff --check origin/develop...HEAD：通过
- 新增 9 个对应 review 场景的回归断言

当前画布状态层尚未挂载到实际页面，没有可操作的浏览器验证入口。

## Review 状态

Claude Code Ultrareview 当前不可用，普通只读 review 未产生可审计输出；经确认，本 PR 先直接创建，等待 GitHub review。