### PR TITLE
feat(canvas): 增加连线与节点检查面板（COD-128）

### DIFF
--- a/apps/app/src/integrations/trpc/routers/pipelines.ts
+++ b/apps/app/src/integrations/trpc/routers/pipelines.ts
@@ -54,7 +54,10 @@ export const pipelinesRouter = router({
     .input(
       z.object({
         id: z.string(),
-        patch: PipelineSchema.omit({ createdAt: true, updatedAt: true }).partial(),
+        patch: PipelineSchema.omit({ createdAt: true, updatedAt: true }).partial().extend({
+          edges: PipelineGraphSnapshotSchema.shape.edges.optional(),
+          nodes: PipelineGraphSnapshotSchema.shape.nodes.optional(),
+        }),
       }),
     )
     .mutation(({ input }) =>

--- a/apps/app/src/pages/WorkspacePage/canvas/CanvasRoot.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/CanvasRoot.tsx
@@ -4,11 +4,13 @@ import { useTranslation } from "react-i18next";
 import type { PipelineData } from "@repo/schemas";
 import { fromPipelineSnapshot } from "./_store/canvasTypes";
 import { CanvasStoreProvider } from "./_store/canvasStore";
+import { EdgeInspector } from "./panels/EdgeInspector";
+import { NodeConfig } from "./panels/NodeConfig";
 import { CanvasFlow } from "./flow";
 import { CanvasEmptyState } from "./CanvasEmptyState";
 
 export type CanvasRootProps = {
-  pipeline: Pick<PipelineData, "edges" | "nodes">;
+  pipeline: Pick<PipelineData, "edges" | "id" | "nodes">;
 };
 
 export const CanvasRoot = ({ pipeline }: CanvasRootProps) => {
@@ -27,6 +29,8 @@ export const CanvasRoot = ({ pipeline }: CanvasRootProps) => {
           lang={i18n.language}
         >
           <CanvasFlow />
+          <EdgeInspector pipelineId={pipeline.id} />
+          <NodeConfig pipelineId={pipeline.id} />
           <CanvasEmptyState />
         </div>
       </CanvasStoreProvider>

--- a/apps/app/src/pages/WorkspacePage/canvas/CanvasRoot.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/CanvasRoot.unit.test.tsx
@@ -5,6 +5,7 @@ import { CanvasRoot } from "./CanvasRoot";
 
 vi.mock("@refinedev/core", () => ({
   useDataProvider: () => () => ({}),
+  useUpdate: () => ({ mutateAsync: vi.fn() }),
 }));
 
 vi.mock("@xyflow/react", () => ({

--- a/apps/app/src/pages/WorkspacePage/canvas/edges/SemanticEdge.stories.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/edges/SemanticEdge.stories.tsx
@@ -1,0 +1,40 @@
+import { Position, ReactFlowProvider } from "@xyflow/react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { CanvasStoreProvider } from "../_store/canvasStore";
+import { SemanticEdge } from "./SemanticEdge";
+
+const meta: Meta<typeof SemanticEdge> = {
+  title: "WorkspacePage/CanvasV2/Edges",
+  component: SemanticEdge,
+  decorators: [
+    (Story) => (
+      <ReactFlowProvider>
+        <CanvasStoreProvider>
+          <svg className="h-40 w-80 bg-muted">
+            <Story />
+          </svg>
+        </CanvasStoreProvider>
+      </ReactFlowProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SemanticEdge>;
+
+export const Semantic: Story = {
+  args: {
+    data: { label: "document" },
+    id: "edge-story",
+    selected: true,
+    source: "node-a",
+    sourcePosition: Position.Right,
+    sourceX: 40,
+    sourceY: 80,
+    target: "node-b",
+    targetPosition: Position.Left,
+    targetX: 260,
+    targetY: 80,
+  },
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/edges/SemanticEdge.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/edges/SemanticEdge.tsx
@@ -1,0 +1,108 @@
+import { ArrowRightLeft, RotateCcw, ShieldCheck } from "lucide-react";
+import { BaseEdge, EdgeLabelRenderer, getBezierPath, type EdgeProps } from "@xyflow/react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@repo/ui/lib/utils";
+import type { PipelineEdgeData } from "@repo/schemas";
+import { useCanvasStore } from "../_store/canvasStore";
+
+type SemanticEdgeState = "idle" | "pending" | "flow" | "done" | "selected";
+
+const edgeStateClass: Record<SemanticEdgeState, string> = {
+  idle: "stroke-muted-foreground/45",
+  pending: "stroke-muted-foreground/40 opacity-60",
+  flow: "stroke-foreground edge-flow",
+  done: "stroke-emerald-500",
+  selected: "stroke-foreground",
+};
+
+const edgeLabelClass: Record<SemanticEdgeState, string> = {
+  idle: "bg-card text-foreground/80 ring-border",
+  pending: "bg-card text-muted-foreground ring-border opacity-70",
+  flow: "bg-foreground text-primary-foreground ring-foreground",
+  done: "bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-400",
+  selected: "bg-foreground text-primary-foreground ring-foreground",
+};
+
+const getSemanticEdgeState = (
+  selected: boolean | undefined,
+  phase: string,
+  sourceStatus?: string,
+  targetStatus?: string,
+): SemanticEdgeState => {
+  if (selected) return "selected";
+  if (phase === "proposal") return "pending";
+  if (sourceStatus === "done" && targetStatus === "running") return "flow";
+  if (sourceStatus === "done" && targetStatus === "done") return "done";
+
+  return "idle";
+};
+
+export const SemanticEdge = ({
+  data,
+  id,
+  selected,
+  source,
+  sourceX,
+  sourceY,
+  sourcePosition,
+  target,
+  targetX,
+  targetY,
+  targetPosition,
+}: EdgeProps) => {
+  const { t } = useTranslation();
+  const edgeData = data as PipelineEdgeData | undefined;
+  const pendingProposal = useCanvasStore((state) => state.pendingProposal);
+  const sourceStatus = useCanvasStore((state) => state.nodeRunStatuses[source]);
+  const targetStatus = useCanvasStore((state) => state.nodeRunStatuses[target]);
+  const inspectEdgeId = useCanvasStore((state) => state.inspectEdgeId);
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourcePosition,
+    sourceX,
+    sourceY,
+    targetPosition,
+    targetX,
+    targetY,
+  });
+  const semanticState = getSemanticEdgeState(
+    selected || inspectEdgeId === id,
+    pendingProposal ? "proposal" : "applied",
+    sourceStatus,
+    targetStatus,
+  );
+  const label = edgeData?.label || t("workspace.canvas.edges.defaultLabel");
+  const isLoopEdge = Boolean(edgeData?.condition);
+  const Icon = edgeData?.qualityGate ? ShieldCheck : isLoopEdge ? RotateCcw : ArrowRightLeft;
+
+  return (
+    <>
+      <BaseEdge
+        className={cn(
+          "stroke-[2px]",
+          edgeStateClass[semanticState],
+          isLoopEdge && "stroke-amber-500 [stroke-dasharray:6_4]",
+        )}
+        id={id}
+        path={edgePath}
+      />
+      <EdgeLabelRenderer>
+        <div
+          className="nodrag nopan absolute -translate-x-1/2 -translate-y-1/2"
+          style={{ transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)` }}
+        >
+          <div
+            className={cn(
+              "flex items-center gap-1 rounded-full px-2 py-0.5 text-[9.5px] shadow-sm ring-1 transition-all",
+              edgeLabelClass[semanticState],
+              isLoopEdge && "bg-amber-500/10 text-foreground ring-amber-500/30",
+            )}
+            data-testid="canvas-v2-semantic-edge-label"
+          >
+            <Icon className="h-2.5 w-2.5" />
+            <span className="max-w-28 truncate font-mono">{label}</span>
+          </div>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/edges/SemanticEdge.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/edges/SemanticEdge.unit.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import type * as ReactFlowModule from "@xyflow/react";
+import { Position } from "@xyflow/react";
+import { describe, expect, it, vi } from "vitest";
+import { CanvasStoreContext, createCanvasStore, type CanvasStore } from "../_store/canvasStore";
+import { SemanticEdge } from "./SemanticEdge";
+
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactFlowModule>();
+
+  return {
+    ...actual,
+    BaseEdge: ({ className }: { className?: string }) => (
+      <path className={className} data-testid="semantic-edge-path" />
+    ),
+    EdgeLabelRenderer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const makeWrapper =
+  (store: CanvasStore) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <CanvasStoreContext.Provider value={store}>{children}</CanvasStoreContext.Provider>
+  );
+
+const renderEdge = (store: CanvasStore, data?: { label: string }) =>
+  render(
+    <svg>
+      <SemanticEdge
+        data={data}
+        id="edge-1"
+        source="node-a"
+        sourcePosition={Position.Right}
+        sourceX={0}
+        sourceY={0}
+        target="node-b"
+        targetPosition={Position.Left}
+        targetX={200}
+        targetY={0}
+      />
+    </svg>,
+    { wrapper: makeWrapper(store) },
+  );
+
+describe("SemanticEdge", () => {
+  it("renders the edge semantic label", () => {
+    const store = createCanvasStore();
+    renderEdge(store, { label: "approved_payload" });
+
+    expect(screen.getByTestId("canvas-v2-semantic-edge-label")).toHaveTextContent(
+      "approved_payload",
+    );
+  });
+
+  it("uses the translated default label when no label is configured", () => {
+    const store = createCanvasStore();
+    renderEdge(store);
+
+    expect(screen.getByTestId("canvas-v2-semantic-edge-label")).toHaveTextContent(/^(data|数据)$/);
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/edges/index.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/edges/index.ts
@@ -1,0 +1,1 @@
+export * from "./SemanticEdge";

--- a/apps/app/src/pages/WorkspacePage/canvas/flow/CanvasFlow.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/flow/CanvasFlow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, type DragEvent } from "react";
+import { useEffect, useMemo, type DragEvent } from "react";
 import { useDataProvider } from "@refinedev/core";
 import { ResultAsync } from "neverthrow";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -15,6 +15,7 @@ import {
 } from "@xyflow/react";
 import type { CompoundNodeData } from "@repo/schemas";
 import { toastStore } from "@/store/toastStore";
+import { SemanticEdge } from "../edges";
 import {
   CompoundNode,
   FileNode,
@@ -48,32 +49,22 @@ const nodeTypes = {
   prompt: PromptNode,
 };
 
+const edgeTypes = {
+  semantic: SemanticEdge,
+};
+
 const defaultEdgeOptions = {
-  type: "default",
+  type: "semantic",
 } satisfies Partial<CanvasEdge>;
 
 const proOptions: ProOptions = { hideAttribution: true };
 const defaultViewport = { x: 0, y: 0, zoom: 0.9 };
-
-const makeSnapshot = (nodes: CanvasNode[], edges: CanvasEdge[]) => ({ edges, nodes });
 
 const hasNodeChangeMutation = (changes: NodeChange<CanvasNode>[]): boolean =>
   changes.some((change) => change.type !== "select" && change.type !== "dimensions");
 
 const hasEdgeChangeMutation = (changes: EdgeChange<CanvasEdge>[]): boolean =>
   changes.some((change) => change.type !== "select");
-
-const getNodeDragPhase = (changes: NodeChange<CanvasNode>[]): "dragging" | "ended" | null => {
-  const positionChanges = changes.filter((change) => change.type === "position");
-  if (positionChanges.some((change) => change.dragging === true)) {
-    return "dragging";
-  }
-  if (positionChanges.some((change) => change.dragging === false)) {
-    return "ended";
-  }
-
-  return null;
-};
 
 const handleComponentDragOver = (event: DragEvent<HTMLDivElement>) => {
   if (!hasCanvasComponentDragPayload(event.dataTransfer.types)) {
@@ -88,7 +79,6 @@ export const CanvasFlow = () => {
   const { i18n } = useTranslation();
   const getDataProvider = useDataProvider();
   const canvasStore = useCanvasStoreApi();
-  const nodeDragSnapshotRef = useRef<ReturnType<typeof makeSnapshot> | null>(null);
   const nodes = useCanvasStore((state) => state.nodes);
   const edges = useCanvasStore((state) => state.edges);
   const canvasTool = useCanvasStore((state) => state.canvasTool);
@@ -102,9 +92,12 @@ export const CanvasFlow = () => {
   const handleNodesChange = useCanvasStore((state) => state.handleNodesChange);
   const openEdgeInspector = useCanvasStore((state) => state.openEdgeInspector);
   const openNodeConfig = useCanvasStore((state) => state.openNodeConfig);
+  const configNodeId = useCanvasStore((state) => state.configNodeId);
+  const inspectEdgeId = useCanvasStore((state) => state.inspectEdgeId);
+  const setConfigNodeId = useCanvasStore((state) => state.setConfigNodeId);
+  const setInspectEdgeId = useCanvasStore((state) => state.setInspectEdgeId);
   const pushDrillStack = useCanvasStore((state) => state.pushDrillStack);
   const popDrillStack = useCanvasStore((state) => state.popDrillStack);
-  const recordHistory = useCanvasStore((state) => state.recordHistory);
   const redo = useCanvasStore((state) => state.redo);
   const selectEdge = useCanvasStore((state) => state.selectEdge);
   const selectNode = useCanvasStore((state) => state.selectNode);
@@ -126,7 +119,7 @@ export const CanvasFlow = () => {
     [visibleGraph.edges, visibleGraph.nodes],
   );
   const renderedEdges = useMemo(
-    () => routedEdges.map((edge) => ({ ...edge, animated: false, type: "default" })),
+    () => routedEdges.map((edge) => ({ ...edge, animated: false, type: "semantic" })),
     [routedEdges],
   );
   const visibleNodeIds = visibleGraph.nodes.map((node) => node.id).join("\u0000");
@@ -138,12 +131,6 @@ export const CanvasFlow = () => {
 
     void fitView({ padding: 0.1 });
   }, [fitView, nodesInitialized, visibleNodeIds, visibleGraph.nodes.length]);
-
-  const getCurrentGraphSnapshot = () => {
-    const state = canvasStore.getState();
-
-    return makeSnapshot(state.nodes, state.edges);
-  };
 
   const handleDrop = async (event: DragEvent<HTMLDivElement>) => {
     if (isPreviewing || isDrilling) {
@@ -161,21 +148,17 @@ export const CanvasFlow = () => {
     event.stopPropagation();
     const position = screenToFlowPosition({ x: event.clientX, y: event.clientY });
     if (payload.kind === "object") {
-      const previous = getCurrentGraphSnapshot();
       addNodeFromCatalog({ position, type: payload.type });
-      recordHistory(previous);
 
       return;
     }
 
     if (payload.kind === "operation") {
-      const previous = getCurrentGraphSnapshot();
       addNodeFromCatalog({
         data: makeOperationNodeData(payload.operation),
         position,
         type: "operation",
       });
-      recordHistory(previous);
 
       return;
     }
@@ -200,18 +183,15 @@ export const CanvasFlow = () => {
         return;
       }
 
-      const previous = makeSnapshot(state.nodes, state.edges);
       state.addNodeFromCatalog({
         data: makeOperationNodeData(operationResult.value),
         position,
         type: "operation",
       });
-      canvasStore.getState().recordHistory(previous);
 
       return;
     }
 
-    const previous = getCurrentGraphSnapshot();
     addNodeFromCatalog({
       data: {
         ...(makeDefaultNodeData("compound", { label: payload.compoundKind }) as CompoundNodeData),
@@ -220,7 +200,6 @@ export const CanvasFlow = () => {
       position,
       type: "compound",
     });
-    recordHistory(previous);
   };
 
   const handleFlowConnect = (connection: Connection) => {
@@ -228,9 +207,7 @@ export const CanvasFlow = () => {
       return;
     }
 
-    const previous = getCurrentGraphSnapshot();
     handleConnect(connection);
-    recordHistory(previous);
   };
 
   const handleFlowEdgesChange = (changes: EdgeChange<CanvasEdge>[]) => {
@@ -238,44 +215,11 @@ export const CanvasFlow = () => {
       return;
     }
 
-    const previous = getCurrentGraphSnapshot();
-    if (hasEdgeChangeMutation(changes)) {
-      handleEdgesChange(changes);
-      recordHistory(previous);
-
-      return;
-    }
     handleEdgesChange(changes);
   };
 
   const handleFlowNodesChange = (changes: NodeChange<CanvasNode>[]) => {
     if (isPreviewing && hasNodeChangeMutation(changes)) {
-      nodeDragSnapshotRef.current = null;
-
-      return;
-    }
-
-    const dragPhase = getNodeDragPhase(changes);
-    if (dragPhase === "dragging") {
-      nodeDragSnapshotRef.current ??= getCurrentGraphSnapshot();
-      handleNodesChange(changes);
-
-      return;
-    }
-    if (dragPhase === "ended" && nodeDragSnapshotRef.current) {
-      const previous = nodeDragSnapshotRef.current;
-      nodeDragSnapshotRef.current = null;
-      handleNodesChange(changes);
-      recordHistory(previous);
-
-      return;
-    }
-
-    const previous = getCurrentGraphSnapshot();
-    if (hasNodeChangeMutation(changes)) {
-      handleNodesChange(changes);
-      recordHistory(previous);
-
       return;
     }
     handleNodesChange(changes);
@@ -322,10 +266,8 @@ export const CanvasFlow = () => {
       return;
     }
 
-    const previous = getCurrentGraphSnapshot();
     deleteSelected(selectedIds);
     setSelectedIds([]);
-    recordHistory(previous);
   };
 
   const handleUndo = () => {
@@ -364,6 +306,12 @@ export const CanvasFlow = () => {
   useHotkeys(
     "escape",
     () => {
+      if (configNodeId || inspectEdgeId) {
+        setConfigNodeId(null);
+        setInspectEdgeId(null);
+
+        return;
+      }
       if (drillStack.length > 0) {
         popDrillStack();
 
@@ -373,7 +321,7 @@ export const CanvasFlow = () => {
     },
     {
       enableOnContentEditable: false,
-      enableOnFormTags: false,
+      enableOnFormTags: true,
     },
   );
 
@@ -393,6 +341,7 @@ export const CanvasFlow = () => {
         defaultViewport={defaultViewport}
         deleteKeyCode={null}
         edges={renderedEdges}
+        edgeTypes={edgeTypes}
         maxZoom={1.6}
         minZoom={0.35}
         nodeDragThreshold={2}

--- a/apps/app/src/pages/WorkspacePage/canvas/flow/CanvasFlow.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/flow/CanvasFlow.unit.test.tsx
@@ -22,6 +22,7 @@ type ReactFlowProps = {
 };
 
 const hotkeyHandlers = new Map<string, () => void>();
+const hotkeyOptions = new Map<string, { enableOnFormTags?: boolean }>();
 const latestReactFlowPropsRef = { current: null as ReactFlowProps | null };
 const refineMocks = vi.hoisted(() => ({ create: vi.fn(), getList: vi.fn() }));
 const reactFlowMocks = vi.hoisted(() => ({ fitView: vi.fn(async () => true) }));
@@ -34,8 +35,9 @@ vi.mock("@refinedev/core", () => ({
 }));
 
 vi.mock("react-hotkeys-hook", () => ({
-  useHotkeys: (keys: string, handler: () => void) => {
+  useHotkeys: (keys: string, handler: () => void, options: { enableOnFormTags?: boolean } = {}) => {
     hotkeyHandlers.set(keys, handler);
+    hotkeyOptions.set(keys, options);
   },
 }));
 
@@ -105,6 +107,7 @@ const makeDataTransfer = (payload: Parameters<typeof encodeCanvasComponentDragPa
 describe("CanvasFlow", () => {
   beforeEach(() => {
     hotkeyHandlers.clear();
+    hotkeyOptions.clear();
     latestReactFlowPropsRef.current = null;
     reactFlowMocks.fitView.mockClear();
     refineMocks.create.mockReset();
@@ -299,6 +302,17 @@ describe("CanvasFlow", () => {
 
     expect(store.getState().nodes.map((node) => node.id)).toEqual(["node-a", "node-b"]);
     expect(store.getState().proposalPreview).not.toBeNull();
+  });
+
+  it("closes an inspector with Escape while a form control is focused", () => {
+    const store = createCanvasStore({ nodes: [makeNode("node-a")] });
+    store.getState().openNodeConfig("node-a");
+    render(<CanvasFlow />, { wrapper: makeWrapper(store) });
+
+    act(() => hotkeyHandlers.get("escape")?.());
+
+    expect(store.getState().configNodeId).toBeNull();
+    expect(hotkeyOptions.get("escape")?.enableOnFormTags).toBe(true);
   });
 
   it("fits the visible graph after node dimensions initialize", () => {

--- a/apps/app/src/pages/WorkspacePage/canvas/nodes/GNodeShell.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/nodes/GNodeShell.tsx
@@ -122,9 +122,7 @@ export const GNodeShell = ({
     }
 
     const state = canvasStore.getState();
-    const previous = { edges: state.edges, nodes: state.nodes };
     state.duplicateNode(id);
-    canvasStore.getState().recordHistory(previous);
   };
   const handleDeleteClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -133,9 +131,7 @@ export const GNodeShell = ({
     }
 
     const state = canvasStore.getState();
-    const previous = { edges: state.edges, nodes: state.nodes };
     state.deleteNode(id);
-    canvasStore.getState().recordHistory(previous);
   };
 
   return (

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/EdgeInspector/EdgeInspector.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/EdgeInspector/EdgeInspector.tsx
@@ -1,0 +1,124 @@
+import { ArrowRightLeft, Unlink, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@repo/ui/button";
+import { Input } from "@repo/ui/input";
+import { Label } from "@repo/ui/label";
+import type { PipelineEdgeData } from "@repo/schemas";
+import { useCanvasStore, useCanvasStoreApi } from "../../_store/canvasStore";
+import { toPipelineSnapshot } from "../../_store/canvasTypes";
+import { EdgeMappingsSection } from "./EdgeMappingsSection";
+import { EdgeQualityGateSection } from "./EdgeQualityGateSection";
+import { EdgeTransformSection } from "./EdgeTransformSection";
+import { usePipelineSnapshotPersistence } from "../usePipelineSnapshotPersistence";
+
+export type EdgeInspectorProps = {
+  pipelineId: string;
+};
+
+export const EdgeInspector = ({ pipelineId }: EdgeInspectorProps) => {
+  const { t } = useTranslation();
+  const inspectEdgeId = useCanvasStore((state) => state.inspectEdgeId);
+  const drillStack = useCanvasStore((state) => state.drillStack);
+  const nodes = useCanvasStore((state) => state.nodes);
+  const edges = useCanvasStore((state) => state.edges);
+  const updateEdgeData = useCanvasStore((state) => state.updateEdgeData);
+  const deleteEdge = useCanvasStore((state) => state.deleteEdge);
+  const setInspectEdgeId = useCanvasStore((state) => state.setInspectEdgeId);
+  const canvasStore = useCanvasStoreApi();
+  const persistSnapshot = usePipelineSnapshotPersistence(pipelineId);
+  const activeCompound = nodes.find((node) => node.id === drillStack.at(-1));
+  const childEdges =
+    activeCompound?.data.nodeType === "compound" ? (activeCompound.data.childEdges ?? []) : [];
+  const edge =
+    edges.find((item) => item.id === inspectEdgeId) ??
+    childEdges.find((item) => item.id === inspectEdgeId);
+
+  if (!edge) {
+    return null;
+  }
+
+  const edgeData: PipelineEdgeData = { label: edge.data?.label ?? "", ...edge.data };
+  const sourceLabel = nodes.find((node) => node.id === edge.source)?.data.label ?? edge.source;
+  const targetLabel = nodes.find((node) => node.id === edge.target)?.data.label ?? edge.target;
+  const handleClose = () => setInspectEdgeId(null);
+
+  const handleEdgeDataChange = (nextData: PipelineEdgeData) => {
+    updateEdgeData(edge.id, nextData);
+    const state = canvasStore.getState();
+    persistSnapshot(toPipelineSnapshot({ edges: state.edges, nodes: state.nodes }));
+  };
+
+  const handleDelete = () => {
+    deleteEdge(edge.id);
+    const state = canvasStore.getState();
+    persistSnapshot(toPipelineSnapshot({ edges: state.edges, nodes: state.nodes }));
+    setInspectEdgeId(null);
+  };
+
+  const handleConditionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const expression = event.target.value.trim();
+    handleEdgeDataChange({
+      ...edgeData,
+      condition: expression ? { ...edgeData.condition, expression } : undefined,
+    });
+  };
+
+  return (
+    <aside
+      aria-label={t("workspace.canvas.edgeInspector.title")}
+      className="absolute bottom-20 left-1/2 z-40 flex w-[calc(100%-2rem)] max-w-[420px] -translate-x-1/2 flex-col overflow-hidden rounded-2xl bg-card shadow-xl ring-1 ring-border"
+      data-testid="canvas-v2-edge-inspector"
+      role="dialog"
+    >
+      <div className="flex items-center gap-2 border-b border-border/70 px-3.5 py-2.5">
+        <div className="flex size-6 items-center justify-center rounded-md bg-muted">
+          <ArrowRightLeft className="size-3.5 text-foreground/80" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-semibold">{t("workspace.canvas.edgeInspector.title")}</div>
+          <div className="truncate text-[10px] text-muted-foreground">
+            {sourceLabel} <span className="px-1 text-foreground/40">→</span> {targetLabel}
+          </div>
+        </div>
+        <Button
+          aria-label={t("workspace.canvas.edgeInspector.deleteEdge")}
+          data-testid="edge-inspector-delete"
+          size="icon"
+          variant="ghost"
+          onClick={handleDelete}
+        >
+          <Unlink className="size-3.5" />
+        </Button>
+        <Button
+          aria-label={t("workspace.canvas.edgeInspector.close")}
+          data-testid="edge-inspector-close"
+          size="icon"
+          variant="ghost"
+          onClick={handleClose}
+        >
+          <X className="size-3.5" />
+        </Button>
+      </div>
+
+      <div className="max-h-[50vh] space-y-3 overflow-y-auto px-3.5 py-3">
+        <EdgeMappingsSection edgeData={edgeData} onChange={handleEdgeDataChange} />
+
+        <div className="space-y-2 rounded-xl bg-muted/60 px-2.5 py-2 ring-1 ring-border">
+          <Label className="text-[11px] font-medium text-muted-foreground" htmlFor="edge-condition">
+            {t("workspace.canvas.edgeInspector.condition")}
+          </Label>
+          <Input
+            data-testid="edge-inspector-condition"
+            id="edge-condition"
+            placeholder='content.includes("approved")'
+            value={edgeData.condition?.expression ?? ""}
+            onChange={handleConditionChange}
+          />
+        </div>
+
+        <EdgeTransformSection edgeData={edgeData} onChange={handleEdgeDataChange} />
+        <EdgeQualityGateSection edgeData={edgeData} onChange={handleEdgeDataChange} />
+      </div>
+    </aside>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/EdgeInspector/EdgeInspector.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/EdgeInspector/EdgeInspector.unit.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { CompoundNodeData } from "@repo/schemas";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CanvasStoreContext, createCanvasStore, type CanvasStore } from "../../_store/canvasStore";
+import type { CanvasEdge, CanvasNode } from "../../_store/canvasTypes";
+import { EdgeInspector } from "./EdgeInspector";
+
+const mutateMock = vi.fn();
+
+vi.mock("@refinedev/core", () => ({
+  useUpdate: () => ({ mutateAsync: mutateMock }),
+}));
+
+const nodes: CanvasNode[] = [
+  {
+    data: { label: "Source", nodeType: "prompt", prompt: "" },
+    id: "node-a",
+    position: { x: 0, y: 0 },
+    type: "prompt",
+  },
+  {
+    data: {
+      config: {},
+      label: "Parse",
+      nodeType: "operation",
+      operationId: "op-1",
+      operationName: "Parse",
+      status: "idle",
+    },
+    id: "node-b",
+    position: { x: 200, y: 0 },
+    type: "operation",
+  },
+];
+
+const edge: CanvasEdge = {
+  data: {
+    dataContract: {
+      mappings: [
+        { enabled: true, fromField: "vocabulary", toInput: "source_terms", type: "Term[]" },
+        { enabled: false, fromField: "text_blocks", toInput: "blocks", type: "Block[]" },
+      ],
+    },
+    label: "vocabulary",
+  },
+  id: "edge-1",
+  source: "node-a",
+  target: "node-b",
+};
+
+const compoundNode: CanvasNode = {
+  data: {
+    boundaryEdges: [],
+    childEdges: [edge],
+    childNodeIds: ["node-a", "node-b"],
+    compoundKind: "custom",
+    label: "Compound",
+    nodeType: "compound",
+  },
+  id: "compound-1",
+  position: { x: 0, y: 0 },
+  type: "compound",
+};
+
+const makeWrapper =
+  (store: CanvasStore) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <CanvasStoreContext.Provider value={store}>{children}</CanvasStoreContext.Provider>
+  );
+
+describe("EdgeInspector", () => {
+  beforeEach(() => {
+    mutateMock.mockReset().mockResolvedValue({});
+  });
+
+  it("renders nothing without an inspected edge", () => {
+    const store = createCanvasStore({ edges: [edge], nodes });
+    render(<EdgeInspector pipelineId="pipeline-1" />, { wrapper: makeWrapper(store) });
+
+    expect(screen.queryByTestId("canvas-v2-edge-inspector")).not.toBeInTheDocument();
+  });
+
+  it("toggles a mapping and persists the edges", async () => {
+    const user = userEvent.setup();
+    const store = createCanvasStore({ edges: [edge], nodes });
+    store.getState().openEdgeInspector("edge-1");
+    render(<EdgeInspector pipelineId="pipeline-1" />, { wrapper: makeWrapper(store) });
+
+    await user.click(screen.getByTestId("edge-inspector-mapping-0"));
+
+    const mappings = store.getState().edges[0]?.data?.dataContract?.mappings;
+    expect(mappings?.[0]?.enabled).toBe(false);
+    await waitFor(() =>
+      expect(mutateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "pipeline-1",
+          values: expect.objectContaining({ edges: expect.anything(), nodes: expect.anything() }),
+        }),
+      ),
+    );
+  });
+
+  it("deletes the edge and closes", async () => {
+    const user = userEvent.setup();
+    const store = createCanvasStore({ edges: [edge], nodes });
+    store.getState().openEdgeInspector("edge-1");
+    render(<EdgeInspector pipelineId="pipeline-1" />, { wrapper: makeWrapper(store) });
+
+    await user.click(screen.getByTestId("edge-inspector-delete"));
+
+    expect(store.getState().edges).toHaveLength(0);
+    expect(store.getState().inspectEdgeId).toBeNull();
+    await waitFor(() => expect(mutateMock).toHaveBeenCalled());
+  });
+
+  it("inspects and persists an edge inside the active compound", async () => {
+    const user = userEvent.setup();
+    const childNodes = nodes.map((node) => ({
+      ...node,
+      extent: "parent" as const,
+      parentId: "compound-1",
+    }));
+    const store = createCanvasStore({ nodes: [compoundNode, ...childNodes] });
+    store.setState({ drillStack: ["compound-1"] });
+    store.getState().openEdgeInspector("edge-1");
+    render(<EdgeInspector pipelineId="pipeline-compound" />, { wrapper: makeWrapper(store) });
+
+    await user.click(screen.getByTestId("edge-inspector-mapping-0"));
+
+    expect(screen.getByTestId("canvas-v2-edge-inspector")).toBeInTheDocument();
+    expect(
+      (store.getState().nodes[0]!.data as CompoundNodeData).childEdges?.[0]?.data?.dataContract
+        ?.mappings[0]?.enabled,
+    ).toBe(false);
+    await waitFor(() =>
+      expect(mutateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          values: expect.objectContaining({ nodes: expect.anything() }),
+        }),
+      ),
+    );
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/EdgeInspector/EdgeMappingsSection.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/EdgeInspector/EdgeMappingsSection.tsx
@@ -1,0 +1,96 @@
+import { Info } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@repo/ui/lib/utils";
+import type { PipelineEdgeData } from "@repo/schemas";
+
+type EdgeMappingsSectionProps = {
+  edgeData: PipelineEdgeData;
+  onChange: (data: PipelineEdgeData) => void;
+};
+
+export const EdgeMappingsSection = ({ edgeData, onChange }: EdgeMappingsSectionProps) => {
+  const { t } = useTranslation();
+  const mappings = edgeData.dataContract?.mappings ?? [];
+  const enabledCount = mappings.filter((mapping) => mapping.enabled).length;
+
+  const handleMappingToggle = (mappingIndex: number) => {
+    const nextMappings = mappings.map((mapping, index) =>
+      index === mappingIndex ? { ...mapping, enabled: !mapping.enabled } : mapping,
+    );
+    onChange({
+      ...edgeData,
+      dataContract: { ...edgeData.dataContract, mappings: nextMappings },
+    });
+  };
+
+  if (mappings.length === 0) {
+    return (
+      <div className="rounded-xl bg-muted p-3 text-xs text-muted-foreground ring-1 ring-border">
+        {t("workspace.canvas.edgeInspector.noMappings")}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-2 grid grid-cols-[1fr_auto_1fr] gap-2 px-1 text-[9.5px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+        <span>{t("workspace.canvas.edgeInspector.sourceField")}</span>
+        <span>{t("workspace.canvas.edgeInspector.flow")}</span>
+        <span>{t("workspace.canvas.edgeInspector.targetInput")}</span>
+      </div>
+      <div className="space-y-1.5">
+        {mappings.map((mapping, index) => (
+          <button
+            key={`${mapping.fromField}-${mapping.toInput}-${index}`}
+            aria-pressed={mapping.enabled}
+            className={cn(
+              "grid w-full grid-cols-[1fr_auto_1fr] items-center gap-2 rounded-xl px-2.5 py-2 text-left ring-1 transition-all",
+              mapping.enabled
+                ? "bg-muted ring-border hover:ring-ring/50"
+                : "bg-card opacity-55 ring-border/60 hover:opacity-80",
+            )}
+            data-testid={`edge-inspector-mapping-${index}`}
+            type="button"
+            onClick={() => handleMappingToggle(index)}
+          >
+            <span className="min-w-0">
+              <span className="block truncate font-mono text-[11px] font-medium">
+                {mapping.fromField}
+              </span>
+              {mapping.type ? (
+                <span className="block truncate text-[9.5px] text-muted-foreground">
+                  {mapping.type}
+                </span>
+              ) : null}
+            </span>
+            <span
+              className={cn(
+                "flex h-4 w-7 items-center rounded-full p-0.5 transition-colors",
+                mapping.enabled ? "bg-foreground" : "bg-muted-foreground/30",
+              )}
+            >
+              <span
+                className={cn(
+                  "size-3 rounded-full bg-background transition-transform",
+                  mapping.enabled && "translate-x-3",
+                )}
+              />
+            </span>
+            <span
+              className={cn("truncate font-mono text-[11px]", !mapping.enabled && "line-through")}
+            >
+              {mapping.enabled ? mapping.toInput : t("workspace.canvas.edgeInspector.dropped")}
+            </span>
+          </button>
+        ))}
+      </div>
+      <div className="mt-2 flex items-center gap-1.5 text-[10.5px] text-muted-foreground">
+        <Info className="size-3" />
+        {t("workspace.canvas.edgeInspector.toggleHint", {
+          enabled: enabledCount,
+          total: mappings.length,
+        })}
+      </div>
+    </div>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/EdgeInspector/EdgeQualityGateSection.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/EdgeInspector/EdgeQualityGateSection.tsx
@@ -1,0 +1,91 @@
+import { useTranslation } from "react-i18next";
+import { Input } from "@repo/ui/input";
+import { Label } from "@repo/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui/select";
+import type { PipelineEdgeData } from "@repo/schemas";
+
+type EdgeQualityGateSectionProps = {
+  edgeData: PipelineEdgeData;
+  onChange: (data: PipelineEdgeData) => void;
+};
+
+const ON_FAIL_OPTIONS = ["retry", "skip", "fail"] as const;
+
+export const EdgeQualityGateSection = ({ edgeData, onChange }: EdgeQualityGateSectionProps) => {
+  const { t } = useTranslation();
+
+  const handleCriteriaChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const criteria = event.target.value.trim();
+    onChange({
+      ...edgeData,
+      qualityGate: criteria
+        ? {
+            criteria,
+            maxRetries: edgeData.qualityGate?.maxRetries,
+            onFail: edgeData.qualityGate?.onFail ?? "skip",
+          }
+        : undefined,
+    });
+  };
+
+  const handleMaxRetriesChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.valueAsNumber;
+    if (!Number.isFinite(value) || !edgeData.qualityGate) {
+      return;
+    }
+    onChange({
+      ...edgeData,
+      qualityGate: { ...edgeData.qualityGate, maxRetries: Math.max(0, Math.floor(value)) },
+    });
+  };
+
+  const handleOnFailChange = (value: (typeof ON_FAIL_OPTIONS)[number] | null) => {
+    if (!value || !edgeData.qualityGate) {
+      return;
+    }
+    onChange({
+      ...edgeData,
+      qualityGate: { ...edgeData.qualityGate, onFail: value },
+    });
+  };
+
+  return (
+    <div className="space-y-2 rounded-xl bg-muted/60 px-2.5 py-2 ring-1 ring-border">
+      <Label className="text-[11px] font-medium text-muted-foreground" htmlFor="edge-quality">
+        {t("workspace.canvas.edgeInspector.qualityGate")}
+      </Label>
+      <Input
+        data-testid="edge-inspector-quality"
+        id="edge-quality"
+        placeholder={t("workspace.canvas.edgeInspector.qualityPlaceholder")}
+        value={edgeData.qualityGate?.criteria ?? ""}
+        onChange={handleCriteriaChange}
+      />
+      {edgeData.qualityGate ? (
+        <div className="grid grid-cols-[1fr_1.4fr] gap-2">
+          <Input
+            aria-label={t("workspace.canvas.edgeInspector.maxRetries")}
+            inputMode="numeric"
+            min={0}
+            step={1}
+            type="number"
+            value={edgeData.qualityGate.maxRetries ?? 0}
+            onChange={handleMaxRetriesChange}
+          />
+          <Select value={edgeData.qualityGate.onFail} onValueChange={handleOnFailChange}>
+            <SelectTrigger aria-label={t("workspace.canvas.edgeInspector.onFail")}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {ON_FAIL_OPTIONS.map((option) => (
+                <SelectItem key={option} value={option}>
+                  {option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/EdgeInspector/EdgeTransformSection.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/EdgeInspector/EdgeTransformSection.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from "react-i18next";
+import { Button } from "@repo/ui/button";
+import type { PipelineEdgeData } from "@repo/schemas";
+
+type EdgeTransformSectionProps = {
+  edgeData: PipelineEdgeData;
+  onChange: (data: PipelineEdgeData) => void;
+};
+
+const TRANSFORM_OPTIONS = ["trim", "uppercase", "lowercase"] as const;
+
+export const EdgeTransformSection = ({ edgeData, onChange }: EdgeTransformSectionProps) => {
+  const { t } = useTranslation();
+  const handleAdd = (type: (typeof TRANSFORM_OPTIONS)[number]) =>
+    onChange({
+      ...edgeData,
+      transform: { steps: [...(edgeData.transform?.steps ?? []), { config: {}, type }] },
+    });
+  const handleClear = () => onChange({ ...edgeData, transform: undefined });
+
+  return (
+    <div className="space-y-2 rounded-xl bg-muted/60 px-2.5 py-2 ring-1 ring-border">
+      <div className="text-[11px] font-medium text-muted-foreground">
+        {t("workspace.canvas.edgeInspector.transform")}
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {TRANSFORM_OPTIONS.map((type) => (
+          <Button
+            key={type}
+            className="h-7 px-2 text-[11px]"
+            size="sm"
+            type="button"
+            variant="secondary"
+            onClick={() => handleAdd(type)}
+          >
+            {type}
+          </Button>
+        ))}
+        <Button
+          className="h-7 px-2 text-[11px]"
+          size="sm"
+          type="button"
+          variant="ghost"
+          onClick={handleClear}
+        >
+          {t("workspace.canvas.edgeInspector.clear")}
+        </Button>
+      </div>
+      <div className="text-[11px] text-muted-foreground">
+        {(edgeData.transform?.steps ?? []).map((step) => step.type).join(" → ") ||
+          t("workspace.canvas.edgeInspector.noTransform")}
+      </div>
+    </div>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/EdgeInspector/index.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/EdgeInspector/index.ts
@@ -1,0 +1,1 @@
+export * from "./EdgeInspector";

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/CheckpointSection.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/CheckpointSection.tsx
@@ -1,0 +1,55 @@
+import { Flag } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@repo/ui/lib/utils";
+import type { NodeConfigSectionProps } from "./types";
+
+export const CheckpointSection = ({ node, onPatch }: NodeConfigSectionProps) => {
+  const { t } = useTranslation();
+  const isOperation = node.data.nodeType === "operation";
+  const checked = node.data.nodeType === "operation" ? Boolean(node.data.checkpoint) : false;
+  const handleToggle = () => onPatch({ checkpoint: !checked });
+
+  return (
+    <section className="space-y-2 rounded-xl bg-muted/60 p-3 ring-1 ring-border">
+      <div className="flex items-center gap-2">
+        <Flag className="size-3.5 text-muted-foreground" />
+        <h3 className="text-xs font-semibold">
+          {t("workspace.canvas.nodeConfig.checkpoint.title")}
+        </h3>
+      </div>
+      <button
+        aria-pressed={checked}
+        className={cn(
+          "flex w-full items-center gap-2.5 rounded-xl bg-card px-2.5 py-2 text-left ring-1 ring-border",
+          !isOperation && "cursor-not-allowed opacity-50",
+        )}
+        data-testid="node-config-checkpoint"
+        disabled={!isOperation}
+        type="button"
+        onClick={handleToggle}
+      >
+        <span
+          className={cn(
+            "flex h-5 w-9 shrink-0 items-center rounded-full p-0.5 transition-colors",
+            checked ? "bg-foreground" : "bg-muted-foreground/30",
+          )}
+        >
+          <span
+            className={cn(
+              "size-4 rounded-full bg-background transition-transform",
+              checked && "translate-x-4",
+            )}
+          />
+        </span>
+        <span className="flex-1 text-xs">
+          <span className="font-medium">
+            {t("workspace.canvas.nodeConfig.checkpoint.pauseForReview")}
+          </span>{" "}
+          <span className="text-muted-foreground">
+            {t("workspace.canvas.nodeConfig.checkpoint.afterStep")}
+          </span>
+        </span>
+      </button>
+    </section>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/ExecutorSection.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/ExecutorSection.tsx
@@ -1,0 +1,119 @@
+import { Cpu, Sparkles } from "lucide-react";
+import { useList } from "@refinedev/core";
+import { useTranslation } from "react-i18next";
+import type { AgentRuntimeConfig, Skill } from "@repo/schemas";
+import { Label } from "@repo/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui/select";
+import { ResourceName } from "@/integrations/refine/dataProvider";
+import type { NodeConfigSectionProps } from "./types";
+
+const DEFAULT_EXECUTOR_VALUE = "__default__";
+
+export const ExecutorSection = ({ node, onPatch }: NodeConfigSectionProps) => {
+  const { t } = useTranslation();
+  const { result: runtimeResult } = useList<AgentRuntimeConfig>({
+    resource: ResourceName.agentRuntimes,
+  });
+  const { result: skillsResult } = useList<Skill>({
+    resource: ResourceName.skills,
+  });
+  const runtimes = runtimeResult.data;
+  const skills = skillsResult.data;
+  const handleRuntimeChange = (value: string | null) => {
+    if (!value) {
+      return;
+    }
+    onPatch({
+      agentId: undefined,
+      agentRuntime: value === DEFAULT_EXECUTOR_VALUE ? undefined : value,
+    });
+  };
+  const handleSkillChange = (value: string | null) => {
+    if (!value) {
+      return;
+    }
+    onPatch({
+      agentId: value === DEFAULT_EXECUTOR_VALUE ? undefined : value,
+      agentRuntime: undefined,
+    });
+  };
+
+  if (node.data.nodeType !== "operation") {
+    return (
+      <section className="space-y-2 rounded-xl bg-muted/60 p-3 ring-1 ring-border">
+        <div className="flex items-center gap-2">
+          <Cpu className="size-3.5 text-muted-foreground" />
+          <h3 className="text-xs font-semibold">
+            {t("workspace.canvas.nodeConfig.executor.title")}
+          </h3>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {t("workspace.canvas.nodeConfig.executor.operationOnly")}
+        </p>
+      </section>
+    );
+  }
+
+  const operationData = node.data;
+  const runtimeValue = operationData.agentRuntime ?? DEFAULT_EXECUTOR_VALUE;
+  const runtimeLabel =
+    runtimes.find((runtime) => runtime.type === operationData.agentRuntime)?.name ??
+    t("workspace.canvas.nodeConfig.executor.defaultRuntime");
+  const skillValue = operationData.agentId ?? DEFAULT_EXECUTOR_VALUE;
+  const skillLabel =
+    skills.find((skill) => skill.id === operationData.agentId)?.label ??
+    t("workspace.canvas.nodeConfig.executor.noSkill");
+
+  return (
+    <section className="space-y-3 rounded-xl bg-muted/60 p-3 ring-1 ring-border">
+      <div className="flex items-center gap-2">
+        <Cpu className="size-3.5 text-muted-foreground" />
+        <h3 className="text-xs font-semibold">{t("workspace.canvas.nodeConfig.executor.title")}</h3>
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor={`node-config-${node.id}-runtime`}>
+          {t("workspace.canvas.nodeConfig.executor.runtime")}
+        </Label>
+        <Select value={runtimeValue} onValueChange={handleRuntimeChange}>
+          <SelectTrigger data-testid="node-config-runtime" id={`node-config-${node.id}-runtime`}>
+            <SelectValue>{runtimeLabel}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={DEFAULT_EXECUTOR_VALUE}>
+              {t("workspace.canvas.nodeConfig.executor.defaultRuntime")}
+            </SelectItem>
+            {runtimes.map((runtime) => (
+              <SelectItem key={runtime.id} value={runtime.type}>
+                {runtime.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor={`node-config-${node.id}-skill`}>
+          {t("workspace.canvas.nodeConfig.executor.skill")}
+        </Label>
+        <Select value={skillValue} onValueChange={handleSkillChange}>
+          <SelectTrigger data-testid="node-config-skill" id={`node-config-${node.id}-skill`}>
+            <SelectValue>{skillLabel}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={DEFAULT_EXECUTOR_VALUE}>
+              {t("workspace.canvas.nodeConfig.executor.noSkill")}
+            </SelectItem>
+            {skills.map((skill) => (
+              <SelectItem key={skill.id} value={skill.id}>
+                {skill.label || skill.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex items-start gap-2 rounded-md bg-card px-2 py-1.5 text-[11px] text-muted-foreground">
+        <Sparkles className="mt-0.5 size-3" />
+        <span>{t("workspace.canvas.nodeConfig.executor.hint")}</span>
+      </div>
+    </section>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/IOSection.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/IOSection.tsx
@@ -1,0 +1,56 @@
+import { ArrowDownToLine, ArrowUpFromLine } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { NodeConfigSectionProps } from "./types";
+
+const getEdgeLabel = (edge: NodeConfigSectionProps["edges"][number]) => edge.data?.label || "data";
+
+export const IOSection = ({ node, edges }: NodeConfigSectionProps) => {
+  const { t } = useTranslation();
+  const incoming = edges.filter((edge) => edge.target === node.id);
+  const outgoing = edges.filter((edge) => edge.source === node.id);
+
+  const renderEdges = (items: typeof edges, direction: "in" | "out") =>
+    items.length > 0 ? (
+      <div className="space-y-1">
+        {items.map((edge) => (
+          <div key={edge.id} className="rounded-md bg-card px-2 py-1.5 text-xs ring-1 ring-border">
+            <div className="truncate font-mono">{getEdgeLabel(edge)}</div>
+            <div className="mt-0.5 text-[10.5px] text-muted-foreground">
+              {direction === "in" ? `${edge.source} → ${node.id}` : `${node.id} → ${edge.target}`}
+            </div>
+          </div>
+        ))}
+      </div>
+    ) : (
+      <p className="text-xs text-muted-foreground">
+        {direction === "in"
+          ? t("workspace.canvas.nodeConfig.io.noInputs")
+          : t("workspace.canvas.nodeConfig.io.noOutputs")}
+      </p>
+    );
+
+  return (
+    <section className="space-y-3 rounded-xl bg-muted/60 p-3 ring-1 ring-border">
+      <div className="flex items-center gap-2">
+        <ArrowDownToLine className="size-3.5 text-muted-foreground" />
+        <h3 className="text-xs font-semibold">{t("workspace.canvas.nodeConfig.io.title")}</h3>
+      </div>
+      <div className="space-y-2">
+        <div>
+          <div className="mb-1 flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+            <ArrowDownToLine className="size-3" />
+            {t("workspace.canvas.nodeConfig.io.inputs")}
+          </div>
+          {renderEdges(incoming, "in")}
+        </div>
+        <div>
+          <div className="mb-1 flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+            <ArrowUpFromLine className="size-3" />
+            {t("workspace.canvas.nodeConfig.io.outputs")}
+          </div>
+          {renderEdges(outgoing, "out")}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/LastRunSection.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/LastRunSection.tsx
@@ -1,0 +1,34 @@
+import { Activity } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useCanvasStore } from "../../_store/canvasStore";
+import type { NodeConfigSectionProps } from "./types";
+
+export const LastRunSection = ({ node }: NodeConfigSectionProps) => {
+  const { t } = useTranslation();
+  const runStatus = useCanvasStore((state) => state.nodeRunStatuses[node.id]);
+  const llmContent = useCanvasStore((state) => state.nodeLlmContent[node.id]);
+  const status = runStatus ?? ("status" in node.data ? node.data.status : "idle");
+
+  return (
+    <section className="space-y-2 rounded-xl bg-muted/60 p-3 ring-1 ring-border">
+      <div className="flex items-center gap-2">
+        <Activity className="size-3.5 text-muted-foreground" />
+        <h3 className="text-xs font-semibold">{t("workspace.canvas.nodeConfig.lastRun.title")}</h3>
+      </div>
+      <div className="grid grid-cols-[72px_1fr] gap-2 text-xs">
+        <span className="text-muted-foreground">
+          {t("workspace.canvas.nodeConfig.lastRun.status")}
+        </span>
+        <span className="font-mono" data-testid="node-config-last-run-status">
+          {String(status ?? "idle")}
+        </span>
+        <span className="text-muted-foreground">
+          {t("workspace.canvas.nodeConfig.lastRun.output")}
+        </span>
+        <span className="truncate">
+          {llmContent || t("workspace.canvas.nodeConfig.lastRun.noOutput")}
+        </span>
+      </div>
+    </section>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/NodeConfig.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/NodeConfig.tsx
@@ -1,0 +1,19 @@
+import { useCanvasStore } from "../../_store/canvasStore";
+import { NodeConfigDialog } from "./NodeConfigDialog";
+
+export type NodeConfigProps = {
+  pipelineId: string;
+};
+
+export const NodeConfig = ({ pipelineId }: NodeConfigProps) => {
+  const configNodeId = useCanvasStore((state) => state.configNodeId);
+  const node = useCanvasStore((state) =>
+    state.nodes.find((item) => item.id === state.configNodeId),
+  );
+
+  if (!configNodeId || !node) {
+    return null;
+  }
+
+  return <NodeConfigDialog key={node.id} node={node} pipelineId={pipelineId} />;
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/NodeConfig.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/NodeConfig.unit.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CanvasStoreContext, createCanvasStore, type CanvasStore } from "../../_store/canvasStore";
+import type { CanvasNode } from "../../_store/canvasTypes";
+import { toastStore } from "@/store/toastStore";
+import { NodeConfig } from "./NodeConfig";
+
+const mutateMock = vi.fn();
+
+vi.mock("@refinedev/core", () => ({
+  useList: () => ({ result: { data: [], total: 0 } }),
+  useUpdate: () => ({ mutateAsync: mutateMock }),
+}));
+
+const operationNode: CanvasNode = {
+  data: {
+    config: {},
+    label: "Parse",
+    nodeType: "operation",
+    operationId: "op-1",
+    operationName: "Parse",
+    status: "idle",
+  },
+  id: "node-op",
+  position: { x: 0, y: 0 },
+  type: "operation",
+};
+
+const makeWrapper =
+  (store: CanvasStore) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <CanvasStoreContext.Provider value={store}>{children}</CanvasStoreContext.Provider>
+  );
+
+describe("NodeConfig", () => {
+  beforeEach(() => {
+    mutateMock.mockReset().mockResolvedValue({});
+    toastStore.setState({ toasts: [] });
+  });
+
+  it("renders nothing while no node is being configured", () => {
+    const store = createCanvasStore({ nodes: [operationNode] });
+    render(<NodeConfig pipelineId="pipeline-1" />, { wrapper: makeWrapper(store) });
+
+    expect(screen.queryByTestId("canvas-v2-node-config")).not.toBeInTheDocument();
+  });
+
+  it("patches the label and persists the pipeline", async () => {
+    const user = userEvent.setup();
+    const store = createCanvasStore({ nodes: [operationNode] });
+    store.getState().openNodeConfig("node-op");
+    render(<NodeConfig pipelineId="pipeline-1" />, { wrapper: makeWrapper(store) });
+
+    await user.type(screen.getByTestId("node-config-label"), "!");
+
+    const data = store.getState().nodes[0]?.data as { label: string; operationName: string };
+    expect(data.label).toBe("Parse!");
+    expect(data.operationName).toBe("Parse!");
+    await waitFor(() =>
+      expect(mutateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "pipeline-1",
+          values: expect.objectContaining({ edges: expect.anything(), nodes: expect.anything() }),
+        }),
+      ),
+    );
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles the checkpoint flag", async () => {
+    const user = userEvent.setup();
+    const store = createCanvasStore({ nodes: [operationNode] });
+    store.getState().openNodeConfig("node-op");
+    render(<NodeConfig pipelineId="pipeline-1" />, { wrapper: makeWrapper(store) });
+
+    await user.click(screen.getByTestId("node-config-checkpoint"));
+
+    expect((store.getState().nodes[0]!.data as { checkpoint?: boolean }).checkpoint).toBe(true);
+    await waitFor(() => expect(mutateMock).toHaveBeenCalled());
+  });
+
+  it("resets edits back to the open snapshot", async () => {
+    const user = userEvent.setup();
+    const store = createCanvasStore({ nodes: [operationNode] });
+    store.getState().openNodeConfig("node-op");
+    render(<NodeConfig pipelineId="pipeline-1" />, { wrapper: makeWrapper(store) });
+
+    await user.type(screen.getByTestId("node-config-label"), "!");
+    await user.click(screen.getByTestId("node-config-reset"));
+
+    expect((store.getState().nodes[0]!.data as { label: string }).label).toBe("Parse");
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("closes via Done", async () => {
+    const user = userEvent.setup();
+    const store = createCanvasStore({ nodes: [operationNode] });
+    store.getState().openNodeConfig("node-op");
+    render(<NodeConfig pipelineId="pipeline-1" />, { wrapper: makeWrapper(store) });
+
+    await user.click(screen.getByTestId("node-config-done"));
+
+    expect(store.getState().configNodeId).toBeNull();
+  });
+
+  it("reports a failed pipeline save", async () => {
+    const user = userEvent.setup();
+    mutateMock.mockRejectedValueOnce(new Error("offline"));
+    const store = createCanvasStore({ nodes: [operationNode] });
+    store.getState().openNodeConfig("node-op");
+    render(<NodeConfig pipelineId="pipeline-error" />, { wrapper: makeWrapper(store) });
+
+    await user.type(screen.getByTestId("node-config-label"), "!");
+
+    await waitFor(() => expect(toastStore.getState().toasts.at(-1)?.type).toBe("error"));
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/NodeConfigDialog.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/NodeConfigDialog.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { Settings2, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@repo/ui/button";
+import { Input } from "@repo/ui/input";
+import { useCanvasStore, useCanvasStoreApi } from "../../_store/canvasStore";
+import { toPipelineSnapshot, type CanvasNode } from "../../_store/canvasTypes";
+import { CheckpointSection } from "./CheckpointSection";
+import { ExecutorSection } from "./ExecutorSection";
+import { IOSection } from "./IOSection";
+import { LastRunSection } from "./LastRunSection";
+import { PromptSection } from "./PromptSection";
+import type { NodeConfigPatch } from "./types";
+import { usePipelineSnapshotPersistence } from "../usePipelineSnapshotPersistence";
+
+type NodeConfigDialogProps = {
+  node: CanvasNode;
+  pipelineId: string;
+};
+
+const handleDialogClick = (event: React.MouseEvent) => event.stopPropagation();
+
+export const NodeConfigDialog = ({ node, pipelineId }: NodeConfigDialogProps) => {
+  const { t } = useTranslation();
+  const edges = useCanvasStore((state) => state.edges);
+  const updateNodeData = useCanvasStore((state) => state.updateNodeData);
+  const setConfigNodeId = useCanvasStore((state) => state.setConfigNodeId);
+  const canvasStore = useCanvasStoreApi();
+  const persistSnapshot = usePipelineSnapshotPersistence(pipelineId);
+  const [snapshotData] = useState<Record<string, unknown>>(() => structuredClone(node.data));
+
+  const handlePatch = (patch: NodeConfigPatch) => {
+    const nextPatch =
+      node.data.nodeType === "operation" && typeof patch.label === "string"
+        ? { ...patch, operationName: patch.label }
+        : patch;
+    updateNodeData(node.id, nextPatch as Partial<typeof node.data>);
+    const state = canvasStore.getState();
+    persistSnapshot(toPipelineSnapshot({ edges: state.edges, nodes: state.nodes }));
+  };
+
+  const handleReset = () => {
+    updateNodeData(node.id, snapshotData as Partial<typeof node.data>);
+    const state = canvasStore.getState();
+    persistSnapshot(toPipelineSnapshot({ edges: state.edges, nodes: state.nodes }));
+  };
+
+  const dirty = JSON.stringify(node.data) !== JSON.stringify(snapshotData);
+  const handleClose = () => setConfigNodeId(null);
+
+  return (
+    <div
+      aria-label={t("workspace.canvas.nodeConfig.editable")}
+      aria-modal="true"
+      className="absolute inset-0 z-40 grid place-items-center p-6"
+      data-testid="canvas-v2-node-config"
+      role="dialog"
+      onClick={handleClose}
+    >
+      <div className="absolute inset-0 bg-foreground/10 backdrop-blur-[1px]" />
+      <div
+        className="relative flex max-h-full w-full max-w-[440px] flex-col overflow-hidden rounded-2xl bg-card shadow-xl ring-1 ring-border"
+        onClick={handleDialogClick}
+      >
+        <div className="flex items-center gap-2.5 border-b border-border/70 px-4 py-3">
+          <div className="flex size-8 items-center justify-center rounded-lg bg-muted">
+            <Settings2 className="size-4 text-muted-foreground" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <Input
+              className="-mx-1 h-auto w-full truncate border-0 bg-transparent px-1 py-0 text-sm font-semibold shadow-none hover:bg-muted focus-visible:bg-muted focus-visible:ring-1"
+              data-testid="node-config-label"
+              value={String(node.data.label ?? "")}
+              onChange={(event) => handlePatch({ label: event.target.value })}
+            />
+            <div className="px-1 text-[10.5px] text-muted-foreground">
+              {node.type} · {t("workspace.canvas.nodeConfig.editable")}
+            </div>
+          </div>
+          <Button
+            aria-label={t("workspace.canvas.nodeConfig.close")}
+            data-testid="node-config-close"
+            size="icon"
+            variant="ghost"
+            onClick={handleClose}
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+
+        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-3">
+          <PromptSection edges={edges} node={node} onPatch={handlePatch} />
+          <ExecutorSection edges={edges} node={node} onPatch={handlePatch} />
+          <CheckpointSection edges={edges} node={node} onPatch={handlePatch} />
+          <LastRunSection edges={edges} node={node} onPatch={handlePatch} />
+          <IOSection edges={edges} node={node} onPatch={handlePatch} />
+        </div>
+
+        <div className="flex items-center gap-2 border-t border-border/70 px-4 py-3">
+          <Button className="flex-1" data-testid="node-config-done" onClick={handleClose}>
+            {t("workspace.canvas.nodeConfig.done")}
+          </Button>
+          <Button
+            data-testid="node-config-reset"
+            disabled={!dirty}
+            variant="outline"
+            onClick={handleReset}
+          >
+            {t("workspace.canvas.nodeConfig.reset")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/PromptSection.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/PromptSection.tsx
@@ -1,0 +1,60 @@
+import { MessageSquareText } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Label } from "@repo/ui/label";
+import { Textarea } from "@repo/ui/textarea";
+import type { NodeConfigSectionProps } from "./types";
+
+const getPromptValue = (node: NodeConfigSectionProps["node"]) => {
+  const data = node.data;
+
+  if (data.nodeType === "prompt") {
+    return data.prompt;
+  }
+
+  if (data.nodeType === "operation") {
+    return data.loopConditionPrompt ?? "";
+  }
+
+  return "";
+};
+
+export const PromptSection = ({ node, onPatch }: NodeConfigSectionProps) => {
+  const { t } = useTranslation();
+  const isPromptEditable = node.data.nodeType === "prompt" || node.data.nodeType === "operation";
+  const handlePromptChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    onPatch(
+      node.data.nodeType === "prompt"
+        ? { prompt: event.target.value }
+        : { loopConditionPrompt: event.target.value },
+    );
+  };
+
+  return (
+    <section className="space-y-2 rounded-xl bg-muted/60 p-3 ring-1 ring-border">
+      <div className="flex items-center gap-2">
+        <MessageSquareText className="size-3.5 text-muted-foreground" />
+        <h3 className="text-xs font-semibold">{t("workspace.canvas.nodeConfig.prompt.title")}</h3>
+      </div>
+      {isPromptEditable ? (
+        <div className="space-y-1.5">
+          <Label htmlFor={`node-config-${node.id}-prompt`}>
+            {node.data.nodeType === "prompt"
+              ? t("workspace.canvas.nodeConfig.prompt.promptText")
+              : t("workspace.canvas.nodeConfig.prompt.loopCondition")}
+          </Label>
+          <Textarea
+            data-testid="node-config-prompt"
+            id={`node-config-${node.id}-prompt`}
+            rows={5}
+            value={getPromptValue(node)}
+            onChange={handlePromptChange}
+          />
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          {t("workspace.canvas.nodeConfig.prompt.unavailable")}
+        </p>
+      )}
+    </section>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/index.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/index.ts
@@ -1,0 +1,1 @@
+export * from "./NodeConfig";

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/types.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/NodeConfig/types.ts
@@ -1,0 +1,9 @@
+import type { CanvasEdge, CanvasNode } from "../../_store/canvasTypes";
+
+export type NodeConfigPatch = Record<string, unknown>;
+
+export type NodeConfigSectionProps = {
+  edges: CanvasEdge[];
+  node: CanvasNode;
+  onPatch: (patch: NodeConfigPatch) => void;
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/panels/usePipelineSnapshotPersistence.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/panels/usePipelineSnapshotPersistence.ts
@@ -1,0 +1,71 @@
+import { useUpdate, type HttpError } from "@refinedev/core";
+import { useTranslation } from "react-i18next";
+import type { PipelineData, PipelineGraphSnapshot } from "@repo/schemas";
+import { ResourceName } from "@/integrations/refine/dataProvider";
+import { toastStore } from "@/store/toastStore";
+
+const SAVE_DELAY_MS = 400;
+
+type PendingSave = {
+  snapshot: PipelineGraphSnapshot;
+  timeout: ReturnType<typeof setTimeout>;
+  update: (snapshot: PipelineGraphSnapshot) => Promise<unknown>;
+};
+
+const pendingSaves = new Map<string, PendingSave>();
+const saveQueues = new Map<string, Promise<unknown>>();
+
+const enqueueSave = (pipelineId: string, save: () => Promise<unknown>) => {
+  const previous = saveQueues.get(pipelineId) ?? Promise.resolve();
+  const next = previous.catch(() => undefined).then(save);
+  saveQueues.set(pipelineId, next);
+  void next
+    .finally(() => {
+      if (saveQueues.get(pipelineId) === next) {
+        saveQueues.delete(pipelineId);
+      }
+    })
+    .catch(() => undefined);
+};
+
+export const usePipelineSnapshotPersistence = (pipelineId: string) => {
+  const { t } = useTranslation();
+  const { mutateAsync: updatePipeline } = useUpdate<
+    PipelineData,
+    HttpError,
+    Partial<PipelineData>
+  >();
+
+  return (snapshot: PipelineGraphSnapshot) => {
+    const pending = pendingSaves.get(pipelineId);
+    if (pending) {
+      clearTimeout(pending.timeout);
+    }
+
+    const update = (latestSnapshot: PipelineGraphSnapshot) =>
+      updatePipeline({
+        id: pipelineId,
+        resource: ResourceName.pipelines,
+        successNotification: false,
+        values: latestSnapshot,
+      }).catch((error: unknown) => {
+        toastStore.getState().addToast({
+          description: t("canvas.floatingMenu.saveFailedDescription"),
+          title: t("canvas.saveFailed"),
+          type: "error",
+        });
+
+        throw error;
+      });
+    const timeout = setTimeout(() => {
+      const latest = pendingSaves.get(pipelineId);
+      if (!latest) {
+        return;
+      }
+      pendingSaves.delete(pipelineId);
+      enqueueSave(pipelineId, () => latest.update(latest.snapshot));
+    }, SAVE_DELAY_MS);
+
+    pendingSaves.set(pipelineId, { snapshot, timeout, update });
+  };
+};

--- a/packages/schemas/src/pipeline/PipelineSchema.unit.test.ts
+++ b/packages/schemas/src/pipeline/PipelineSchema.unit.test.ts
@@ -29,4 +29,21 @@ describe("PipelineSchema", () => {
   it("keeps legacy pipeline payloads compatible", () => {
     expect(PipelineSchema.parse(basePipeline)).toMatchObject({ id: "pipeline-1" });
   });
+
+  it("preserves compound parent references on pipeline nodes", () => {
+    const parsed = PipelineSchema.parse({
+      ...basePipeline,
+      nodes: [
+        {
+          data: { filePath: "source.ts", label: "Source", nodeType: "file" },
+          id: "child-node",
+          parentId: "compound-node",
+          position: { x: 20, y: 40 },
+          type: "file",
+        },
+      ],
+    });
+
+    expect(parsed.nodes[0]?.parentId).toBe("compound-node");
+  });
 });

--- a/packages/schemas/src/pipeline/node/PipelineNodeSchema.ts
+++ b/packages/schemas/src/pipeline/node/PipelineNodeSchema.ts
@@ -7,6 +7,7 @@ export const PipelineNodeSchema = z.object({
   id: z.string(),
   type: BuiltinNodeTypeSchema,
   metaType: MetaNodeTypeSchema.optional(),
+  parentId: z.string().optional(),
   position: z.object({ x: z.number(), y: z.number() }),
   data: PipelineNodeDataSchema,
 });


### PR DESCRIPTION
## PR 做了什么

- 新增 SemanticEdge，展示连线语义标签、条件/质量门图标和运行状态
- 新增 Edge Inspector，可编辑字段映射、条件、转换和质量门，并支持 compound 内部子边
- 新增 Node Config，可编辑提示词、执行器、检查点和 I/O 配置
- 面板编辑使用 400ms trailing debounce，并按 pipeline 串行持久化完整 nodes + edges 快照
- Pipeline update 使用 PipelineGraphSnapshotSchema，保留 parentId、style、extent 等画布字段
- 修复 #143 后 CanvasFlow/GNodeShell 重复记录撤销历史的问题

## 独立 review 与修复

Claude Code 两轮只读 review 发现并推动修复：

- 修复逐按键并发写导致旧快照覆盖新值的竞态
- 修复 compound 子边点击后 Inspector 不出现
- 修复只保存半份快照导致 compound 边副本脱节
- 修复 parentId/style/extent 被更新路由 schema 剥离
- 保存失败不再静默，输入框聚焦时 Esc 也可关闭面板
- 增加 dialog、aria-pressed 与移动端宽度约束

## 验证

- `@ordine/app` typecheck 通过
- `@ordine/app` lint 通过（仅保留 develop 既有 route func-style warning）
- 相关测试：6 files / 37 tests passed
- `@repo/schemas`：11 files / 59 tests passed，typecheck/lint 通过
- 浏览器 Storybook 验证：1440x900 与 375x812 下均可打开 Edge Inspector / Node Config；节点改名后 Reset 正常；面板无溢出且背景不透明；console 0 errors

## 基线说明

- 仓库级 typecheck 仍被 `packages/db-schema` 既有 Node 类型缺失阻塞
- 仓库级测试仍被 `@repo/views` 测试环境缺失 localStorage 阻塞
- app 全量测试中的旧 CanvasSettingsDrawer 输入用例仅保留首字符；A/B 验证去掉本 PR schema 改动后仍复现

Linear: COD-128