### PR TITLE
feat: 完成 Agent Bar 对话引擎（COD-131）

### DIFF
--- a/packages/views/src/constants.ts
+++ b/packages/views/src/constants.ts
@@ -1,6 +1,7 @@
 export const ResourceName = {
   agents: "agents",
   agentRuntimes: "agentRuntimes",
+  conversationMessages: "conversationMessages",
   filesystem: "filesystem",
   operations: "operations",
   pipelineAssets: "pipelineAssets",

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.stories.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.stories.tsx
@@ -112,7 +112,7 @@ const meta: Meta<typeof AgentPanelStory> = {
     docs: {
       description: {
         component:
-          "Right-side AI assistant panel for proposing canvas graph edits. Stories focus on overflow behavior for diagnostics and proposal review without a backend.",
+          "Canvas conversation baseline reusing Alan's Agent Bar styling: a bg-surface panel with a compact status header, plain assistant text, and foreground user bubbles. Stories also cover diagnostics and proposal review without a backend.",
       },
     },
   },
@@ -124,6 +124,14 @@ type Story = StoryObj<typeof AgentPanelStory>;
 
 export const Default: Story = {
   args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Baseline conversation flow with Alan-style assistant text, user bubbles, runtime selection, context upload, and the pinned request input.",
+      },
+    },
+  },
 };
 
 export const OverflowContent: Story = {

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.stories.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.stories.tsx
@@ -5,6 +5,7 @@ import { CanvasPageStoreContext, createCanvasPageStore, type CanvasPageStore } f
 import { AgentPanel } from "./AgentPanel";
 import { setCanvasDataProvider } from "../../../lib/canvasDataProvider";
 import { canvasStoryDataProvider } from "../storybookData";
+import { AgentBarStoreProvider } from "./_store";
 
 setCanvasDataProvider(canvasStoryDataProvider);
 
@@ -94,9 +95,11 @@ const AgentPanelStory = ({
 
   return (
     <CanvasPageStoreContext.Provider value={storeRef.current}>
-      <div className="relative h-[540px] w-[420px] overflow-hidden rounded-md border bg-slate-50">
-        <AgentPanel />
-      </div>
+      <AgentBarStoreProvider pipelineId="story-pipeline">
+        <div className="relative h-[540px] w-[420px] overflow-hidden rounded-md border bg-slate-50">
+          <AgentPanel />
+        </div>
+      </AgentBarStoreProvider>
     </CanvasPageStoreContext.Provider>
   );
 };

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -2,8 +2,7 @@ import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import {
-  Bot,
-  X,
+  ChevronsRight,
   Send,
   Loader2,
   AlertCircle,
@@ -33,6 +32,7 @@ import { createPipelineAgentSessionsClient } from "../../../lib/pipelineAgentSes
 import { usePlatform } from "../../../platform";
 import { toastStore } from "../../../store/toastStore";
 import { useAgentBarStore } from "./_store";
+import { Assistant, Bubble } from "./messages";
 import { useAgentConversation } from "./useAgentConversation";
 
 interface RuntimeState {
@@ -368,36 +368,58 @@ export const AgentPanel = () => {
   const proposal = activeProposal;
   const hasProposal = proposal !== null;
   const canApplyProposal = hasProposal && !hasBlockingDiagnostics;
+  const selectedRuntime = runtimeOptions.find((runtime) => runtime.id === selectedRuntimeId);
+  const isConversationActive = isSending || agentPanel.isLoading;
+  const headerSubtitle = isConversationActive
+    ? (streamingProgress ?? t("canvas.agentPanel.thinking"))
+    : selectedRuntime
+      ? formatRuntimeLabel(selectedRuntime)
+      : t("canvas.agentPanel.runtimePlaceholder");
 
   return (
-    <div className="absolute bottom-0 right-0 top-0 z-30 flex w-80 flex-col border-l bg-background shadow-lg">
-      {/* Header */}
-      <div className="flex h-12 items-center justify-between border-b px-4">
-        <div className="flex items-center gap-2 text-sm font-medium">
-          <Bot className="h-4 w-4 text-primary" />
-          <span>{t("canvas.agentPanel.title")}</span>
+    <div
+      className="absolute bottom-0 right-0 top-0 z-30 flex w-[min(22.5rem,100%)] flex-col border-l bg-surface"
+      data-testid="canvas-agent-panel"
+    >
+      <header
+        className="flex shrink-0 items-center justify-between px-3.5 pb-2 pt-3"
+        data-testid="canvas-agent-panel-header"
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            className={cn(
+              "size-1.5 shrink-0 rounded-full",
+              isConversationActive ? "animate-pulse bg-foreground" : "bg-success",
+            )}
+            data-testid="canvas-agent-panel-status-dot"
+          />
+          <span className="text-[12px] font-semibold">{t("canvas.agentPanel.title")}</span>
+          <span className="truncate text-[10.5px] text-muted-foreground">· {headerSubtitle}</span>
         </div>
         <Button
           aria-label={t("canvas.agentPanel.close")}
-          className="h-7 w-7"
+          className="h-7 w-7 shrink-0"
+          data-testid="canvas-agent-panel-collapse"
           size="icon"
           title={t("canvas.agentPanel.close")}
           variant="ghost"
           onClick={handleToggleAgentPanel}
         >
-          <X className="h-4 w-4" />
+          <ChevronsRight className="size-3.5" />
         </Button>
-      </div>
+      </header>
 
-      {/* Messages */}
-      <div className="border-b px-3 py-2">
-        <div className="flex flex-col gap-1">
-          <span className="text-xs font-medium text-muted-foreground">
+      <div
+        className="mx-3 mb-1 rounded-lg bg-surface-2 px-2.5 py-2 ring-1 ring-border-strong"
+        data-testid="canvas-agent-panel-runtime-context"
+      >
+        <div className="flex flex-col gap-1.5">
+          <span className="text-[10.5px] font-medium text-muted-foreground">
             {t("canvas.agentPanel.runtimeLabel")}
           </span>
           <Select value={selectedRuntimeId} onValueChange={handleRuntimeValueChange}>
             <SelectTrigger
-              className="h-8 w-full text-xs"
+              className="h-7 w-full text-[11px]"
               disabled={isLoadingRuntimes || runtimeOptions.length === 0}
             >
               <SelectValue
@@ -425,13 +447,21 @@ export const AgentPanel = () => {
             type="file"
             onChange={handleUploadChange}
           />
-          <div className="flex flex-wrap gap-2 pt-2">
-            <Button size="sm" variant="outline" onClick={handleUploadButtonClick}>
+          <div className="flex flex-wrap items-center gap-1.5 pt-1.5">
+            <Button
+              className="h-7 px-2 text-[10.5px]"
+              size="sm"
+              variant="outline"
+              onClick={handleUploadButtonClick}
+            >
               <Upload className="h-3.5 w-3.5" />
               {t("canvas.agentPanel.upload")}
             </Button>
             {attachments.map((attachment) => (
-              <span key={attachment.id} className="rounded-md border px-2 py-1 text-xs">
+              <span
+                key={attachment.id}
+                className="rounded-md border border-border-strong bg-surface px-1.5 py-0.5 text-[10.5px]"
+              >
                 {attachment.filename}
               </span>
             ))}
@@ -439,37 +469,29 @@ export const AgentPanel = () => {
         </div>
       </div>
 
-      <ScrollArea className="flex-1">
+      <ScrollArea className="min-h-0 flex-1" data-testid="canvas-agent-panel-messages">
         <div className="flex flex-col gap-3 p-3">
-          {messages.length === 0 && (
-            <div className="mr-auto max-w-[90%] rounded-lg bg-muted px-3 py-2 text-sm">
-              {t("canvas.agentPanel.welcome")}
-            </div>
+          {messages.length === 0 && <Assistant>{t("canvas.agentPanel.welcome")}</Assistant>}
+          {messages.map((msg) =>
+            msg.role === "user" ? (
+              <Bubble
+                key={msg.id}
+                attachmentLabel={msg.metadata?.attachments
+                  ?.map((attachment) => attachment.name)
+                  .join(", ")}
+              >
+                {msg.content}
+              </Bubble>
+            ) : (
+              <Assistant key={msg.id}>{msg.content}</Assistant>
+            ),
           )}
-          {messages.map((msg) => (
-            <div
-              key={msg.id}
-              className={cn(
-                "max-w-[90%] rounded-lg px-3 py-2 text-sm",
-                msg.role === "user"
-                  ? "ml-auto bg-primary text-primary-foreground"
-                  : "mr-auto bg-muted",
-              )}
-            >
-              {msg.content}
-            </div>
-          ))}
           {streamingAssistantText && (
-            <div className="mr-auto max-w-[90%] whitespace-pre-wrap rounded-lg border border-dashed bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-              {streamingAssistantText}
-            </div>
+            <Assistant className="whitespace-pre-wrap">{streamingAssistantText}</Assistant>
           )}
 
-          {(isSending || agentPanel.isLoading) && (
-            <div className="mr-auto flex items-center gap-2 rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              {streamingProgress ?? t("canvas.agentPanel.thinking")}
-            </div>
+          {isConversationActive && (
+            <Assistant isThinking>{streamingProgress ?? t("canvas.agentPanel.thinking")}</Assistant>
           )}
           <div ref={messagesEndRef} />
 
@@ -564,9 +586,9 @@ export const AgentPanel = () => {
       )}
 
       {/* Input */}
-      <div className="flex items-center gap-2 border-t p-3">
+      <div className="flex items-center gap-2 border-t border-border/70 bg-surface p-3">
         <Input
-          className="h-9 flex-1 text-sm"
+          className="h-9 flex-1 bg-surface-2 text-[12px]"
           disabled={isSending || agentPanel.isLoading || isLoadingRuntimes}
           placeholder={t("canvas.agentPanel.inputPlaceholder")}
           value={inputValue}

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -97,6 +97,7 @@ export const AgentPanel = () => {
   const edges = useStore(store, (state) => state.edges);
   const [inputValue, setInputValue] = useState("");
   const [isPreparingSend, setIsPreparingSend] = useState(false);
+  const [isPreparingUpload, setIsPreparingUpload] = useState(false);
   const [isLoadingRuntimes, setIsLoadingRuntimes] = useState(true);
   const [needsRuntimeSetup, setNeedsRuntimeSetup] = useState(false);
   const [runtimeOptions, setRuntimeOptions] = useState<AgentRuntimeConfig[]>([]);
@@ -107,6 +108,7 @@ export const AgentPanel = () => {
     applyProposal,
     discardProposal,
     ensureSession,
+    isLoading: isHistoryLoading,
     isSending: isConversationSending,
     messages,
     resetSession,
@@ -119,6 +121,7 @@ export const AgentPanel = () => {
   const attachmentGraphSignatureRef = useRef<string | null>(null);
   const sendInFlightRef = useRef(false);
   const isSending = isPreparingSend || isConversationSending;
+  const isUploadBlocked = isHistoryLoading || isPreparingUpload || isSending;
 
   const scrollToBottom = useCallback(() => {
     requestAnimationFrame(() => {
@@ -200,7 +203,7 @@ export const AgentPanel = () => {
   }, [messages.length, scrollToBottom, streamingAssistantText, streamingProgress]);
 
   const doSend = useCallback(async () => {
-    if (isSending || sendInFlightRef.current) {
+    if (isHistoryLoading || isSending || sendInFlightRef.current) {
       return;
     }
     sendInFlightRef.current = true;
@@ -269,6 +272,7 @@ export const AgentPanel = () => {
     addMessage,
     fetchRuntimeState,
     inputValue,
+    isHistoryLoading,
     isSending,
     pipelineId,
     selectedRuntimeId,
@@ -300,52 +304,75 @@ export const AgentPanel = () => {
     void doSend();
   }, [doSend]);
 
-  const handleUploadButtonClick = useCallback(() => {
-    void ensureSession().then(() => fileInputRef.current?.click());
-  }, [ensureSession]);
+  const handleUploadButtonClick = useCallback(async () => {
+    if (isUploadBlocked) {
+      return;
+    }
+
+    setIsPreparingUpload(true);
+    try {
+      await ensureSession();
+      fileInputRef.current?.click();
+    } finally {
+      setIsPreparingUpload(false);
+    }
+  }, [ensureSession, isUploadBlocked]);
 
   const handleUploadChange = useCallback(
     async (event: React.ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
-      if (!file) {
-        return;
-      }
-
       event.target.value = "";
-
-      const sessionId = await ensureSession();
-      const uploadResult = await ResultAsync.fromPromise(
-        pipelineAgentSessionsClient.uploadAttachment(
-          sessionId,
-          file,
-          selectedRuntimeId ? { runtimeId: selectedRuntimeId } : undefined,
-        ),
-        (error) => (error instanceof Error ? error : new Error(String(error))),
-      );
-      if (uploadResult.isErr()) {
-        toastStore.getState().addToast({
-          type: "error",
-          title: t("canvas.agentPanel.errorTitle"),
-          description: uploadResult.error.message,
-        });
-
+      if (!file || isUploadBlocked) {
         return;
       }
 
-      const attachment = uploadResult.value.attachment;
-      if (attachment) {
-        attachmentGraphSignatureRef.current = JSON.stringify({ edges, nodes, pipelineId });
-        setAttachments((prev) => [
-          ...prev,
-          {
-            id: attachment.id,
-            filename: attachment.filename,
-            parseStatus: attachment.parseStatus ?? "parsed",
-          },
-        ]);
+      setIsPreparingUpload(true);
+      try {
+        const sessionId = await ensureSession();
+        const uploadResult = await ResultAsync.fromPromise(
+          pipelineAgentSessionsClient.uploadAttachment(
+            sessionId,
+            file,
+            selectedRuntimeId ? { runtimeId: selectedRuntimeId } : undefined,
+          ),
+          (error) => (error instanceof Error ? error : new Error(String(error))),
+        );
+        if (uploadResult.isErr()) {
+          toastStore.getState().addToast({
+            type: "error",
+            title: t("canvas.agentPanel.errorTitle"),
+            description: uploadResult.error.message,
+          });
+
+          return;
+        }
+
+        const attachment = uploadResult.value.attachment;
+        if (attachment) {
+          attachmentGraphSignatureRef.current = JSON.stringify({ edges, nodes, pipelineId });
+          setAttachments((prev) => [
+            ...prev,
+            {
+              id: attachment.id,
+              filename: attachment.filename,
+              parseStatus: attachment.parseStatus ?? "parsed",
+            },
+          ]);
+        }
+      } finally {
+        setIsPreparingUpload(false);
       }
     },
-    [edges, ensureSession, nodes, pipelineAgentSessionsClient, pipelineId, selectedRuntimeId, t],
+    [
+      edges,
+      ensureSession,
+      isUploadBlocked,
+      nodes,
+      pipelineAgentSessionsClient,
+      pipelineId,
+      selectedRuntimeId,
+      t,
+    ],
   );
 
   const hasBlockingDiagnostics =
@@ -444,12 +471,14 @@ export const AgentPanel = () => {
             ref={fileInputRef}
             aria-label={t("canvas.agentPanel.upload")}
             className="hidden"
+            disabled={isUploadBlocked}
             type="file"
             onChange={handleUploadChange}
           />
           <div className="flex flex-wrap items-center gap-1.5 pt-1.5">
             <Button
               className="h-7 px-2 text-[10.5px]"
+              disabled={isUploadBlocked}
               size="sm"
               variant="outline"
               onClick={handleUploadButtonClick}
@@ -589,7 +618,7 @@ export const AgentPanel = () => {
       <div className="flex items-center gap-2 border-t border-border/70 bg-surface p-3">
         <Input
           className="h-9 flex-1 bg-surface-2 text-[12px]"
-          disabled={isSending || agentPanel.isLoading || isLoadingRuntimes}
+          disabled={isSending || isHistoryLoading || agentPanel.isLoading || isLoadingRuntimes}
           placeholder={t("canvas.agentPanel.inputPlaceholder")}
           value={inputValue}
           onChange={handleInputValueChange}
@@ -600,6 +629,7 @@ export const AgentPanel = () => {
           className="h-9 w-9"
           disabled={
             isSending ||
+            isHistoryLoading ||
             agentPanel.isLoading ||
             isLoadingRuntimes ||
             !selectedRuntimeId ||
@@ -610,7 +640,7 @@ export const AgentPanel = () => {
           variant="ghost"
           onClick={handleSendClick}
         >
-          {isSending || agentPanel.isLoading ? (
+          {isSending || isHistoryLoading || agentPanel.isLoading ? (
             <Loader2 className="h-4 w-4 animate-spin" />
           ) : (
             <Send className="h-4 w-4" />

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -122,6 +122,7 @@ export const AgentPanel = () => {
   const sendInFlightRef = useRef(false);
   const isSending = isPreparingSend || isConversationSending;
   const isUploadBlocked = isHistoryLoading || isPreparingUpload || isSending;
+  const isUploadInputBlocked = isHistoryLoading || isSending;
 
   const scrollToBottom = useCallback(() => {
     requestAnimationFrame(() => {
@@ -203,7 +204,7 @@ export const AgentPanel = () => {
   }, [messages.length, scrollToBottom, streamingAssistantText, streamingProgress]);
 
   const doSend = useCallback(async () => {
-    if (isHistoryLoading || isSending || sendInFlightRef.current) {
+    if (isHistoryLoading || isPreparingUpload || isSending || sendInFlightRef.current) {
       return;
     }
     sendInFlightRef.current = true;
@@ -273,6 +274,7 @@ export const AgentPanel = () => {
     fetchRuntimeState,
     inputValue,
     isHistoryLoading,
+    isPreparingUpload,
     isSending,
     pipelineId,
     selectedRuntimeId,
@@ -311,12 +313,23 @@ export const AgentPanel = () => {
 
     setIsPreparingUpload(true);
     try {
-      await ensureSession();
+      const sessionResult = await ResultAsync.fromPromise(ensureSession(), (error) =>
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      if (sessionResult.isErr()) {
+        toastStore.getState().addToast({
+          type: "error",
+          title: t("canvas.agentPanel.errorTitle"),
+          description: sessionResult.error.message,
+        });
+
+        return;
+      }
       fileInputRef.current?.click();
     } finally {
       setIsPreparingUpload(false);
     }
-  }, [ensureSession, isUploadBlocked]);
+  }, [ensureSession, isUploadBlocked, t]);
 
   const handleUploadChange = useCallback(
     async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -328,13 +341,16 @@ export const AgentPanel = () => {
 
       setIsPreparingUpload(true);
       try {
-        const sessionId = await ensureSession();
         const uploadResult = await ResultAsync.fromPromise(
-          pipelineAgentSessionsClient.uploadAttachment(
-            sessionId,
-            file,
-            selectedRuntimeId ? { runtimeId: selectedRuntimeId } : undefined,
-          ),
+          (async () => {
+            const sessionId = await ensureSession();
+
+            return pipelineAgentSessionsClient.uploadAttachment(
+              sessionId,
+              file,
+              selectedRuntimeId ? { runtimeId: selectedRuntimeId } : undefined,
+            );
+          })(),
           (error) => (error instanceof Error ? error : new Error(String(error))),
         );
         if (uploadResult.isErr()) {
@@ -471,7 +487,7 @@ export const AgentPanel = () => {
             ref={fileInputRef}
             aria-label={t("canvas.agentPanel.upload")}
             className="hidden"
-            disabled={isUploadBlocked}
+            disabled={isUploadInputBlocked}
             type="file"
             onChange={handleUploadChange}
           />
@@ -618,7 +634,13 @@ export const AgentPanel = () => {
       <div className="flex items-center gap-2 border-t border-border/70 bg-surface p-3">
         <Input
           className="h-9 flex-1 bg-surface-2 text-[12px]"
-          disabled={isSending || isHistoryLoading || agentPanel.isLoading || isLoadingRuntimes}
+          disabled={
+            isSending ||
+            isPreparingUpload ||
+            isHistoryLoading ||
+            agentPanel.isLoading ||
+            isLoadingRuntimes
+          }
           placeholder={t("canvas.agentPanel.inputPlaceholder")}
           value={inputValue}
           onChange={handleInputValueChange}
@@ -629,6 +651,7 @@ export const AgentPanel = () => {
           className="h-9 w-9"
           disabled={
             isSending ||
+            isPreparingUpload ||
             isHistoryLoading ||
             agentPanel.isLoading ||
             isLoadingRuntimes ||

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -25,27 +25,15 @@ import {
 } from "@repo/ui/select";
 import { cn } from "@repo/ui/lib/utils";
 import { ResultAsync } from "neverthrow";
-import type {
-  AgentRuntimeConfig,
-  PipelineActionProposal,
-  PipelineAction,
-  PipelineActionDiagnostic,
-} from "@repo/schemas";
+import type { AgentRuntimeConfig, PipelineAction } from "@repo/schemas";
 import { useCanvasPageStore } from "../_store";
 import { ResourceName } from "../../../constants";
 import { getCanvasDataProvider } from "../../../lib/canvasDataProvider";
-import {
-  createPipelineAgentSessionsClient,
-  type PipelineAgentPlanEvent,
-} from "../../../lib/pipelineAgentSessionsClient";
+import { createPipelineAgentSessionsClient } from "../../../lib/pipelineAgentSessionsClient";
 import { usePlatform } from "../../../platform";
 import { toastStore } from "../../../store/toastStore";
-
-interface Message {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-}
+import { useAgentBarStore } from "./_store";
+import { useAgentConversation } from "./useAgentConversation";
 
 interface RuntimeState {
   runtimeOptions: AgentRuntimeConfig[];
@@ -56,11 +44,6 @@ interface AttachmentItem {
   id: string;
   filename: string;
   parseStatus: string;
-}
-
-interface LocalProposalPreview {
-  diagnosticsPreview: PipelineActionDiagnostic[] | null;
-  proposal: PipelineActionProposal;
 }
 
 const getActionLabel = (
@@ -109,37 +92,33 @@ export const AgentPanel = () => {
 
   const agentPanel = useStore(store, (state) => state.agentPanel);
   const handleToggleAgentPanel = useStore(store, (state) => state.toggleAgentPanel);
-  const setPendingProposal = useStore(store, (state) => state.setPendingProposal);
-  const clearPendingProposal = useStore(store, (state) => state.clearPendingProposal);
-  const applyAgentProposal = useStore(store, (state) => state.applyAgentProposal);
   const pipelineId = useStore(store, (state) => state.pipelineId);
   const nodes = useStore(store, (state) => state.nodes);
   const edges = useStore(store, (state) => state.edges);
-
-  const [messages, setMessages] = useState<Message[]>([
-    {
-      id: "welcome",
-      role: "assistant",
-      content: t("canvas.agentPanel.welcome"),
-    },
-  ]);
   const [inputValue, setInputValue] = useState("");
-  const [isSending, setIsSending] = useState(false);
+  const [isPreparingSend, setIsPreparingSend] = useState(false);
   const [isLoadingRuntimes, setIsLoadingRuntimes] = useState(true);
   const [needsRuntimeSetup, setNeedsRuntimeSetup] = useState(false);
   const [runtimeOptions, setRuntimeOptions] = useState<AgentRuntimeConfig[]>([]);
   const [selectedRuntimeId, setSelectedRuntimeId] = useState<string | null>(null);
   const [attachments, setAttachments] = useState<AttachmentItem[]>([]);
-  const [localProposalPreview, setLocalProposalPreview] = useState<LocalProposalPreview | null>(
-    null,
-  );
-  const [streamingAssistantText, setStreamingAssistantText] = useState("");
-  const [streamingProgress, setStreamingProgress] = useState<string | null>(null);
+  const addMessage = useAgentBarStore((state) => state.addMessage);
+  const {
+    applyProposal,
+    discardProposal,
+    ensureSession,
+    isSending: isConversationSending,
+    messages,
+    resetSession,
+    streamingAssistantText,
+    streamingProgress,
+    submitMessage,
+  } = useAgentConversation({ pipelineId });
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const sessionIdRef = useRef<string | null>(null);
-  const sessionGraphSignatureRef = useRef<string | null>(null);
-  const proposalIdRef = useRef<string | null>(null);
+  const attachmentGraphSignatureRef = useRef<string | null>(null);
+  const sendInFlightRef = useRef(false);
+  const isSending = isPreparingSend || isConversationSending;
 
   const scrollToBottom = useCallback(() => {
     requestAnimationFrame(() => {
@@ -198,294 +177,104 @@ export const AgentPanel = () => {
     );
   }, [fetchRuntimeState]);
 
-  const ensureSession = useCallback(async () => {
-    const graphSignature = JSON.stringify({
-      pipelineId,
-      nodes,
-      edges,
-    });
-    if (sessionIdRef.current && sessionGraphSignatureRef.current === graphSignature) {
-      return sessionIdRef.current;
-    }
-    const session = await pipelineAgentSessionsClient.createSession({
-      entrypoint: "canvas-agent-panel",
-      mode: "edit",
-      ...(pipelineId ? { pipelineId } : {}),
-      snapshot: { nodes, edges },
-    });
-    sessionIdRef.current = session.id;
-    sessionGraphSignatureRef.current = graphSignature;
-
-    return session.id;
-  }, [edges, nodes, pipelineAgentSessionsClient, pipelineId]);
-
   useEffect(() => {
-    const nextSignature = JSON.stringify({
-      pipelineId,
-      nodes,
-      edges,
-    });
+    const graphSignature = JSON.stringify({ edges, nodes, pipelineId });
     if (
-      sessionGraphSignatureRef.current &&
-      sessionGraphSignatureRef.current !== nextSignature &&
-      attachments.length > 0
+      attachments.length > 0 &&
+      attachmentGraphSignatureRef.current &&
+      attachmentGraphSignatureRef.current !== graphSignature
     ) {
       setAttachments([]);
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: `system-context-reset-${Date.now()}`,
-          role: "assistant",
-          content: t("canvas.agentPanel.contextReset"),
-        },
-      ]);
-      sessionIdRef.current = null;
-      sessionGraphSignatureRef.current = null;
-      proposalIdRef.current = null;
+      attachmentGraphSignatureRef.current = null;
+      addMessage({
+        content: t("canvas.agentPanel.contextReset"),
+        id: `system-context-reset-${Date.now()}`,
+        role: "assistant",
+      });
+      resetSession();
     }
-  }, [attachments.length, edges, nodes, pipelineId, t]);
+  }, [addMessage, attachments.length, edges, nodes, pipelineId, resetSession, t]);
 
-  const handlePlanEvent = useCallback(
-    (event: PipelineAgentPlanEvent) => {
-      if (event.type === "phase") {
-        setStreamingProgress(event.phase);
-
-        return;
-      }
-
-      if (event.type === "progress") {
-        setStreamingProgress(event.message);
-
-        return;
-      }
-
-      if (event.type === "assistant_chunk") {
-        setStreamingAssistantText((current) =>
-          current.length === 0 ? event.text : `${current}\n${event.text}`,
-        );
-
-        return;
-      }
-
-      if (event.type === "question") {
-        setStreamingAssistantText("");
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: `assistant-question-${Date.now()}`,
-            role: "assistant",
-            content: event.question,
-          },
-        ]);
-        setStreamingProgress(null);
-        setIsSending(false);
-        scrollToBottom();
-
-        return;
-      }
-
-      if (event.type === "proposal_ready" && event.proposal.mode === "edit") {
-        const editProposal = event.proposal;
-        setStreamingAssistantText("");
-        proposalIdRef.current = event.proposalId;
-        const nextProposal: PipelineActionProposal = {
-          summary: editProposal.summary,
-          actions: editProposal.actions,
-        };
-        setLocalProposalPreview({
-          proposal: nextProposal,
-          diagnosticsPreview: editProposal.diagnosticsPreview,
-        });
-        setPendingProposal(nextProposal, editProposal.diagnosticsPreview);
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: `assistant-proposal-${Date.now()}`,
-            role: "assistant",
-            content: editProposal.summary,
-          },
-        ]);
-        setStreamingProgress(null);
-        setIsSending(false);
-        scrollToBottom();
-
-        return;
-      }
-
-      if (event.type === "error") {
-        setStreamingAssistantText("");
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: `assistant-error-${Date.now()}`,
-            role: "assistant",
-            content: event.message,
-          },
-        ]);
-        setStreamingProgress(null);
-        setIsSending(false);
-        scrollToBottom();
-      }
-    },
-    [scrollToBottom, setPendingProposal],
-  );
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages.length, scrollToBottom, streamingAssistantText, streamingProgress]);
 
   const doSend = useCallback(async () => {
-    if (isSending) {
+    if (isSending || sendInFlightRef.current) {
       return;
     }
-    const text = inputValue.trim();
-    if (!text) {
-      return;
-    }
-    if (!pipelineId) {
-      toastStore.getState().addToast({
-        type: "error",
-        title: t("canvas.runFailed"),
-        description: t("canvas.noPipelineId"),
-      });
-
-      return;
-    }
-
-    const previousProposalId = proposalIdRef.current;
-    clearPendingProposal();
-
-    const userMessage: Message = {
-      id: `user-${Date.now()}`,
-      role: "user",
-      content: text,
-    };
-
-    setMessages((prev) => [...prev, userMessage]);
-    setInputValue("");
-    setLocalProposalPreview(null);
-    setStreamingAssistantText("");
-    scrollToBottom();
-    setIsSending(true);
-    setStreamingProgress(null);
-
-    const runtimeSetupResult = await fetchRuntimeState();
-
-    if (runtimeSetupResult.isErr()) {
-      const assistantMessage: Message = {
-        id: `assistant-${Date.now()}`,
-        role: "assistant",
-        content: t("canvas.agentPanel.error"),
-      };
-      setMessages((prev) => [...prev, assistantMessage]);
-      toastStore.getState().addToast({
-        type: "error",
-        title: t("canvas.agentPanel.errorTitle"),
-        description: runtimeSetupResult.error.message,
-      });
-      setIsSending(false);
-      scrollToBottom();
-
-      return;
-    }
-
-    const { runtimeOptions: nextRuntimeOptions, suggestedRuntimeId } = runtimeSetupResult.value;
-    setRuntimeOptions(nextRuntimeOptions);
-    const effectiveRuntimeId =
-      selectedRuntimeId && nextRuntimeOptions.some((runtime) => runtime.id === selectedRuntimeId)
-        ? selectedRuntimeId
-        : suggestedRuntimeId;
-    setSelectedRuntimeId(effectiveRuntimeId);
-
-    if (!effectiveRuntimeId) {
-      setNeedsRuntimeSetup(true);
-      const assistantMessage: Message = {
-        id: `assistant-${Date.now()}`,
-        role: "assistant",
-        content: t("canvas.agentPanel.runtimeNotConfigured"),
-      };
-      setMessages((prev) => [...prev, assistantMessage]);
-      setIsSending(false);
-      scrollToBottom();
-
-      return;
-    }
-
-    setNeedsRuntimeSetup(false);
-
-    const sessionId = await ensureSession();
-    const sendResult = await ResultAsync.fromPromise(
-      (async () => {
-        await pipelineAgentSessionsClient.appendMessage(sessionId, {
-          role: "user",
-          kind: "text",
-          content: text,
+    sendInFlightRef.current = true;
+    setIsPreparingSend(true);
+    try {
+      const text = inputValue.trim();
+      if (!text) {
+        return;
+      }
+      if (!pipelineId) {
+        toastStore.getState().addToast({
+          type: "error",
+          title: t("canvas.runFailed"),
+          description: t("canvas.noPipelineId"),
         });
 
-        const streamedTerminalEvent = { current: false };
-        await pipelineAgentSessionsClient.planSessionStream(sessionId, {
-          runtimeId: effectiveRuntimeId,
-          onEvent: (event) => {
-            if (
-              event.type === "question" ||
-              event.type === "error" ||
-              (event.type === "proposal_ready" && event.proposal.mode === "edit")
-            ) {
-              streamedTerminalEvent.current = true;
-            }
-            handlePlanEvent(event);
-          },
-        });
-        if (!streamedTerminalEvent.current) {
-          const latestProposal = await pipelineAgentSessionsClient.getLatestReadyProposal(
-            sessionId,
-            "edit",
-            { excludeProposalId: previousProposalId },
-          );
-          if (latestProposal && latestProposal.proposal.mode === "edit") {
-            handlePlanEvent({
-              type: "proposal_ready",
-              proposal: latestProposal.proposal,
-              proposalId: latestProposal.proposalId,
-            });
+        return;
+      }
 
-            return;
-          }
+      const runtimeSetupResult = await fetchRuntimeState();
 
-          const latestQuestion =
-            await pipelineAgentSessionsClient.getLatestAssistantQuestion(sessionId);
-          if (latestQuestion) {
-            handlePlanEvent({
-              type: "question",
-              question: latestQuestion.question,
-            });
-          }
-        }
-      })(),
-      (error) => (error instanceof Error ? error : new Error(String(error))),
-    );
-    if (sendResult.isErr()) {
-      setStreamingAssistantText("");
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: `assistant-error-${Date.now()}`,
+      if (runtimeSetupResult.isErr()) {
+        addMessage({
+          content: t("canvas.agentPanel.error"),
+          id: `assistant-${Date.now()}`,
           role: "assistant",
-          content: sendResult.error.message,
-        },
-      ]);
-      setStreamingProgress(null);
-      setIsSending(false);
-      scrollToBottom();
+        });
+        toastStore.getState().addToast({
+          type: "error",
+          title: t("canvas.agentPanel.errorTitle"),
+          description: runtimeSetupResult.error.message,
+        });
+        scrollToBottom();
+
+        return;
+      }
+
+      const { runtimeOptions: nextRuntimeOptions, suggestedRuntimeId } = runtimeSetupResult.value;
+      setRuntimeOptions(nextRuntimeOptions);
+      const effectiveRuntimeId =
+        selectedRuntimeId && nextRuntimeOptions.some((runtime) => runtime.id === selectedRuntimeId)
+          ? selectedRuntimeId
+          : suggestedRuntimeId;
+      setSelectedRuntimeId(effectiveRuntimeId);
+
+      if (!effectiveRuntimeId) {
+        setNeedsRuntimeSetup(true);
+        addMessage({
+          content: t("canvas.agentPanel.runtimeNotConfigured"),
+          id: `assistant-${Date.now()}`,
+          role: "assistant",
+        });
+        scrollToBottom();
+
+        return;
+      }
+
+      setNeedsRuntimeSetup(false);
+      setInputValue("");
+      await submitMessage({ content: text, runtimeId: effectiveRuntimeId });
+    } finally {
+      sendInFlightRef.current = false;
+      setIsPreparingSend(false);
     }
   }, [
+    addMessage,
+    fetchRuntimeState,
     inputValue,
     isSending,
-    clearPendingProposal,
     pipelineId,
-    ensureSession,
-    fetchRuntimeState,
-    handlePlanEvent,
-    pipelineAgentSessionsClient,
     selectedRuntimeId,
-    t,
     scrollToBottom,
+    submitMessage,
+    t,
   ]);
 
   const handleKeyDown = useCallback(
@@ -545,6 +334,7 @@ export const AgentPanel = () => {
 
       const attachment = uploadResult.value.attachment;
       if (attachment) {
+        attachmentGraphSignatureRef.current = JSON.stringify({ edges, nodes, pipelineId });
         setAttachments((prev) => [
           ...prev,
           {
@@ -555,112 +345,25 @@ export const AgentPanel = () => {
         ]);
       }
     },
-    [ensureSession, pipelineAgentSessionsClient, selectedRuntimeId, t],
+    [edges, ensureSession, nodes, pipelineAgentSessionsClient, pipelineId, selectedRuntimeId, t],
   );
 
   const hasBlockingDiagnostics =
     agentPanel.diagnostics?.some((diagnostic) => diagnostic.severity === "error") ?? false;
 
-  const activeProposal = agentPanel.pendingProposal ?? localProposalPreview?.proposal ?? null;
-  const activeDiagnostics =
-    agentPanel.diagnostics ?? localProposalPreview?.diagnosticsPreview ?? null;
+  const activeProposal = agentPanel.pendingProposal;
+  const activeDiagnostics = agentPanel.diagnostics;
 
   const handleApply = useCallback(() => {
     if (!activeProposal || hasBlockingDiagnostics) {
       return;
     }
-
-    const run = async () => {
-      const approvalResult = await ResultAsync.fromPromise(
-        sessionIdRef.current && proposalIdRef.current
-          ? pipelineAgentSessionsClient.approveProposal(sessionIdRef.current, proposalIdRef.current)
-          : Promise.resolve(),
-        (error) => (error instanceof Error ? error : new Error(String(error))),
-      );
-      if (approvalResult.isErr()) {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: `assistant-error-${Date.now()}`,
-            role: "assistant",
-            content: approvalResult.error.message,
-          },
-        ]);
-        scrollToBottom();
-
-        return;
-      }
-
-      const applied = applyAgentProposal(activeProposal);
-      if (!applied) {
-        return;
-      }
-
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: `system-${Date.now()}`,
-          role: "assistant",
-          content: t("canvas.agentPanel.applied"),
-        },
-      ]);
-      setLocalProposalPreview(null);
-      sessionIdRef.current = null;
-      sessionGraphSignatureRef.current = null;
-      proposalIdRef.current = null;
-      scrollToBottom();
-    };
-
-    void run();
-  }, [
-    activeProposal,
-    applyAgentProposal,
-    hasBlockingDiagnostics,
-    pipelineAgentSessionsClient,
-    scrollToBottom,
-    t,
-  ]);
+    void applyProposal();
+  }, [activeProposal, applyProposal, hasBlockingDiagnostics]);
 
   const handleDiscard = useCallback(() => {
-    const run = async () => {
-      const sessionId = sessionIdRef.current;
-      const proposalId = proposalIdRef.current;
-      const supersedeResult = await ResultAsync.fromPromise(
-        sessionId && proposalId
-          ? pipelineAgentSessionsClient.supersedeProposal(sessionId, proposalId)
-          : Promise.resolve(),
-        (error) => (error instanceof Error ? error : new Error(String(error))),
-      );
-      if (supersedeResult.isErr()) {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: `assistant-error-${Date.now()}`,
-            role: "assistant",
-            content: supersedeResult.error.message,
-          },
-        ]);
-        scrollToBottom();
-
-        return;
-      }
-
-      clearPendingProposal();
-      setLocalProposalPreview(null);
-      proposalIdRef.current = null;
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: `system-${Date.now()}`,
-          role: "assistant",
-          content: t("canvas.agentPanel.discarded"),
-        },
-      ]);
-      scrollToBottom();
-    };
-
-    void run();
-  }, [clearPendingProposal, pipelineAgentSessionsClient, scrollToBottom, t]);
+    void discardProposal();
+  }, [discardProposal]);
 
   const proposal = activeProposal;
   const hasProposal = proposal !== null;
@@ -738,6 +441,11 @@ export const AgentPanel = () => {
 
       <ScrollArea className="flex-1">
         <div className="flex flex-col gap-3 p-3">
+          {messages.length === 0 && (
+            <div className="mr-auto max-w-[90%] rounded-lg bg-muted px-3 py-2 text-sm">
+              {t("canvas.agentPanel.welcome")}
+            </div>
+          )}
           {messages.map((msg) => (
             <div
               key={msg.id}

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "../../../test/test-wrapper";
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentPanel } from "./AgentPanel";
@@ -11,8 +11,13 @@ import {
   type CanvasPageStore,
 } from "../_store";
 import { useRef, type ReactNode } from "react";
-import type { PipelineActionProposal, PipelineActionDiagnostic } from "@repo/schemas";
+import type {
+  AgentRuntimeConfig,
+  PipelineActionProposal,
+  PipelineActionDiagnostic,
+} from "@repo/schemas";
 import { ok } from "neverthrow";
+import { AgentBarStoreProvider } from "./_store";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -164,7 +169,9 @@ const wrapperWithMutableStore = () => {
     },
   });
   const Wrapper = ({ children }: { children?: ReactNode }) => (
-    <CanvasPageStoreContext.Provider value={store}>{children}</CanvasPageStoreContext.Provider>
+    <CanvasPageStoreContext.Provider value={store}>
+      <AgentBarStoreProvider pipelineId="pipe-1">{children}</AgentBarStoreProvider>
+    </CanvasPageStoreContext.Provider>
   );
 
   return { store: store as CanvasPageStore, Wrapper };
@@ -256,6 +263,41 @@ describe("AgentPanel", () => {
     await waitFor(() => {
       expect(screen.getByText("Which output node should receive the report?")).toBeInTheDocument();
     });
+  });
+
+  it("deduplicates submits while runtime validation is in flight", async () => {
+    render(<AgentPanel />, { wrapper: wrapperWithState() });
+    const input = screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder");
+    await waitFor(() => {
+      expect(mockGetList).toHaveBeenCalled();
+    });
+
+    let resolveRuntimeOptions!: (value: { data: AgentRuntimeConfig[]; total: number }) => void;
+    mockGetList.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRuntimeOptions = resolve;
+        }),
+    );
+
+    await userEvent.type(input, "Tighten the graph");
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mockGetList).toHaveBeenCalledTimes(2);
+    resolveRuntimeOptions({
+      data: [
+        {
+          id: "runtime-codex",
+          name: "Codex Local",
+          type: "codex",
+          connection: { mode: "local" },
+        },
+      ],
+      total: 1,
+    });
+
+    await waitFor(() => expect(mockCreateSession).toHaveBeenCalledTimes(1));
   });
 
   it("uploads a file into the edit session context", async () => {

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -230,6 +230,21 @@ describe("AgentPanel", () => {
     expect(screen.getByText("canvas.agentPanel.title")).toBeInTheDocument();
     expect(screen.getByText("canvas.agentPanel.welcome")).toBeInTheDocument();
     expect(screen.getByText("canvas.agentPanel.runtimeLabel")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-agent-panel")).toHaveClass("bg-surface");
+    expect(screen.getByTestId("canvas-agent-panel")).toHaveClass("w-[min(22.5rem,100%)]");
+    expect(screen.getByTestId("canvas-agent-panel-header")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-agent-panel-status-dot")).toHaveClass("bg-success");
+    expect(screen.getByTestId("canvas-agent-panel-collapse")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-agent-panel-runtime-context")).toHaveClass(
+      "mx-3",
+      "mb-1",
+      "rounded-lg",
+      "bg-surface-2",
+    );
+    expect(screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder")).toHaveClass(
+      "bg-surface-2",
+    );
+    expect(screen.getByTestId("agent-assistant")).toHaveClass("text-[12px]");
   });
 
   it("creates an edit session, sends a message, and displays a streamed follow-up question", async () => {
@@ -263,6 +278,12 @@ describe("AgentPanel", () => {
     await waitFor(() => {
       expect(screen.getByText("Which output node should receive the report?")).toBeInTheDocument();
     });
+    expect(screen.getByText("Tighten the graph").closest("div")).toHaveClass("bg-foreground");
+    expect(
+      screen
+        .getByText("Which output node should receive the report?")
+        .closest('[data-testid="agent-assistant"]'),
+    ).toHaveClass("text-[12px]");
   });
 
   it("deduplicates submits while runtime validation is in flight", async () => {

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -342,12 +342,49 @@ describe("AgentPanel", () => {
     });
   });
 
+  it("keeps send and upload controls disabled until history hydration completes", async () => {
+    let resolveHistory: ((value: { data: never[]; total: number }) => void) | null = null;
+    mockGetList.mockImplementation(({ resource }: { resource: string }) => {
+      if (resource === "conversationMessages") {
+        return new Promise<{ data: never[]; total: number }>((resolve) => {
+          resolveHistory = resolve;
+        });
+      }
+
+      return Promise.resolve({
+        data: [
+          {
+            id: "runtime-codex",
+            name: "Codex Local",
+            type: "codex",
+            connection: { mode: "local" },
+          },
+        ],
+        total: 1,
+      });
+    });
+
+    render(<AgentPanel />, { wrapper: wrapperWithState() });
+
+    expect(screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder")).toBeDisabled();
+    expect(screen.getByLabelText("canvas.agentPanel.upload")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "canvas.agentPanel.upload" })).toBeDisabled();
+
+    resolveHistory?.({ data: [], total: 0 });
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder")).toBeEnabled();
+      expect(screen.getByRole("button", { name: "canvas.agentPanel.upload" })).toBeEnabled();
+    });
+  });
+
   it("clears uploaded attachments when graph signature changes", async () => {
     const { store, Wrapper } = wrapperWithMutableStore();
     render(<AgentPanel />, { wrapper: Wrapper });
 
     const file = new File(["hello"], "brief.txt", { type: "text/plain" });
-    await userEvent.upload(screen.getByLabelText("canvas.agentPanel.upload"), file);
+    const uploadInput = screen.getByLabelText("canvas.agentPanel.upload");
+    await waitFor(() => expect(uploadInput).toBeEnabled());
+    await userEvent.upload(uploadInput, file);
     await waitFor(() => {
       expect(screen.getByText("brief.txt")).toBeInTheDocument();
     });

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -342,8 +342,49 @@ describe("AgentPanel", () => {
     });
   });
 
+  it("opens the file picker after session preparation without disabling the file input", async () => {
+    render(<AgentPanel />, { wrapper: wrapperWithState() });
+
+    const input = screen.getByLabelText("canvas.agentPanel.upload") as HTMLInputElement;
+    await waitFor(() => expect(input).toBeEnabled());
+    const clickInput = vi.spyOn(input, "click");
+
+    await userEvent.click(screen.getByRole("button", { name: "canvas.agentPanel.upload" }));
+
+    await waitFor(() => expect(clickInput).toHaveBeenCalledTimes(1));
+    expect(input).toBeEnabled();
+  });
+
+  it("blocks sending while an attachment upload is in flight", async () => {
+    let resolveUpload: (value: {
+      attachment: { filename: string; id: string; parseStatus: string };
+    }) => void = () => undefined;
+    mockUploadAttachment.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUpload = resolve;
+        }),
+    );
+    render(<AgentPanel />, { wrapper: wrapperWithState() });
+
+    const uploadInput = screen.getByLabelText("canvas.agentPanel.upload");
+    await waitFor(() => expect(uploadInput).toBeEnabled());
+    await userEvent.upload(uploadInput, new File(["hello"], "brief.txt", { type: "text/plain" }));
+    await waitFor(() => expect(mockUploadAttachment).toHaveBeenCalledTimes(1));
+
+    const messageInput = screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder");
+    expect(messageInput).toBeDisabled();
+    fireEvent.keyDown(messageInput, { key: "Enter" });
+    expect(mockPlanSessionStream).not.toHaveBeenCalled();
+
+    resolveUpload({
+      attachment: { filename: "brief.txt", id: "attachment-1", parseStatus: "parsed" },
+    });
+    await waitFor(() => expect(messageInput).toBeEnabled());
+  });
+
   it("keeps send and upload controls disabled until history hydration completes", async () => {
-    let resolveHistory: ((value: { data: never[]; total: number }) => void) | null = null;
+    let resolveHistory: (value: { data: never[]; total: number }) => void = () => undefined;
     mockGetList.mockImplementation(({ resource }: { resource: string }) => {
       if (resource === "conversationMessages") {
         return new Promise<{ data: never[]; total: number }>((resolve) => {
@@ -370,7 +411,7 @@ describe("AgentPanel", () => {
     expect(screen.getByLabelText("canvas.agentPanel.upload")).toBeDisabled();
     expect(screen.getByRole("button", { name: "canvas.agentPanel.upload" })).toBeDisabled();
 
-    resolveHistory?.({ data: [], total: 0 });
+    resolveHistory({ data: [], total: 0 });
     await waitFor(() => {
       expect(screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder")).toBeEnabled();
       expect(screen.getByRole("button", { name: "canvas.agentPanel.upload" })).toBeEnabled();

--- a/packages/views/src/pages/CanvasPage/AgentPanel/_store/agentBarStore.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/_store/agentBarStore.ts
@@ -1,0 +1,150 @@
+import { createContext, createElement, useContext, useRef, type ReactNode } from "react";
+import { useStore } from "zustand";
+import { createStore, type StoreApi } from "zustand/vanilla";
+import type { ConversationMessageMetadata } from "@repo/schemas";
+
+export type AgentConversationState = "idle" | "thinking" | "streaming" | "done";
+
+export type AgentBarMessage = {
+  content: string;
+  id: string;
+  isThinking?: boolean;
+  metadata?: ConversationMessageMetadata;
+  phase?: string | null;
+  role: "assistant" | "user";
+};
+
+export type AgentBarState = {
+  conversationState: AgentConversationState;
+  messages: AgentBarMessage[];
+  pipelineId: string | null;
+  proposalId: string | null;
+  sessionGraphSignature: string | null;
+  sessionId: string | null;
+  streamingAssistantText: string;
+  streamingProgress: string | null;
+  addMessage: (message: AgentBarMessage) => void;
+  appendStreamingAssistantText: (text: string) => void;
+  clearMessages: () => void;
+  removeMessage: (id: string) => void;
+  resetAgentBar: () => void;
+  resetSession: () => void;
+  resolveMessage: (id: string) => void;
+  setConversationState: (state: AgentConversationState) => void;
+  setMessages: (messages: AgentBarMessage[]) => void;
+  setProposalId: (proposalId: string | null) => void;
+  setSession: (sessionId: string, graphSignature: string) => void;
+  setStreamingAssistantText: (text: string) => void;
+  setStreamingProgress: (progress: string | null) => void;
+};
+
+const initialSessionState = {
+  proposalId: null,
+  sessionGraphSignature: null,
+  sessionId: null,
+} as const;
+
+export type AgentBarStore = StoreApi<AgentBarState>;
+
+export const countUnresolvedAnchors = (
+  messages: readonly AgentBarMessage[],
+  refId: string,
+): number =>
+  messages.filter(
+    (message) =>
+      !message.metadata?.resolved &&
+      !message.isThinking &&
+      (message.metadata?.referencedNodeIds ?? []).includes(refId),
+  ).length;
+
+export const countAnchorsByRef = (messages: readonly AgentBarMessage[]): Record<string, number> => {
+  const counts: Record<string, number> = {};
+  for (const message of messages) {
+    if (message.metadata?.resolved || message.isThinking) {
+      continue;
+    }
+    for (const refId of message.metadata?.referencedNodeIds ?? []) {
+      counts[refId] = (counts[refId] ?? 0) + 1;
+    }
+  }
+
+  return counts;
+};
+
+export const createAgentBarStore = (pipelineId: string | null = null): AgentBarStore =>
+  createStore<AgentBarState>((set) => ({
+    conversationState: "idle",
+    messages: [],
+    pipelineId,
+    ...initialSessionState,
+    streamingAssistantText: "",
+    streamingProgress: null,
+    addMessage: (message) =>
+      set((state) => ({
+        messages: [...state.messages.filter((item) => item.id !== message.id), message],
+      })),
+    appendStreamingAssistantText: (text) =>
+      set((state) => ({
+        streamingAssistantText:
+          state.streamingAssistantText.length === 0
+            ? text
+            : `${state.streamingAssistantText}\n${text}`,
+      })),
+    clearMessages: () => set({ messages: [] }),
+    removeMessage: (id) =>
+      set((state) => ({ messages: state.messages.filter((message) => message.id !== id) })),
+    resetAgentBar: () =>
+      set({
+        conversationState: "idle",
+        messages: [],
+        ...initialSessionState,
+        streamingAssistantText: "",
+        streamingProgress: null,
+      }),
+    resetSession: () => set(initialSessionState),
+    resolveMessage: (id) =>
+      set((state) => ({
+        messages: state.messages.map((message) =>
+          message.id === id
+            ? { ...message, metadata: { ...message.metadata, resolved: true } }
+            : message,
+        ),
+      })),
+    setConversationState: (conversationState) => set({ conversationState }),
+    setMessages: (messages) => set({ messages }),
+    setProposalId: (proposalId) => set({ proposalId }),
+    setSession: (sessionId, sessionGraphSignature) =>
+      set({ sessionId, sessionGraphSignature, proposalId: null }),
+    setStreamingAssistantText: (streamingAssistantText) => set({ streamingAssistantText }),
+    setStreamingProgress: (streamingProgress) => set({ streamingProgress }),
+  }));
+
+export const AgentBarStoreContext = createContext<AgentBarStore | null>(null);
+
+export const AgentBarStoreProvider = ({
+  children,
+  pipelineId,
+}: {
+  children: ReactNode;
+  pipelineId: string | null;
+}) => {
+  const storeRef = useRef<AgentBarStore | null>(null);
+
+  if (!storeRef.current || storeRef.current.getState().pipelineId !== pipelineId) {
+    storeRef.current = createAgentBarStore(pipelineId);
+  }
+
+  return createElement(AgentBarStoreContext.Provider, { value: storeRef.current }, children);
+};
+
+export const useAgentBarStoreApi = (): AgentBarStore => {
+  const store = useContext(AgentBarStoreContext);
+  if (!store) {
+    throw new Error("useAgentBarStore must be used within AgentBarStoreProvider");
+  }
+
+  return store;
+};
+
+export const useAgentBarStore = <T>(selector: (state: AgentBarState) => T): T =>
+  useStore(useAgentBarStoreApi(), selector);

--- a/packages/views/src/pages/CanvasPage/AgentPanel/_store/agentBarStore.unit.test.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/_store/agentBarStore.unit.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  countAnchorsByRef,
+  countUnresolvedAnchors,
+  createAgentBarStore,
+  type AgentBarMessage,
+} from "./agentBarStore";
+
+const message = (id: string): AgentBarMessage => ({
+  content: `message ${id}`,
+  id,
+  role: "user",
+});
+
+describe("createAgentBarStore", () => {
+  it("isolates conversations by pipeline", () => {
+    const storeA = createAgentBarStore("pipeline-a");
+    const storeB = createAgentBarStore("pipeline-b");
+
+    storeA.getState().addMessage(message("a1"));
+    storeB.getState().addMessage(message("b1"));
+
+    expect(storeA.getState().messages.map((item) => item.id)).toEqual(["a1"]);
+    expect(storeB.getState().messages.map((item) => item.id)).toEqual(["b1"]);
+  });
+
+  it("replaces an optimistic message with the persisted copy", () => {
+    const store = createAgentBarStore("pipeline-a");
+    store.getState().addMessage(message("m1"));
+    store.getState().addMessage({ ...message("m1"), content: "persisted" });
+
+    expect(store.getState().messages).toEqual([
+      expect.objectContaining({ id: "m1", content: "persisted" }),
+    ]);
+  });
+
+  it("tracks idle to thinking to streaming to done transitions", () => {
+    const store = createAgentBarStore("pipeline-a");
+
+    store.getState().setConversationState("thinking");
+    expect(store.getState().conversationState).toBe("thinking");
+
+    store.getState().appendStreamingAssistantText("first");
+    store.getState().appendStreamingAssistantText("second");
+    store.getState().setConversationState("streaming");
+    expect(store.getState().conversationState).toBe("streaming");
+    expect(store.getState().streamingAssistantText).toBe("first\nsecond");
+
+    store.getState().setConversationState("done");
+    expect(store.getState().conversationState).toBe("done");
+  });
+
+  it("resets session state without clearing conversation history", () => {
+    const store = createAgentBarStore("pipeline-a");
+    store.getState().addMessage(message("m1"));
+    store.getState().setSession("session-1", "graph-1");
+    store.getState().setProposalId("proposal-1");
+
+    store.getState().resetSession();
+
+    expect(store.getState()).toMatchObject({
+      messages: [expect.objectContaining({ id: "m1" })],
+      proposalId: null,
+      sessionGraphSignature: null,
+      sessionId: null,
+    });
+  });
+
+  it("counts and resolves referenced canvas anchors", () => {
+    const store = createAgentBarStore("pipeline-a");
+    store.getState().addMessage({
+      ...message("m1"),
+      metadata: { referencedNodeIds: ["node-1", "node-2"] },
+    });
+    store.getState().addMessage({
+      ...message("m2"),
+      metadata: { referencedNodeIds: ["node-1"] },
+    });
+
+    expect(countUnresolvedAnchors(store.getState().messages, "node-1")).toBe(2);
+    expect(countAnchorsByRef(store.getState().messages)).toEqual({ "node-1": 2, "node-2": 1 });
+
+    store.getState().resolveMessage("m1");
+
+    expect(countUnresolvedAnchors(store.getState().messages, "node-1")).toBe(1);
+    expect(countAnchorsByRef(store.getState().messages)).toEqual({ "node-1": 1 });
+  });
+});

--- a/packages/views/src/pages/CanvasPage/AgentPanel/_store/index.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/_store/index.ts
@@ -1,0 +1,1 @@
+export * from "./agentBarStore";

--- a/packages/views/src/pages/CanvasPage/AgentPanel/context/buildAgentContext.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/context/buildAgentContext.ts
@@ -1,0 +1,59 @@
+import type { AgentContextPayload, WorkspaceCanvasRef } from "@repo/schemas";
+
+export const HISTORY_WINDOW_LIMIT = 20;
+
+export type BuildAgentContextJob = {
+  id: string;
+  status: string;
+};
+
+export type BuildAgentContextInput = {
+  activeJob: BuildAgentContextJob | null;
+  anchorCounts: Record<string, number>;
+  canvasRefs: WorkspaceCanvasRef[];
+  dismissed: string[];
+  hasConversation: boolean;
+  latestJob: BuildAgentContextJob | null;
+  nodeRunStatuses: Record<string, string>;
+  pipelineId: string | null;
+  pipelineName?: string;
+  refLabelById?: Record<string, string>;
+};
+
+export const buildAgentContext = (input: BuildAgentContextInput): AgentContextPayload => {
+  const selection = input.canvasRefs
+    .filter((ref) => !input.dismissed.includes(ref.id))
+    .map((ref) => ({
+      label: ref.label,
+      refId: ref.id,
+      type: ref.type === "edge" ? ("edge" as const) : ("node" as const),
+    }));
+
+  const anchors = Object.entries(input.anchorCounts)
+    .filter(([, count]) => count > 0)
+    .map(([refId, count]) => ({
+      count,
+      label: input.refLabelById?.[refId],
+      refId,
+    }));
+
+  const relevantJob =
+    input.activeJob ?? (input.latestJob?.status === "failed" ? input.latestJob : null);
+
+  return {
+    anchors,
+    project: input.pipelineId
+      ? { pipelineId: input.pipelineId, pipelineName: input.pipelineName }
+      : undefined,
+    runState: relevantJob
+      ? {
+          jobId: relevantJob.id,
+          nodeStatuses: input.nodeRunStatuses,
+          status: relevantJob.status,
+        }
+      : undefined,
+    selection,
+    snapshotIncluded: true,
+    threadWindow: { enabled: input.hasConversation, limit: HISTORY_WINDOW_LIMIT },
+  };
+};

--- a/packages/views/src/pages/CanvasPage/AgentPanel/context/buildAgentContext.unit.test.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/context/buildAgentContext.unit.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceCanvasRef } from "@repo/schemas";
+import { buildAgentContext, HISTORY_WINDOW_LIMIT } from "./buildAgentContext";
+
+const ref = (id: string, type: "node" | "edge" = "node"): WorkspaceCanvasRef => ({
+  baseId: id,
+  id,
+  kind: type,
+  label: `Label ${id}`,
+  path: [],
+  type,
+});
+
+const baseInput = {
+  activeJob: null,
+  anchorCounts: {},
+  canvasRefs: [],
+  dismissed: [],
+  hasConversation: false,
+  latestJob: null,
+  nodeRunStatuses: {},
+  pipelineId: "pipeline-1" as string | null,
+  pipelineName: "Demo",
+};
+
+describe("buildAgentContext", () => {
+  it("serializes the default pipeline context", () => {
+    expect(buildAgentContext(baseInput)).toEqual({
+      anchors: [],
+      project: { pipelineId: "pipeline-1", pipelineName: "Demo" },
+      runState: undefined,
+      selection: [],
+      snapshotIncluded: true,
+      threadWindow: { enabled: false, limit: HISTORY_WINDOW_LIMIT },
+    });
+  });
+
+  it("maps active refs and excludes dismissed refs", () => {
+    const payload = buildAgentContext({
+      ...baseInput,
+      canvasRefs: [ref("node-1"), ref("edge-1", "edge"), ref("node-2")],
+      dismissed: ["node-2"],
+    });
+
+    expect(payload.selection).toEqual([
+      { label: "Label node-1", refId: "node-1", type: "node" },
+      { label: "Label edge-1", refId: "edge-1", type: "edge" },
+    ]);
+  });
+
+  it("includes active run state and conversation history availability", () => {
+    const payload = buildAgentContext({
+      ...baseInput,
+      activeJob: { id: "job-1", status: "running" },
+      hasConversation: true,
+      nodeRunStatuses: { "node-1": "running" },
+    });
+
+    expect(payload.runState).toEqual({
+      jobId: "job-1",
+      nodeStatuses: { "node-1": "running" },
+      status: "running",
+    });
+    expect(payload.threadWindow.enabled).toBe(true);
+  });
+
+  it("falls back to the latest failed job and omits an absent project", () => {
+    const payload = buildAgentContext({
+      ...baseInput,
+      latestJob: { id: "job-9", status: "failed" },
+      pipelineId: null,
+    });
+
+    expect(payload.project).toBeUndefined();
+    expect(payload.runState?.jobId).toBe("job-9");
+    expect(payload.memory).toBeUndefined();
+  });
+});

--- a/packages/views/src/pages/CanvasPage/AgentPanel/context/index.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/context/index.ts
@@ -1,0 +1,2 @@
+export * from "./buildAgentContext";
+export * from "./useAgentContext";

--- a/packages/views/src/pages/CanvasPage/AgentPanel/context/useAgentContext.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/context/useAgentContext.ts
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+import { useStore } from "zustand";
+import type { WorkspaceCanvasRef } from "@repo/schemas";
+import { useCanvasPageStore } from "../../_store";
+import { countAnchorsByRef, useAgentBarStore } from "../_store";
+import { buildAgentContext } from "./buildAgentContext";
+
+export const useAgentContext = () => {
+  const canvasStore = useCanvasPageStore();
+  const activeJobId = useStore(canvasStore, (state) => state.activeJobId);
+  const edges = useStore(canvasStore, (state) => state.edges);
+  const isRunning = useStore(canvasStore, (state) => state.isRunning);
+  const messages = useAgentBarStore((state) => state.messages);
+  const nodeRunStatuses = useStore(canvasStore, (state) => state.nodeRunStatuses);
+  const nodes = useStore(canvasStore, (state) => state.nodes);
+  const pipelineId = useStore(canvasStore, (state) => state.pipelineId);
+  const pipelineName = useStore(canvasStore, (state) => state.pipelineName);
+  const selectedEdgeId = useStore(canvasStore, (state) => state.selectedEdgeId);
+  const selectedNodeId = useStore(canvasStore, (state) => state.selectedNodeId);
+
+  return useMemo(() => {
+    const canvasRefs: WorkspaceCanvasRef[] = [];
+    const selectedNode = nodes.find((node) => node.id === selectedNodeId);
+    if (selectedNode) {
+      canvasRefs.push({
+        baseId: selectedNode.id,
+        id: selectedNode.id,
+        kind: selectedNode.type,
+        label: selectedNode.data.label ?? selectedNode.id,
+        path: [],
+        type: "node",
+      });
+    }
+
+    const selectedEdge = edges.find((edge) => edge.id === selectedEdgeId);
+    if (selectedEdge) {
+      canvasRefs.push({
+        baseId: selectedEdge.id,
+        id: selectedEdge.id,
+        kind: "edge",
+        label: selectedEdge.data?.label || `${selectedEdge.source} -> ${selectedEdge.target}`,
+        path: [],
+        type: "edge",
+      });
+    }
+
+    const refLabelById = Object.fromEntries(
+      nodes.map((node) => [node.id, node.data.label ?? node.id]),
+    );
+
+    return buildAgentContext({
+      activeJob: activeJobId && isRunning ? { id: activeJobId, status: "running" } : null,
+      anchorCounts: countAnchorsByRef(messages),
+      canvasRefs,
+      dismissed: [],
+      hasConversation: messages.length > 0,
+      latestJob: null,
+      nodeRunStatuses,
+      pipelineId,
+      pipelineName,
+      refLabelById,
+    });
+  }, [
+    activeJobId,
+    edges,
+    isRunning,
+    messages,
+    nodeRunStatuses,
+    nodes,
+    pipelineId,
+    pipelineName,
+    selectedEdgeId,
+    selectedNodeId,
+  ]);
+};

--- a/packages/views/src/pages/CanvasPage/AgentPanel/messages/Assistant.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/messages/Assistant.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+import { LoaderCircle } from "lucide-react";
+import { cn } from "@repo/ui/lib/utils";
+import { Icon } from "../../../../components/primitives";
+
+export type AssistantProps = {
+  children: ReactNode;
+  className?: string;
+  isThinking?: boolean;
+};
+
+/** Minimal assistant message: plain text with an optional thinking indicator. */
+export const Assistant = ({ children, className, isThinking = false }: AssistantProps) => (
+  <div
+    className={cn("text-[12px] leading-relaxed text-foreground/90", className)}
+    data-testid="agent-assistant"
+  >
+    {isThinking ? (
+      <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+        <Icon className="animate-spin" icon={LoaderCircle} size={11} />
+        {children}
+      </span>
+    ) : (
+      children
+    )}
+  </div>
+);

--- a/packages/views/src/pages/CanvasPage/AgentPanel/messages/Bubble.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/messages/Bubble.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+import { cn } from "@repo/ui/lib/utils";
+
+export type BubbleProps = {
+  children: ReactNode;
+  className?: string;
+  attachmentLabel?: string;
+};
+
+/** Foreground bubble used for user-authored messages. */
+export const Bubble = ({ attachmentLabel, children, className }: BubbleProps) => (
+  <div className="flex justify-end">
+    <div
+      className={cn(
+        "max-w-[88%] rounded-2xl rounded-br-md bg-foreground px-3 py-2 text-[12px] leading-relaxed text-primary-foreground",
+        className,
+      )}
+    >
+      {attachmentLabel ? (
+        <div className="mb-1 text-[10.5px] font-medium opacity-80">{attachmentLabel}</div>
+      ) : null}
+      {children}
+    </div>
+  </div>
+);

--- a/packages/views/src/pages/CanvasPage/AgentPanel/messages/index.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/messages/index.ts
@@ -1,0 +1,2 @@
+export * from "./Assistant";
+export * from "./Bubble";

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
@@ -1,0 +1,363 @@
+import { useCallback, useMemo } from "react";
+import { ResultAsync } from "neverthrow";
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import type { PipelineActionProposal } from "@repo/schemas";
+import { useCanvasPageStore } from "../_store";
+import {
+  createPipelineAgentSessionsClient,
+  type PipelineAgentPlanEvent,
+} from "../../../lib/pipelineAgentSessionsClient";
+import { usePlatform } from "../../../platform";
+import { useAgentBarStore, useAgentBarStoreApi } from "./_store";
+import { HISTORY_WINDOW_LIMIT, useAgentContext } from "./context";
+import { useAgentConversationPersistence } from "./useAgentConversationPersistence";
+
+export type AgentConversationSubmitInput = {
+  content: string;
+  runtimeId: string;
+};
+
+export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null }) => {
+  const { t } = useTranslation();
+  const platform = usePlatform();
+  const client = useMemo(() => createPipelineAgentSessionsClient(platform), [platform]);
+  const canvasStore = useCanvasPageStore();
+  const agentBarStore = useAgentBarStoreApi();
+  const agentContext = useAgentContext();
+  const agentPanel = useStore(canvasStore, (state) => state.agentPanel);
+  const applyAgentProposal = useStore(canvasStore, (state) => state.applyAgentProposal);
+  const clearPendingProposal = useStore(canvasStore, (state) => state.clearPendingProposal);
+  const edges = useStore(canvasStore, (state) => state.edges);
+  const nodes = useStore(canvasStore, (state) => state.nodes);
+  const setPendingProposal = useStore(canvasStore, (state) => state.setPendingProposal);
+  const conversationState = useAgentBarStore((state) => state.conversationState);
+  const messages = useAgentBarStore((state) => state.messages);
+  const streamingAssistantText = useAgentBarStore((state) => state.streamingAssistantText);
+  const streamingProgress = useAgentBarStore((state) => state.streamingProgress);
+  const {
+    isLoading,
+    isSending: isPersisting,
+    sendMessage,
+  } = useAgentConversationPersistence({
+    phase: conversationState,
+    pipelineId,
+  });
+
+  const ensureSession = useCallback(async () => {
+    const graphSignature = JSON.stringify({ edges, nodes, pipelineId });
+    const current = agentBarStore.getState();
+    if (current.sessionId && current.sessionGraphSignature === graphSignature) {
+      return current.sessionId;
+    }
+
+    const session = await client.createSession({
+      entrypoint: "canvas-agent-panel",
+      mode: "edit",
+      ...(pipelineId ? { pipelineId } : {}),
+      snapshot: { edges, nodes },
+    });
+
+    const history = current.messages.slice(-HISTORY_WINDOW_LIMIT);
+    for (const message of history) {
+      await client.appendMessage(session.id, {
+        content: message.content,
+        kind: "text",
+        role: message.role,
+      });
+    }
+
+    agentBarStore.getState().setSession(session.id, graphSignature);
+
+    return session.id;
+  }, [agentBarStore, client, edges, nodes, pipelineId]);
+
+  const finishWithAssistantMessage = useCallback(
+    async (content: string) => {
+      const state = agentBarStore.getState();
+      state.setStreamingAssistantText("");
+      state.setStreamingProgress(null);
+      state.setConversationState("done");
+
+      return Boolean(await sendMessage({ content, phase: "done", role: "assistant" }));
+    },
+    [agentBarStore, sendMessage],
+  );
+
+  const handlePlanEvent = useCallback(
+    (event: PipelineAgentPlanEvent): Promise<boolean> | null => {
+      const state = agentBarStore.getState();
+
+      if (event.type === "phase") {
+        state.setConversationState("thinking");
+        state.setStreamingProgress(event.phase);
+
+        return null;
+      }
+
+      if (event.type === "progress") {
+        state.setConversationState("thinking");
+        state.setStreamingProgress(event.message);
+
+        return null;
+      }
+
+      if (event.type === "assistant_chunk") {
+        state.setConversationState("streaming");
+        state.appendStreamingAssistantText(event.text);
+
+        return null;
+      }
+
+      if (event.type === "question") {
+        return finishWithAssistantMessage(event.question);
+      }
+
+      if (event.type === "proposal_ready" && event.proposal.mode === "edit") {
+        const proposal: PipelineActionProposal = {
+          actions: event.proposal.actions,
+          summary: event.proposal.summary,
+        };
+        state.setProposalId(event.proposalId);
+        setPendingProposal(proposal, event.proposal.diagnosticsPreview);
+        return finishWithAssistantMessage(event.proposal.summary);
+      }
+
+      if (event.type === "error") {
+        return finishWithAssistantMessage(event.message);
+      }
+
+      if (event.type === "done") {
+        state.setStreamingProgress(null);
+        state.setConversationState("done");
+      }
+
+      return null;
+    },
+    [agentBarStore, finishWithAssistantMessage, setPendingProposal],
+  );
+
+  const submitMessage = useCallback(
+    async ({ content, runtimeId }: AgentConversationSubmitInput) => {
+      const trimmedContent = content.trim();
+      if (
+        !pipelineId ||
+        trimmedContent.length === 0 ||
+        conversationState === "thinking" ||
+        conversationState === "streaming"
+      ) {
+        return false;
+      }
+
+      clearPendingProposal();
+      const state = agentBarStore.getState();
+      state.setConversationState("thinking");
+      state.setStreamingAssistantText("");
+      state.setStreamingProgress(null);
+
+      const result = await ResultAsync.fromPromise(
+        (async () => {
+          const sessionId = await ensureSession();
+          await client.appendMessage(sessionId, {
+            content: JSON.stringify({ context: agentContext, type: "agent_context" }),
+            kind: "text",
+            role: "system",
+          });
+          const persistedMessage = await sendMessage({
+            content: trimmedContent,
+            phase: "thinking",
+            role: "user",
+          });
+          if (!persistedMessage) {
+            throw new Error(t("canvas.agentPanel.error"));
+          }
+          await client.appendMessage(sessionId, {
+            content: trimmedContent,
+            kind: "text",
+            role: "user",
+          });
+
+          const previousProposalId = state.proposalId;
+          const streamedTerminalEvent = { current: false };
+          const terminalPersistences: Promise<boolean>[] = [];
+          let streamFailed = false;
+          await client.planSessionStream(sessionId, {
+            runtimeId,
+            onEvent: (event) => {
+              if (
+                event.type === "question" ||
+                event.type === "error" ||
+                (event.type === "proposal_ready" && event.proposal.mode === "edit")
+              ) {
+                streamedTerminalEvent.current = true;
+              }
+              if (event.type === "error") {
+                streamFailed = true;
+              }
+              const persistence = handlePlanEvent(event);
+              if (persistence) {
+                terminalPersistences.push(persistence);
+              }
+            },
+          });
+
+          if (streamedTerminalEvent.current) {
+            const persisted = await Promise.all(terminalPersistences);
+            if (persisted.some((value) => !value)) {
+              throw new Error(t("canvas.agentPanel.error"));
+            }
+
+            return !streamFailed;
+          }
+
+          const latestProposal = await client.getLatestReadyProposal(sessionId, "edit", {
+            excludeProposalId: previousProposalId,
+          });
+          if (latestProposal && latestProposal.proposal.mode === "edit") {
+            const persisted = await handlePlanEvent({
+              proposal: latestProposal.proposal,
+              proposalId: latestProposal.proposalId,
+              type: "proposal_ready",
+            });
+            if (!persisted) {
+              throw new Error(t("canvas.agentPanel.error"));
+            }
+
+            return true;
+          }
+
+          const latestQuestion = await client.getLatestAssistantQuestion(sessionId);
+          if (latestQuestion) {
+            const persisted = await handlePlanEvent({
+              question: latestQuestion.question,
+              type: "question",
+            });
+            if (!persisted) {
+              throw new Error(t("canvas.agentPanel.error"));
+            }
+          }
+
+          return true;
+        })(),
+        (error) => (error instanceof Error ? error : new Error(String(error))),
+      );
+
+      if (result.isErr()) {
+        const persisted = await finishWithAssistantMessage(result.error.message);
+        if (!persisted) {
+          agentBarStore.getState().addMessage({
+            content: result.error.message,
+            id: `assistant-error-${Date.now()}`,
+            phase: "done",
+            role: "assistant",
+          });
+        }
+
+        return false;
+      }
+
+      if (!result.value) {
+        return false;
+      }
+
+      if (agentBarStore.getState().conversationState !== "done") {
+        agentBarStore.getState().setConversationState("done");
+      }
+
+      return true;
+    },
+    [
+      agentBarStore,
+      agentContext,
+      clearPendingProposal,
+      client,
+      conversationState,
+      ensureSession,
+      finishWithAssistantMessage,
+      handlePlanEvent,
+      pipelineId,
+      sendMessage,
+      t,
+    ],
+  );
+
+  const applyProposal = useCallback(async () => {
+    const proposal = agentPanel.pendingProposal;
+    const hasBlockingDiagnostics =
+      agentPanel.diagnostics?.some((diagnostic) => diagnostic.severity === "error") ?? false;
+    if (!proposal || hasBlockingDiagnostics) {
+      return false;
+    }
+
+    const { proposalId, sessionId } = agentBarStore.getState();
+    const approval = await ResultAsync.fromPromise(
+      sessionId && proposalId ? client.approveProposal(sessionId, proposalId) : Promise.resolve(),
+      (error) => (error instanceof Error ? error : new Error(String(error))),
+    );
+    if (approval.isErr()) {
+      await finishWithAssistantMessage(approval.error.message);
+
+      return false;
+    }
+
+    if (!applyAgentProposal(proposal)) {
+      return false;
+    }
+
+    await sendMessage({
+      content: t("canvas.agentPanel.applied"),
+      phase: "done",
+      role: "assistant",
+    });
+    agentBarStore.getState().resetSession();
+
+    return true;
+  }, [
+    agentBarStore,
+    agentPanel,
+    applyAgentProposal,
+    client,
+    finishWithAssistantMessage,
+    sendMessage,
+    t,
+  ]);
+
+  const discardProposal = useCallback(async () => {
+    const { proposalId, sessionId } = agentBarStore.getState();
+    const superseded = await ResultAsync.fromPromise(
+      sessionId && proposalId ? client.supersedeProposal(sessionId, proposalId) : Promise.resolve(),
+      (error) => (error instanceof Error ? error : new Error(String(error))),
+    );
+    if (superseded.isErr()) {
+      await finishWithAssistantMessage(superseded.error.message);
+
+      return false;
+    }
+
+    clearPendingProposal();
+    agentBarStore.getState().setProposalId(null);
+    await sendMessage({
+      content: t("canvas.agentPanel.discarded"),
+      phase: "done",
+      role: "assistant",
+    });
+
+    return true;
+  }, [agentBarStore, clearPendingProposal, client, finishWithAssistantMessage, sendMessage, t]);
+
+  return {
+    agentContext,
+    applyProposal,
+    conversationState,
+    discardProposal,
+    ensureSession,
+    isLoading,
+    isSending:
+      isPersisting || conversationState === "thinking" || conversationState === "streaming",
+    messages,
+    resetSession: agentBarStore.getState().resetSession,
+    streamingAssistantText,
+    streamingProgress,
+    submitMessage,
+  };
+};

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { ResultAsync } from "neverthrow";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
@@ -35,6 +35,10 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
   const messages = useAgentBarStore((state) => state.messages);
   const streamingAssistantText = useAgentBarStore((state) => state.streamingAssistantText);
   const streamingProgress = useAgentBarStore((state) => state.streamingProgress);
+  const sessionCreationRef = useRef<{
+    graphSignature: string;
+    promise: Promise<string>;
+  } | null>(null);
   const {
     isLoading,
     isSending: isPersisting,
@@ -46,30 +50,68 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
 
   const ensureSession = useCallback(async () => {
     const graphSignature = JSON.stringify({ edges, nodes, pipelineId });
-    const current = agentBarStore.getState();
-    if (current.sessionId && current.sessionGraphSignature === graphSignature) {
-      return current.sessionId;
+    const existingSessionId = () => {
+      const current = agentBarStore.getState();
+
+      return current.sessionGraphSignature === graphSignature ? current.sessionId : null;
+    };
+    const existing = existingSessionId();
+    if (existing) {
+      return existing;
     }
 
-    const session = await client.createSession({
-      entrypoint: "canvas-agent-panel",
-      mode: "edit",
-      ...(pipelineId ? { pipelineId } : {}),
-      snapshot: { edges, nodes },
-    });
+    while (sessionCreationRef.current) {
+      const pending = sessionCreationRef.current;
+      if (pending.graphSignature === graphSignature) {
+        return pending.promise;
+      }
 
-    const history = current.messages.slice(-HISTORY_WINDOW_LIMIT);
-    for (const message of history) {
-      await client.appendMessage(session.id, {
-        content: message.content,
-        kind: "text",
-        role: message.role,
+      try {
+        await pending.promise;
+      } catch {
+        // A failed creation for an obsolete graph must not prevent a retry for this graph.
+      }
+
+      const sessionId = existingSessionId();
+      if (sessionId) {
+        return sessionId;
+      }
+    }
+
+    let creationPromise: Promise<string>;
+    creationPromise = (async () => {
+      const currentSessionId = existingSessionId();
+      if (currentSessionId) {
+        return currentSessionId;
+      }
+
+      const session = await client.createSession({
+        entrypoint: "canvas-agent-panel",
+        mode: "edit",
+        ...(pipelineId ? { pipelineId } : {}),
+        snapshot: { edges, nodes },
       });
-    }
 
-    agentBarStore.getState().setSession(session.id, graphSignature);
+      const history = agentBarStore.getState().messages.slice(-HISTORY_WINDOW_LIMIT);
+      for (const message of history) {
+        await client.appendMessage(session.id, {
+          content: message.content,
+          kind: "text",
+          role: message.role,
+        });
+      }
 
-    return session.id;
+      agentBarStore.getState().setSession(session.id, graphSignature);
+
+      return session.id;
+    })().finally(() => {
+      if (sessionCreationRef.current?.promise === creationPromise) {
+        sessionCreationRef.current = null;
+      }
+    });
+    sessionCreationRef.current = { graphSignature, promise: creationPromise };
+
+    return creationPromise;
   }, [agentBarStore, client, edges, nodes, pipelineId]);
 
   const finishWithAssistantMessage = useCallback(
@@ -142,6 +184,7 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
       const trimmedContent = content.trim();
       if (
         !pipelineId ||
+        isLoading ||
         trimmedContent.length === 0 ||
         conversationState === "thinking" ||
         conversationState === "streaming"
@@ -275,6 +318,7 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
       ensureSession,
       finishWithAssistantMessage,
       handlePlanEvent,
+      isLoading,
       pipelineId,
       sendMessage,
       t,

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.unit.test.tsx
@@ -1,0 +1,146 @@
+import { act, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { render } from "../../../test/test-wrapper";
+import { CanvasPageStoreContext, createCanvasPageStore } from "../_store";
+import type { PipelineAgentPlanEvent } from "../../../lib/pipelineAgentSessionsClient";
+import { AgentBarStoreProvider } from "./_store";
+import { useAgentConversation } from "./useAgentConversation";
+
+const mocks = vi.hoisted(() => ({
+  appendMessage: vi.fn(),
+  createSession: vi.fn(),
+  getLatestAssistantQuestion: vi.fn(),
+  getLatestReadyProposal: vi.fn(),
+  planSessionStream: vi.fn(),
+  sendMessage: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("../../../lib/pipelineAgentSessionsClient", () => ({
+  createPipelineAgentSessionsClient: () => ({
+    appendMessage: (...args: unknown[]) => mocks.appendMessage(...args),
+    approveProposal: vi.fn(),
+    createSession: (...args: unknown[]) => mocks.createSession(...args),
+    getLatestAssistantQuestion: (...args: unknown[]) => mocks.getLatestAssistantQuestion(...args),
+    getLatestReadyProposal: (...args: unknown[]) => mocks.getLatestReadyProposal(...args),
+    planSessionStream: (...args: unknown[]) => mocks.planSessionStream(...args),
+    supersedeProposal: vi.fn(),
+  }),
+}));
+
+vi.mock("./useAgentConversationPersistence", () => ({
+  useAgentConversationPersistence: () => ({
+    isLoading: false,
+    isSending: false,
+    sendMessage: (...args: unknown[]) => mocks.sendMessage(...args),
+  }),
+}));
+
+const store = createCanvasPageStore([], [], "pipe-1", "Pipeline 1");
+
+const Wrapper = ({ children }: { children?: ReactNode }) => (
+  <CanvasPageStoreContext.Provider value={store}>
+    <AgentBarStoreProvider pipelineId="pipe-1">{children}</AgentBarStoreProvider>
+  </CanvasPageStoreContext.Provider>
+);
+
+const Harness = () => {
+  const { conversationState, streamingAssistantText, submitMessage } = useAgentConversation({
+    pipelineId: "pipe-1",
+  });
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => void submitMessage({ content: "Tighten graph", runtimeId: "runtime-1" })}
+      >
+        Send
+      </button>
+      <span data-testid="state">{conversationState}</span>
+      <span data-testid="stream">{streamingAssistantText}</span>
+    </div>
+  );
+};
+
+describe("useAgentConversation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createSession.mockResolvedValue({
+      entrypoint: "canvas-agent-panel",
+      id: "session-1",
+      mode: "edit",
+      status: "draft",
+    });
+    mocks.appendMessage.mockResolvedValue({ id: "message-1" });
+    mocks.getLatestAssistantQuestion.mockResolvedValue(null);
+    mocks.getLatestReadyProposal.mockResolvedValue(null);
+    mocks.sendMessage.mockResolvedValue({ id: "persisted-message" });
+  });
+
+  it("transitions idle to thinking to streaming to done while processing SSE events", async () => {
+    let emit: ((event: PipelineAgentPlanEvent) => void) | null = null;
+    let finishStream: (() => void) | null = null;
+    mocks.planSessionStream.mockImplementation(
+      async (_sessionId: string, input: { onEvent: (event: PipelineAgentPlanEvent) => void }) => {
+        emit = input.onEvent;
+        input.onEvent({ phase: "planning", type: "phase" });
+        await new Promise<void>((resolve) => {
+          finishStream = resolve;
+        });
+      },
+    );
+
+    render(<Harness />, { wrapper: Wrapper });
+    expect(screen.getByTestId("state")).toHaveTextContent("idle");
+
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => expect(screen.getByTestId("state")).toHaveTextContent("thinking"));
+
+    act(() => emit?.({ text: "Drafting", type: "assistant_chunk" }));
+    expect(screen.getByTestId("state")).toHaveTextContent("streaming");
+    expect(screen.getByTestId("stream")).toHaveTextContent("Drafting");
+
+    act(() => emit?.({ question: "Which branch?", type: "question" }));
+    await waitFor(() => expect(screen.getByTestId("state")).toHaveTextContent("done"));
+
+    act(() => finishStream?.());
+    await waitFor(() => {
+      expect(mocks.sendMessage).toHaveBeenCalledWith({
+        content: "Which branch?",
+        phase: "done",
+        role: "assistant",
+      });
+    });
+  });
+
+  it("sends the serialized current context before the user message", async () => {
+    mocks.planSessionStream.mockImplementation(
+      async (_sessionId: string, input: { onEvent: (event: PipelineAgentPlanEvent) => void }) => {
+        input.onEvent({ question: "Done", type: "question" });
+      },
+    );
+
+    render(<Harness />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(mocks.appendMessage).toHaveBeenCalledTimes(2));
+    expect(mocks.appendMessage.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        kind: "text",
+        role: "system",
+        content: expect.stringContaining('"pipelineId":"pipe-1"'),
+      }),
+    );
+    expect(mocks.appendMessage.mock.calls[1]?.[1]).toEqual({
+      content: "Tighten graph",
+      kind: "text",
+      role: "user",
+    });
+  });
+});

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.unit.test.tsx
@@ -1,7 +1,7 @@
 import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { render } from "../../../test/test-wrapper";
 import { CanvasPageStoreContext, createCanvasPageStore } from "../_store";
 import type { PipelineAgentPlanEvent } from "../../../lib/pipelineAgentSessionsClient";
@@ -71,15 +71,19 @@ const Harness = () => {
 
 const EnsureSessionHarness = () => {
   const { ensureSession } = useAgentConversation({ pipelineId: "pipe-1" });
+  const [sessionA, setSessionA] = useState("");
+  const [sessionB, setSessionB] = useState("");
 
   return (
     <div>
-      <button type="button" onClick={() => void ensureSession()}>
+      <button type="button" onClick={() => void ensureSession().then(setSessionA)}>
         Ensure A
       </button>
-      <button type="button" onClick={() => void ensureSession()}>
+      <button type="button" onClick={() => void ensureSession().then(setSessionB)}>
         Ensure B
       </button>
+      <span data-testid="session-a">{sessionA}</span>
+      <span data-testid="session-b">{sessionB}</span>
     </div>
   );
 };
@@ -190,6 +194,10 @@ describe("useAgentConversation", () => {
         id: "session-1",
       }),
     );
-    await waitFor(() => expect(mocks.createSession).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(screen.getByTestId("session-a")).toHaveTextContent("session-1");
+      expect(screen.getByTestId("session-b")).toHaveTextContent("session-1");
+    });
+    expect(mocks.createSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.unit.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   createSession: vi.fn(),
   getLatestAssistantQuestion: vi.fn(),
   getLatestReadyProposal: vi.fn(),
+  isHistoryLoading: false,
   planSessionStream: vi.fn(),
   sendMessage: vi.fn(),
 }));
@@ -35,7 +36,7 @@ vi.mock("../../../lib/pipelineAgentSessionsClient", () => ({
 
 vi.mock("./useAgentConversationPersistence", () => ({
   useAgentConversationPersistence: () => ({
-    isLoading: false,
+    isLoading: mocks.isHistoryLoading,
     isSending: false,
     sendMessage: (...args: unknown[]) => mocks.sendMessage(...args),
   }),
@@ -68,9 +69,25 @@ const Harness = () => {
   );
 };
 
+const EnsureSessionHarness = () => {
+  const { ensureSession } = useAgentConversation({ pipelineId: "pipe-1" });
+
+  return (
+    <div>
+      <button type="button" onClick={() => void ensureSession()}>
+        Ensure A
+      </button>
+      <button type="button" onClick={() => void ensureSession()}>
+        Ensure B
+      </button>
+    </div>
+  );
+};
+
 describe("useAgentConversation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.isHistoryLoading = false;
     mocks.createSession.mockResolvedValue({
       entrypoint: "canvas-agent-panel",
       id: "session-1",
@@ -142,5 +159,37 @@ describe("useAgentConversation", () => {
       kind: "text",
       role: "user",
     });
+  });
+
+  it("does not create a session while conversation history is loading", async () => {
+    mocks.isHistoryLoading = true;
+
+    render(<Harness />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(mocks.createSession).not.toHaveBeenCalled();
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("shares one session creation across concurrent callers", async () => {
+    let resolveSession: ((session: { id: string }) => void) | null = null;
+    mocks.createSession.mockImplementation(
+      () =>
+        new Promise<{ id: string }>((resolve) => {
+          resolveSession = resolve;
+        }),
+    );
+
+    render(<EnsureSessionHarness />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByRole("button", { name: "Ensure A" }));
+    await userEvent.click(screen.getByRole("button", { name: "Ensure B" }));
+
+    expect(mocks.createSession).toHaveBeenCalledTimes(1);
+    act(() =>
+      resolveSession?.({
+        id: "session-1",
+      }),
+    );
+    await waitFor(() => expect(mocks.createSession).toHaveBeenCalledTimes(1));
   });
 });

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversationPersistence.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversationPersistence.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect } from "react";
+import { useCreate, useList, type HttpError } from "@refinedev/core";
+import { ResultAsync } from "neverthrow";
+import type {
+  ConversationMessage,
+  ConversationMessageMetadata,
+  ConversationRole,
+  CreateConversationMessageInput,
+} from "@repo/schemas";
+import { ResourceName } from "../../../constants";
+import { useAgentBarStore } from "./_store";
+import { HISTORY_WINDOW_LIMIT } from "./context";
+
+type PersistConversationMessageInput = CreateConversationMessageInput & {
+  id: string;
+};
+
+export type SendAgentMessageInput = {
+  content: string;
+  metadata?: ConversationMessageMetadata;
+  phase?: string;
+  role?: "assistant" | "user";
+};
+
+const createMessageId = () =>
+  `conversation-message-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+const toConversationRole = (role: "assistant" | "user"): ConversationRole =>
+  role === "assistant" ? "agent" : "user";
+
+export const toAgentBarMessage = (message: ConversationMessage) => ({
+  content: message.content,
+  id: message.id,
+  metadata: message.metadata ?? undefined,
+  phase: message.phase,
+  role: message.role === "user" ? ("user" as const) : ("assistant" as const),
+});
+
+export const useAgentConversationPersistence = ({
+  phase,
+  pipelineId,
+}: {
+  phase: string;
+  pipelineId: string | null;
+}) => {
+  const { result: conversationResult, query: conversationQuery } = useList<ConversationMessage>({
+    filters: pipelineId
+      ? [
+          { field: "pipelineId", operator: "eq", value: pipelineId },
+          { field: "limit", operator: "eq", value: HISTORY_WINDOW_LIMIT },
+        ]
+      : [],
+    queryOptions: { enabled: Boolean(pipelineId), retry: false },
+    resource: ResourceName.conversationMessages,
+  });
+  const { mutateAsync: createConversationMessage, mutation: createMutation } = useCreate<
+    ConversationMessage,
+    HttpError,
+    PersistConversationMessageInput
+  >();
+  const addMessage = useAgentBarStore((state) => state.addMessage);
+  const removeMessage = useAgentBarStore((state) => state.removeMessage);
+  const setMessages = useAgentBarStore((state) => state.setMessages);
+
+  useEffect(() => {
+    if (!pipelineId) {
+      setMessages([]);
+
+      return;
+    }
+
+    setMessages(conversationResult.data.map(toAgentBarMessage));
+  }, [conversationResult.data, pipelineId, setMessages]);
+
+  const sendMessage = useCallback(
+    async ({ content, metadata, phase: messagePhase, role = "user" }: SendAgentMessageInput) => {
+      const trimmedContent = content.trim();
+      if (!pipelineId || trimmedContent.length === 0) {
+        return null;
+      }
+
+      const id = createMessageId();
+      addMessage({ content: trimmedContent, id, metadata, phase: messagePhase ?? phase, role });
+
+      const created = await ResultAsync.fromPromise(
+        createConversationMessage({
+          errorNotification: false,
+          resource: ResourceName.conversationMessages,
+          successNotification: false,
+          values: {
+            content: trimmedContent,
+            id,
+            metadata: metadata ?? null,
+            phase: messagePhase ?? phase,
+            pipelineId,
+            role: toConversationRole(role),
+          },
+        }),
+        (error) => (error instanceof Error ? error : new Error(String(error))),
+      );
+
+      if (created.isErr()) {
+        removeMessage(id);
+
+        return null;
+      }
+
+      if (conversationQuery?.refetch) {
+        await ResultAsync.fromPromise(conversationQuery.refetch(), (error) =>
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+
+      return created.value.data;
+    },
+    [addMessage, conversationQuery, createConversationMessage, phase, pipelineId, removeMessage],
+  );
+
+  return {
+    isLoading: conversationQuery?.isLoading ?? false,
+    isSending: createMutation.isPending,
+    sendMessage,
+  };
+};

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversationPersistence.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversationPersistence.unit.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConversationMessage } from "@repo/schemas";
+import { ResourceName } from "../../../constants";
+import { AgentBarStoreProvider, useAgentBarStore } from "./_store";
+import { HISTORY_WINDOW_LIMIT } from "./context";
+import { useAgentConversationPersistence } from "./useAgentConversationPersistence";
+
+const refineMocks = vi.hoisted(() => ({
+  createConversationMessage: vi.fn(),
+  conversationMessages: [] as ConversationMessage[],
+  refetch: vi.fn(),
+  useList: vi.fn(),
+}));
+
+vi.mock("@refinedev/core", () => ({
+  useCreate: () => ({
+    mutateAsync: refineMocks.createConversationMessage,
+    mutation: { isPending: false },
+  }),
+  useList: (input: unknown) => {
+    refineMocks.useList(input);
+
+    return {
+      query: { isLoading: false, refetch: refineMocks.refetch },
+      result: {
+        data: refineMocks.conversationMessages,
+        total: refineMocks.conversationMessages.length,
+      },
+    };
+  },
+}));
+
+const ConversationHarness = () => {
+  const messages = useAgentBarStore((state) => state.messages);
+  const { sendMessage } = useAgentConversationPersistence({
+    phase: "thinking",
+    pipelineId: "pipe-1",
+  });
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          void sendMessage({
+            content: " Persist this ",
+            metadata: { referencedNodeIds: ["node-1"] },
+          })
+        }
+      >
+        Send persisted message
+      </button>
+      {messages.map((message) => (
+        <span key={message.id}>{message.content}</span>
+      ))}
+    </div>
+  );
+};
+
+const renderHarness = () =>
+  render(
+    <AgentBarStoreProvider pipelineId="pipe-1">
+      <ConversationHarness />
+    </AgentBarStoreProvider>,
+  );
+
+describe("useAgentConversationPersistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    refineMocks.refetch.mockResolvedValue({});
+    refineMocks.conversationMessages = [];
+  });
+
+  it("hydrates the latest persisted pipeline conversation window", async () => {
+    refineMocks.conversationMessages = [
+      {
+        content: "Previously persisted",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        id: "msg-1",
+        metadata: { referencedNodeIds: ["node-1"] },
+        phase: "done",
+        pipelineId: "pipe-1",
+        role: "agent",
+      },
+    ];
+
+    renderHarness();
+
+    expect(await screen.findByText("Previously persisted")).toBeInTheDocument();
+    expect(refineMocks.useList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: [
+          { field: "pipelineId", operator: "eq", value: "pipe-1" },
+          { field: "limit", operator: "eq", value: HISTORY_WINDOW_LIMIT },
+        ],
+        resource: ResourceName.conversationMessages,
+      }),
+    );
+  });
+
+  it("persists trimmed messages with phase and metadata", async () => {
+    refineMocks.createConversationMessage.mockResolvedValue({
+      data: {
+        content: "Persist this",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        id: "msg-created",
+        metadata: { referencedNodeIds: ["node-1"] },
+        phase: "thinking",
+        pipelineId: "pipe-1",
+        role: "user",
+      },
+    });
+
+    renderHarness();
+    await userEvent.click(screen.getByRole("button", { name: "Send persisted message" }));
+
+    await waitFor(() => {
+      expect(refineMocks.createConversationMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: ResourceName.conversationMessages,
+          values: expect.objectContaining({
+            content: "Persist this",
+            metadata: { referencedNodeIds: ["node-1"] },
+            phase: "thinking",
+            pipelineId: "pipe-1",
+            role: "user",
+          }),
+        }),
+      );
+    });
+    expect(refineMocks.refetch).toHaveBeenCalled();
+    expect(screen.getByText("Persist this")).toBeInTheDocument();
+  });
+
+  it("removes an optimistic message when persistence fails", async () => {
+    refineMocks.createConversationMessage.mockRejectedValue(new Error("offline"));
+
+    renderHarness();
+    await userEvent.click(screen.getByRole("button", { name: "Send persisted message" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Persist this")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/views/src/pages/CanvasPage/_store/provider.tsx
+++ b/packages/views/src/pages/CanvasPage/_store/provider.tsx
@@ -3,6 +3,7 @@ import { useDataProvider } from "@refinedev/core";
 import { setCanvasDataProvider } from "../../../lib/canvasDataProvider";
 import { CanvasPageStoreContext, createCanvasPageStore } from "./canvasPageStore";
 import type { PipelineNode, PipelineEdge } from "./canvasSlice";
+import { AgentBarStoreProvider } from "../AgentPanel/_store";
 
 interface LoadedPipeline {
   id: string;
@@ -40,7 +41,7 @@ export const CanvasPageStoreProvider = ({ children, pipeline }: Props) => {
 
   return (
     <CanvasPageStoreContext.Provider value={storeRef.current}>
-      {children}
+      <AgentBarStoreProvider pipelineId={pipeline?.id ?? null}>{children}</AgentBarStoreProvider>
     </CanvasPageStoreContext.Provider>
   );
 };


### PR DESCRIPTION
## Summary
- 从 Alan PR #105 迁移 Agent Bar 消息 Store、锚点统计、上下文构建与持久化语义，并适配当前共享 `packages/views` 架构
- 保留现有 Pipeline Agent Session SSE 链路，抽出 `useAgentConversation` 统一会话创建、历史回放、状态机与提案审批/丢弃
- 按 Pipeline 隔离并持久化最近 20 条对话，自动注入当前画布选择、未解决锚点、运行状态和图快照上下文
- 迁移 Alan 的基础对话视觉：紧凑状态栏、Assistant 纯文本、用户消息气泡、运行时上下文面板与统一输入区
- 增加运行时校验期间的重复提交防护，并等待终态 Assistant 消息持久化完成
- 补齐 Store、上下文、SSE 状态转换、持久化与 AgentPanel 回归测试

## Scope boundary
- 本 PR 只包含 COD-131 的对话引擎、Store 与基础消息流视觉
- 富消息卡片与 view transforms 留给 COD-132
- Composer / ContextStrip 留给 COD-133
- 双栏、拖拽宽度与完整 Workspace shell 留给 COD-134

## Verification
- `bun --filter @repo/views test`（69 files, 295 tests）
- `bun --filter @repo/views check-types`
- `bun --filter @ordine/app check-types`
- `bun --filter @ordine/desktop-app build`
- 六个视觉变更文件 `oxfmt --check`
- `git diff --check`
- 本地浏览器 1280x720：面板展开/收起/重开正常，宽度 360px，无横向溢出，控制台 0 error
- 用户已在本地页面完成视觉验收

Linear: COD-131
