### PR TITLE
feat: 完成 Agent Bar Composer 与上下文条（COD-133）

### DIFF
--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.stories.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.stories.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useRef } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import type { PipelineActionDiagnostic, PipelineActionProposal } from "@repo/schemas";
+import type {
+  AgentContextPayload,
+  PipelineActionDiagnostic,
+  PipelineActionProposal,
+  ProposeAttachment,
+  WorkspaceCanvasRef,
+} from "@repo/schemas";
 import { CanvasPageStoreContext, createCanvasPageStore, type CanvasPageStore } from "../_store";
 import { AgentPanel } from "./AgentPanel";
 import {
@@ -23,6 +29,7 @@ import {
 } from "./messages";
 import type { AgentBarMessage } from "./_store";
 import type { MessageTurnSubmitInput } from "./messages/MessageTurn";
+import { Composer } from "./Composer";
 import { setCanvasDataProvider } from "../../../lib/canvasDataProvider";
 import { canvasStoryDataProvider } from "../storybookData";
 import { AgentBarStoreProvider } from "./_store";
@@ -184,6 +191,7 @@ const CardsGallery = () => (
       isLast
       isSending={false}
       message={galleryMessage}
+      refs={[]}
       runtimeId="story-runtime"
       visibleMessages={[galleryMessage]}
       onEditDraft={() => undefined}
@@ -254,6 +262,77 @@ export const AllCards: Story = {
     docs: {
       description: {
         story: "Stable 360px gallery containing every AgentPanel message card.",
+      },
+    },
+  },
+};
+
+const composerContext: AgentContextPayload = {
+  anchors: [{ count: 2, label: "Review", refId: "review-node" }],
+  project: { pipelineId: "story-pipeline", pipelineName: "Story Pipeline" },
+  selection: [{ label: "Review", refId: "review-node", type: "node" }],
+  snapshotIncluded: true,
+  threadWindow: { enabled: true, limit: 20 },
+};
+
+const composerRefs: WorkspaceCanvasRef[] = [
+  {
+    baseId: "review-node",
+    id: "review-node",
+    kind: "operation",
+    label: "Review",
+    path: [],
+    type: "node",
+  },
+  {
+    baseId: "output-edge",
+    id: "output-edge",
+    kind: "edge",
+    label: "Review -> Output",
+    path: [],
+    type: "edge",
+  },
+];
+
+const composerAttachments: ProposeAttachment[] = [
+  { name: "requirements.md", size: 1842, type: "text/markdown" },
+  { name: "pipeline.json", size: 5830, type: "application/json" },
+];
+
+const ComposerGallery = () => (
+  <div className="flex w-[420px] max-w-full flex-col gap-4 border bg-surface p-3">
+    <Composer
+      agentContext={composerContext}
+      canRemoveAttachments={false}
+      clearAttachmentsOnSubmit={false}
+      defaultAttachments={composerAttachments}
+      onAttach={async (files) =>
+        files.map((file) => ({ name: file.name, size: file.size, type: file.type }))
+      }
+      onRemoveRef={() => undefined}
+      onSubmit={() => undefined}
+      refs={composerRefs}
+      runtimeId="story-runtime"
+    />
+    <Composer
+      agentContext={{ ...composerContext, selection: [] }}
+      contextDefaultOpen
+      disabled
+      onAttach={() => undefined}
+      onRemoveRef={() => undefined}
+      refs={[]}
+      runtimeId="story-runtime"
+    />
+  </div>
+);
+
+export const ComposerBaseline: Story = {
+  render: () => <ComposerGallery />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "COD-133 focused gallery for the collapsed and expanded context strip, current references, attachment chips, multiline composer, and disabled state.",
       },
     },
   },

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -1,10 +1,9 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
-import { ChevronsRight, Send, Loader2, AlertCircle, AlertTriangle, Upload } from "lucide-react";
+import { ChevronsRight, AlertCircle, AlertTriangle } from "lucide-react";
 import { Button } from "@repo/ui/button";
 import { ScrollArea } from "@repo/ui/scroll-area";
-import { Input } from "@repo/ui/input";
 import {
   Select,
   SelectContent,
@@ -15,7 +14,7 @@ import {
 } from "@repo/ui/select";
 import { cn } from "@repo/ui/lib/utils";
 import { ResultAsync } from "neverthrow";
-import type { AgentRuntimeConfig } from "@repo/schemas";
+import type { AgentRuntimeConfig, ProposeAttachment, WorkspaceCanvasRef } from "@repo/schemas";
 import { useCanvasPageStore } from "../_store";
 import { ResourceName } from "../../../constants";
 import { getCanvasDataProvider } from "../../../lib/canvasDataProvider";
@@ -25,18 +24,13 @@ import { toastStore } from "../../../store/toastStore";
 import { useAgentBarStore } from "./_store";
 import { Assistant, MessageTurn, ProposalCard } from "./messages";
 import type { MessageTurnSubmitInput } from "./messages/MessageTurn";
+import { Composer, type ComposerSubmitInput } from "./Composer";
 import { buildProposalItems } from "./proposalView";
 import { useAgentConversation } from "./useAgentConversation";
 
 interface RuntimeState {
   runtimeOptions: AgentRuntimeConfig[];
   suggestedRuntimeId: string | null;
-}
-
-interface AttachmentItem {
-  id: string;
-  filename: string;
-  parseStatus: string;
 }
 
 const formatRuntimeLabel = (runtime: AgentRuntimeConfig): string =>
@@ -56,17 +50,17 @@ export const AgentPanel = () => {
   const pipelineId = useStore(store, (state) => state.pipelineId);
   const nodes = useStore(store, (state) => state.nodes);
   const edges = useStore(store, (state) => state.edges);
-  const [inputValue, setInputValue] = useState("");
+  const [composerDraft, setComposerDraft] = useState<string | null>(null);
   const [isPreparingSend, setIsPreparingSend] = useState(false);
   const [isPreparingUpload, setIsPreparingUpload] = useState(false);
   const [isLoadingRuntimes, setIsLoadingRuntimes] = useState(true);
   const [needsRuntimeSetup, setNeedsRuntimeSetup] = useState(false);
   const [runtimeOptions, setRuntimeOptions] = useState<AgentRuntimeConfig[]>([]);
   const [selectedRuntimeId, setSelectedRuntimeId] = useState<string | null>(null);
-  const [attachments, setAttachments] = useState<AttachmentItem[]>([]);
   const addMessage = useAgentBarStore((state) => state.addMessage);
   const {
     applyProposal,
+    agentContext,
     discardProposal,
     ensureSession,
     isLoading: isHistoryLoading,
@@ -78,12 +72,60 @@ export const AgentPanel = () => {
     submitMessage,
   } = useAgentConversation({ pipelineId });
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const attachmentGraphSignatureRef = useRef<string | null>(null);
   const sendInFlightRef = useRef(false);
   const isSending = isPreparingSend || isConversationSending;
   const isUploadBlocked = isHistoryLoading || isPreparingUpload || isSending;
-  const isUploadInputBlocked = isHistoryLoading || isSending;
+  const selectedNodeId = useStore(store, (state) => state.selectedNodeId);
+  const selectedEdgeId = useStore(store, (state) => state.selectedEdgeId);
+  const selectNode = useStore(store, (state) => state.selectNode);
+  const selectEdge = useStore(store, (state) => state.selectEdge);
+  const focusNode = useStore(store, (state) => state.focusNode);
+  const focusEdge = useStore(store, (state) => state.focusEdge);
+  const graphSignature = useMemo(
+    () => JSON.stringify({ edges, nodes, pipelineId }),
+    [edges, nodes, pipelineId],
+  );
+  const canvasRefs = useMemo<WorkspaceCanvasRef[]>(
+    () => [
+      ...nodes.map((node) => ({
+        baseId: node.id,
+        id: node.id,
+        kind: node.type,
+        label: node.data.label ?? node.id,
+        path: [],
+        type: "node" as const,
+      })),
+      ...edges.map((edge) => ({
+        baseId: edge.id,
+        id: edge.id,
+        kind: "edge",
+        label: edge.data?.label || `${edge.source} -> ${edge.target}`,
+        path: [],
+        type: "edge" as const,
+      })),
+    ],
+    [edges, nodes],
+  );
+  const selectedRefs = useMemo<WorkspaceCanvasRef[]>(
+    () =>
+      agentContext.selection.map((selection) => {
+        const currentRef = canvasRefs.find((ref) => ref.id === selection.refId);
+        if (currentRef) {
+          return currentRef;
+        }
+
+        return {
+          baseId: selection.refId,
+          id: selection.refId,
+          kind: selection.type,
+          label: selection.label ?? selection.refId,
+          path: [],
+          type: selection.type,
+        };
+      }),
+    [agentContext.selection, canvasRefs],
+  );
 
   const scrollToBottom = useCallback(() => {
     requestAnimationFrame(() => {
@@ -143,13 +185,10 @@ export const AgentPanel = () => {
   }, [fetchRuntimeState]);
 
   useEffect(() => {
-    const graphSignature = JSON.stringify({ edges, nodes, pipelineId });
     if (
-      attachments.length > 0 &&
       attachmentGraphSignatureRef.current &&
       attachmentGraphSignatureRef.current !== graphSignature
     ) {
-      setAttachments([]);
       attachmentGraphSignatureRef.current = null;
       addMessage({
         content: t("canvas.agentPanel.contextReset"),
@@ -158,94 +197,14 @@ export const AgentPanel = () => {
       });
       resetSession();
     }
-  }, [addMessage, attachments.length, edges, nodes, pipelineId, resetSession, t]);
+  }, [addMessage, graphSignature, resetSession, t]);
 
   useEffect(() => {
     scrollToBottom();
   }, [messages.length, scrollToBottom, streamingAssistantText, streamingProgress]);
 
-  const doSend = useCallback(async () => {
-    if (isHistoryLoading || isPreparingUpload || isSending || sendInFlightRef.current) {
-      return;
-    }
-    sendInFlightRef.current = true;
-    setIsPreparingSend(true);
-    try {
-      const text = inputValue.trim();
-      if (!text) {
-        return;
-      }
-      if (!pipelineId) {
-        toastStore.getState().addToast({
-          type: "error",
-          title: t("canvas.runFailed"),
-          description: t("canvas.noPipelineId"),
-        });
-
-        return;
-      }
-
-      const runtimeSetupResult = await fetchRuntimeState();
-
-      if (runtimeSetupResult.isErr()) {
-        addMessage({
-          content: t("canvas.agentPanel.error"),
-          id: `assistant-${Date.now()}`,
-          role: "assistant",
-        });
-        toastStore.getState().addToast({
-          type: "error",
-          title: t("canvas.agentPanel.errorTitle"),
-          description: runtimeSetupResult.error.message,
-        });
-        scrollToBottom();
-
-        return;
-      }
-
-      const { runtimeOptions: nextRuntimeOptions, suggestedRuntimeId } = runtimeSetupResult.value;
-      setRuntimeOptions(nextRuntimeOptions);
-      const effectiveRuntimeId =
-        selectedRuntimeId && nextRuntimeOptions.some((runtime) => runtime.id === selectedRuntimeId)
-          ? selectedRuntimeId
-          : suggestedRuntimeId;
-      setSelectedRuntimeId(effectiveRuntimeId);
-
-      if (!effectiveRuntimeId) {
-        setNeedsRuntimeSetup(true);
-        addMessage({
-          content: t("canvas.agentPanel.runtimeNotConfigured"),
-          id: `assistant-${Date.now()}`,
-          role: "assistant",
-        });
-        scrollToBottom();
-
-        return;
-      }
-
-      setNeedsRuntimeSetup(false);
-      setInputValue("");
-      await submitMessage({ content: text, runtimeId: effectiveRuntimeId });
-    } finally {
-      sendInFlightRef.current = false;
-      setIsPreparingSend(false);
-    }
-  }, [
-    addMessage,
-    fetchRuntimeState,
-    inputValue,
-    isHistoryLoading,
-    isPreparingUpload,
-    isSending,
-    pipelineId,
-    selectedRuntimeId,
-    scrollToBottom,
-    submitMessage,
-    t,
-  ]);
-
   const handleMessageSubmit = useCallback(
-    ({ content, runtimeId }: MessageTurnSubmitInput) => {
+    ({ content, metadata, runtimeId }: MessageTurnSubmitInput) => {
       const trimmedContent = content.trim();
       if (
         !runtimeId ||
@@ -261,7 +220,7 @@ export const AgentPanel = () => {
 
       sendInFlightRef.current = true;
       setIsPreparingSend(true);
-      void submitMessage({ content: trimmedContent, runtimeId }).finally(() => {
+      void submitMessage({ content: trimmedContent, metadata, runtimeId }).finally(() => {
         sendInFlightRef.current = false;
         setIsPreparingSend(false);
       });
@@ -273,112 +232,184 @@ export const AgentPanel = () => {
     setNeedsRuntimeSetup(true);
   }, []);
 
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>) => {
-      if (event.key === "Enter" && !event.shiftKey) {
-        event.preventDefault();
-        void doSend();
-      }
-    },
-    [doSend],
-  );
-
-  const handleInputValueChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(event.target.value);
-  }, []);
-
   const handleRuntimeValueChange = useCallback((runtimeId: string | null) => {
     setSelectedRuntimeId(runtimeId);
     setNeedsRuntimeSetup(false);
   }, []);
 
-  const handleSendClick = useCallback(() => {
-    void doSend();
-  }, [doSend]);
-
-  const handleUploadButtonClick = useCallback(async () => {
-    if (isUploadBlocked) {
-      return;
-    }
-
-    setIsPreparingUpload(true);
-    try {
-      const sessionResult = await ResultAsync.fromPromise(ensureSession(), (error) =>
-        error instanceof Error ? error : new Error(String(error)),
-      );
-      if (sessionResult.isErr()) {
-        toastStore.getState().addToast({
-          type: "error",
-          title: t("canvas.agentPanel.errorTitle"),
-          description: sessionResult.error.message,
-        });
-
-        return;
+  const handleComposerSubmit = useCallback(
+    async ({ content, metadata }: ComposerSubmitInput) => {
+      if (
+        isHistoryLoading ||
+        isPreparingUpload ||
+        isSending ||
+        agentPanel.isLoading ||
+        sendInFlightRef.current
+      ) {
+        return false;
       }
-      fileInputRef.current?.click();
-    } finally {
-      setIsPreparingUpload(false);
-    }
-  }, [ensureSession, isUploadBlocked, t]);
 
-  const handleUploadChange = useCallback(
-    async (event: React.ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      event.target.value = "";
-      if (!file || isUploadBlocked) {
-        return;
+      sendInFlightRef.current = true;
+      setIsPreparingSend(true);
+      try {
+        if (!pipelineId) {
+          toastStore.getState().addToast({
+            type: "error",
+            title: t("canvas.runFailed"),
+            description: t("canvas.noPipelineId"),
+          });
+
+          return false;
+        }
+
+        const runtimeSetupResult = await fetchRuntimeState();
+        if (runtimeSetupResult.isErr()) {
+          addMessage({
+            content: t("canvas.agentPanel.error"),
+            id: `assistant-${Date.now()}`,
+            role: "assistant",
+          });
+          toastStore.getState().addToast({
+            type: "error",
+            title: t("canvas.agentPanel.errorTitle"),
+            description: runtimeSetupResult.error.message,
+          });
+          scrollToBottom();
+
+          return false;
+        }
+
+        const { runtimeOptions: nextRuntimeOptions, suggestedRuntimeId } = runtimeSetupResult.value;
+        setRuntimeOptions(nextRuntimeOptions);
+        const effectiveRuntimeId =
+          selectedRuntimeId &&
+          nextRuntimeOptions.some((runtime) => runtime.id === selectedRuntimeId)
+            ? selectedRuntimeId
+            : suggestedRuntimeId;
+        setSelectedRuntimeId(effectiveRuntimeId);
+        if (!effectiveRuntimeId) {
+          setNeedsRuntimeSetup(true);
+          addMessage({
+            content: t("canvas.agentPanel.runtimeNotConfigured"),
+            id: `assistant-${Date.now()}`,
+            role: "assistant",
+          });
+          scrollToBottom();
+
+          return false;
+        }
+
+        setNeedsRuntimeSetup(false);
+        return await submitMessage({ content, metadata, runtimeId: effectiveRuntimeId });
+      } finally {
+        sendInFlightRef.current = false;
+        setIsPreparingSend(false);
+      }
+    },
+    [
+      addMessage,
+      agentPanel.isLoading,
+      fetchRuntimeState,
+      isHistoryLoading,
+      isPreparingUpload,
+      isSending,
+      pipelineId,
+      scrollToBottom,
+      selectedRuntimeId,
+      submitMessage,
+      t,
+    ],
+  );
+
+  const handleComposerAttach = useCallback(
+    async (files: File[]): Promise<ProposeAttachment[]> => {
+      if (isUploadBlocked) {
+        return [];
       }
 
       setIsPreparingUpload(true);
       try {
-        const uploadResult = await ResultAsync.fromPromise(
-          (async () => {
-            const sessionId = await ensureSession();
-
-            return pipelineAgentSessionsClient.uploadAttachment(
-              sessionId,
-              file,
-              selectedRuntimeId ? { runtimeId: selectedRuntimeId } : undefined,
-            );
-          })(),
-          (error) => (error instanceof Error ? error : new Error(String(error))),
+        const sessionResult = await ResultAsync.fromPromise(ensureSession(), (error) =>
+          error instanceof Error ? error : new Error(String(error)),
         );
-        if (uploadResult.isErr()) {
+        if (sessionResult.isErr()) {
           toastStore.getState().addToast({
             type: "error",
             title: t("canvas.agentPanel.errorTitle"),
-            description: uploadResult.error.message,
+            description: sessionResult.error.message,
           });
 
-          return;
+          return [];
         }
 
-        const attachment = uploadResult.value.attachment;
-        if (attachment) {
-          attachmentGraphSignatureRef.current = JSON.stringify({ edges, nodes, pipelineId });
-          setAttachments((prev) => [
-            ...prev,
-            {
-              id: attachment.id,
-              filename: attachment.filename,
-              parseStatus: attachment.parseStatus ?? "parsed",
-            },
-          ]);
+        const uploaded: ProposeAttachment[] = [];
+        for (const file of files) {
+          const uploadResult = await ResultAsync.fromPromise(
+            pipelineAgentSessionsClient.uploadAttachment(
+              sessionResult.value,
+              file,
+              selectedRuntimeId ? { runtimeId: selectedRuntimeId } : undefined,
+            ),
+            (error) => (error instanceof Error ? error : new Error(String(error))),
+          );
+          if (uploadResult.isErr()) {
+            toastStore.getState().addToast({
+              type: "error",
+              title: t("canvas.agentPanel.errorTitle"),
+              description: uploadResult.error.message,
+            });
+            continue;
+          }
+
+          const attachment = uploadResult.value.attachment;
+          if (attachment) {
+            uploaded.push({
+              name: file.webkitRelativePath || attachment.filename,
+              size: file.size,
+              type: file.type || undefined,
+            });
+          }
         }
+        if (uploaded.length > 0) {
+          attachmentGraphSignatureRef.current = graphSignature;
+        }
+
+        return uploaded;
       } finally {
         setIsPreparingUpload(false);
       }
     },
     [
-      edges,
       ensureSession,
+      graphSignature,
       isUploadBlocked,
-      nodes,
       pipelineAgentSessionsClient,
-      pipelineId,
       selectedRuntimeId,
       t,
     ],
+  );
+
+  const handleRemoveRef = useCallback(
+    (id: string) => {
+      if (selectedNodeId === id) {
+        selectNode(null);
+      }
+      if (selectedEdgeId === id) {
+        selectEdge(null);
+      }
+    },
+    [selectEdge, selectNode, selectedEdgeId, selectedNodeId],
+  );
+
+  const handleFocusRef = useCallback(
+    (ref: WorkspaceCanvasRef) => {
+      if (ref.type === "edge") {
+        focusEdge(ref.baseId);
+      } else {
+        focusNode(ref.baseId);
+      }
+    },
+    [focusEdge, focusNode],
   );
 
   const hasBlockingDiagnostics =
@@ -410,7 +441,7 @@ export const AgentPanel = () => {
     }
   }, [handleMessageSubmit, selectedRuntimeId, t]);
   const handleRevise = useCallback(() => {
-    setInputValue(t("canvas.agentPanel.proposalDetails.revisePrompt"));
+    setComposerDraft(t("canvas.agentPanel.proposalDetails.revisePrompt"));
   }, [t]);
   const selectedRuntime = runtimeOptions.find((runtime) => runtime.id === selectedRuntimeId);
   const isConversationActive = isSending || agentPanel.isLoading;
@@ -484,34 +515,6 @@ export const AgentPanel = () => {
               </SelectGroup>
             </SelectContent>
           </Select>
-          <input
-            ref={fileInputRef}
-            aria-label={t("canvas.agentPanel.upload")}
-            className="hidden"
-            disabled={isUploadInputBlocked}
-            type="file"
-            onChange={handleUploadChange}
-          />
-          <div className="flex flex-wrap items-center gap-1.5 pt-1.5">
-            <Button
-              className="h-7 px-2 text-[10.5px]"
-              disabled={isUploadBlocked}
-              size="sm"
-              variant="outline"
-              onClick={handleUploadButtonClick}
-            >
-              <Upload className="h-3.5 w-3.5" />
-              {t("canvas.agentPanel.upload")}
-            </Button>
-            {attachments.map((attachment) => (
-              <span
-                key={attachment.id}
-                className="rounded-md border border-border-strong bg-surface px-1.5 py-0.5 text-[10.5px]"
-              >
-                {attachment.filename}
-              </span>
-            ))}
-          </div>
         </div>
       </div>
 
@@ -525,8 +528,9 @@ export const AgentPanel = () => {
               isSending={isSending || isPreparingUpload || isHistoryLoading || agentPanel.isLoading}
               message={msg}
               runtimeId={selectedRuntimeId}
+              refs={canvasRefs}
               visibleMessages={messages}
-              onEditDraft={setInputValue}
+              onEditDraft={setComposerDraft}
               onOpenSettings={handleOpenRuntimeSettings}
               onSubmit={handleMessageSubmit}
             />
@@ -606,45 +610,25 @@ export const AgentPanel = () => {
         </div>
       )}
 
-      {/* Input */}
-      <div className="flex items-center gap-2 border-t border-border/70 bg-surface p-3">
-        <Input
-          className="h-9 flex-1 bg-surface-2 text-[12px]"
+      <div className="shrink-0 border-t border-border/70 bg-surface">
+        <Composer
+          agentContext={agentContext}
+          canRemoveAttachments={false}
+          clearAttachmentsOnSubmit={false}
           disabled={
-            isSending ||
-            isPreparingUpload ||
-            isHistoryLoading ||
-            agentPanel.isLoading ||
-            isLoadingRuntimes
+            isHistoryLoading || isLoadingRuntimes || isPreparingUpload || agentPanel.isLoading
           }
-          placeholder={t("canvas.agentPanel.inputPlaceholder")}
-          value={inputValue}
-          onChange={handleInputValueChange}
-          onKeyDown={handleKeyDown}
+          draft={composerDraft}
+          isSending={isSending}
+          onAttach={handleComposerAttach}
+          onDraftConsumed={() => setComposerDraft(null)}
+          onFocusRef={handleFocusRef}
+          onRemoveRef={handleRemoveRef}
+          onSubmit={handleComposerSubmit}
+          refs={selectedRefs}
+          resetKey={graphSignature}
+          runtimeId={selectedRuntimeId}
         />
-        <Button
-          aria-label={t("canvas.agentPanel.send")}
-          className="h-9 w-9"
-          disabled={
-            isSending ||
-            isPreparingUpload ||
-            isHistoryLoading ||
-            agentPanel.isLoading ||
-            isLoadingRuntimes ||
-            !selectedRuntimeId ||
-            !inputValue.trim()
-          }
-          size="icon"
-          title={t("canvas.agentPanel.send")}
-          variant="ghost"
-          onClick={handleSendClick}
-        >
-          {isSending || isHistoryLoading || agentPanel.isLoading ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Send className="h-4 w-4" />
-          )}
-        </Button>
       </div>
     </div>
   );

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -104,10 +104,6 @@ vi.mock("@repo/ui/scroll-area", () => ({
   ),
 }));
 
-vi.mock("@repo/ui/input", () => ({
-  Input: (props: React.ComponentProps<"input">) => <input {...props} />,
-}));
-
 const wrapperWithoutPipeline = ({ children }: { children?: ReactNode }) => (
   <CanvasPageStoreProvider>{children}</CanvasPageStoreProvider>
 );
@@ -241,10 +237,34 @@ describe("AgentPanel", () => {
       "rounded-lg",
       "bg-surface-2",
     );
-    expect(screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder")).toHaveClass(
-      "bg-surface-2",
+    expect(screen.getByPlaceholderText("workspace.agentBar.composer.placeholder")).toHaveClass(
+      "bg-transparent",
     );
     expect(screen.getByTestId("agent-assistant")).toHaveClass("text-[12px]");
+  });
+
+  it("binds composer reference removal to the selected Canvas node", async () => {
+    const { store, Wrapper } = wrapperWithMutableStore();
+    store.setState({
+      nodes: [
+        {
+          id: "node-1",
+          type: "folder",
+          position: { x: 0, y: 0 },
+          data: {
+            nodeType: "folder",
+            label: "Input folder",
+            folderPath: "/tmp/project",
+          },
+        },
+      ] as never,
+      selectedNodeId: "node-1",
+    });
+
+    render(<AgentPanel />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByTestId("ref-chip-remove-node-1"));
+
+    expect(store.getState().selectedNodeId).toBeNull();
   });
 
   it("creates an edit session, sends a message, and displays a streamed follow-up question", async () => {
@@ -254,7 +274,7 @@ describe("AgentPanel", () => {
     });
 
     render(<AgentPanel />, { wrapper: wrapperWithState() });
-    const input = screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder");
+    const input = screen.getByPlaceholderText("workspace.agentBar.composer.placeholder");
     await waitFor(() => {
       expect(mockGetList).toHaveBeenCalled();
     });
@@ -288,7 +308,7 @@ describe("AgentPanel", () => {
 
   it("deduplicates submits while runtime validation is in flight", async () => {
     render(<AgentPanel />, { wrapper: wrapperWithState() });
-    const input = screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder");
+    const input = screen.getByPlaceholderText("workspace.agentBar.composer.placeholder");
     await waitFor(() => {
       expect(mockGetList).toHaveBeenCalled();
     });
@@ -328,7 +348,7 @@ describe("AgentPanel", () => {
     });
 
     const file = new File(["hello"], "brief.txt", { type: "text/plain" });
-    const input = screen.getByLabelText("canvas.agentPanel.upload") as HTMLInputElement;
+    const input = screen.getByTestId("agent-composer-file-input") as HTMLInputElement;
     await userEvent.upload(input, file);
 
     await waitFor(() => {
@@ -345,11 +365,21 @@ describe("AgentPanel", () => {
   it("opens the file picker after session preparation without disabling the file input", async () => {
     render(<AgentPanel />, { wrapper: wrapperWithState() });
 
-    const input = screen.getByLabelText("canvas.agentPanel.upload") as HTMLInputElement;
-    await waitFor(() => expect(input).toBeEnabled());
+    const input = screen.getByTestId("agent-composer-file-input") as HTMLInputElement;
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "workspace.agentBar.composer.attach" }),
+      ).toBeEnabled(),
+    );
     const clickInput = vi.spyOn(input, "click");
 
-    await userEvent.click(screen.getByRole("button", { name: "canvas.agentPanel.upload" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "workspace.agentBar.composer.attach" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-composer-attach-files")).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByTestId("agent-composer-attach-files"));
 
     await waitFor(() => expect(clickInput).toHaveBeenCalledTimes(1));
     expect(input).toBeEnabled();
@@ -367,12 +397,12 @@ describe("AgentPanel", () => {
     );
     render(<AgentPanel />, { wrapper: wrapperWithState() });
 
-    const uploadInput = screen.getByLabelText("canvas.agentPanel.upload");
+    const uploadInput = screen.getByTestId("agent-composer-file-input");
     await waitFor(() => expect(uploadInput).toBeEnabled());
     await userEvent.upload(uploadInput, new File(["hello"], "brief.txt", { type: "text/plain" }));
     await waitFor(() => expect(mockUploadAttachment).toHaveBeenCalledTimes(1));
 
-    const messageInput = screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder");
+    const messageInput = screen.getByPlaceholderText("workspace.agentBar.composer.placeholder");
     expect(messageInput).toBeDisabled();
     fireEvent.keyDown(messageInput, { key: "Enter" });
     expect(mockPlanSessionStream).not.toHaveBeenCalled();
@@ -407,14 +437,17 @@ describe("AgentPanel", () => {
 
     render(<AgentPanel />, { wrapper: wrapperWithState() });
 
-    expect(screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder")).toBeDisabled();
-    expect(screen.getByLabelText("canvas.agentPanel.upload")).toBeDisabled();
-    expect(screen.getByRole("button", { name: "canvas.agentPanel.upload" })).toBeDisabled();
+    expect(screen.getByPlaceholderText("workspace.agentBar.composer.placeholder")).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "workspace.agentBar.composer.attach" }),
+    ).toBeDisabled();
 
     resolveHistory({ data: [], total: 0 });
     await waitFor(() => {
-      expect(screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder")).toBeEnabled();
-      expect(screen.getByRole("button", { name: "canvas.agentPanel.upload" })).toBeEnabled();
+      expect(screen.getByPlaceholderText("workspace.agentBar.composer.placeholder")).toBeEnabled();
+      expect(
+        screen.getByRole("button", { name: "workspace.agentBar.composer.attach" }),
+      ).toBeEnabled();
     });
   });
 
@@ -423,7 +456,7 @@ describe("AgentPanel", () => {
     render(<AgentPanel />, { wrapper: Wrapper });
 
     const file = new File(["hello"], "brief.txt", { type: "text/plain" });
-    const uploadInput = screen.getByLabelText("canvas.agentPanel.upload");
+    const uploadInput = screen.getByTestId("agent-composer-file-input");
     await waitFor(() => expect(uploadInput).toBeEnabled());
     await userEvent.upload(uploadInput, file);
     await waitFor(() => {
@@ -487,7 +520,7 @@ describe("AgentPanel", () => {
     });
 
     render(<AgentPanel />, { wrapper: wrapperWithState() });
-    const input = screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder");
+    const input = screen.getByPlaceholderText("workspace.agentBar.composer.placeholder");
     await waitFor(() => {
       expect(mockGetList).toHaveBeenCalled();
     });
@@ -535,7 +568,7 @@ describe("AgentPanel", () => {
     });
 
     render(<AgentPanel />, { wrapper: wrapperWithState() });
-    const input = screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder");
+    const input = screen.getByPlaceholderText("workspace.agentBar.composer.placeholder");
     await waitFor(() => {
       expect(mockGetList).toHaveBeenCalled();
     });
@@ -579,7 +612,7 @@ describe("AgentPanel", () => {
       expect(mockGetList).toHaveBeenCalled();
     });
     await userEvent.type(
-      screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder"),
+      screen.getByPlaceholderText("workspace.agentBar.composer.placeholder"),
       "Suggest an edit",
     );
     await userEvent.keyboard("{Enter}");
@@ -627,7 +660,7 @@ describe("AgentPanel", () => {
       expect(mockGetList).toHaveBeenCalled();
     });
     await userEvent.type(
-      screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder"),
+      screen.getByPlaceholderText("workspace.agentBar.composer.placeholder"),
       "Suggest an edit",
     );
     await userEvent.keyboard("{Enter}");
@@ -695,7 +728,7 @@ describe("AgentPanel", () => {
     });
 
     render(<AgentPanel />, { wrapper: wrapperWithState() });
-    const input = screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder");
+    const input = screen.getByPlaceholderText("workspace.agentBar.composer.placeholder");
     await waitFor(() => {
       expect(mockGetList).toHaveBeenCalled();
     });
@@ -746,11 +779,11 @@ describe("AgentPanel", () => {
       expect(mockGetList).toHaveBeenCalled();
     });
 
-    const input = screen.getByPlaceholderText("canvas.agentPanel.inputPlaceholder");
+    const input = screen.getByPlaceholderText("workspace.agentBar.composer.placeholder");
     await userEvent.type(input, "test");
     await userEvent.keyboard("{Enter}");
 
     expect(mockCreateSession).not.toHaveBeenCalled();
-    expect(screen.queryByText("test")).not.toBeInTheDocument();
+    expect(input).toHaveValue("test");
   });
 });

--- a/packages/views/src/pages/CanvasPage/AgentPanel/Composer/AttachMenu.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/Composer/AttachMenu.tsx
@@ -1,0 +1,102 @@
+import { useRef, type ChangeEvent } from "react";
+import { FileUp, FolderUp, Plus, type LucideIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@repo/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@repo/ui/dropdown-menu";
+
+export type AttachMenuProps = {
+  disabled?: boolean;
+  onAttach: (files: File[]) => void | Promise<void>;
+};
+
+type AttachMenuEntry = {
+  icon: LucideIcon;
+  id: string;
+  labelKey: string;
+  onSelect: () => void;
+};
+
+export const AttachMenu = ({ disabled = false, onAttach }: AttachMenuProps) => {
+  const { t } = useTranslation();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = [...(event.target.files ?? [])];
+    event.target.value = "";
+    if (files.length > 0) {
+      void onAttach(files);
+    }
+  };
+
+  const entries: AttachMenuEntry[] = [
+    {
+      icon: FileUp,
+      id: "files",
+      labelKey: "workspace.agentBar.composer.attachMenu.files",
+      onSelect: () => fileInputRef.current?.click(),
+    },
+    {
+      icon: FolderUp,
+      id: "folder",
+      labelKey: "workspace.agentBar.composer.attachMenu.folder",
+      onSelect: () => folderInputRef.current?.click(),
+    },
+  ];
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              aria-label={t("workspace.agentBar.composer.attach")}
+              className="h-7 w-7 rounded-lg"
+              data-testid="agent-composer-attach-trigger"
+              disabled={disabled}
+              size="icon"
+              type="button"
+              variant="ghost"
+            />
+          }
+        >
+          <Plus className="h-4 w-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" side="top">
+          {entries.map((entry) => (
+            <DropdownMenuItem
+              key={entry.id}
+              data-testid={`agent-composer-attach-${entry.id}`}
+              onClick={entry.onSelect}
+            >
+              <entry.icon className="mr-2 h-3.5 w-3.5" />
+              {t(entry.labelKey)}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <input
+        ref={fileInputRef}
+        multiple
+        className="hidden"
+        data-testid="agent-composer-file-input"
+        type="file"
+        onChange={handleInputChange}
+      />
+      <input
+        ref={folderInputRef}
+        multiple
+        className="hidden"
+        data-testid="agent-composer-folder-input"
+        type="file"
+        {...({ directory: "", webkitdirectory: "" } as Record<string, string>)}
+        onChange={handleInputChange}
+      />
+    </>
+  );
+};

--- a/packages/views/src/pages/CanvasPage/AgentPanel/Composer/Composer.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/Composer/Composer.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent } from "react";
+import { ArrowUp, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type {
+  AgentContextPayload,
+  ConversationMessageMetadata,
+  ProposeAttachment,
+  WorkspaceCanvasRef,
+} from "@repo/schemas";
+import { Button } from "@repo/ui/button";
+import { Textarea } from "@repo/ui/textarea";
+import { Icon } from "../../../../components/primitives";
+import { AttachMenu } from "./AttachMenu";
+import { ContextStrip } from "./ContextStrip";
+import { RefChips } from "./RefChips";
+
+export type ComposerSubmitInput = {
+  content: string;
+  metadata: ConversationMessageMetadata;
+};
+
+export type ComposerProps = {
+  agentContext: AgentContextPayload;
+  attachments?: ProposeAttachment[];
+  canRemoveAttachments?: boolean;
+  clearAttachmentsOnSubmit?: boolean;
+  contextDefaultOpen?: boolean;
+  defaultAttachments?: ProposeAttachment[];
+  disabled?: boolean;
+  draft?: string | null;
+  isSending?: boolean;
+  onAttach?: (files: File[]) => ProposeAttachment[] | void | Promise<ProposeAttachment[] | void>;
+  onDraftConsumed?: () => void;
+  onFocusRef?: (ref: WorkspaceCanvasRef) => void;
+  onRemoveRef: (id: string) => void;
+  onSubmit?: (input: ComposerSubmitInput) => boolean | void | Promise<boolean | void>;
+  refs: WorkspaceCanvasRef[];
+  resetKey?: string;
+  runtimeId?: string | null;
+};
+
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const toMetadataAttachment = ({ content: _content, ...metadata }: ProposeAttachment) => metadata;
+
+export const Composer = ({
+  agentContext,
+  attachments: controlledAttachments,
+  canRemoveAttachments = true,
+  clearAttachmentsOnSubmit = true,
+  contextDefaultOpen = false,
+  defaultAttachments = [],
+  disabled = false,
+  draft = null,
+  isSending = false,
+  onAttach,
+  onDraftConsumed,
+  onFocusRef,
+  onRemoveRef,
+  onSubmit,
+  refs,
+  resetKey,
+  runtimeId,
+}: ComposerProps) => {
+  const { t } = useTranslation();
+  const [text, setText] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [localAttachments, setLocalAttachments] = useState<ProposeAttachment[]>(defaultAttachments);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const previousResetKeyRef = useRef(resetKey);
+  const attachments = controlledAttachments ?? localAttachments;
+  const isDisabled = disabled || isSending;
+
+  useEffect(() => {
+    if (draft !== null) {
+      setText(draft);
+      onDraftConsumed?.();
+      textareaRef.current?.focus();
+    }
+  }, [draft, onDraftConsumed]);
+
+  useEffect(() => {
+    if (previousResetKeyRef.current !== resetKey) {
+      previousResetKeyRef.current = resetKey;
+      setLocalAttachments([]);
+    }
+  }, [resetKey]);
+
+  const setAttachments = (next: ProposeAttachment[]) => {
+    if (controlledAttachments === undefined) {
+      setLocalAttachments(next);
+    }
+  };
+
+  const trimmedText = text.trim();
+  const canSend =
+    Boolean(runtimeId) &&
+    !isDisabled &&
+    !isSubmitting &&
+    (trimmedText.length > 0 || attachments.length > 0);
+  const placeholder =
+    refs.length > 0
+      ? t("workspace.agentBar.composer.placeholderWithRefs")
+      : t("workspace.agentBar.composer.placeholder");
+
+  const handleAttachmentRemoveClick = (name: string) => {
+    setAttachments(attachments.filter((attachment) => attachment.name !== name));
+  };
+
+  const handleAttach = async (files: File[]) => {
+    if (!onAttach || isDisabled) {
+      return;
+    }
+    const known = new Set(attachments.map((attachment) => attachment.name));
+    const newFiles = files.filter((file) => !known.has(file.webkitRelativePath || file.name));
+    if (newFiles.length === 0) {
+      return;
+    }
+
+    const incoming = await onAttach(newFiles);
+    if (!incoming || incoming.length === 0) {
+      return;
+    }
+    setAttachments([
+      ...attachments,
+      ...incoming.filter((attachment) => !known.has(attachment.name)),
+    ]);
+  };
+
+  const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setText(event.target.value);
+    event.target.style.height = "auto";
+    event.target.style.height = `${Math.min(96, event.target.scrollHeight)}px`;
+  };
+
+  const handleSubmit = async () => {
+    if (!canSend) {
+      return;
+    }
+    setIsSubmitting(true);
+    const content =
+      trimmedText.length > 0
+        ? trimmedText
+        : t("workspace.agentBar.composer.reverseDefault", {
+            names: attachments.map((attachment) => attachment.name).join(", "),
+          });
+    const metadata: ConversationMessageMetadata = {
+      attachments: attachments.map(toMetadataAttachment),
+      referencedNodeIds: refs.map((ref) => ref.id),
+    };
+
+    try {
+      const submitted = await onSubmit?.({ content, metadata });
+      if (submitted === false) {
+        return;
+      }
+      setText("");
+      if (clearAttachmentsOnSubmit) {
+        setAttachments([]);
+      }
+      if (textareaRef.current) {
+        textareaRef.current.style.height = "auto";
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      void handleSubmit();
+    }
+  };
+
+  return (
+    <div data-testid="agent-composer">
+      <ContextStrip context={agentContext} defaultOpen={contextDefaultOpen} />
+      <div className="p-3 pt-2">
+        <RefChips refs={refs} onFocusRef={onFocusRef} onRemoveRef={onRemoveRef} />
+        {attachments.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5 pb-1.5">
+            {attachments.map((attachment) => (
+              <span
+                key={attachment.name}
+                className="inline-flex max-w-full items-center gap-1 rounded-full bg-surface-2 px-2 py-0.5 text-[10px] font-medium text-muted-foreground ring-1 ring-border"
+                data-testid="agent-composer-attachment-chip"
+              >
+                <span className="truncate">{attachment.name}</span>
+                {attachment.size !== undefined ? (
+                  <span className="shrink-0 text-muted-foreground/70">
+                    {formatBytes(attachment.size)}
+                  </span>
+                ) : null}
+                {canRemoveAttachments ? (
+                  <button
+                    aria-label={t("workspace.agentBar.composer.removeAttachment", {
+                      name: attachment.name,
+                    })}
+                    className="rounded-full p-0.5 hover:bg-foreground/10"
+                    type="button"
+                    onClick={() => handleAttachmentRemoveClick(attachment.name)}
+                  >
+                    <Icon icon={X} size={9} />
+                  </button>
+                ) : null}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        <div className="flex items-end gap-1.5 rounded-2xl bg-background p-2 ring-1 ring-border focus-within:ring-border-strong">
+          <AttachMenu disabled={isDisabled || !onAttach} onAttach={handleAttach} />
+          <Textarea
+            ref={textareaRef}
+            aria-label={t("workspace.agentBar.composer.messageLabel")}
+            className="min-h-7 flex-1 resize-none border-none bg-transparent px-0 py-1 text-[12px] shadow-none focus-visible:ring-0 disabled:bg-transparent dark:disabled:bg-transparent"
+            disabled={isDisabled}
+            placeholder={placeholder}
+            rows={1}
+            value={text}
+            onChange={handleTextChange}
+            onKeyDown={handleKeyDown}
+          />
+          <Button
+            aria-label={t("workspace.agentBar.composer.send")}
+            className="h-7 w-7 rounded-full"
+            data-testid="agent-composer-send"
+            disabled={!canSend}
+            size="icon"
+            type="button"
+            onClick={() => void handleSubmit()}
+          >
+            <ArrowUp className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/views/src/pages/CanvasPage/AgentPanel/Composer/Composer.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/Composer/Composer.unit.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { AgentContextPayload, WorkspaceCanvasRef } from "@repo/schemas";
+import { describe, expect, it, vi } from "vitest";
+import { Composer } from "./Composer";
+
+const context: AgentContextPayload = {
+  anchors: [],
+  project: { pipelineId: "pipeline-1", pipelineName: "Demo pipeline" },
+  selection: [{ label: "Review", refId: "review-node", type: "node" }],
+  snapshotIncluded: true,
+  threadWindow: { enabled: true, limit: 20 },
+};
+
+const refs: WorkspaceCanvasRef[] = [
+  {
+    baseId: "review-node",
+    id: "review-node",
+    kind: "operation",
+    label: "Review",
+    path: [],
+    type: "node",
+  },
+];
+
+const renderComposer = (props: Partial<React.ComponentProps<typeof Composer>> = {}) =>
+  render(
+    <Composer
+      agentContext={context}
+      onAttach={vi.fn()}
+      onRemoveRef={vi.fn()}
+      refs={refs}
+      runtimeId="runtime-1"
+      {...props}
+    />,
+  );
+
+describe("Agent Bar Composer", () => {
+  it("submits multiline text with current canvas references and clears the draft", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderComposer({ onSubmit });
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "Add a review step");
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    await user.type(input, "after transform");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        content: "Add a review step\nafter transform",
+        metadata: { attachments: [], referencedNodeIds: ["review-node"] },
+      });
+      expect(input).toHaveValue("");
+    });
+  });
+
+  it("uploads through AttachMenu and renders removable attachment chips", async () => {
+    const user = userEvent.setup();
+    const onAttach = vi
+      .fn()
+      .mockResolvedValue([{ name: "brief.md", size: 12, type: "text/markdown" }]);
+    const onRemoveRef = vi.fn();
+    renderComposer({ onAttach, onRemoveRef });
+
+    await user.click(screen.getByTestId("agent-composer-attach-trigger"));
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-composer-attach-files")).toBeInTheDocument(),
+    );
+    await user.click(screen.getByTestId("agent-composer-attach-files"));
+    await user.upload(
+      screen.getByTestId("agent-composer-file-input"),
+      new File(["hello world!"], "brief.md", { type: "text/markdown" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-composer-attachment-chip")).toHaveTextContent("brief.md"),
+    );
+    expect(onAttach).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByTestId("ref-chip-remove-review-node"));
+    expect(onRemoveRef).toHaveBeenCalledWith("review-node");
+  });
+
+  it("expands the context strip and keeps the composer controls disabled", async () => {
+    const user = userEvent.setup();
+    renderComposer({ disabled: true });
+
+    expect(screen.queryByTestId("agent-context-items")).not.toBeInTheDocument();
+    await user.click(screen.getByTestId("agent-context-toggle"));
+    expect(screen.getByTestId("agent-context-items")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-context-item-project")).toHaveAttribute(
+      "data-context-on",
+      "true",
+    );
+    expect(screen.getByRole("textbox")).toBeDisabled();
+    expect(screen.getByTestId("agent-composer-attach-trigger")).toBeDisabled();
+    expect(screen.getByTestId("agent-composer-send")).toBeDisabled();
+  });
+
+  it("keeps the draft when the product submit gate rejects the send", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(false);
+    renderComposer({ onSubmit });
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "Keep this draft{Enter}");
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(input).toHaveValue("Keep this draft");
+  });
+
+  it("keeps session-scoped attachment context visible after a successful send", async () => {
+    const user = userEvent.setup();
+    renderComposer({
+      canRemoveAttachments: false,
+      clearAttachmentsOnSubmit: false,
+      defaultAttachments: [{ name: "brief.md", size: 12, type: "text/markdown" }],
+      onSubmit: vi.fn().mockResolvedValue(true),
+    });
+
+    await user.type(screen.getByRole("textbox"), "Use the brief{Enter}");
+
+    const chip = screen.getByTestId("agent-composer-attachment-chip");
+    expect(chip).toHaveTextContent("brief.md");
+    expect(chip.querySelector("button")).toBeNull();
+  });
+});

--- a/packages/views/src/pages/CanvasPage/AgentPanel/Composer/ContextStrip.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/Composer/ContextStrip.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Layers } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@repo/ui/lib/utils";
+import type { AgentContextPayload } from "@repo/schemas";
+import { Icon } from "../../../../components/primitives";
+
+export type ContextStripProps = {
+  context: AgentContextPayload;
+  defaultOpen?: boolean;
+};
+
+type ContextItem = {
+  dim?: boolean;
+  hot?: boolean;
+  id: string;
+  label: string;
+  on: boolean;
+  rule: string;
+};
+
+const LIVE_RUN_STATUSES = new Set(["queued", "running"]);
+
+export const ContextStrip = ({ context, defaultOpen = false }: ContextStripProps) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(defaultOpen);
+  const running = Boolean(context.runState && LIVE_RUN_STATUSES.has(context.runState.status));
+  const selectionLabel = context.selection.map((item) => item.label ?? item.refId).join(", ");
+  const anchorCount = context.anchors.reduce((total, anchor) => total + anchor.count, 0);
+  const trackedNodeCount = context.runState
+    ? Object.values(context.runState.nodeStatuses).filter((status) => status !== "idle").length
+    : 0;
+  const projectLabel = context.project?.pipelineName ?? context.project?.pipelineId;
+  const items: ContextItem[] = [
+    {
+      id: "project",
+      label: projectLabel
+        ? `${t("workspace.agentBar.context.items.project")} · ${projectLabel}`
+        : t("workspace.agentBar.context.items.project"),
+      on: Boolean(context.project),
+      rule: t("workspace.agentBar.context.rules.always"),
+    },
+    {
+      dim: running,
+      id: "snapshot",
+      label: t("workspace.agentBar.context.items.snapshot"),
+      on: context.snapshotIncluded,
+      rule: t("workspace.agentBar.context.rules.always"),
+    },
+    {
+      id: "thread",
+      label: t("workspace.agentBar.context.items.thread"),
+      on: context.threadWindow.enabled,
+      rule: t("workspace.agentBar.context.rules.windowed"),
+    },
+    {
+      id: "selection",
+      label:
+        context.selection.length > 0
+          ? t("workspace.agentBar.context.items.selectionWith", { refs: selectionLabel })
+          : t("workspace.agentBar.context.items.selection"),
+      on: context.selection.length > 0,
+      rule: t("workspace.agentBar.context.rules.whenSelected"),
+    },
+    {
+      id: "annotations",
+      label:
+        anchorCount > 0
+          ? t("workspace.agentBar.context.items.annotationsWith", { count: anchorCount })
+          : t("workspace.agentBar.context.items.annotations"),
+      on: anchorCount > 0,
+      rule: t("workspace.agentBar.context.rules.whenPresent"),
+    },
+    {
+      hot: running,
+      id: "runState",
+      label: t("workspace.agentBar.context.items.runState"),
+      on: Boolean(context.runState),
+      rule: t("workspace.agentBar.context.rules.runtime"),
+    },
+    {
+      hot: running,
+      id: "nodeRuntime",
+      label: t("workspace.agentBar.context.items.nodeRuntime"),
+      on: trackedNodeCount > 0,
+      rule: t("workspace.agentBar.context.rules.runtime"),
+    },
+    {
+      dim: true,
+      id: "memory",
+      label: t("workspace.agentBar.context.items.memory"),
+      on: Boolean(context.memory),
+      rule: t("workspace.agentBar.context.rules.notImplemented"),
+    },
+  ];
+  const activeCount = items.filter((item) => item.on).length;
+  const summary = running
+    ? t("workspace.agentBar.context.summary.running")
+    : context.selection.length > 0
+      ? t("workspace.agentBar.context.summary.selection")
+      : anchorCount > 0
+        ? t("workspace.agentBar.context.summary.annotations")
+        : t("workspace.agentBar.context.summary.default");
+
+  return (
+    <div className="px-3 pt-2" data-testid="agent-context-strip">
+      <button
+        aria-expanded={open}
+        className="flex w-full items-center gap-1.5 rounded-lg px-1.5 py-1 text-left text-[10px] text-muted-foreground transition-colors hover:bg-accent/50"
+        data-testid="agent-context-toggle"
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+      >
+        <Icon icon={Layers} size={11} />
+        <span className="font-medium">{t("workspace.agentBar.context.title")}</span>
+        <span className="rounded-full bg-surface-2 px-1.5 py-0.5 font-mono text-[9px]">
+          {t("workspace.agentBar.context.itemCount", { count: activeCount })}
+        </span>
+        <span className="truncate text-foreground/45">{summary}</span>
+        <Icon className="ml-auto shrink-0" icon={open ? ChevronDown : ChevronUp} size={11} />
+      </button>
+      {open ? (
+        <div
+          className="mt-1 space-y-0.5 rounded-xl bg-surface-2 p-2 ring-1 ring-border"
+          data-testid="agent-context-items"
+        >
+          {items.map((item) => (
+            <div
+              key={item.id}
+              className={cn(
+                "flex items-center gap-2 rounded-lg px-1.5 py-1 text-[10.5px]",
+                !item.on && "opacity-40",
+              )}
+              data-context-on={item.on ? "true" : "false"}
+              data-testid={`agent-context-item-${item.id}`}
+            >
+              <span className="flex size-3 items-center justify-center">
+                {item.on ? (
+                  <span
+                    className={cn(
+                      "size-[7px] rounded-full",
+                      item.hot ? "bg-foreground" : item.dim ? "bg-foreground/35" : "bg-success",
+                    )}
+                  />
+                ) : (
+                  <span className="size-[7px] rounded-full ring-1 ring-inset ring-border-strong" />
+                )}
+              </span>
+              <span
+                className={cn(
+                  "flex-1 truncate",
+                  item.hot ? "font-medium text-foreground" : "text-foreground/80",
+                )}
+              >
+                {item.label}
+              </span>
+              <span className="shrink-0 font-mono text-[9px] text-muted-foreground/70">
+                {item.rule}
+              </span>
+            </div>
+          ))}
+          <div className="px-1.5 pt-1 text-[9px] leading-snug text-muted-foreground/70">
+            {running
+              ? t("workspace.agentBar.context.footer.running")
+              : t("workspace.agentBar.context.footer.editing")}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/views/src/pages/CanvasPage/AgentPanel/Composer/ContextStrip.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/Composer/ContextStrip.unit.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import type { AgentContextPayload } from "@repo/schemas";
+import { ContextStrip } from "./ContextStrip";
+
+const baseContext: AgentContextPayload = {
+  anchors: [],
+  project: { pipelineId: "pipeline-1", pipelineName: "Demo pipeline" },
+  selection: [],
+  snapshotIncluded: true,
+  threadWindow: { enabled: false, limit: 20 },
+};
+
+describe("ContextStrip", () => {
+  it("shows the real pipeline and selected Canvas items", async () => {
+    const user = userEvent.setup();
+    render(
+      <ContextStrip
+        context={{
+          ...baseContext,
+          selection: [{ label: "Review", refId: "review-node", type: "node" }],
+        }}
+      />,
+    );
+
+    const toggle = screen.getByTestId("agent-context-toggle");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/Demo pipeline/)).toBeInTheDocument();
+    expect(screen.getByText(/Review/)).toBeInTheDocument();
+    expect(screen.getByTestId("agent-context-item-selection")).toHaveAttribute(
+      "data-context-on",
+      "true",
+    );
+  });
+
+  it("can render an expanded acceptance state", () => {
+    render(<ContextStrip context={baseContext} defaultOpen />);
+
+    expect(screen.getByTestId("agent-context-items")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-context-item-project")).toHaveAttribute(
+      "data-context-on",
+      "true",
+    );
+    expect(screen.getByTestId("agent-context-item-selection")).toHaveAttribute(
+      "data-context-on",
+      "false",
+    );
+  });
+});

--- a/packages/views/src/pages/CanvasPage/AgentPanel/Composer/RefChips.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/Composer/RefChips.tsx
@@ -1,0 +1,68 @@
+import { ArrowRightLeft, Box, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@repo/ui/lib/utils";
+import type { WorkspaceCanvasRef } from "@repo/schemas";
+import { Icon } from "../../../../components/primitives";
+
+export type RefChipsProps = {
+  refs: WorkspaceCanvasRef[];
+  onFocusRef?: (ref: WorkspaceCanvasRef) => void;
+  onHoverRef?: (id: string | null) => void;
+  onRemoveRef?: (id: string) => void;
+  small?: boolean;
+};
+
+export const RefChips = ({
+  onFocusRef,
+  onHoverRef,
+  onRemoveRef,
+  refs,
+  small = false,
+}: RefChipsProps) => {
+  const { t } = useTranslation();
+
+  if (refs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-1", !small && "pb-1.5")}>
+      {refs.map((ref) => (
+        <span
+          key={ref.id}
+          className={cn(
+            "group inline-flex max-w-45 items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ring-1 ring-transparent transition-all hover:ring-border-strong",
+            onFocusRef && "cursor-pointer",
+            small ? "bg-foreground/10" : "bg-accent",
+          )}
+          data-testid={`ref-chip-${ref.id}`}
+          title={t("workspace.agentBar.refChipTitle")}
+          onClick={() => onFocusRef?.(ref)}
+          onMouseEnter={() => onHoverRef?.(ref.id)}
+          onMouseLeave={() => onHoverRef?.(null)}
+        >
+          <Icon
+            className="shrink-0 text-foreground/60"
+            icon={ref.type === "edge" ? ArrowRightLeft : Box}
+            size={9}
+          />
+          <span className="truncate">{ref.label}</span>
+          {onRemoveRef ? (
+            <button
+              aria-label={t("workspace.agentBar.removeRef", { label: ref.label })}
+              className="ml-0.5 shrink-0 rounded-full p-0.5 hover:bg-foreground/10"
+              data-testid={`ref-chip-remove-${ref.id}`}
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onRemoveRef(ref.id);
+              }}
+            >
+              <Icon icon={X} size={9} />
+            </button>
+          ) : null}
+        </span>
+      ))}
+    </div>
+  );
+};

--- a/packages/views/src/pages/CanvasPage/AgentPanel/Composer/RefChips.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/Composer/RefChips.unit.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { WorkspaceCanvasRef } from "@repo/schemas";
+import { RefChips } from "./RefChips";
+
+const ref: WorkspaceCanvasRef = {
+  baseId: "review-node",
+  id: "review-node",
+  kind: "operation",
+  label: "Review",
+  path: [],
+  type: "node",
+};
+
+describe("RefChips", () => {
+  it("focuses the exact Canvas ref on click", async () => {
+    const user = userEvent.setup();
+    const onFocusRef = vi.fn();
+    render(<RefChips refs={[ref]} onFocusRef={onFocusRef} />);
+
+    await user.click(screen.getByTestId("ref-chip-review-node"));
+
+    expect(onFocusRef).toHaveBeenCalledWith(ref);
+  });
+
+  it("removes a ref without also focusing it", async () => {
+    const user = userEvent.setup();
+    const onFocusRef = vi.fn();
+    const onRemoveRef = vi.fn();
+    render(<RefChips refs={[ref]} onFocusRef={onFocusRef} onRemoveRef={onRemoveRef} />);
+
+    await user.click(screen.getByTestId("ref-chip-remove-review-node"));
+
+    expect(onRemoveRef).toHaveBeenCalledWith("review-node");
+    expect(onFocusRef).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/src/pages/CanvasPage/AgentPanel/Composer/index.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/Composer/index.ts
@@ -1,0 +1,4 @@
+export * from "./AttachMenu";
+export * from "./Composer";
+export * from "./ContextStrip";
+export * from "./RefChips";

--- a/packages/views/src/pages/CanvasPage/AgentPanel/messages/MessageTurn.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/messages/MessageTurn.tsx
@@ -1,4 +1,6 @@
 import { useTranslation } from "react-i18next";
+import type { ConversationMessageMetadata, WorkspaceCanvasRef } from "@repo/schemas";
+import { cn } from "@repo/ui/lib/utils";
 import { Assistant } from "./Assistant";
 import { Bubble } from "./Bubble";
 import { ClarifyOptions } from "./ClarifyOptions";
@@ -6,9 +8,11 @@ import { ErrorActions } from "./ErrorActions";
 import { ErrorCard } from "./ErrorCard";
 import { MessageActions } from "./MessageActions";
 import type { AgentBarMessage } from "../_store";
+import { RefChips } from "../Composer";
 
 export type MessageTurnSubmitInput = {
   content: string;
+  metadata?: ConversationMessageMetadata;
   runtimeId: string;
 };
 
@@ -16,6 +20,7 @@ export type MessageTurnProps = {
   isLast: boolean;
   isSending: boolean;
   message: AgentBarMessage;
+  refs: WorkspaceCanvasRef[];
   runtimeId: string | null;
   visibleMessages: AgentBarMessage[];
   onEditDraft: (content: string) => void;
@@ -24,14 +29,14 @@ export type MessageTurnProps = {
 };
 
 /**
- * Shared message presentation for the canvas panel. Product actions only use
- * the current session submit contract; attachments and canvas references are
- * intentionally not reconstructed when retrying an old message.
+ * Shared message presentation for the canvas panel. Historical references are
+ * resolved against the current canvas when possible and otherwise shown by id.
  */
 export const MessageTurn = ({
   isLast,
   isSending,
   message,
+  refs,
   runtimeId,
   visibleMessages,
   onEditDraft,
@@ -46,9 +51,25 @@ export const MessageTurn = ({
     message.role === "assistant" && clarifyOptions.length > 0 && isLast && !isSending;
   const showErrorActions = message.role === "assistant" && Boolean(errorCode) && isLast;
 
-  const submit = (content: string) => {
+  const messageRefs = (message.metadata?.referencedNodeIds ?? []).map((id) => {
+    const currentRef = refs.find((ref) => ref.id === id);
+    if (currentRef) {
+      return currentRef;
+    }
+
+    return {
+      baseId: id,
+      id,
+      kind: "node",
+      label: id,
+      path: [],
+      type: "node" as const,
+    } satisfies WorkspaceCanvasRef;
+  });
+
+  const submit = (content: string, metadata?: ConversationMessageMetadata) => {
     if (runtimeId) {
-      onSubmit({ content, runtimeId });
+      onSubmit(metadata ? { content, metadata, runtimeId } : { content, runtimeId });
     }
   };
 
@@ -74,6 +95,11 @@ export const MessageTurn = ({
   return (
     <div className="group/turn relative space-y-1">
       {body}
+      {messageRefs.length > 0 ? (
+        <div className={cn(message.role === "user" && "flex justify-end")}>
+          <RefChips refs={messageRefs} small />
+        </div>
+      ) : null}
       {!message.isThinking && message.content.trim().length > 0 ? (
         <MessageActions
           align={message.role === "user" ? "right" : "left"}

--- a/packages/views/src/pages/CanvasPage/AgentPanel/messages/messages.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/messages/messages.unit.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import type { WorkspaceCanvasRef } from "@repo/schemas";
 import {
   Assistant,
   Bubble,
@@ -44,6 +45,7 @@ describe("AgentBar message components", () => {
         isLast
         isSending={false}
         message={message}
+        refs={[]}
         runtimeId="runtime-1"
         visibleMessages={[message]}
         onEditDraft={onEditDraft}
@@ -77,6 +79,7 @@ describe("AgentBar message components", () => {
         isLast
         isSending={false}
         message={assistantMessage}
+        refs={[]}
         runtimeId="runtime-1"
         visibleMessages={[firstMessage, assistantMessage]}
         onEditDraft={vi.fn()}
@@ -102,6 +105,7 @@ describe("AgentBar message components", () => {
         isLast
         isSending={false}
         message={errorMessage}
+        refs={[]}
         runtimeId="runtime-1"
         visibleMessages={[firstMessage, errorMessage]}
         onEditDraft={vi.fn()}
@@ -117,6 +121,44 @@ describe("AgentBar message components", () => {
     });
   });
 
+  it("renders historical references as read-only chips with current labels or ids", () => {
+    const message: AgentBarMessage = {
+      content: "Update the selected nodes.",
+      id: "user-with-refs",
+      metadata: { referencedNodeIds: ["current-node", "deleted-node"] },
+      role: "user",
+    };
+    const currentRefs: WorkspaceCanvasRef[] = [
+      {
+        baseId: "current-node",
+        id: "current-node",
+        kind: "operation",
+        label: "Current review",
+        path: [],
+        type: "node",
+      },
+    ];
+
+    render(
+      <MessageTurn
+        isLast
+        isSending={false}
+        message={message}
+        refs={currentRefs}
+        runtimeId="runtime-1"
+        visibleMessages={[message]}
+        onEditDraft={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("ref-chip-current-node")).toHaveTextContent("Current review");
+    expect(screen.getByTestId("ref-chip-deleted-node")).toHaveTextContent("deleted-node");
+    expect(screen.queryByTestId("ref-chip-remove-current-node")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("ref-chip-remove-deleted-node")).not.toBeInTheDocument();
+  });
+
   it("keeps runtime-dependent actions inactive until a runtime is selected", () => {
     const userMessage: AgentBarMessage = {
       content: "Add a validation node.",
@@ -128,6 +170,7 @@ describe("AgentBar message components", () => {
         isLast
         isSending={false}
         message={userMessage}
+        refs={[]}
         runtimeId={null}
         visibleMessages={[userMessage]}
         onEditDraft={vi.fn()}
@@ -150,6 +193,7 @@ describe("AgentBar message components", () => {
         isLast
         isSending={false}
         message={clarifyMessage}
+        refs={[]}
         runtimeId={null}
         visibleMessages={[clarifyMessage]}
         onEditDraft={vi.fn()}
@@ -171,6 +215,7 @@ describe("AgentBar message components", () => {
         isLast
         isSending={false}
         message={errorMessage}
+        refs={[]}
         runtimeId={null}
         visibleMessages={[errorMessage]}
         onEditDraft={vi.fn()}

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useRef } from "react";
 import { ResultAsync } from "neverthrow";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
-import type { PipelineActionProposal } from "@repo/schemas";
+import type { ConversationMessageMetadata, PipelineActionProposal } from "@repo/schemas";
 import { useCanvasPageStore } from "../_store";
 import {
   createPipelineAgentSessionsClient,
@@ -15,6 +15,7 @@ import { useAgentConversationPersistence } from "./useAgentConversationPersisten
 
 export type AgentConversationSubmitInput = {
   content: string;
+  metadata?: ConversationMessageMetadata;
   runtimeId: string;
 };
 
@@ -180,7 +181,7 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
   );
 
   const submitMessage = useCallback(
-    async ({ content, runtimeId }: AgentConversationSubmitInput) => {
+    async ({ content, metadata, runtimeId }: AgentConversationSubmitInput) => {
       const trimmedContent = content.trim();
       if (
         !pipelineId ||
@@ -208,6 +209,7 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
           });
           const persistedMessage = await sendMessage({
             content: trimmedContent,
+            metadata,
             phase: "thinking",
             role: "user",
           });


### PR DESCRIPTION
## Summary

- Port Alan's Agent Bar Composer, ContextStrip, AttachMenu, and RefChips into the shared Canvas AgentPanel.
- Replace the single-line input with a multiline composer supporting Enter to send and Shift+Enter for a newline.
- Bind the context strip and reference chips to the real pipeline, Canvas selection, focus/remove actions, and persisted conversation metadata.
- Keep file/folder attachments on the existing pipeline-agent session upload path with hydration, upload, and send serialization preserved.
- Add a focused Storybook acceptance gallery plus component and integration coverage.

## Stack

This is a stacked PR based on #147 (`cod-132-agent-bar-message-cards`). Merge #147 first, then this PR.

Linear: COD-133

## Validation

- `bun run --cwd packages/views test --run src/pages/CanvasPage/AgentPanel/Composer src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx src/pages/CanvasPage/AgentPanel/messages/messages.unit.test.tsx src/pages/CanvasPage/AgentPanel/useAgentConversation.unit.test.tsx` — 6 files / 42 tests passed
- `bun run --cwd packages/views test --run` — 75 files / 325 tests passed
- `bun run --cwd packages/views check-types` — passed
- `bun run --cwd apps/app check-types` — passed
- `bun run --cwd apps/desktop-app build` — passed
- `git diff --check` — passed
- Browser verified Enter, Shift+Enter, attachment menu, desktop and 375px layouts, and zero console errors
- Visual acceptance completed before publishing
