### PR TITLE
feat(canvas): 增加 Chrome 风格工具栏与组件面板（COD-129）

### DIFF
--- a/apps/app/src/integrations/refine/resources/custom.ts
+++ b/apps/app/src/integrations/refine/resources/custom.ts
@@ -2,6 +2,7 @@ import { trpcClient } from "@/integrations/trpc/client";
 
 export const CustomEndpoint = {
   pipelinesRun: "pipelines/run",
+  pipelinesCancel: "pipelines/cancel",
   pipelinesAnalyzeIntent: "pipelines/analyzeIntent",
   pipelinesGenerateStructure: "pipelines/generateStructure",
   pipelinesOptimizeFromDistillation: "pipelines/optimizeFromDistillation",
@@ -36,6 +37,8 @@ type Input<T extends (...args: never[]) => unknown> = Parameters<T>[0];
 export const customEndpoints: Record<string, CustomHandler> = {
   [CustomEndpoint.pipelinesRun]: (payload) =>
     trpcClient.pipelines.run.mutate(payload as Input<typeof trpcClient.pipelines.run.mutate>),
+  [CustomEndpoint.pipelinesCancel]: (payload) =>
+    trpcClient.pipelines.cancel.mutate(payload as Input<typeof trpcClient.pipelines.cancel.mutate>),
   [CustomEndpoint.pipelinesAnalyzeIntent]: (payload) =>
     trpcClient.pipelines.analyzeIntent.mutate(
       payload as Input<typeof trpcClient.pipelines.analyzeIntent.mutate>,

--- a/apps/app/src/integrations/trpc/router.unit.test.ts
+++ b/apps/app/src/integrations/trpc/router.unit.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   conversationsGetAll: vi.fn(),
   pipelineAssetsGetAll: vi.fn(),
   pipelineAssetsGetUsageCount: vi.fn(),
+  pipelineCancelRun: vi.fn(),
   projectsGetAll: vi.fn(),
   routinesGetByPipelineId: vi.fn(),
   routinesGetAll: vi.fn(),
@@ -41,7 +42,7 @@ vi.mock("./services", () => ({
     getAll: mocks.pipelineAssetsGetAll,
     getUsageCount: mocks.pipelineAssetsGetUsageCount,
   },
-  pipelineRunnerService: {},
+  pipelineRunnerService: { cancelRun: mocks.pipelineCancelRun },
   pipelinesService: {},
   projectsService: { getAll: mocks.projectsGetAll },
   refinementsService: {},
@@ -54,11 +55,16 @@ vi.mock("./services", () => ({
   skillsService: {},
   usageService: { getDailyTokenSeries: mocks.usageGetDailyTokenSeries },
 }));
+vi.mock("@repo/services", () => ({
+  getProposeProgress: vi.fn(),
+  setProposeProgress: vi.fn(),
+}));
 
 import { router } from "./init";
 import { connectorsRouter } from "./routers/connectors";
 import { conversationsRouter } from "./routers/conversations";
 import { pipelineAssetsRouter } from "./routers/pipelineAssets";
+import { pipelinesRouter } from "./routers/pipelines";
 import { projectsRouter } from "./routers/projects";
 import { routinesRouter } from "./routers/routines";
 import { usageRouter } from "./routers/usage";
@@ -67,6 +73,7 @@ const domainRouter = router({
   connectors: connectorsRouter,
   conversations: conversationsRouter,
   pipelineAssets: pipelineAssetsRouter,
+  pipelines: pipelinesRouter,
   projects: projectsRouter,
   routines: routinesRouter,
   usage: usageRouter,
@@ -80,6 +87,7 @@ beforeEach(() => {
   mocks.conversationsGetAll.mockResolvedValue(ok([]));
   mocks.pipelineAssetsGetAll.mockResolvedValue(ok([]));
   mocks.pipelineAssetsGetUsageCount.mockResolvedValue(ok({ assetId: "asset-1", count: 1 }));
+  mocks.pipelineCancelRun.mockResolvedValue(ok({ cancelled: true, jobId: "job-1" }));
   mocks.projectsGetAll.mockResolvedValue(ok([]));
   mocks.routinesGetAll.mockResolvedValue([]);
   mocks.routinesGetByPipelineId.mockResolvedValue([]);
@@ -123,6 +131,19 @@ describe("domain tRPC routers", () => {
       code: "UNAUTHORIZED",
     });
     expect(mocks.connectorsConnect).not.toHaveBeenCalled();
+  });
+
+  it("requires a session to cancel pipeline runs", async () => {
+    const caller = domainRouter.createCaller({ session: null });
+    const authedCaller = domainRouter.createCaller({ session: { user: { id: "user-1" } } });
+
+    await expect(caller.pipelines.cancel({ jobId: "job-1" })).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    await expect(authedCaller.pipelines.cancel({ jobId: "job-1" })).resolves.toEqual({
+      cancelled: true,
+      jobId: "job-1",
+    });
   });
 
   it("filters pipeline routines by enabled status", async () => {

--- a/apps/app/src/integrations/trpc/routers/pipelines.ts
+++ b/apps/app/src/integrations/trpc/routers/pipelines.ts
@@ -1,6 +1,6 @@
 import { z } from "zod/v4";
 import { TRPCError } from "@trpc/server";
-import { publicProcedure, router } from "../init";
+import { authedProcedure, publicProcedure, router } from "../init";
 import { pipelinesService, pipelineRunnerService } from "../services";
 import { getProposeProgress, setProposeProgress } from "@repo/services";
 import {
@@ -100,6 +100,15 @@ export const pipelinesRouter = router({
 
       return result.value;
     }),
+
+  cancel: authedProcedure.input(z.object({ jobId: z.string() })).mutation(async ({ input }) => {
+    const result = await pipelineRunnerService.cancelRun(input.jobId);
+    if (result.isErr()) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: result.error.message });
+    }
+
+    return result.value;
+  }),
 
   optimizeFromDistillation: publicProcedure
     .input(

--- a/apps/app/src/pages/WorkspacePage/canvas/CanvasRoot.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/CanvasRoot.tsx
@@ -7,10 +7,11 @@ import { CanvasStoreProvider } from "./_store/canvasStore";
 import { EdgeInspector } from "./panels/EdgeInspector";
 import { NodeConfig } from "./panels/NodeConfig";
 import { CanvasFlow } from "./flow";
+import { CanvasToolbar, ComponentPanel, TopPill } from "./chrome";
 import { CanvasEmptyState } from "./CanvasEmptyState";
 
 export type CanvasRootProps = {
-  pipeline: Pick<PipelineData, "edges" | "id" | "nodes">;
+  pipeline: Pick<PipelineData, "edges" | "id" | "name" | "nodes" | "version">;
 };
 
 export const CanvasRoot = ({ pipeline }: CanvasRootProps) => {
@@ -29,6 +30,11 @@ export const CanvasRoot = ({ pipeline }: CanvasRootProps) => {
           lang={i18n.language}
         >
           <CanvasFlow />
+          <TopPill
+            pipeline={{ id: pipeline.id, name: pipeline.name, version: pipeline.version ?? 1 }}
+          />
+          <CanvasToolbar />
+          <ComponentPanel />
           <EdgeInspector pipelineId={pipeline.id} />
           <NodeConfig pipelineId={pipeline.id} />
           <CanvasEmptyState />

--- a/apps/app/src/pages/WorkspacePage/canvas/CanvasRoot.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/CanvasRoot.unit.test.tsx
@@ -5,7 +5,8 @@ import { CanvasRoot } from "./CanvasRoot";
 
 vi.mock("@refinedev/core", () => ({
   useDataProvider: () => () => ({}),
-  useUpdate: () => ({ mutateAsync: vi.fn() }),
+  useList: () => ({ result: { data: [], total: 0 } }),
+  useUpdate: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
 }));
 
 vi.mock("@xyflow/react", () => ({
@@ -25,7 +26,10 @@ vi.mock("@xyflow/react", () => ({
   useReactFlow: () => ({
     fitView: vi.fn(),
     screenToFlowPosition: ({ x, y }: { x: number; y: number }) => ({ x, y }),
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
   }),
+  useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
   useUpdateNodeInternals: () => () => undefined,
 }));
 

--- a/apps/app/src/pages/WorkspacePage/canvas/CanvasRoot.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/CanvasRoot.unit.test.tsx
@@ -6,6 +6,7 @@ import { CanvasRoot } from "./CanvasRoot";
 vi.mock("@refinedev/core", () => ({
   useDataProvider: () => () => ({}),
   useList: () => ({ result: { data: [], total: 0 } }),
+  useOne: () => ({ query: {} }),
   useUpdate: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
 }));
 

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/CanvasToolbar.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/CanvasToolbar.tsx
@@ -1,0 +1,82 @@
+import { Hand, Minus, MousePointer2, Plus } from "lucide-react";
+import { useReactFlow, useViewport } from "@xyflow/react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@repo/ui/lib/utils";
+import { useCanvasStore } from "../_store/canvasStore";
+
+export const CanvasToolbar = () => {
+  const { t } = useTranslation();
+  const canvasTool = useCanvasStore((state) => state.canvasTool);
+  const setCanvasTool = useCanvasStore((state) => state.setCanvasTool);
+  const { fitView, zoomIn, zoomOut } = useReactFlow();
+  const { zoom } = useViewport();
+  const handleSelectTool = () => setCanvasTool("select");
+  const handlePanTool = () => setCanvasTool("hand");
+  const handleZoomOut = () => void zoomOut({ duration: 150 });
+  const handleResetView = () => void fitView({ duration: 200 });
+  const handleZoomIn = () => void zoomIn({ duration: 150 });
+
+  return (
+    <div
+      className="pointer-events-auto absolute bottom-4 right-4 z-20 flex items-center gap-0.5 rounded-full bg-surface p-1 shadow-pill ring-1 ring-border"
+      data-testid="canvas-v2-toolbar"
+    >
+      <button
+        className={cn(
+          "rounded-full p-1.5 transition-colors",
+          canvasTool === "select"
+            ? "bg-accent text-foreground"
+            : "text-muted-foreground hover:bg-accent/60",
+        )}
+        data-testid="canvas-v2-tool-select"
+        title={t("workspace.canvas.chrome.toolbar.select")}
+        type="button"
+        onClick={handleSelectTool}
+      >
+        <MousePointer2 className="size-3.5" />
+      </button>
+      <button
+        className={cn(
+          "rounded-full p-1.5 transition-colors",
+          canvasTool === "hand"
+            ? "bg-accent text-foreground"
+            : "text-muted-foreground hover:bg-accent/60",
+        )}
+        data-testid="canvas-v2-tool-hand"
+        title={t("workspace.canvas.chrome.toolbar.pan")}
+        type="button"
+        onClick={handlePanTool}
+      >
+        <Hand className="size-3.5" />
+      </button>
+      <div className="mx-0.5 h-4 w-px bg-border-strong" />
+      <button
+        className="rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+        data-testid="canvas-v2-zoom-out"
+        title={t("workspace.canvas.chrome.toolbar.zoomOut")}
+        type="button"
+        onClick={handleZoomOut}
+      >
+        <Minus className="size-3.5" />
+      </button>
+      <button
+        className="px-1 font-mono text-[11px] tabular-nums text-muted-foreground transition-colors hover:text-foreground"
+        data-testid="canvas-v2-zoom-reset"
+        title={t("workspace.canvas.chrome.toolbar.resetView")}
+        type="button"
+        onClick={handleResetView}
+      >
+        {Math.round(zoom * 100)}%
+      </button>
+      <button
+        className="rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+        data-testid="canvas-v2-zoom-in"
+        title={t("workspace.canvas.chrome.toolbar.zoomIn")}
+        type="button"
+        onClick={handleZoomIn}
+      >
+        <Plus className="size-3.5" />
+      </button>
+    </div>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/CanvasToolbar.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/CanvasToolbar.unit.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CanvasStoreContext, createCanvasStore, type CanvasStore } from "../_store/canvasStore";
+import { CanvasToolbar } from "./CanvasToolbar";
+
+const flowMocks = vi.hoisted(() => ({ fitView: vi.fn(), zoomIn: vi.fn(), zoomOut: vi.fn() }));
+
+vi.mock("@xyflow/react", () => ({
+  useReactFlow: () => flowMocks,
+  useViewport: () => ({ x: 0, y: 0, zoom: 0.78 }),
+}));
+
+const makeWrapper =
+  (store: CanvasStore) =>
+  ({ children }: React.PropsWithChildren) => (
+    <CanvasStoreContext.Provider value={store}>{children}</CanvasStoreContext.Provider>
+  );
+
+describe("CanvasToolbar", () => {
+  beforeEach(() => {
+    flowMocks.fitView.mockReset();
+    flowMocks.zoomIn.mockReset();
+    flowMocks.zoomOut.mockReset();
+  });
+
+  it("switches tools and controls the viewport", async () => {
+    const user = userEvent.setup();
+    const store = createCanvasStore();
+    render(<CanvasToolbar />, { wrapper: makeWrapper(store) });
+
+    await user.click(screen.getByTestId("canvas-v2-tool-hand"));
+    expect(store.getState().canvasTool).toBe("hand");
+    await user.click(screen.getByTestId("canvas-v2-tool-select"));
+    expect(store.getState().canvasTool).toBe("select");
+
+    expect(screen.getByTestId("canvas-v2-zoom-reset")).toHaveTextContent("78%");
+    await user.click(screen.getByTestId("canvas-v2-zoom-in"));
+    await user.click(screen.getByTestId("canvas-v2-zoom-out"));
+    await user.click(screen.getByTestId("canvas-v2-zoom-reset"));
+
+    expect(flowMocks.zoomIn).toHaveBeenCalled();
+    expect(flowMocks.zoomOut).toHaveBeenCalled();
+    expect(flowMocks.fitView).toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/ComponentPanel.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/ComponentPanel.tsx
@@ -1,0 +1,230 @@
+import { useRef, type DragEvent } from "react";
+import { useList } from "@refinedev/core";
+import { useReactFlow } from "@xyflow/react";
+import {
+  Boxes,
+  File,
+  FolderGit2,
+  FolderOpen,
+  GitFork,
+  HardDrive,
+  MessageSquare,
+  Plus,
+  Split,
+  Users,
+  Workflow,
+  type LucideIcon,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@repo/ui/lib/utils";
+import type { CompoundNodeData, Operation } from "@repo/schemas";
+import { ResourceName } from "@/integrations/refine/dataProvider";
+import { useCanvasStore } from "../_store/canvasStore";
+import {
+  CANVAS_COMPONENT_DRAG_MIME,
+  encodeCanvasComponentDragPayload,
+  type CanvasComponentDragPayload,
+} from "../utils/canvasComponentDragPayload";
+import { makeDefaultNodeData } from "../utils/makeDefaultNodeData";
+import { makeOperationNodeData } from "../utils/makeOperationNodeData";
+
+type PaletteEntry = {
+  icon: LucideIcon;
+  id: string;
+  label: string;
+  payload: CanvasComponentDragPayload;
+};
+
+const OBJECT_ENTRIES: ReadonlyArray<{
+  icon: LucideIcon;
+  type: "file" | "folder" | "github-project" | "prompt";
+}> = [
+  { icon: FolderOpen, type: "folder" },
+  { icon: File, type: "file" },
+  { icon: FolderGit2, type: "github-project" },
+  { icon: MessageSquare, type: "prompt" },
+];
+
+const COMPOUND_ENTRIES: ReadonlyArray<{
+  icon: LucideIcon;
+  kind: "council" | "delegation" | "verify";
+}> = [
+  { icon: GitFork, kind: "verify" },
+  { icon: Users, kind: "council" },
+  { icon: Split, kind: "delegation" },
+];
+
+const OUTPUT_ENTRIES: ReadonlyArray<{
+  icon: LucideIcon;
+  type: "output-local-path" | "output-project-path";
+}> = [
+  { icon: HardDrive, type: "output-local-path" },
+  { icon: Boxes, type: "output-project-path" },
+];
+
+const jitterPosition = () => Math.random() * 40 - 20;
+
+const handleDragStart = (
+  event: DragEvent<HTMLButtonElement>,
+  payload: CanvasComponentDragPayload,
+) => {
+  event.dataTransfer.setData(CANVAS_COMPONENT_DRAG_MIME, encodeCanvasComponentDragPayload(payload));
+  event.dataTransfer.effectAllowed = "copy";
+};
+
+export const ComponentPanel = () => {
+  const { t } = useTranslation();
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const compPanelOpen = useCanvasStore((state) => state.compPanelOpen);
+  const toggleCompPanelOpen = useCanvasStore((state) => state.toggleCompPanelOpen);
+  const addNodeFromCatalog = useCanvasStore((state) => state.addNodeFromCatalog);
+  const drillStack = useCanvasStore((state) => state.drillStack);
+  const { screenToFlowPosition } = useReactFlow();
+  const { result: operationsResult } = useList<Operation>({
+    resource: ResourceName.operations,
+  });
+  const operations = operationsResult.data;
+
+  if (drillStack.length > 0) {
+    return null;
+  }
+
+  const groups: ReadonlyArray<{ entries: PaletteEntry[]; key: string }> = [
+    {
+      entries: OBJECT_ENTRIES.map(({ icon, type }) => ({
+        icon,
+        id: `object-${type}`,
+        label: t(`workspace.canvas.chrome.components.items.${type}`),
+        payload: { kind: "object", type },
+      })),
+      key: "inputObjects",
+    },
+    {
+      entries: operations.map((operation) => ({
+        icon: Workflow,
+        id: `operation-${operation.id}`,
+        label: operation.name,
+        payload: { kind: "operation", operation },
+      })),
+      key: "operations",
+    },
+    {
+      entries: COMPOUND_ENTRIES.map(({ icon, kind }) => ({
+        icon,
+        id: `compound-${kind}`,
+        label: t(`workspace.canvas.chrome.components.items.${kind}`),
+        payload: { compoundKind: kind, kind: "compound" },
+      })),
+      key: "compound",
+    },
+    {
+      entries: OUTPUT_ENTRIES.map(({ icon, type }) => ({
+        icon,
+        id: `output-${type}`,
+        label: t(`workspace.canvas.chrome.components.items.${type}`),
+        payload: { kind: "object", type },
+      })),
+      key: "output",
+    },
+  ];
+
+  const centerPosition = () => {
+    const root = panelRef.current?.closest('[data-testid="canvas-v2-root"]');
+    const rect = root?.getBoundingClientRect();
+
+    return screenToFlowPosition({
+      x: (rect ? rect.left + rect.width / 2 : window.innerWidth / 2) + jitterPosition(),
+      y: (rect ? rect.top + rect.height / 2 : window.innerHeight / 2) + jitterPosition(),
+    });
+  };
+
+  const handleAddEntry = (payload: CanvasComponentDragPayload) => {
+    const position = centerPosition();
+
+    if (payload.kind === "object") {
+      addNodeFromCatalog({ position, type: payload.type });
+    } else if (payload.kind === "operation") {
+      addNodeFromCatalog({
+        data: makeOperationNodeData(payload.operation),
+        position,
+        type: "operation",
+      });
+    } else if (payload.kind === "compound") {
+      addNodeFromCatalog({
+        data: {
+          ...(makeDefaultNodeData("compound", {
+            label: payload.compoundKind,
+          }) as CompoundNodeData),
+          compoundKind: payload.compoundKind,
+        },
+        position,
+        type: "compound",
+      });
+    } else {
+      return;
+    }
+  };
+
+  const handleToggleComponentPanel = () => toggleCompPanelOpen();
+
+  return (
+    <div ref={panelRef} className="pointer-events-auto absolute left-3 top-16 z-10">
+      <button
+        className={cn(
+          "flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs shadow-pill ring-1 transition-colors",
+          compPanelOpen
+            ? "bg-foreground text-background ring-foreground"
+            : "bg-surface ring-border hover:ring-border-strong",
+        )}
+        data-testid="canvas-v2-components-toggle"
+        type="button"
+        onClick={handleToggleComponentPanel}
+      >
+        <Boxes className="size-3.5" />
+        {t("workspace.canvas.chrome.components.trigger")}
+      </button>
+      {compPanelOpen ? (
+        <div
+          className="mt-2 max-h-[60vh] w-[230px] overflow-y-auto rounded-2xl bg-surface p-2.5 shadow-float ring-1 ring-border"
+          data-testid="canvas-v2-components-panel"
+        >
+          <div className="mb-1.5 px-1 text-[10px] leading-snug text-muted-foreground">
+            {t("workspace.canvas.chrome.components.hint")}
+          </div>
+          {groups.map((group) => (
+            <div key={group.key} className="mb-2 last:mb-0">
+              <div className="px-1 pb-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                {t(`workspace.canvas.chrome.components.groups.${group.key}`)}
+              </div>
+              <div className="space-y-0.5">
+                {group.entries.length === 0 ? (
+                  <div className="px-2 py-1 text-[11px] text-muted-foreground/70">
+                    {t("workspace.canvas.chrome.components.emptyGroup")}
+                  </div>
+                ) : (
+                  group.entries.map((entry) => (
+                    <button
+                      key={entry.id}
+                      className="flex w-full cursor-grab items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs ring-1 ring-transparent transition-colors hover:bg-accent/60 hover:ring-border"
+                      data-testid={`canvas-v2-component-${entry.id}`}
+                      draggable={true}
+                      type="button"
+                      onClick={() => handleAddEntry(entry.payload)}
+                      onDragStart={(event) => handleDragStart(event, entry.payload)}
+                    >
+                      <span className="flex size-5 items-center justify-center rounded-md bg-surface-2">
+                        <entry.icon className="size-3 text-foreground/70" />
+                      </span>
+                      <span className="min-w-0 flex-1 truncate">{entry.label}</span>
+                      <Plus className="size-3 text-muted-foreground/50" />
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/ComponentPanel.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/ComponentPanel.unit.test.tsx
@@ -1,0 +1,54 @@
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Operation } from "@repo/schemas";
+import { describe, expect, it, vi } from "vitest";
+import { CanvasStoreContext, createCanvasStore, type CanvasStore } from "../_store/canvasStore";
+import { CANVAS_COMPONENT_DRAG_MIME } from "../utils/canvasComponentDragPayload";
+import { ComponentPanel } from "./ComponentPanel";
+
+const operation = {
+  acceptedObjectTypes: ["file", "folder", "github-project", "prompt"],
+  config: { inputs: [], outputs: [] },
+  description: "Parse a PDF",
+  id: "op-1",
+  name: "Parse PDF",
+} satisfies Operation;
+
+vi.mock("@refinedev/core", () => ({
+  useList: () => ({ result: { data: [operation], total: 1 } }),
+}));
+
+vi.mock("@xyflow/react", () => ({
+  useReactFlow: () => ({
+    screenToFlowPosition: ({ x, y }: { x: number; y: number }) => ({ x, y }),
+  }),
+}));
+
+const makeWrapper =
+  (store: CanvasStore) =>
+  ({ children }: React.PropsWithChildren) => (
+    <CanvasStoreContext.Provider value={store}>{children}</CanvasStoreContext.Provider>
+  );
+
+describe("ComponentPanel", () => {
+  it("opens, adds nodes, and writes the drag payload", async () => {
+    const user = userEvent.setup();
+    const store = createCanvasStore();
+    render(<ComponentPanel />, { wrapper: makeWrapper(store) });
+
+    await user.click(screen.getByTestId("canvas-v2-components-toggle"));
+    await user.click(screen.getByTestId("canvas-v2-component-object-folder"));
+    expect(store.getState().nodes[0]?.type).toBe("folder");
+    expect(store.getState().historyPast).toHaveLength(1);
+
+    const setData = vi.fn();
+    const dragStart = createEvent.dragStart(
+      screen.getByTestId("canvas-v2-component-operation-op-1"),
+    );
+    Object.defineProperty(dragStart, "dataTransfer", {
+      value: { effectAllowed: "none", setData, types: [] },
+    });
+    fireEvent(screen.getByTestId("canvas-v2-component-operation-op-1"), dragStart);
+    expect(setData).toHaveBeenCalledWith(CANVAS_COMPONENT_DRAG_MIME, expect.any(String));
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/StateLegend.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/StateLegend.tsx
@@ -1,0 +1,65 @@
+import { CircleDashed } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Popover, PopoverContent, PopoverTrigger } from "@repo/ui/popover";
+import type { NodeRunStatus } from "@repo/schemas";
+import { cn } from "@repo/ui/lib/utils";
+
+type LegendTone = "err" | "fg" | "neutral" | "ok" | "warn";
+
+const STATE_DEFS: ReadonlyArray<readonly [NodeRunStatus, LegendTone]> = [
+  ["idle", "neutral"],
+  ["queued", "neutral"],
+  ["running", "fg"],
+  ["retrying", "warn"],
+  ["waitingForUser", "warn"],
+  ["done", "ok"],
+  ["failed", "err"],
+  ["skipped", "neutral"],
+  ["cancelled", "neutral"],
+];
+
+const TONE_CLASS: Record<Exclude<LegendTone, "neutral">, string> = {
+  err: "bg-destructive",
+  fg: "bg-foreground",
+  ok: "bg-success",
+  warn: "bg-warning",
+};
+
+export const StateLegend = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        className="pointer-events-auto flex items-center gap-1.5 rounded-full bg-surface px-3 py-1.5 text-xs text-foreground shadow-soft ring-1 ring-border transition-colors hover:ring-border-strong data-[popup-open]:bg-foreground data-[popup-open]:text-background"
+        data-testid="canvas-v2-state-legend-trigger"
+      >
+        <CircleDashed className="size-3.5" />
+        {t("workspace.canvas.chrome.states.trigger")}
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-52 rounded-2xl p-2.5" sideOffset={8}>
+        <div
+          className="px-1 pb-1.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground"
+          data-testid="canvas-v2-state-legend"
+        >
+          {t("workspace.canvas.chrome.states.title")}
+        </div>
+        <div className="space-y-0.5">
+          {STATE_DEFS.map(([status, tone]) => (
+            <div key={status} className="flex items-center gap-2 rounded-lg px-1.5 py-1 text-xs">
+              <span className="relative inline-flex size-2 items-center justify-center">
+                {tone === "neutral" ? (
+                  <span className="size-2 rounded-full bg-surface shadow-[inset_0_0_0_1.5px_var(--color-muted-foreground)]" />
+                ) : (
+                  <span className={cn("size-2 rounded-full", TONE_CLASS[tone])} />
+                )}
+              </span>
+              <span className="flex-1">{t(`workspace.canvas.chrome.states.${status}`)}</span>
+              <span className="font-mono text-[9px] text-muted-foreground/70">{status}</span>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/TopPill.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/TopPill.tsx
@@ -1,0 +1,317 @@
+import { useMemo, useState, type FocusEvent, type KeyboardEvent } from "react";
+import { useUpdate } from "@refinedev/core";
+import { ResultAsync } from "neverthrow";
+import { ChevronRight, CornerUpLeft, Layers, Play, Square, Workflow } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@repo/ui/lib/utils";
+import { dataProvider, ResourceName } from "@/integrations/refine/dataProvider";
+import { toastStore } from "@/store/toastStore";
+import { toPipelineSnapshot, type CanvasEdge, type CanvasNode } from "../_store/canvasTypes";
+import { useCanvasStore } from "../_store/canvasStore";
+import { StateLegend } from "./StateLegend";
+import { VersionMenu, type VersionMenuRunState } from "./VersionMenu";
+
+export type TopPillPipeline = {
+  id: string;
+  name: string;
+  version: number;
+};
+
+export type TopPillProps = {
+  pipeline: TopPillPipeline;
+};
+
+type RunStartResponse = {
+  jobId: string;
+};
+
+const stableGraphJson = (nodes: readonly CanvasNode[], edges: readonly CanvasEdge[]): string =>
+  JSON.stringify({
+    edges: edges.map((edge) => ({
+      data: edge.data,
+      id: edge.id,
+      source: edge.source,
+      sourceHandle: edge.sourceHandle ?? null,
+      target: edge.target,
+      targetHandle: edge.targetHandle ?? null,
+    })),
+    nodes: nodes.map((node) => ({
+      data: node.data,
+      id: node.id,
+      parentId: node.parentId ?? null,
+      position: node.position,
+      style: node.style ?? null,
+      type: node.type,
+    })),
+  });
+
+export const TopPill = ({ pipeline }: TopPillProps) => {
+  const { t } = useTranslation();
+  const nodes = useCanvasStore((state) => state.nodes);
+  const edges = useCanvasStore((state) => state.edges);
+  const drillStack = useCanvasStore((state) => state.drillStack);
+  const setDrillStack = useCanvasStore((state) => state.setDrillStack);
+  const popDrillStack = useCanvasStore((state) => state.popDrillStack);
+  const activeJobId = useCanvasStore((state) => state.activeJobId);
+  const latestJob = useCanvasStore((state) => state.latestJob);
+  const beginRun = useCanvasStore((state) => state.beginRun);
+  const { mutate: updatePipeline } = useUpdate();
+
+  const [renaming, setRenaming] = useState(false);
+  const [version, setVersion] = useState(pipeline.version);
+  const [isStartingRun, setIsStartingRun] = useState(false);
+  const graphJson = useMemo(() => stableGraphJson(nodes, edges), [edges, nodes]);
+  const [savedGraphJson, setSavedGraphJson] = useState(graphJson);
+
+  const dirty = graphJson !== savedGraphJson;
+  const running = activeJobId !== null;
+  const hasOperationNode = nodes.some((node) => node.type === "operation");
+  const canRun = hasOperationNode && !running && !isStartingRun;
+  const atRoot = drillStack.length === 0;
+  const runState: VersionMenuRunState = running
+    ? "running"
+    : latestJob?.status === "done" && !dirty
+      ? "done"
+      : "draft";
+
+  const crumbs = useMemo(() => {
+    const nodeById = new Map(nodes.map((node) => [node.id, node]));
+
+    return [
+      { id: "root", label: pipeline.name },
+      ...drillStack.map((nodeId) => ({
+        id: nodeId,
+        label:
+          (nodeById.get(nodeId)?.data as { label?: string } | undefined)?.label ??
+          t("workspace.canvas.chrome.breadcrumb.compoundFallback"),
+      })),
+    ];
+  }, [drillStack, nodes, pipeline.name, t]);
+
+  const handlePersistGraph = (nextVersion: number, successMessage: string) => {
+    const snapshot = toPipelineSnapshot({ edges, nodes });
+    updatePipeline(
+      {
+        id: pipeline.id,
+        resource: ResourceName.pipelines,
+        successNotification: false,
+        errorNotification: false,
+        values: {
+          edges: snapshot.edges,
+          nodes: snapshot.nodes,
+          version: nextVersion,
+        },
+      },
+      {
+        onError: () =>
+          toastStore.getState().addToast({
+            title: t("workspace.canvas.chrome.version.saveFailed"),
+            type: "error",
+          }),
+        onSuccess: () => {
+          setSavedGraphJson(graphJson);
+          setVersion(nextVersion);
+          toastStore.getState().addToast({
+            title: successMessage,
+            type: "success",
+          });
+        },
+      },
+    );
+  };
+
+  const handleCommitRename = (value: string) => {
+    setRenaming(false);
+    const name = value.trim();
+    if (!name || name === pipeline.name) {
+      return;
+    }
+
+    updatePipeline({
+      id: pipeline.id,
+      resource: ResourceName.pipelines,
+      successNotification: false,
+      errorNotification: false,
+      values: { name },
+    });
+  };
+
+  const handleRun = () => {
+    setIsStartingRun(true);
+    void ResultAsync.fromPromise(
+      dataProvider.custom!({
+        method: "post",
+        payload: { id: pipeline.id },
+        url: "pipelines/run",
+      }),
+      () => t("workspace.canvas.chrome.run.startFailed"),
+    ).match(
+      (response) => {
+        const { jobId } = response.data as RunStartResponse;
+        beginRun(jobId);
+        setIsStartingRun(false);
+        toastStore.getState().addToast({
+          description: t("workspace.canvas.chrome.run.startedDescription", { jobId }),
+          title: t("workspace.canvas.chrome.run.started"),
+          type: "success",
+        });
+      },
+      (error) => {
+        setIsStartingRun(false);
+        toastStore.getState().addToast({
+          title: error,
+          type: "error",
+        });
+      },
+    );
+  };
+
+  const handleDrillOut = () => popDrillStack();
+  const handleOverwrite = () =>
+    handlePersistGraph(version, t("workspace.canvas.chrome.version.saveSuccess", { version }));
+  const handleSaveAsNew = () =>
+    handlePersistGraph(
+      version + 1,
+      t("workspace.canvas.chrome.version.saveAsNewSuccess", { version: version + 1 }),
+    );
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 top-0 z-20 flex items-start justify-between gap-2 p-3"
+      data-testid="canvas-v2-top-pill"
+    >
+      <div className="pointer-events-auto flex min-w-0 items-center gap-2">
+        <div className="flex min-w-0 items-center gap-1 rounded-full bg-surface px-2.5 py-1.5 shadow-pill ring-1 ring-border">
+          {atRoot ? (
+            <Workflow className="size-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <Layers className="size-3.5 shrink-0 text-muted-foreground" />
+          )}
+          {crumbs.map((crumb, index) => {
+            const isLast = index === crumbs.length - 1;
+            const handleRenameBlur = (event: FocusEvent<HTMLInputElement>) =>
+              handleCommitRename(event.target.value);
+            const handleRenameKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+              if (event.key === "Enter") {
+                handleCommitRename(event.currentTarget.value);
+              }
+              if (event.key === "Escape") {
+                setRenaming(false);
+              }
+            };
+            const handleCrumbClick = () => {
+              if (index === 0 && isLast) {
+                setRenaming(true);
+
+                return;
+              }
+              setDrillStack(drillStack.slice(0, index));
+            };
+            const handleCrumbDoubleClick = () => {
+              if (index === 0) {
+                setRenaming(true);
+              }
+            };
+
+            if (index === 0 && renaming) {
+              return (
+                <input
+                  key="rename"
+                  autoFocus
+                  className="w-44 rounded-md bg-surface-2 px-1.5 py-0.5 text-xs font-semibold focus:outline-none focus:ring-1 focus:ring-border-strong"
+                  data-testid="canvas-v2-rename-input"
+                  defaultValue={crumb.label}
+                  onBlur={handleRenameBlur}
+                  onKeyDown={handleRenameKeyDown}
+                />
+              );
+            }
+
+            return (
+              <span key={crumb.id} className="flex min-w-0 items-center gap-1">
+                {index > 0 ? (
+                  <ChevronRight className="size-3 shrink-0 text-muted-foreground/50" />
+                ) : null}
+                <button
+                  className={cn(
+                    "truncate whitespace-nowrap rounded-full px-1.5 py-0.5 text-xs transition-colors",
+                    isLast
+                      ? "font-semibold text-foreground"
+                      : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+                  )}
+                  data-testid={`canvas-v2-crumb-${index}`}
+                  title={
+                    index === 0 ? t("workspace.canvas.chrome.breadcrumb.renameTitle") : undefined
+                  }
+                  type="button"
+                  onClick={handleCrumbClick}
+                  onDoubleClick={handleCrumbDoubleClick}
+                >
+                  {crumb.label}
+                </button>
+              </span>
+            );
+          })}
+          {atRoot ? (
+            <VersionMenu
+              dirty={dirty}
+              runState={runState}
+              version={version}
+              onOverwrite={handleOverwrite}
+              onSaveAsNew={handleSaveAsNew}
+            />
+          ) : null}
+        </div>
+        {atRoot ? null : (
+          <button
+            className="flex items-center gap-1.5 rounded-full bg-surface px-3 py-1.5 text-xs shadow-pill ring-1 ring-border transition-colors hover:ring-border-strong"
+            data-testid="canvas-v2-drill-out"
+            type="button"
+            onClick={handleDrillOut}
+          >
+            <CornerUpLeft className="size-3.5" />
+            {t("workspace.canvas.chrome.breadcrumb.drillOut")}
+          </button>
+        )}
+      </div>
+
+      <div className="pointer-events-auto flex shrink-0 items-center gap-2">
+        {atRoot ? <StateLegend /> : null}
+        {atRoot ? (
+          running ? (
+            <button
+              disabled
+              className="flex items-center gap-1.5 rounded-full bg-surface px-3.5 py-1.5 text-xs font-medium text-foreground shadow-pill ring-1 ring-border opacity-70"
+              data-testid="canvas-v2-stop"
+              type="button"
+            >
+              <Square className="size-3.5" />
+              {t("workspace.canvas.chrome.run.stop")}
+            </button>
+          ) : (
+            <button
+              className={cn(
+                "flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs font-medium shadow-pill transition-all",
+                canRun
+                  ? "bg-foreground text-background hover:opacity-90"
+                  : "cursor-not-allowed bg-surface text-muted-foreground ring-1 ring-border",
+              )}
+              data-testid="canvas-v2-run"
+              disabled={!canRun}
+              title={
+                hasOperationNode ? undefined : t("workspace.canvas.chrome.run.noRunnableNodes")
+              }
+              type="button"
+              onClick={handleRun}
+            >
+              <Play className="size-3.5 fill-current" />
+              {latestJob
+                ? t("workspace.canvas.chrome.run.rerun")
+                : t("workspace.canvas.chrome.run.run")}
+            </button>
+          )
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/TopPill.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/TopPill.tsx
@@ -1,13 +1,14 @@
 import { useMemo, useState, type FocusEvent, type KeyboardEvent } from "react";
-import { useUpdate } from "@refinedev/core";
+import { useOne, useUpdate } from "@refinedev/core";
 import { ResultAsync } from "neverthrow";
 import { ChevronRight, CornerUpLeft, Layers, Play, Square, Workflow } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import type { Job } from "@repo/schemas";
 import { cn } from "@repo/ui/lib/utils";
 import { dataProvider, ResourceName } from "@/integrations/refine/dataProvider";
 import { toastStore } from "@/store/toastStore";
 import { toPipelineSnapshot, type CanvasEdge, type CanvasNode } from "../_store/canvasTypes";
-import { useCanvasStore } from "../_store/canvasStore";
+import { useCanvasStore, useCanvasStoreApi } from "../_store/canvasStore";
 import { StateLegend } from "./StateLegend";
 import { VersionMenu, type VersionMenuRunState } from "./VersionMenu";
 
@@ -24,6 +25,15 @@ export type TopPillProps = {
 type RunStartResponse = {
   jobId: string;
 };
+
+const RUN_POLL_INTERVAL = 1000;
+const TERMINAL_JOB_STATUSES = new Set<Job["status"]>([
+  "cancelled",
+  "done",
+  "expired",
+  "failed",
+  "skipped",
+]);
 
 const stableGraphJson = (nodes: readonly CanvasNode[], edges: readonly CanvasEdge[]): string =>
   JSON.stringify({
@@ -47,6 +57,7 @@ const stableGraphJson = (nodes: readonly CanvasNode[], edges: readonly CanvasEdg
 
 export const TopPill = ({ pipeline }: TopPillProps) => {
   const { t } = useTranslation();
+  const canvasStore = useCanvasStoreApi();
   const nodes = useCanvasStore((state) => state.nodes);
   const edges = useCanvasStore((state) => state.edges);
   const drillStack = useCanvasStore((state) => state.drillStack);
@@ -54,14 +65,39 @@ export const TopPill = ({ pipeline }: TopPillProps) => {
   const popDrillStack = useCanvasStore((state) => state.popDrillStack);
   const activeJobId = useCanvasStore((state) => state.activeJobId);
   const latestJob = useCanvasStore((state) => state.latestJob);
+  const applyJobSnapshot = useCanvasStore((state) => state.applyJobSnapshot);
   const beginRun = useCanvasStore((state) => state.beginRun);
   const { mutate: updatePipeline } = useUpdate();
 
   const [renaming, setRenaming] = useState(false);
-  const [version, setVersion] = useState(pipeline.version);
   const [isStartingRun, setIsStartingRun] = useState(false);
+  const [isStoppingRun, setIsStoppingRun] = useState(false);
   const graphJson = useMemo(() => stableGraphJson(nodes, edges), [edges, nodes]);
   const [savedGraphJson, setSavedGraphJson] = useState(graphJson);
+
+  useOne<Job>({
+    resource: ResourceName.jobs,
+    id: activeJobId ?? "",
+    queryOptions: {
+      enabled: activeJobId !== null,
+      queryFn: async () => {
+        const response = await dataProvider.getOne!<Job>({
+          id: activeJobId ?? "",
+          resource: ResourceName.jobs,
+        });
+        if (canvasStore.getState().activeJobId === response.data.id) {
+          applyJobSnapshot(response.data);
+        }
+
+        return response;
+      },
+      refetchInterval: (query) => {
+        const status = (query.state.data?.data as Job | undefined)?.status;
+
+        return status && TERMINAL_JOB_STATUSES.has(status) ? false : RUN_POLL_INTERVAL;
+      },
+    },
+  });
 
   const dirty = graphJson !== savedGraphJson;
   const running = activeJobId !== null;
@@ -88,7 +124,7 @@ export const TopPill = ({ pipeline }: TopPillProps) => {
     ];
   }, [drillStack, nodes, pipeline.name, t]);
 
-  const handlePersistGraph = (nextVersion: number, successMessage: string) => {
+  const handlePersistGraph = () => {
     const snapshot = toPipelineSnapshot({ edges, nodes });
     updatePipeline(
       {
@@ -99,7 +135,6 @@ export const TopPill = ({ pipeline }: TopPillProps) => {
         values: {
           edges: snapshot.edges,
           nodes: snapshot.nodes,
-          version: nextVersion,
         },
       },
       {
@@ -110,9 +145,10 @@ export const TopPill = ({ pipeline }: TopPillProps) => {
           }),
         onSuccess: () => {
           setSavedGraphJson(graphJson);
-          setVersion(nextVersion);
           toastStore.getState().addToast({
-            title: successMessage,
+            title: t("workspace.canvas.chrome.version.saveSuccess", {
+              version: pipeline.version,
+            }),
             type: "success",
           });
         },
@@ -166,14 +202,49 @@ export const TopPill = ({ pipeline }: TopPillProps) => {
     );
   };
 
+  const handleStop = () => {
+    if (!activeJobId) {
+      return;
+    }
+
+    const jobId = activeJobId;
+    setIsStoppingRun(true);
+    void ResultAsync.fromPromise(
+      dataProvider.custom!({
+        method: "post",
+        payload: { jobId },
+        url: "pipelines/cancel",
+      }),
+      () => t("workspace.canvas.chrome.run.stopFailed"),
+    )
+      .andThen(() =>
+        ResultAsync.fromPromise(
+          dataProvider.getOne!<Job>({ id: jobId, resource: ResourceName.jobs }),
+          () => t("workspace.canvas.chrome.run.stopFailed"),
+        ),
+      )
+      .match(
+        (response) => {
+          if (canvasStore.getState().activeJobId === jobId) {
+            applyJobSnapshot(response.data);
+          }
+          setIsStoppingRun(false);
+          toastStore.getState().addToast({
+            title: t("workspace.canvas.chrome.run.stopped"),
+            type: "success",
+          });
+        },
+        (error) => {
+          setIsStoppingRun(false);
+          toastStore.getState().addToast({
+            title: error,
+            type: "error",
+          });
+        },
+      );
+  };
+
   const handleDrillOut = () => popDrillStack();
-  const handleOverwrite = () =>
-    handlePersistGraph(version, t("workspace.canvas.chrome.version.saveSuccess", { version }));
-  const handleSaveAsNew = () =>
-    handlePersistGraph(
-      version + 1,
-      t("workspace.canvas.chrome.version.saveAsNewSuccess", { version: version + 1 }),
-    );
 
   return (
     <div
@@ -256,9 +327,8 @@ export const TopPill = ({ pipeline }: TopPillProps) => {
             <VersionMenu
               dirty={dirty}
               runState={runState}
-              version={version}
-              onOverwrite={handleOverwrite}
-              onSaveAsNew={handleSaveAsNew}
+              version={pipeline.version}
+              onSave={handlePersistGraph}
             />
           ) : null}
         </div>
@@ -280,10 +350,11 @@ export const TopPill = ({ pipeline }: TopPillProps) => {
         {atRoot ? (
           running ? (
             <button
-              disabled
-              className="flex items-center gap-1.5 rounded-full bg-surface px-3.5 py-1.5 text-xs font-medium text-foreground shadow-pill ring-1 ring-border opacity-70"
+              className="flex items-center gap-1.5 rounded-full bg-surface px-3.5 py-1.5 text-xs font-medium text-foreground shadow-pill ring-1 ring-border transition-colors hover:ring-border-strong disabled:cursor-wait disabled:opacity-70"
               data-testid="canvas-v2-stop"
+              disabled={isStoppingRun}
               type="button"
+              onClick={handleStop}
             >
               <Square className="size-3.5" />
               {t("workspace.canvas.chrome.run.stop")}

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/TopPill.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/TopPill.unit.test.tsx
@@ -7,11 +7,19 @@ import { TopPill } from "./TopPill";
 
 const mutateMock = vi.fn();
 const customMock = vi.fn();
+const getOneMock = vi.fn();
+const useOneMock = vi.fn();
 
-vi.mock("@refinedev/core", () => ({ useUpdate: () => ({ mutate: mutateMock }) }));
+vi.mock("@refinedev/core", () => ({
+  useOne: (...args: unknown[]) => useOneMock(...args),
+  useUpdate: () => ({ mutate: mutateMock }),
+}));
 vi.mock("@/integrations/refine/dataProvider", () => ({
-  ResourceName: { pipelines: "pipelines" },
-  dataProvider: { custom: (...args: unknown[]) => customMock(...args) },
+  ResourceName: { jobs: "jobs", pipelines: "pipelines" },
+  dataProvider: {
+    custom: (...args: unknown[]) => customMock(...args),
+    getOne: (...args: unknown[]) => getOneMock(...args),
+  },
 }));
 vi.mock("@repo/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
@@ -66,7 +74,10 @@ const makeWrapper =
 describe("TopPill", () => {
   beforeEach(() => {
     customMock.mockReset();
+    getOneMock.mockReset();
     mutateMock.mockReset();
+    useOneMock.mockReset();
+    useOneMock.mockReturnValue({ query: {} });
   });
 
   it("shows pipeline state and persists a renamed pipeline", async () => {
@@ -87,9 +98,17 @@ describe("TopPill", () => {
     );
   });
 
-  it("starts a runnable pipeline and exposes its running state", async () => {
+  it("starts and cancels a runnable pipeline", async () => {
     const user = userEvent.setup();
     customMock.mockResolvedValueOnce({ data: { jobId: "job-42" } });
+    customMock.mockResolvedValueOnce({ data: { cancelled: true, jobId: "job-42" } });
+    getOneMock.mockResolvedValueOnce({
+      data: {
+        id: "job-42",
+        nodeStatuses: null,
+        status: "cancelled",
+      },
+    });
     const store = createCanvasStore({ nodes: [operationNode] });
     render(<TopPill pipeline={{ id: "pipeline-1", name: "Quiz pipeline", version: 2 }} />, {
       wrapper: makeWrapper(store),
@@ -105,6 +124,45 @@ describe("TopPill", () => {
         url: "pipelines/run",
       }),
     );
-    expect(screen.getByTestId("canvas-v2-stop")).toBeDisabled();
+    await user.click(screen.getByTestId("canvas-v2-stop"));
+
+    await waitFor(() => expect(store.getState().activeJobId).toBeNull());
+    expect(customMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        payload: { jobId: "job-42" },
+        url: "pipelines/cancel",
+      }),
+    );
+  });
+
+  it("ignores a stale polling response after a newer run starts", async () => {
+    const deferred = {
+      resolve: null as
+        | null
+        | ((value: { data: { id: string; nodeStatuses: null; status: string } }) => void),
+    };
+    getOneMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        deferred.resolve = resolve;
+      }),
+    );
+    const store = createCanvasStore({ nodes: [operationNode] });
+    render(<TopPill pipeline={{ id: "pipeline-1", name: "Quiz pipeline", version: 2 }} />, {
+      wrapper: makeWrapper(store),
+    });
+
+    store.getState().beginRun("job-a");
+    await waitFor(() =>
+      expect(useOneMock).toHaveBeenLastCalledWith(expect.objectContaining({ id: "job-a" })),
+    );
+    const options = useOneMock.mock.lastCall?.[0] as {
+      queryOptions: { queryFn: () => Promise<unknown> };
+    };
+    const poll = options.queryOptions.queryFn();
+    store.getState().beginRun("job-b");
+    deferred.resolve?.({ data: { id: "job-a", nodeStatuses: null, status: "cancelled" } });
+    await poll;
+
+    expect(store.getState().activeJobId).toBe("job-b");
   });
 });

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/TopPill.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/TopPill.unit.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CanvasStoreContext, createCanvasStore, type CanvasStore } from "../_store/canvasStore";
+import type { CanvasNode } from "../_store/canvasTypes";
+import { TopPill } from "./TopPill";
+
+const mutateMock = vi.fn();
+const customMock = vi.fn();
+
+vi.mock("@refinedev/core", () => ({ useUpdate: () => ({ mutate: mutateMock }) }));
+vi.mock("@/integrations/refine/dataProvider", () => ({
+  ResourceName: { pipelines: "pipelines" },
+  dataProvider: { custom: (...args: unknown[]) => customMock(...args) },
+}));
+vi.mock("@repo/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuGroup: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, ...props }: React.ComponentProps<"button">) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  DropdownMenuLabel: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children, ...props }: React.ComponentProps<"button">) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+vi.mock("@repo/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+vi.mock("@repo/ui/popover", () => ({
+  Popover: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  PopoverContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  PopoverTrigger: ({ children, ...props }: React.ComponentProps<"button">) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+const operationNode: CanvasNode = {
+  data: {
+    config: {},
+    label: "Parse",
+    nodeType: "operation",
+    operationId: "op-1",
+    operationName: "Parse",
+    status: "idle",
+  },
+  id: "node-op",
+  position: { x: 0, y: 0 },
+  type: "operation",
+};
+
+const makeWrapper =
+  (store: CanvasStore) =>
+  ({ children }: React.PropsWithChildren) => (
+    <CanvasStoreContext.Provider value={store}>{children}</CanvasStoreContext.Provider>
+  );
+
+describe("TopPill", () => {
+  beforeEach(() => {
+    customMock.mockReset();
+    mutateMock.mockReset();
+  });
+
+  it("shows pipeline state and persists a renamed pipeline", async () => {
+    const user = userEvent.setup();
+    const store = createCanvasStore({ nodes: [operationNode] });
+    render(<TopPill pipeline={{ id: "pipeline-1", name: "Quiz pipeline", version: 2 }} />, {
+      wrapper: makeWrapper(store),
+    });
+
+    expect(screen.getByTestId("canvas-v2-run")).toBeEnabled();
+    await user.click(screen.getByTestId("canvas-v2-crumb-0"));
+    const input = screen.getByTestId("canvas-v2-rename-input");
+    await user.clear(input);
+    await user.type(input, "Renamed pipeline{Enter}");
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "pipeline-1", values: { name: "Renamed pipeline" } }),
+    );
+  });
+
+  it("starts a runnable pipeline and exposes its running state", async () => {
+    const user = userEvent.setup();
+    customMock.mockResolvedValueOnce({ data: { jobId: "job-42" } });
+    const store = createCanvasStore({ nodes: [operationNode] });
+    render(<TopPill pipeline={{ id: "pipeline-1", name: "Quiz pipeline", version: 2 }} />, {
+      wrapper: makeWrapper(store),
+    });
+
+    await user.click(screen.getByTestId("canvas-v2-run"));
+
+    await waitFor(() => expect(store.getState().activeJobId).toBe("job-42"));
+    expect(customMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "post",
+        payload: { id: "pipeline-1" },
+        url: "pipelines/run",
+      }),
+    );
+    expect(screen.getByTestId("canvas-v2-stop")).toBeDisabled();
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/VersionMenu.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/VersionMenu.tsx
@@ -1,0 +1,102 @@
+import { ChevronDown, GitBranch, GitCommitHorizontal, Save } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@repo/ui/dropdown-menu";
+import { ScrollArea } from "@repo/ui/scroll-area";
+
+export type VersionMenuRunState = "done" | "draft" | "running";
+
+export type VersionMenuProps = {
+  dirty: boolean;
+  runState: VersionMenuRunState;
+  version: number;
+  onOverwrite: () => void;
+  onSaveAsNew: () => void;
+};
+
+export const VersionMenu = ({
+  dirty,
+  runState,
+  version,
+  onOverwrite,
+  onSaveAsNew,
+}: VersionMenuProps) => {
+  const { t } = useTranslation();
+  const versions = Array.from({ length: version }, (_, index) => version - index);
+  const handleOverwriteClick = () => onOverwrite();
+  const handleSaveAsNewClick = () => onSaveAsNew();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className="ml-0.5 flex items-center gap-1 whitespace-nowrap rounded-full bg-surface-2 px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-accent/70"
+        data-testid="canvas-v2-version-menu-trigger"
+      >
+        <span className="font-mono">v{version}</span>
+        {dirty ? (
+          <span className="flex items-center gap-1 text-foreground/80">
+            <span className="size-1.5 rounded-full bg-warning" />
+            {t("workspace.canvas.chrome.version.unsaved")}
+          </span>
+        ) : (
+          <span>
+            · {t(`workspace.canvas.chrome.version.state.${runState}`)} ·{" "}
+            {t("workspace.canvas.chrome.version.saved")}
+          </span>
+        )}
+        <ChevronDown className="size-2.5" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-56 rounded-2xl" sideOffset={6}>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+            {t("workspace.canvas.chrome.version.saveChanges")}
+          </DropdownMenuLabel>
+          <DropdownMenuItem
+            data-testid="canvas-v2-version-overwrite"
+            disabled={!dirty}
+            onClick={handleOverwriteClick}
+          >
+            <Save className="size-3.5 text-muted-foreground" />
+            <span className="flex-1">
+              {t("workspace.canvas.chrome.version.overwrite", { version })}
+            </span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            data-testid="canvas-v2-version-save-as-new"
+            onClick={handleSaveAsNewClick}
+          >
+            <GitBranch className="size-3.5 text-muted-foreground" />
+            <span className="flex-1">{t("workspace.canvas.chrome.version.saveAsNew")}</span>
+            <span className="font-mono text-[10px] text-muted-foreground">v{version + 1}</span>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+            {t("workspace.canvas.chrome.version.history")}
+          </DropdownMenuLabel>
+          <ScrollArea className="max-h-32">
+            {versions.map((entry) => (
+              <div key={entry} className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs">
+                <GitCommitHorizontal className="size-3.5 text-muted-foreground" />
+                <span className="flex-1 font-mono">v{entry}</span>
+                {entry === version ? (
+                  <span className="text-[10px] text-muted-foreground">
+                    {t("workspace.canvas.chrome.version.current")}
+                  </span>
+                ) : null}
+              </div>
+            ))}
+          </ScrollArea>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/VersionMenu.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/VersionMenu.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, GitBranch, GitCommitHorizontal, Save } from "lucide-react";
+import { ChevronDown, Save } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   DropdownMenu,
@@ -6,10 +6,8 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@repo/ui/dropdown-menu";
-import { ScrollArea } from "@repo/ui/scroll-area";
 
 export type VersionMenuRunState = "done" | "draft" | "running";
 
@@ -17,21 +15,12 @@ export type VersionMenuProps = {
   dirty: boolean;
   runState: VersionMenuRunState;
   version: number;
-  onOverwrite: () => void;
-  onSaveAsNew: () => void;
+  onSave: () => void;
 };
 
-export const VersionMenu = ({
-  dirty,
-  runState,
-  version,
-  onOverwrite,
-  onSaveAsNew,
-}: VersionMenuProps) => {
+export const VersionMenu = ({ dirty, runState, version, onSave }: VersionMenuProps) => {
   const { t } = useTranslation();
-  const versions = Array.from({ length: version }, (_, index) => version - index);
-  const handleOverwriteClick = () => onOverwrite();
-  const handleSaveAsNewClick = () => onSaveAsNew();
+  const handleSaveClick = () => onSave();
 
   return (
     <DropdownMenu>
@@ -61,40 +50,13 @@ export const VersionMenu = ({
           <DropdownMenuItem
             data-testid="canvas-v2-version-overwrite"
             disabled={!dirty}
-            onClick={handleOverwriteClick}
+            onClick={handleSaveClick}
           >
             <Save className="size-3.5 text-muted-foreground" />
             <span className="flex-1">
               {t("workspace.canvas.chrome.version.overwrite", { version })}
             </span>
           </DropdownMenuItem>
-          <DropdownMenuItem
-            data-testid="canvas-v2-version-save-as-new"
-            onClick={handleSaveAsNewClick}
-          >
-            <GitBranch className="size-3.5 text-muted-foreground" />
-            <span className="flex-1">{t("workspace.canvas.chrome.version.saveAsNew")}</span>
-            <span className="font-mono text-[10px] text-muted-foreground">v{version + 1}</span>
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
-        <DropdownMenuSeparator />
-        <DropdownMenuGroup>
-          <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-            {t("workspace.canvas.chrome.version.history")}
-          </DropdownMenuLabel>
-          <ScrollArea className="max-h-32">
-            {versions.map((entry) => (
-              <div key={entry} className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs">
-                <GitCommitHorizontal className="size-3.5 text-muted-foreground" />
-                <span className="flex-1 font-mono">v{entry}</span>
-                {entry === version ? (
-                  <span className="text-[10px] text-muted-foreground">
-                    {t("workspace.canvas.chrome.version.current")}
-                  </span>
-                ) : null}
-              </div>
-            ))}
-          </ScrollArea>
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/VersionMenu.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/VersionMenu.unit.test.tsx
@@ -26,34 +26,19 @@ vi.mock("@repo/ui/scroll-area", () => ({
 }));
 
 describe("VersionMenu", () => {
-  it("only overwrites dirty graphs and can save a new version", async () => {
+  it("only saves dirty graphs without presenting synthetic history", async () => {
     const user = userEvent.setup();
-    const handleOverwrite = vi.fn();
-    const handleSaveAsNew = vi.fn();
+    const handleSave = vi.fn();
     const { rerender } = render(
-      <VersionMenu
-        dirty={false}
-        runState="draft"
-        version={3}
-        onOverwrite={handleOverwrite}
-        onSaveAsNew={handleSaveAsNew}
-      />,
+      <VersionMenu dirty={false} runState="draft" version={3} onSave={handleSave} />,
     );
 
     expect(screen.getByTestId("canvas-v2-version-overwrite")).toBeDisabled();
-    rerender(
-      <VersionMenu
-        dirty
-        runState="running"
-        version={3}
-        onOverwrite={handleOverwrite}
-        onSaveAsNew={handleSaveAsNew}
-      />,
-    );
+    rerender(<VersionMenu dirty runState="running" version={3} onSave={handleSave} />);
     await user.click(screen.getByTestId("canvas-v2-version-overwrite"));
-    await user.click(screen.getByTestId("canvas-v2-version-save-as-new"));
 
-    expect(handleOverwrite).toHaveBeenCalledOnce();
-    expect(handleSaveAsNew).toHaveBeenCalledOnce();
+    expect(handleSave).toHaveBeenCalledOnce();
+    expect(screen.queryByTestId("canvas-v2-version-save-as-new")).not.toBeInTheDocument();
+    expect(screen.queryByText("History")).not.toBeInTheDocument();
   });
 });

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/VersionMenu.unit.test.tsx
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/VersionMenu.unit.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { VersionMenu } from "./VersionMenu";
+
+vi.mock("@repo/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuGroup: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, ...props }: React.ComponentProps<"button">) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  DropdownMenuLabel: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children, ...props }: React.ComponentProps<"button">) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@repo/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+describe("VersionMenu", () => {
+  it("only overwrites dirty graphs and can save a new version", async () => {
+    const user = userEvent.setup();
+    const handleOverwrite = vi.fn();
+    const handleSaveAsNew = vi.fn();
+    const { rerender } = render(
+      <VersionMenu
+        dirty={false}
+        runState="draft"
+        version={3}
+        onOverwrite={handleOverwrite}
+        onSaveAsNew={handleSaveAsNew}
+      />,
+    );
+
+    expect(screen.getByTestId("canvas-v2-version-overwrite")).toBeDisabled();
+    rerender(
+      <VersionMenu
+        dirty
+        runState="running"
+        version={3}
+        onOverwrite={handleOverwrite}
+        onSaveAsNew={handleSaveAsNew}
+      />,
+    );
+    await user.click(screen.getByTestId("canvas-v2-version-overwrite"));
+    await user.click(screen.getByTestId("canvas-v2-version-save-as-new"));
+
+    expect(handleOverwrite).toHaveBeenCalledOnce();
+    expect(handleSaveAsNew).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/app/src/pages/WorkspacePage/canvas/chrome/index.ts
+++ b/apps/app/src/pages/WorkspacePage/canvas/chrome/index.ts
@@ -1,0 +1,5 @@
+export * from "./CanvasToolbar";
+export * from "./ComponentPanel";
+export * from "./StateLegend";
+export * from "./TopPill";
+export * from "./VersionMenu";

--- a/apps/app/src/routes/canvas.tsx
+++ b/apps/app/src/routes/canvas.tsx
@@ -1,13 +1,26 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
+import { useOne } from "@refinedev/core";
 import { z } from "zod/v4";
+import type { PipelineData } from "@repo/schemas";
 import { CanvasPage } from "@repo/views/CanvasPage";
+import { PageLoadingState } from "@repo/views/PageLoadingState";
+import { ToastContainer } from "@/components/ToastContainer";
+import { CanvasRoot } from "@/pages/WorkspacePage/canvas";
+import { ResourceName } from "@/integrations/refine/dataProvider";
 import { useSession } from "@/integrations/better-auth-client";
+import { ToastStoreProvider } from "@/store/toastStore";
 
 const CanvasRouteComponent = () => {
   const navigate = useNavigate();
   const { id } = Route.useSearch();
   const { data: session, isPending } = useSession();
+  const { result: pipelineResult, query: pipelineQuery } = useOne<PipelineData>({
+    resource: ResourceName.pipelines,
+    id: id ?? "",
+    queryOptions: { enabled: !!id && !!session },
+  });
+  const pipeline = id ? (pipelineResult ?? null) : null;
 
   useEffect(() => {
     if (!isPending && !session) {
@@ -27,7 +40,34 @@ const CanvasRouteComponent = () => {
     return null;
   }
 
-  return <CanvasPage id={id} />;
+  if (!id) {
+    return <CanvasPage />;
+  }
+
+  if (id && pipelineQuery?.isLoading) {
+    return (
+      <div className="fixed inset-0 flex h-screen w-screen bg-background">
+        <PageLoadingState variant="detail" />
+      </div>
+    );
+  }
+
+  if (!pipeline) {
+    return (
+      <div className="fixed inset-0 flex h-screen w-screen items-center justify-center bg-background">
+        <p className="text-sm text-muted-foreground">Pipeline not found</p>
+      </div>
+    );
+  }
+
+  return (
+    <ToastStoreProvider>
+      <div className="fixed inset-0 h-screen w-screen overflow-hidden">
+        <CanvasRoot pipeline={pipeline} />
+        <ToastContainer />
+      </div>
+    </ToastStoreProvider>
+  );
 };
 
 export const Route = createFileRoute("/canvas")({


### PR DESCRIPTION
## Summary

- 在 Canvas V2 顶部增加 Chrome 风格工具栏、版本菜单与状态图例
- 增加左侧可拖拽组件面板，并接入画布节点创建与撤销历史
- 补充工具栏、组件面板、顶部胶囊及 CanvasRoot 的单元测试

## Verification

- compile、lint 通过
- Canvas 相关测试：23 个文件、125 个测试通过
- 浏览器验证：拖拽后节点数 7 → 8，撤销后 8 → 7
- 浏览器控制台无错误

Linear: COD-129