### PR TITLE
feat: 完成 Agent Bar 工作区外壳集成（COD-134）

### DIFF
--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -693,6 +693,8 @@
       "error": "Request failed. Please try again later.",
       "errorTitle": "AI Assistant Error",
       "close": "Close AI assistant",
+      "resize": "Resize AI assistant",
+      "reopen": "Open AI assistant",
       "send": "Send request",
       "upload": "Upload context",
       "revise": "Revise plan",

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -692,6 +692,8 @@
       "error": "请求失败，请稍后重试。",
       "errorTitle": "AI 助手错误",
       "close": "关闭 AI 助手",
+      "resize": "调整 AI 助手宽度",
+      "reopen": "打开 AI 助手",
       "send": "发送请求",
       "upload": "上传上下文",
       "revise": "修改方案",

--- a/packages/views/src/components/ResizeHandle/ResizeHandle.tsx
+++ b/packages/views/src/components/ResizeHandle/ResizeHandle.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef, type PointerEvent } from "react";
+import { cn } from "@repo/ui/lib/utils";
+
+export interface ResizeHandleProps {
+  ariaLabel: string;
+  line?: boolean;
+  onCollapse?: () => void;
+  onDelta: (delta: number) => void;
+  onDragStart?: () => void;
+  side: "left" | "right";
+}
+
+export const ResizeHandle = ({
+  ariaLabel,
+  line = true,
+  onCollapse,
+  onDelta,
+  onDragStart,
+  side,
+}: ResizeHandleProps) => {
+  const cleanupRef = useRef<() => void>(() => undefined);
+  const startXRef = useRef(0);
+
+  useEffect(() => () => cleanupRef.current(), []);
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    cleanupRef.current();
+    startXRef.current = event.clientX;
+    onDragStart?.();
+
+    const handleMove = (moveEvent: globalThis.PointerEvent) => {
+      const rawDelta = moveEvent.clientX - startXRef.current;
+      onDelta(side === "right" ? -rawDelta : rawDelta);
+    };
+    const cleanup = () => {
+      globalThis.removeEventListener("pointermove", handleMove);
+      globalThis.removeEventListener("pointerup", cleanup);
+      document.body.style.removeProperty("cursor");
+      document.body.style.removeProperty("user-select");
+      cleanupRef.current = () => undefined;
+    };
+
+    cleanupRef.current = cleanup;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    globalThis.addEventListener("pointermove", handleMove);
+    globalThis.addEventListener("pointerup", cleanup);
+  };
+
+  return (
+    <div
+      aria-label={ariaLabel}
+      aria-orientation="vertical"
+      className="group relative z-30 w-px shrink-0 self-stretch cursor-col-resize touch-none"
+      data-testid={`resize-handle-${side}`}
+      role="separator"
+      onDoubleClick={onCollapse}
+      onPointerDown={handlePointerDown}
+    >
+      <div className="absolute inset-y-0 -left-1.5 -right-1.5" />
+      {line ? (
+        <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border transition-colors group-hover:bg-border-strong" />
+      ) : null}
+      <div
+        className={cn(
+          "absolute inset-y-6 left-1/2 w-0.5 -translate-x-1/2 rounded-full bg-foreground/25 opacity-0 transition-opacity group-hover:opacity-100",
+        )}
+      />
+    </div>
+  );
+};

--- a/packages/views/src/components/ResizeHandle/index.ts
+++ b/packages/views/src/components/ResizeHandle/index.ts
@@ -1,0 +1,1 @@
+export * from "./ResizeHandle";

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -452,10 +452,7 @@ export const AgentPanel = () => {
       : t("canvas.agentPanel.runtimePlaceholder");
 
   return (
-    <div
-      className="absolute bottom-0 right-0 top-0 z-30 flex w-[min(22.5rem,100%)] flex-col border-l bg-surface"
-      data-testid="canvas-agent-panel"
-    >
+    <aside className="flex h-full w-full flex-col bg-surface" data-testid="canvas-agent-panel">
       <header
         className="flex shrink-0 items-center justify-between px-3.5 pb-2 pt-3"
         data-testid="canvas-agent-panel-header"
@@ -630,6 +627,6 @@ export const AgentPanel = () => {
           runtimeId={selectedRuntimeId}
         />
       </div>
-    </div>
+    </aside>
   );
 };

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -325,7 +325,7 @@ describe("AgentPanel", () => {
     fireEvent.keyDown(input, { key: "Enter" });
     fireEvent.keyDown(input, { key: "Enter" });
 
-    expect(mockGetList).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(mockGetList).toHaveBeenCalledTimes(2));
     resolveRuntimeOptions({
       data: [
         {

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -227,7 +227,7 @@ describe("AgentPanel", () => {
     expect(screen.getByText("canvas.agentPanel.welcome")).toBeInTheDocument();
     expect(screen.getByText("canvas.agentPanel.runtimeLabel")).toBeInTheDocument();
     expect(screen.getByTestId("canvas-agent-panel")).toHaveClass("bg-surface");
-    expect(screen.getByTestId("canvas-agent-panel")).toHaveClass("w-[min(22.5rem,100%)]");
+    expect(screen.getByTestId("canvas-agent-panel")).toHaveClass("h-full", "w-full");
     expect(screen.getByTestId("canvas-agent-panel-header")).toBeInTheDocument();
     expect(screen.getByTestId("canvas-agent-panel-status-dot")).toHaveClass("bg-success");
     expect(screen.getByTestId("canvas-agent-panel-collapse")).toBeInTheDocument();

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.stories.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.stories.tsx
@@ -1,13 +1,41 @@
+import { useEffect } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Refine } from "@refinedev/core";
 import { ReactFlowProvider } from "@xyflow/react";
-import { CanvasPageStoreProvider } from "../_store";
+import { PlatformProvider, type PlatformCapabilities } from "../../../platform";
+import { CanvasPageStoreProvider, useCanvasPageStore } from "../_store";
 import { canvasStoryDataProvider } from "../storybookData";
 import { CanvasInner } from "./CanvasInner";
 
-const meta: Meta<typeof CanvasInner> = {
+interface CanvasInnerStoryProps {
+  agentPanelOpen?: boolean;
+}
+
+const storyPlatform: PlatformCapabilities = {
+  apiBaseUrl: "",
+  downloadBlob: () => undefined,
+  request: (input, init) => fetch(input, init),
+};
+
+const CanvasInnerStory = ({ agentPanelOpen = false }: CanvasInnerStoryProps) => {
+  const store = useCanvasPageStore();
+
+  useEffect(() => {
+    store.setState((state) => ({
+      agentPanel: { ...state.agentPanel, isOpen: agentPanelOpen },
+    }));
+  }, [agentPanelOpen, store]);
+
+  return (
+    <PlatformProvider value={storyPlatform}>
+      <CanvasInner />
+    </PlatformProvider>
+  );
+};
+
+const meta: Meta<typeof CanvasInnerStory> = {
   title: "CanvasPage/CanvasInner",
-  component: CanvasInner,
+  component: CanvasInnerStory,
   tags: ["autodocs"],
   decorators: [
     (Story) => (
@@ -30,13 +58,25 @@ const meta: Meta<typeof CanvasInner> = {
   },
 };
 export default meta;
-type Story = StoryObj<typeof CanvasInner>;
+type Story = StoryObj<typeof CanvasInnerStory>;
 export const Default: Story = {
-  args: {},
+  args: { agentPanelOpen: false },
   parameters: {
     docs: {
       description: {
         story: "Default empty CanvasInner layout with the empty-state card and status bar visible.",
+      },
+    },
+  },
+};
+
+export const IntegratedAgentPanel: Story = {
+  args: { agentPanelOpen: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Alan-style dual-pane workspace with the Canvas and resizable AgentPanel rendered as siblings.",
       },
     },
   },

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, type MouseEvent as ReactMouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
+import { PanelRightOpen } from "lucide-react";
 import { Button } from "@repo/ui/button";
+import { ResizeHandle } from "../../../components/ResizeHandle";
 import { selectSelectedNode, useCanvasPageStore } from "../_store";
 import { CanvasFlow } from "../CanvasFlow";
 import { CanvasContextMenu } from "../CanvasContextMenu";
@@ -21,11 +23,14 @@ import { CanvasNodePropertiesPanel } from "../CanvasNodePropertiesPanel";
 import { CanvasWorkspaceSidebarOverlay } from "../CanvasWorkspaceSidebarOverlay";
 import { getScreenViewportCenter, getViewportRectCenter } from "../utils/nodePosition";
 
+const AGENT_PANEL_COLLAPSE_AT = 248;
+
 export const CanvasInner = () => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const flowViewportRef = useRef<HTMLDivElement>(null);
   const sidebarResizeStateRef = useRef<{ startClientX: number; startWidth: number } | null>(null);
+  const agentPanelResizeStartWidthRef = useRef(0);
 
   const contextMenu = useStore(store, (state) => state.contextMenu);
   const connectionMenu = useStore(store, (state) => state.connectionMenu);
@@ -33,6 +38,9 @@ export const CanvasInner = () => {
   const isConsoleOpen = useStore(store, (state) => state.isConsoleOpen);
   const isQuickAddOpen = useStore(store, (state) => state.isQuickAddOpen);
   const agentPanelIsOpen = useStore(store, (state) => state.agentPanel.isOpen);
+  const agentPanelWidth = useStore(store, (state) => state.agentPanelWidth);
+  const setAgentPanelWidth = useStore(store, (state) => state.setAgentPanelWidth);
+  const toggleAgentPanel = useStore(store, (state) => state.toggleAgentPanel);
   const nodes = useStore(store, (state) => state.nodes);
   const sidebarPanel = useStore(store, (state) => state.sidebarPanel);
   const isSidebarOpen = useStore(store, (state) => state.isSidebarOpen);
@@ -93,6 +101,18 @@ export const CanvasInner = () => {
       document.body.style.userSelect = "none";
     },
     [workspacePanelWidth],
+  );
+
+  const handleAgentPanelDelta = useCallback(
+    (delta: number) => {
+      const nextWidth = agentPanelResizeStartWidthRef.current + delta;
+      if (nextWidth < AGENT_PANEL_COLLAPSE_AT) {
+        toggleAgentPanel();
+        return;
+      }
+      setAgentPanelWidth(nextWidth);
+    },
+    [setAgentPanelWidth, toggleAgentPanel],
   );
 
   return (
@@ -156,11 +176,42 @@ export const CanvasInner = () => {
             <LlmContentCard />
 
             {isConsoleOpen && <RunConsole />}
-
-            {agentPanelIsOpen && <AgentPanel />}
           </main>
         </div>
       </div>
+
+      {agentPanelIsOpen ? (
+        <ResizeHandle
+          ariaLabel={t("canvas.agentPanel.resize")}
+          side="right"
+          onCollapse={toggleAgentPanel}
+          onDelta={handleAgentPanelDelta}
+          onDragStart={() => {
+            agentPanelResizeStartWidthRef.current = agentPanelWidth;
+          }}
+        />
+      ) : null}
+
+      {agentPanelIsOpen ? (
+        <div
+          className="min-h-0 shrink-0 self-stretch overflow-hidden bg-surface"
+          data-testid="canvas-agent-panel-shell"
+          style={{ width: `${agentPanelWidth}px`, maxWidth: "calc(100% - 3.5625rem)" }}
+        >
+          <AgentPanel />
+        </div>
+      ) : (
+        <button
+          aria-label={t("canvas.agentPanel.reopen")}
+          className="flex w-12 shrink-0 items-center justify-center border-l border-border bg-surface text-muted-foreground hover:bg-accent hover:text-foreground"
+          data-testid="canvas-agent-panel-reopen"
+          title={t("canvas.agentPanel.reopen")}
+          type="button"
+          onClick={toggleAgentPanel}
+        >
+          <PanelRightOpen className="h-4 w-4" />
+        </button>
+      )}
 
       <CanvasSettingsDrawer />
       <CanvasWorkspaceSidebarOverlay />

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
@@ -60,6 +60,10 @@ vi.mock("@tanstack/react-router", () => ({
   ),
 }));
 
+vi.mock("../AgentPanel", () => ({
+  AgentPanel: () => <aside data-testid="canvas-agent-panel" />,
+}));
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 });
@@ -150,6 +154,49 @@ describe("CanvasInner", () => {
     expect(workPanel).toHaveStyle({ width: "560px" });
 
     fireEvent.mouseUp(globalWindow);
+  });
+
+  it("opens the AgentPanel as a resizable right-hand sibling", async () => {
+    const user = userEvent.setup();
+    render(<CanvasInner />, { wrapper });
+
+    expect(screen.getByTestId("canvas-agent-panel-reopen")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+
+    expect(screen.getByTestId("canvas-agent-panel-shell")).toHaveStyle({ width: "360px" });
+    expect(screen.getByTestId("resize-handle-right")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-agent-panel")).toBeInTheDocument();
+  });
+
+  it("resizes and collapses the AgentPanel from the right-side handle", async () => {
+    const user = userEvent.setup();
+    render(<CanvasInner />, { wrapper });
+    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+
+    const globalWindow = globalThis.window;
+    const resizeHandle = screen.getByTestId("resize-handle-right");
+
+    fireEvent.pointerDown(resizeHandle, { clientX: 900 });
+    fireEvent.pointerMove(globalWindow, { clientX: 820 });
+    expect(screen.getByTestId("canvas-agent-panel-shell")).toHaveStyle({ width: "440px" });
+
+    fireEvent.pointerMove(globalWindow, { clientX: 1100 });
+    expect(screen.queryByTestId("canvas-agent-panel-shell")).not.toBeInTheDocument();
+    expect(screen.getByTestId("canvas-agent-panel-reopen")).toBeInTheDocument();
+  });
+
+  it("toggles the AgentPanel from the canvas toolbar", async () => {
+    const user = userEvent.setup();
+    render(<CanvasInner />, { wrapper });
+
+    await user.click(screen.getByRole("button", { name: /^(AI Assistant|AI 助手)$/i }));
+
+    expect(screen.getByTestId("canvas-agent-panel-shell")).toBeInTheDocument();
+
+    await user.dblClick(screen.getByTestId("resize-handle-right"));
+
+    expect(screen.getByTestId("canvas-agent-panel-reopen")).toBeInTheDocument();
   });
 
   it("opens the workspace sidebar overlay from the mini sidebar", async () => {

--- a/packages/views/src/pages/CanvasPage/_store/uiSlice.agentPanelLayout.unit.test.ts
+++ b/packages/views/src/pages/CanvasPage/_store/uiSlice.agentPanelLayout.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { createCanvasPageStore } from "./canvasPageStore";
+
+describe("uiSlice AgentPanel layout", () => {
+  it("stores an independent, clamped right panel width", () => {
+    const store = createCanvasPageStore();
+
+    expect(store.getState().agentPanelWidth).toBe(360);
+
+    store.getState().setAgentPanelWidth(240);
+    expect(store.getState().agentPanelWidth).toBe(300);
+
+    store.getState().setAgentPanelWidth(440);
+    expect(store.getState().agentPanelWidth).toBe(440);
+
+    store.getState().setAgentPanelWidth(640);
+    expect(store.getState().agentPanelWidth).toBe(520);
+  });
+
+  it("toggles the right panel without changing the left panel selection", () => {
+    const store = createCanvasPageStore();
+    store.setState({ sidebarPanel: "properties" });
+
+    store.getState().toggleAgentPanel();
+
+    expect(store.getState().agentPanel.isOpen).toBe(true);
+    expect(store.getState().sidebarPanel).toBe("properties");
+
+    store.getState().toggleAgentPanel();
+
+    expect(store.getState().agentPanel.isOpen).toBe(false);
+    expect(store.getState().sidebarPanel).toBe("properties");
+  });
+});

--- a/packages/views/src/pages/CanvasPage/_store/uiSlice.ts
+++ b/packages/views/src/pages/CanvasPage/_store/uiSlice.ts
@@ -8,7 +8,7 @@ import type {
 import type { CanvasPageStoreSlice } from "./canvasPageStore";
 import { DEFAULT_CANVAS_VIEWPORT } from "../utils/canvasViewport";
 
-export type SidebarPanel = "components" | "properties" | "ai-assistant" | null;
+export type SidebarPanel = "components" | "properties" | null;
 
 export type CanvasComponentCategory = "input" | "operations" | "skills" | "output";
 
@@ -51,8 +51,15 @@ export const DEFAULT_WORKSPACE_PANEL_WIDTH = 352;
 export const MIN_WORKSPACE_PANEL_WIDTH = 288;
 export const MAX_WORKSPACE_PANEL_WIDTH = 560;
 
+export const DEFAULT_AGENT_PANEL_WIDTH = 360;
+export const MIN_AGENT_PANEL_WIDTH = 300;
+export const MAX_AGENT_PANEL_WIDTH = 520;
+
 export const clampWorkspacePanelWidth = (width: number) =>
   Math.min(MAX_WORKSPACE_PANEL_WIDTH, Math.max(MIN_WORKSPACE_PANEL_WIDTH, width));
+
+export const clampAgentPanelWidth = (width: number) =>
+  Math.min(MAX_AGENT_PANEL_WIDTH, Math.max(MIN_AGENT_PANEL_WIDTH, width));
 
 export interface AgentPanelState {
   isOpen: boolean;
@@ -98,6 +105,7 @@ export interface UISlice {
 
   // Agent panel state
   agentPanel: AgentPanelState;
+  agentPanelWidth: number;
 
   // Operation node UI state
   operationAgentDropdownNodeId: string | null;
@@ -153,6 +161,7 @@ export interface UISlice {
   markNodeFailed: (nodeId: string) => void;
 
   // Agent panel actions
+  setAgentPanelWidth: (width: number) => void;
   toggleAgentPanel: () => void;
   setPendingProposal: (
     proposal: PipelineActionProposal | null,
@@ -213,6 +222,7 @@ export const createUISlice = (
     diagnostics: null,
     isLoading: false,
   },
+  agentPanelWidth: DEFAULT_AGENT_PANEL_WIDTH,
   operationAgentDropdownNodeId: null,
   handlePipelineIdChange: (id) => {
     set({ pipelineId: id });
@@ -470,9 +480,12 @@ export const createUISlice = (
     }));
   },
 
+  setAgentPanelWidth: (width) => {
+    set({ agentPanelWidth: clampAgentPanelWidth(width) });
+  },
+
   toggleAgentPanel: () => {
     set((state) => ({
-      sidebarPanel: state.agentPanel.isOpen ? null : "ai-assistant",
       agentPanel: {
         ...state.agentPanel,
         isOpen: !state.agentPanel.isOpen,


### PR DESCRIPTION
## 概要

- 将 AgentPanel 从 Canvas 覆盖层迁移为真正的右侧工作区兄弟面板
- 按验收结果改为与画布直接接壤的平面 1px 分隔线，移除悬浮间距、圆角和阴影
- 新增 300-520px 可拖拽宽度、双击/拖窄收起和独立的恢复入口
- 保留现有 `/canvas` 路由与 CanvasPageStore，避免引入重复的 workspace store / anchor 同步层
- 增加集成 Storybook 场景和布局、交互、状态测试

## 验证

- `@repo/views`：相关 3 个测试文件，29 tests passed
- `bun run --filter @repo/views check-types`
- `bun run --filter @ordine/app check-types`
- `bun run --filter @ordine/app build`
- `git diff --check`
- Storybook 桌面与 375px 视口实测：拖拽、收起、恢复、无横向溢出，应用控制台 0 error

## Base

#149 已合并；本 PR 已重新基于最新 `develop`，当前仅包含 COD-134 的 11 个目标文件。