### PR TITLE
[Stack 1/3] feat: 完成 Agent Bar 工作区外壳集成（COD-134）

### DIFF
--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -693,6 +693,8 @@
       "error": "Request failed. Please try again later.",
       "errorTitle": "AI Assistant Error",
       "close": "Close AI assistant",
+      "resize": "Resize AI assistant",
+      "reopen": "Open AI assistant",
       "send": "Send request",
       "upload": "Upload context",
       "revise": "Revise plan",

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -692,6 +692,8 @@
       "error": "请求失败，请稍后重试。",
       "errorTitle": "AI 助手错误",
       "close": "关闭 AI 助手",
+      "resize": "调整 AI 助手宽度",
+      "reopen": "打开 AI 助手",
       "send": "发送请求",
       "upload": "上传上下文",
       "revise": "修改方案",

--- a/packages/views/src/components/ResizeHandle/ResizeHandle.tsx
+++ b/packages/views/src/components/ResizeHandle/ResizeHandle.tsx
@@ -1,22 +1,30 @@
-import { useEffect, useRef, type PointerEvent } from "react";
+import { useEffect, useRef, type KeyboardEvent, type PointerEvent } from "react";
 import { cn } from "@repo/ui/lib/utils";
 
 export interface ResizeHandleProps {
   ariaLabel: string;
   line?: boolean;
+  max: number;
+  min: number;
   onCollapse?: () => void;
   onDelta: (delta: number) => void;
   onDragStart?: () => void;
   side: "left" | "right";
+  step?: number;
+  value: number;
 }
 
 export const ResizeHandle = ({
   ariaLabel,
   line = true,
+  max,
+  min,
   onCollapse,
   onDelta,
   onDragStart,
   side,
+  step = 8,
+  value,
 }: ResizeHandleProps) => {
   const cleanupRef = useRef<() => void>(() => undefined);
   const startXRef = useRef(0);
@@ -36,6 +44,7 @@ export const ResizeHandle = ({
     const cleanup = () => {
       globalThis.removeEventListener("pointermove", handleMove);
       globalThis.removeEventListener("pointerup", cleanup);
+      globalThis.removeEventListener("pointercancel", cleanup);
       document.body.style.removeProperty("cursor");
       document.body.style.removeProperty("user-select");
       cleanupRef.current = () => undefined;
@@ -46,16 +55,33 @@ export const ResizeHandle = ({
     document.body.style.userSelect = "none";
     globalThis.addEventListener("pointermove", handleMove);
     globalThis.addEventListener("pointerup", cleanup);
+    globalThis.addEventListener("pointercancel", cleanup);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+      return;
+    }
+
+    event.preventDefault();
+    onDragStart?.();
+    const direction = event.key === "ArrowLeft" ? -1 : 1;
+    onDelta(side === "right" ? -direction * step : direction * step);
   };
 
   return (
     <div
       aria-label={ariaLabel}
       aria-orientation="vertical"
-      className="group relative z-30 w-px shrink-0 self-stretch cursor-col-resize touch-none"
+      aria-valuemax={max}
+      aria-valuemin={min}
+      aria-valuenow={value}
+      className="group pointer-events-auto relative z-30 w-px shrink-0 self-stretch cursor-col-resize touch-none focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
       data-testid={`resize-handle-${side}`}
       role="separator"
+      tabIndex={0}
       onDoubleClick={onCollapse}
+      onKeyDown={handleKeyDown}
       onPointerDown={handlePointerDown}
     >
       <div className="absolute inset-y-0 -left-1.5 -right-1.5" />

--- a/packages/views/src/components/ResizeHandle/ResizeHandle.tsx
+++ b/packages/views/src/components/ResizeHandle/ResizeHandle.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef, type PointerEvent } from "react";
+import { cn } from "@repo/ui/lib/utils";
+
+export interface ResizeHandleProps {
+  ariaLabel: string;
+  line?: boolean;
+  onCollapse?: () => void;
+  onDelta: (delta: number) => void;
+  onDragStart?: () => void;
+  side: "left" | "right";
+}
+
+export const ResizeHandle = ({
+  ariaLabel,
+  line = true,
+  onCollapse,
+  onDelta,
+  onDragStart,
+  side,
+}: ResizeHandleProps) => {
+  const cleanupRef = useRef<() => void>(() => undefined);
+  const startXRef = useRef(0);
+
+  useEffect(() => () => cleanupRef.current(), []);
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    cleanupRef.current();
+    startXRef.current = event.clientX;
+    onDragStart?.();
+
+    const handleMove = (moveEvent: globalThis.PointerEvent) => {
+      const rawDelta = moveEvent.clientX - startXRef.current;
+      onDelta(side === "right" ? -rawDelta : rawDelta);
+    };
+    const cleanup = () => {
+      globalThis.removeEventListener("pointermove", handleMove);
+      globalThis.removeEventListener("pointerup", cleanup);
+      document.body.style.removeProperty("cursor");
+      document.body.style.removeProperty("user-select");
+      cleanupRef.current = () => undefined;
+    };
+
+    cleanupRef.current = cleanup;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    globalThis.addEventListener("pointermove", handleMove);
+    globalThis.addEventListener("pointerup", cleanup);
+  };
+
+  return (
+    <div
+      aria-label={ariaLabel}
+      aria-orientation="vertical"
+      className="group relative z-30 w-px shrink-0 self-stretch cursor-col-resize touch-none"
+      data-testid={`resize-handle-${side}`}
+      role="separator"
+      onDoubleClick={onCollapse}
+      onPointerDown={handlePointerDown}
+    >
+      <div className="absolute inset-y-0 -left-1.5 -right-1.5" />
+      {line ? (
+        <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border transition-colors group-hover:bg-border-strong" />
+      ) : null}
+      <div
+        className={cn(
+          "absolute inset-y-6 left-1/2 w-0.5 -translate-x-1/2 rounded-full bg-foreground/25 opacity-0 transition-opacity group-hover:opacity-100",
+        )}
+      />
+    </div>
+  );
+};

--- a/packages/views/src/components/ResizeHandle/index.ts
+++ b/packages/views/src/components/ResizeHandle/index.ts
@@ -1,0 +1,1 @@
+export * from "./ResizeHandle";

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -452,10 +452,7 @@ export const AgentPanel = () => {
       : t("canvas.agentPanel.runtimePlaceholder");
 
   return (
-    <div
-      className="absolute bottom-0 right-0 top-0 z-30 flex w-[min(22.5rem,100%)] flex-col border-l bg-surface"
-      data-testid="canvas-agent-panel"
-    >
+    <aside className="flex h-full w-full flex-col bg-surface" data-testid="canvas-agent-panel">
       <header
         className="flex shrink-0 items-center justify-between px-3.5 pb-2 pt-3"
         data-testid="canvas-agent-panel-header"
@@ -630,6 +627,6 @@ export const AgentPanel = () => {
           runtimeId={selectedRuntimeId}
         />
       </div>
-    </div>
+    </aside>
   );
 };

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -325,7 +325,7 @@ describe("AgentPanel", () => {
     fireEvent.keyDown(input, { key: "Enter" });
     fireEvent.keyDown(input, { key: "Enter" });
 
-    expect(mockGetList).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(mockGetList).toHaveBeenCalledTimes(2));
     resolveRuntimeOptions({
       data: [
         {

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -227,7 +227,7 @@ describe("AgentPanel", () => {
     expect(screen.getByText("canvas.agentPanel.welcome")).toBeInTheDocument();
     expect(screen.getByText("canvas.agentPanel.runtimeLabel")).toBeInTheDocument();
     expect(screen.getByTestId("canvas-agent-panel")).toHaveClass("bg-surface");
-    expect(screen.getByTestId("canvas-agent-panel")).toHaveClass("w-[min(22.5rem,100%)]");
+    expect(screen.getByTestId("canvas-agent-panel")).toHaveClass("h-full", "w-full");
     expect(screen.getByTestId("canvas-agent-panel-header")).toBeInTheDocument();
     expect(screen.getByTestId("canvas-agent-panel-status-dot")).toHaveClass("bg-success");
     expect(screen.getByTestId("canvas-agent-panel-collapse")).toBeInTheDocument();

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.stories.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.stories.tsx
@@ -1,13 +1,41 @@
+import { useEffect } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Refine } from "@refinedev/core";
 import { ReactFlowProvider } from "@xyflow/react";
-import { CanvasPageStoreProvider } from "../_store";
+import { PlatformProvider, type PlatformCapabilities } from "../../../platform";
+import { CanvasPageStoreProvider, useCanvasPageStore } from "../_store";
 import { canvasStoryDataProvider } from "../storybookData";
 import { CanvasInner } from "./CanvasInner";
 
-const meta: Meta<typeof CanvasInner> = {
+interface CanvasInnerStoryProps {
+  agentPanelOpen?: boolean;
+}
+
+const storyPlatform: PlatformCapabilities = {
+  apiBaseUrl: "",
+  downloadBlob: () => undefined,
+  request: (input, init) => fetch(input, init),
+};
+
+const CanvasInnerStory = ({ agentPanelOpen = false }: CanvasInnerStoryProps) => {
+  const store = useCanvasPageStore();
+
+  useEffect(() => {
+    store.setState((state) => ({
+      agentPanel: { ...state.agentPanel, isOpen: agentPanelOpen },
+    }));
+  }, [agentPanelOpen, store]);
+
+  return (
+    <PlatformProvider value={storyPlatform}>
+      <CanvasInner />
+    </PlatformProvider>
+  );
+};
+
+const meta: Meta<typeof CanvasInnerStory> = {
   title: "CanvasPage/CanvasInner",
-  component: CanvasInner,
+  component: CanvasInnerStory,
   tags: ["autodocs"],
   decorators: [
     (Story) => (
@@ -30,13 +58,25 @@ const meta: Meta<typeof CanvasInner> = {
   },
 };
 export default meta;
-type Story = StoryObj<typeof CanvasInner>;
+type Story = StoryObj<typeof CanvasInnerStory>;
 export const Default: Story = {
-  args: {},
+  args: { agentPanelOpen: false },
   parameters: {
     docs: {
       description: {
         story: "Default empty CanvasInner layout with the empty-state card and status bar visible.",
+      },
+    },
+  },
+};
+
+export const IntegratedAgentPanel: Story = {
+  args: { agentPanelOpen: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Alan-style dual-pane workspace with the Canvas and resizable AgentPanel rendered as siblings.",
       },
     },
   },

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, type MouseEvent as ReactMouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
+import { PanelRightOpen } from "lucide-react";
 import { Button } from "@repo/ui/button";
+import { ResizeHandle } from "../../../components/ResizeHandle";
 import { selectSelectedNode, useCanvasPageStore } from "../_store";
 import { CanvasFlow } from "../CanvasFlow";
 import { CanvasContextMenu } from "../CanvasContextMenu";
@@ -21,11 +23,14 @@ import { CanvasNodePropertiesPanel } from "../CanvasNodePropertiesPanel";
 import { CanvasWorkspaceSidebarOverlay } from "../CanvasWorkspaceSidebarOverlay";
 import { getScreenViewportCenter, getViewportRectCenter } from "../utils/nodePosition";
 
+const AGENT_PANEL_COLLAPSE_AT = 248;
+
 export const CanvasInner = () => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const flowViewportRef = useRef<HTMLDivElement>(null);
   const sidebarResizeStateRef = useRef<{ startClientX: number; startWidth: number } | null>(null);
+  const agentPanelResizeStartWidthRef = useRef(0);
 
   const contextMenu = useStore(store, (state) => state.contextMenu);
   const connectionMenu = useStore(store, (state) => state.connectionMenu);
@@ -33,6 +38,9 @@ export const CanvasInner = () => {
   const isConsoleOpen = useStore(store, (state) => state.isConsoleOpen);
   const isQuickAddOpen = useStore(store, (state) => state.isQuickAddOpen);
   const agentPanelIsOpen = useStore(store, (state) => state.agentPanel.isOpen);
+  const agentPanelWidth = useStore(store, (state) => state.agentPanelWidth);
+  const setAgentPanelWidth = useStore(store, (state) => state.setAgentPanelWidth);
+  const toggleAgentPanel = useStore(store, (state) => state.toggleAgentPanel);
   const nodes = useStore(store, (state) => state.nodes);
   const sidebarPanel = useStore(store, (state) => state.sidebarPanel);
   const isSidebarOpen = useStore(store, (state) => state.isSidebarOpen);
@@ -93,6 +101,18 @@ export const CanvasInner = () => {
       document.body.style.userSelect = "none";
     },
     [workspacePanelWidth],
+  );
+
+  const handleAgentPanelDelta = useCallback(
+    (delta: number) => {
+      const nextWidth = agentPanelResizeStartWidthRef.current + delta;
+      if (nextWidth < AGENT_PANEL_COLLAPSE_AT) {
+        toggleAgentPanel();
+        return;
+      }
+      setAgentPanelWidth(nextWidth);
+    },
+    [setAgentPanelWidth, toggleAgentPanel],
   );
 
   return (
@@ -156,11 +176,42 @@ export const CanvasInner = () => {
             <LlmContentCard />
 
             {isConsoleOpen && <RunConsole />}
-
-            {agentPanelIsOpen && <AgentPanel />}
           </main>
         </div>
       </div>
+
+      {agentPanelIsOpen ? (
+        <ResizeHandle
+          ariaLabel={t("canvas.agentPanel.resize")}
+          side="right"
+          onCollapse={toggleAgentPanel}
+          onDelta={handleAgentPanelDelta}
+          onDragStart={() => {
+            agentPanelResizeStartWidthRef.current = agentPanelWidth;
+          }}
+        />
+      ) : null}
+
+      {agentPanelIsOpen ? (
+        <div
+          className="min-h-0 shrink-0 self-stretch overflow-hidden bg-surface"
+          data-testid="canvas-agent-panel-shell"
+          style={{ width: `${agentPanelWidth}px`, maxWidth: "calc(100% - 3.5625rem)" }}
+        >
+          <AgentPanel />
+        </div>
+      ) : (
+        <button
+          aria-label={t("canvas.agentPanel.reopen")}
+          className="flex w-12 shrink-0 items-center justify-center border-l border-border bg-surface text-muted-foreground hover:bg-accent hover:text-foreground"
+          data-testid="canvas-agent-panel-reopen"
+          title={t("canvas.agentPanel.reopen")}
+          type="button"
+          onClick={toggleAgentPanel}
+        >
+          <PanelRightOpen className="h-4 w-4" />
+        </button>
+      )}
 
       <CanvasSettingsDrawer />
       <CanvasWorkspaceSidebarOverlay />

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
@@ -4,7 +4,12 @@ import { useStore } from "zustand";
 import { PanelRightOpen } from "lucide-react";
 import { Button } from "@repo/ui/button";
 import { ResizeHandle } from "../../../components/ResizeHandle";
-import { selectSelectedNode, useCanvasPageStore } from "../_store";
+import {
+  MAX_AGENT_PANEL_WIDTH,
+  MIN_AGENT_PANEL_WIDTH,
+  selectSelectedNode,
+  useCanvasPageStore,
+} from "../_store";
 import { CanvasFlow } from "../CanvasFlow";
 import { CanvasContextMenu } from "../CanvasContextMenu";
 import { ConnectionMenu } from "../ConnectionMenu";
@@ -29,6 +34,7 @@ export const CanvasInner = () => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const flowViewportRef = useRef<HTMLDivElement>(null);
+  const agentPanelShellRef = useRef<HTMLDivElement>(null);
   const sidebarResizeStateRef = useRef<{ startClientX: number; startWidth: number } | null>(null);
   const agentPanelResizeStartWidthRef = useRef(0);
 
@@ -117,7 +123,7 @@ export const CanvasInner = () => {
 
   return (
     <div
-      className="flex h-full min-h-0 w-full overflow-hidden bg-background"
+      className="relative flex h-full min-h-0 w-full overflow-hidden bg-background"
       data-testid="canvas-langflow-shell"
     >
       <CanvasMiniSidebar />
@@ -127,7 +133,7 @@ export const CanvasInner = () => {
 
         <div className="flex min-h-0 flex-1 overflow-hidden">
           {isSidebarOpen && (
-            <div className="relative shrink-0">
+            <div className="relative hidden shrink-0 lg:block">
               <aside
                 className="h-full shrink-0 border-r bg-background"
                 data-testid="canvas-work-panel"
@@ -181,24 +187,31 @@ export const CanvasInner = () => {
       </div>
 
       {agentPanelIsOpen ? (
-        <ResizeHandle
-          ariaLabel={t("canvas.agentPanel.resize")}
-          side="right"
-          onCollapse={toggleAgentPanel}
-          onDelta={handleAgentPanelDelta}
-          onDragStart={() => {
-            agentPanelResizeStartWidthRef.current = agentPanelWidth;
-          }}
-        />
-      ) : null}
-
-      {agentPanelIsOpen ? (
         <div
-          className="min-h-0 shrink-0 self-stretch overflow-hidden bg-surface"
-          data-testid="canvas-agent-panel-shell"
-          style={{ width: `${agentPanelWidth}px`, maxWidth: "calc(100% - 3.5625rem)" }}
+          className="pointer-events-none absolute inset-y-0 right-0 z-40 flex w-[calc(100%_-_3.5rem)] justify-end xl:static xl:z-auto xl:w-auto xl:shrink-0 xl:self-stretch"
+          data-testid="canvas-agent-panel-region"
         >
-          <AgentPanel />
+          <ResizeHandle
+            ariaLabel={t("canvas.agentPanel.resize")}
+            max={MAX_AGENT_PANEL_WIDTH}
+            min={MIN_AGENT_PANEL_WIDTH}
+            side="right"
+            value={agentPanelWidth}
+            onCollapse={toggleAgentPanel}
+            onDelta={handleAgentPanelDelta}
+            onDragStart={() => {
+              const renderedWidth = agentPanelShellRef.current?.getBoundingClientRect().width ?? 0;
+              agentPanelResizeStartWidthRef.current = renderedWidth || agentPanelWidth;
+            }}
+          />
+          <div
+            ref={agentPanelShellRef}
+            className="pointer-events-auto min-h-0 min-w-0 shrink overflow-hidden bg-surface"
+            data-testid="canvas-agent-panel-shell"
+            style={{ width: `${agentPanelWidth}px`, maxWidth: "calc(100% - 1px)" }}
+          >
+            <AgentPanel />
+          </div>
         </div>
       ) : (
         <button

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
@@ -60,6 +60,10 @@ vi.mock("@tanstack/react-router", () => ({
   ),
 }));
 
+vi.mock("../AgentPanel", () => ({
+  AgentPanel: () => <aside data-testid="canvas-agent-panel" />,
+}));
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 });
@@ -150,6 +154,49 @@ describe("CanvasInner", () => {
     expect(workPanel).toHaveStyle({ width: "560px" });
 
     fireEvent.mouseUp(globalWindow);
+  });
+
+  it("opens the AgentPanel as a resizable right-hand sibling", async () => {
+    const user = userEvent.setup();
+    render(<CanvasInner />, { wrapper });
+
+    expect(screen.getByTestId("canvas-agent-panel-reopen")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+
+    expect(screen.getByTestId("canvas-agent-panel-shell")).toHaveStyle({ width: "360px" });
+    expect(screen.getByTestId("resize-handle-right")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-agent-panel")).toBeInTheDocument();
+  });
+
+  it("resizes and collapses the AgentPanel from the right-side handle", async () => {
+    const user = userEvent.setup();
+    render(<CanvasInner />, { wrapper });
+    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+
+    const globalWindow = globalThis.window;
+    const resizeHandle = screen.getByTestId("resize-handle-right");
+
+    fireEvent.pointerDown(resizeHandle, { clientX: 900 });
+    fireEvent.pointerMove(globalWindow, { clientX: 820 });
+    expect(screen.getByTestId("canvas-agent-panel-shell")).toHaveStyle({ width: "440px" });
+
+    fireEvent.pointerMove(globalWindow, { clientX: 1100 });
+    expect(screen.queryByTestId("canvas-agent-panel-shell")).not.toBeInTheDocument();
+    expect(screen.getByTestId("canvas-agent-panel-reopen")).toBeInTheDocument();
+  });
+
+  it("toggles the AgentPanel from the canvas toolbar", async () => {
+    const user = userEvent.setup();
+    render(<CanvasInner />, { wrapper });
+
+    await user.click(screen.getByRole("button", { name: /^(AI Assistant|AI 助手)$/i }));
+
+    expect(screen.getByTestId("canvas-agent-panel-shell")).toBeInTheDocument();
+
+    await user.dblClick(screen.getByTestId("resize-handle-right"));
+
+    expect(screen.getByTestId("canvas-agent-panel-reopen")).toBeInTheDocument();
   });
 
   it("opens the workspace sidebar overlay from the mini sidebar", async () => {

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
@@ -169,6 +169,15 @@ describe("CanvasInner", () => {
     expect(screen.getByTestId("canvas-agent-panel")).toBeInTheDocument();
   });
 
+  it("overlays the AgentPanel below the wide workspace breakpoint", async () => {
+    const user = userEvent.setup();
+    render(<CanvasInner />, { wrapper });
+    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+
+    expect(screen.getByTestId("canvas-agent-panel-region")).toHaveClass("absolute", "xl:static");
+    expect(screen.getByTestId("canvas-work-panel").parentElement).toHaveClass("hidden", "lg:block");
+  });
+
   it("resizes and collapses the AgentPanel from the right-side handle", async () => {
     const user = userEvent.setup();
     render(<CanvasInner />, { wrapper });
@@ -184,6 +193,66 @@ describe("CanvasInner", () => {
     fireEvent.pointerMove(globalWindow, { clientX: 1100 });
     expect(screen.queryByTestId("canvas-agent-panel-shell")).not.toBeInTheDocument();
     expect(screen.getByTestId("canvas-agent-panel-reopen")).toBeInTheDocument();
+  });
+
+  it("starts AgentPanel resizing from its rendered width", async () => {
+    const user = userEvent.setup();
+    render(<CanvasInner />, { wrapper });
+    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+
+    const shell = screen.getByTestId("canvas-agent-panel-shell");
+    vi.spyOn(shell, "getBoundingClientRect").mockReturnValue({
+      x: 57,
+      y: 0,
+      width: 318,
+      height: 640,
+      top: 0,
+      right: 375,
+      bottom: 640,
+      left: 57,
+      toJSON: () => ({}),
+    });
+
+    const resizeHandle = screen.getByTestId("resize-handle-right");
+    fireEvent.pointerDown(resizeHandle, { clientX: 57 });
+    fireEvent.pointerMove(globalThis.window, { clientX: 37 });
+
+    expect(shell).toHaveStyle({ width: "338px" });
+  });
+
+  it("supports keyboard resizing and exposes separator values", async () => {
+    const user = userEvent.setup();
+    render(<CanvasInner />, { wrapper });
+    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+
+    const resizeHandle = screen.getByTestId("resize-handle-right");
+    expect(resizeHandle).toHaveAttribute("tabindex", "0");
+    expect(resizeHandle).toHaveAttribute("aria-valuemin", "300");
+    expect(resizeHandle).toHaveAttribute("aria-valuemax", "520");
+    expect(resizeHandle).toHaveAttribute("aria-valuenow", "360");
+
+    fireEvent.keyDown(resizeHandle, { key: "ArrowLeft" });
+    expect(screen.getByTestId("canvas-agent-panel-shell")).toHaveStyle({ width: "368px" });
+
+    fireEvent.keyDown(resizeHandle, { key: "ArrowRight" });
+    expect(screen.getByTestId("canvas-agent-panel-shell")).toHaveStyle({ width: "360px" });
+  });
+
+  it("cleans up AgentPanel dragging after pointer cancellation", async () => {
+    const user = userEvent.setup();
+    render(<CanvasInner />, { wrapper });
+    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+
+    const resizeHandle = screen.getByTestId("resize-handle-right");
+    fireEvent.pointerDown(resizeHandle, { clientX: 900 });
+    expect(document.body.style.cursor).toBe("col-resize");
+
+    fireEvent.pointerCancel(globalThis.window);
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+
+    fireEvent.pointerMove(globalThis.window, { clientX: 820 });
+    expect(screen.getByTestId("canvas-agent-panel-shell")).toHaveStyle({ width: "360px" });
   });
 
   it("toggles the AgentPanel from the canvas toolbar", async () => {

--- a/packages/views/src/pages/CanvasPage/_store/uiSlice.agentPanelLayout.unit.test.ts
+++ b/packages/views/src/pages/CanvasPage/_store/uiSlice.agentPanelLayout.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { createCanvasPageStore } from "./canvasPageStore";
+
+describe("uiSlice AgentPanel layout", () => {
+  it("stores an independent, clamped right panel width", () => {
+    const store = createCanvasPageStore();
+
+    expect(store.getState().agentPanelWidth).toBe(360);
+
+    store.getState().setAgentPanelWidth(240);
+    expect(store.getState().agentPanelWidth).toBe(300);
+
+    store.getState().setAgentPanelWidth(440);
+    expect(store.getState().agentPanelWidth).toBe(440);
+
+    store.getState().setAgentPanelWidth(640);
+    expect(store.getState().agentPanelWidth).toBe(520);
+  });
+
+  it("toggles the right panel without changing the left panel selection", () => {
+    const store = createCanvasPageStore();
+    store.setState({ sidebarPanel: "properties" });
+
+    store.getState().toggleAgentPanel();
+
+    expect(store.getState().agentPanel.isOpen).toBe(true);
+    expect(store.getState().sidebarPanel).toBe("properties");
+
+    store.getState().toggleAgentPanel();
+
+    expect(store.getState().agentPanel.isOpen).toBe(false);
+    expect(store.getState().sidebarPanel).toBe("properties");
+  });
+});

--- a/packages/views/src/pages/CanvasPage/_store/uiSlice.ts
+++ b/packages/views/src/pages/CanvasPage/_store/uiSlice.ts
@@ -8,7 +8,7 @@ import type {
 import type { CanvasPageStoreSlice } from "./canvasPageStore";
 import { DEFAULT_CANVAS_VIEWPORT } from "../utils/canvasViewport";
 
-export type SidebarPanel = "components" | "properties" | "ai-assistant" | null;
+export type SidebarPanel = "components" | "properties" | null;
 
 export type CanvasComponentCategory = "input" | "operations" | "skills" | "output";
 
@@ -51,8 +51,15 @@ export const DEFAULT_WORKSPACE_PANEL_WIDTH = 352;
 export const MIN_WORKSPACE_PANEL_WIDTH = 288;
 export const MAX_WORKSPACE_PANEL_WIDTH = 560;
 
+export const DEFAULT_AGENT_PANEL_WIDTH = 360;
+export const MIN_AGENT_PANEL_WIDTH = 300;
+export const MAX_AGENT_PANEL_WIDTH = 520;
+
 export const clampWorkspacePanelWidth = (width: number) =>
   Math.min(MAX_WORKSPACE_PANEL_WIDTH, Math.max(MIN_WORKSPACE_PANEL_WIDTH, width));
+
+export const clampAgentPanelWidth = (width: number) =>
+  Math.min(MAX_AGENT_PANEL_WIDTH, Math.max(MIN_AGENT_PANEL_WIDTH, width));
 
 export interface AgentPanelState {
   isOpen: boolean;
@@ -98,6 +105,7 @@ export interface UISlice {
 
   // Agent panel state
   agentPanel: AgentPanelState;
+  agentPanelWidth: number;
 
   // Operation node UI state
   operationAgentDropdownNodeId: string | null;
@@ -153,6 +161,7 @@ export interface UISlice {
   markNodeFailed: (nodeId: string) => void;
 
   // Agent panel actions
+  setAgentPanelWidth: (width: number) => void;
   toggleAgentPanel: () => void;
   setPendingProposal: (
     proposal: PipelineActionProposal | null,
@@ -213,6 +222,7 @@ export const createUISlice = (
     diagnostics: null,
     isLoading: false,
   },
+  agentPanelWidth: DEFAULT_AGENT_PANEL_WIDTH,
   operationAgentDropdownNodeId: null,
   handlePipelineIdChange: (id) => {
     set({ pipelineId: id });
@@ -470,9 +480,12 @@ export const createUISlice = (
     }));
   },
 
+  setAgentPanelWidth: (width) => {
+    set({ agentPanelWidth: clampAgentPanelWidth(width) });
+  },
+
   toggleAgentPanel: () => {
     set((state) => ({
-      sidebarPanel: state.agentPanel.isOpen ? null : "ai-assistant",
       agentPanel: {
         ...state.agentPanel,
         isOpen: !state.agentPanel.isOpen,


### PR DESCRIPTION
## Summary
- replace #151 with the same COD-134 work from the contributor fork
- keep the work panel visible only when the canvas has enough room and overlay the Agent panel on narrower layouts
- make the resize separator keyboard-accessible and clean up drag state on pointer cancellation
- start dragging from the rendered panel width so constrained layouts do not jump

## Verification
- `@repo/views`: 77 test files, 339 tests passed on the stacked COD-135 verification head
- `@repo/views check-types` passed
- Storybook verified at 768px and 375px with no console errors
- `git diff --check` passed

Replaces #151 because its head branch belongs to `forge-town/ordine`; project policy requires contributor changes to be pushed from the fork.

Linear: COD-134