### PR TITLE
fix(settings): 修复项目选择与历史清除回归（COD-137）

### DIFF
--- a/apps/app/src/integrations/refine/dataProvider.unit.test.ts
+++ b/apps/app/src/integrations/refine/dataProvider.unit.test.ts
@@ -90,6 +90,21 @@ describe("dataProvider resource registry", () => {
 });
 
 describe("dataProvider custom registry", () => {
+  it("routes Web conversation history clearing through its tRPC mutation", async () => {
+    const response = await dataProvider.custom!({
+      url: CustomEndpoint.conversationsClearAll,
+      method: "delete",
+      payload: {},
+    });
+
+    expect(response.data).toEqual({ id: "mutated" });
+    expect(calls.at(-1)).toEqual({
+      path: "conversations.clearAll",
+      kind: "mutate",
+      args: undefined,
+    });
+  });
+
   it("routes COD-122 actions through named endpoints", async () => {
     const response = await dataProvider.custom!({
       url: CustomEndpoint.routinesRunNow,

--- a/packages/views/src/pages/SettingsPage/sections/ProjectSection/ProjectSection.tsx
+++ b/packages/views/src/pages/SettingsPage/sections/ProjectSection/ProjectSection.tsx
@@ -18,7 +18,9 @@ export const ProjectSection = () => {
   const { result: projectsResult } = useList<Project>({ resource: ResourceName.projects });
   const { mutate: updateProject } = useUpdate();
   const project =
-    projectsResult.data.find((item) => item.id === currentProjectId) ?? projectsResult.data[0];
+    currentProjectId === null
+      ? undefined
+      : projectsResult.data.find((item) => item.id === currentProjectId);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const handleNameChange = (event: ChangeEvent<HTMLInputElement>) => setName(event.target.value);

--- a/packages/views/src/pages/SettingsPage/sections/ProjectSection/ProjectSection.unit.test.tsx
+++ b/packages/views/src/pages/SettingsPage/sections/ProjectSection/ProjectSection.unit.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSidebarStore, SidebarStoreContext } from "../../../../store/sidebarStore";
+import { ProjectSection } from "./ProjectSection";
+
+const { updateProject } = vi.hoisted(() => ({
+  updateProject: vi.fn(),
+}));
+
+const projects = [
+  {
+    id: "project-1",
+    name: "Alpha",
+    description: "First project",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "project-2",
+    name: "Beta",
+    description: "Second project",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+
+vi.mock("@refinedev/core", () => ({
+  useList: () => ({ result: { data: projects, total: projects.length } }),
+  useUpdate: () => ({ mutate: updateProject }),
+}));
+
+const renderProjectSection = (currentProjectId: string | null) => {
+  const store = createSidebarStore();
+  store.getState().setCurrentProjectId(currentProjectId);
+
+  render(
+    <SidebarStoreContext.Provider value={store}>
+      <ProjectSection />
+    </SidebarStoreContext.Provider>,
+  );
+};
+
+describe("ProjectSection", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    updateProject.mockReset();
+  });
+
+  it("does not fall back to the first project when all projects are selected", () => {
+    renderProjectSection(null);
+
+    expect(screen.getByText("还没有选中项目 — 先在侧栏创建一个。")).toBeInTheDocument();
+    expect(screen.queryByTestId("settings-project-name")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("settings-project-save")).not.toBeInTheDocument();
+    expect(updateProject).not.toHaveBeenCalled();
+  });
+
+  it("updates only the explicitly selected project", () => {
+    renderProjectSection("project-2");
+
+    fireEvent.change(screen.getByTestId("settings-project-name"), {
+      target: { value: "Beta updated" },
+    });
+    fireEvent.click(screen.getByTestId("settings-project-save"));
+
+    expect(updateProject).toHaveBeenCalledWith(
+      {
+        errorNotification: false,
+        id: "project-2",
+        resource: "projects",
+        successNotification: false,
+        values: { description: "Second project", name: "Beta updated" },
+      },
+      { onError: expect.any(Function), onSuccess: expect.any(Function) },
+    );
+  });
+});


### PR DESCRIPTION
## 变更内容

- 将分支重放到最新 `develop`，消除与 #157 / #154 的冲突
- 修复“所有项目”状态静默回退首项的问题；未明确选中项目时不再允许误改任意项目
- 为 Web `conversations/clearAll` 既有映射补充 `dataProvider.custom` 回归测试，确认调用 `trpcClient.conversations.clearAll.mutate()`
- 新增项目设置回归测试，覆盖未选中态与明确 ID 更新

## 验证

- `@repo/views`: 84 个测试文件、361 个用例通过
- `@ordine/app`: 121 个测试文件、563 个用例通过
- `@repo/views` 与 `@ordine/app` typecheck 通过
- `@ordine/app` oxlint 通过（仅有主线既有 `func-style` warning）
- 本次 3 个改动文件 oxfmt 与 `git diff --check` 通过
- 仓库级 `format:check` 仍被 `develop` 上 174 个既有未格式化文件阻断，本次未扩大范围

## 说明

设置页主体已随 #157 进入 `develop`，因此重放后原迁移提交成为重复内容并被 Git 自动丢弃；本 PR 现仅保留 review 指出的修复和对应回归测试。

Linear: COD-137