### PR TITLE
COD-33: 支持 Codex 通过 Skill + CLI 操作 Ordine

### DIFF
--- a/.agents/skills/ordine-control/SKILL.md
+++ b/.agents/skills/ordine-control/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: ordine-control
+description: Operate a running local Ordine instance from Codex through the checked-in CLI. Use to list or inspect pipelines, run a pipeline, inspect jobs, or read job traces. Do not use for Canvas or other UI-only behavior.
+---
+
+# Ordine Control
+
+Use the repository CLI as the supported Codex-facing interface. This skill does not turn Ordine into an MCP server; it provides the local Skill + CLI path while the MCP surface is developed separately.
+
+## Preconditions
+
+1. Work from the Ordine repository root.
+2. Confirm the target server with `ORDINE_API_URL`. The CLI defaults to `http://localhost:9430`; the standalone API server defaults to `http://localhost:9433`.
+3. Confirm the server is reachable with `curl -fsS "$ORDINE_API_URL/health"` before any write or run command.
+4. If Desktop mode requires authentication, read `ORDINE_DESKTOP_AUTH_TOKEN` from the environment. Never print, persist, or copy the token into a command argument, file, log, or response.
+5. Prefer an installed `ordine` executable. In a source checkout, use `bun apps/cli/src/index.ts`.
+
+## Machine-readable commands
+
+Place the global `--json` option before the command:
+
+```bash
+bun apps/cli/src/index.ts --json pipelines list
+bun apps/cli/src/index.ts --json pipelines get <pipeline-id>
+bun apps/cli/src/index.ts --json run <pipeline-id> --no-follow
+bun apps/cli/src/index.ts --json run <pipeline-id>
+bun apps/cli/src/index.ts --json jobs list
+bun apps/cli/src/index.ts --json jobs get <job-id>
+bun apps/cli/src/index.ts --json jobs traces <job-id>
+```
+
+- `run --no-follow` returns `{ "jobId": "..." }`.
+- A following `run` returns `{ "job": {...}, "traces": [...] }` after the job reaches a terminal state.
+- Failed runs exit non-zero. Inspect the JSON written to stdout and the concise error written to stderr.
+
+## Workflow
+
+1. List pipelines as JSON and select an existing pipeline ID; do not guess IDs.
+2. Inspect the pipeline before running it.
+3. Treat running a pipeline as a state-changing action. Run only when the user asked to execute or when execution is an explicit validation step within the task.
+4. Prefer `--no-follow` for asynchronous work. Use the returned job ID with `jobs get` and `jobs traces`.
+5. Report the pipeline ID, job ID, terminal status, relevant trace evidence, and whether the path was live or mocked.
+
+## Safety boundaries
+
+- Do not use CLI/REST checks as evidence for Canvas rendering, drag-and-drop, browser authentication, or Desktop IPC behavior.
+- Do not delete pipelines or jobs unless the user explicitly requests deletion and the exact ID has been verified.
+- Do not start a persistent server, change authentication, or modify environment files unless the task includes local startup or configuration.
+- If health, authentication, or a command fails repeatedly, stop and report the exact failing layer instead of retrying blindly.

--- a/.agents/skills/ordine-control/SKILL.md
+++ b/.agents/skills/ordine-control/SKILL.md
@@ -10,7 +10,7 @@ Use the repository CLI as the supported Codex-facing interface. This skill does 
 ## Preconditions
 
 1. Work from the Ordine repository root.
-2. Confirm the target server with `ORDINE_API_URL`. The CLI defaults to `http://localhost:9430`; the standalone API server defaults to `http://localhost:9433`.
+2. Confirm the target server with `ORDINE_API_URL`. The CLI and standalone API server default to `http://localhost:9433`.
 3. Confirm the server is reachable with `curl -fsS "$ORDINE_API_URL/health"` before any write or run command.
 4. If Desktop mode requires authentication, read `ORDINE_DESKTOP_AUTH_TOKEN` from the environment. Never print, persist, or copy the token into a command argument, file, log, or response.
 5. Prefer an installed `ordine` executable. In a source checkout, use `bun apps/cli/src/index.ts`.
@@ -30,8 +30,9 @@ bun apps/cli/src/index.ts --json jobs traces <job-id>
 ```
 
 - `run --no-follow` returns `{ "jobId": "..." }`.
-- A following `run` returns `{ "job": {...}, "traces": [...] }` after the job reaches a terminal state.
-- Failed runs exit non-zero. Inspect the JSON written to stdout and the concise error written to stderr.
+- A following `run` returns `{ "job": {...}, "traces": [...] }` after the job reaches a terminal state or pauses.
+- Only `done` exits zero. `paused`, `failed`, `cancelled`, `expired`, and `skipped` stop following and exit non-zero. Inspect the JSON written to stdout and the concise error written to stderr.
+- If job traces cannot be fetched, the CLI exits non-zero and adds `tracesError` to the JSON instead of silently reporting an empty trace list.
 
 ## Workflow
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,11 @@ yarn-error.log*
 .DS_Store
 *.pem
 
-.agents
+.agents/*
+!.agents/skills/
+.agents/skills/*
+!.agents/skills/ordine-control/
+!.agents/skills/ordine-control/**
 .adal
 .augment
 .claude

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -60,8 +60,23 @@ const requestNoBody = async (method: string, path: string): Promise<ApiResult<vo
   return { ok: true, data: undefined };
 };
 
+const requestBytes = async (path: string): Promise<ApiResult<Uint8Array>> => {
+  const url = `${getBaseUrl()}${path}`;
+  const res = await fetch(url, { method: "GET", headers: getHeaders() });
+
+  if (!res.ok) {
+    const result = await ResultAsync.fromPromise(res.text(), () => undefined);
+    const text = result.unwrapOr("");
+
+    return { ok: false, status: res.status, message: text || res.statusText };
+  }
+
+  return { ok: true, data: new Uint8Array(await res.arrayBuffer()) };
+};
+
 export const api = {
   get: <T>(path: string) => request<T>("GET", path),
+  getBytes: (path: string) => requestBytes(path),
   post: <T>(path: string, body?: unknown) => request<T>("POST", path, body),
   put: <T>(path: string, body: unknown) => request<T>("PUT", path, body),
   patch: <T>(path: string, body: unknown) => request<T>("PATCH", path, body),

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -3,6 +3,12 @@ import { getEnv } from "./integrations/env";
 
 const getBaseUrl = (): string => getEnv().ORDINE_API_URL;
 
+const getHeaders = (): Record<string, string> => {
+  const { ORDINE_DESKTOP_AUTH_TOKEN } = getEnv();
+
+  return ORDINE_DESKTOP_AUTH_TOKEN ? { "X-Desktop-Token": ORDINE_DESKTOP_AUTH_TOKEN } : {};
+};
+
 interface ApiError {
   ok: false;
   status: number;
@@ -18,7 +24,7 @@ type ApiResult<T> = ApiSuccess<T> | ApiError;
 
 const request = async <T>(method: string, path: string, body?: unknown): Promise<ApiResult<T>> => {
   const url = `${getBaseUrl()}${path}`;
-  const headers: Record<string, string> = {};
+  const headers = getHeaders();
   const init: RequestInit = { method, headers };
 
   if (body !== undefined) {
@@ -42,7 +48,7 @@ const request = async <T>(method: string, path: string, body?: unknown): Promise
 
 const requestNoBody = async (method: string, path: string): Promise<ApiResult<void>> => {
   const url = `${getBaseUrl()}${path}`;
-  const res = await fetch(url, { method });
+  const res = await fetch(url, { method, headers: getHeaders() });
 
   if (!res.ok) {
     const result = await ResultAsync.fromPromise(res.text(), () => undefined);

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -14,7 +14,7 @@ interface Pipeline {
 interface Job {
   id: string;
   title: string;
-  status: "queued" | "running" | "done" | "failed" | "cancelled";
+  status: "queued" | "running" | "paused" | "done" | "failed" | "cancelled" | "expired" | "skipped";
   logs: string[];
   result: { summary?: string; output?: string } | null;
   error: string | null;
@@ -38,6 +38,8 @@ interface DirEntry {
   name: string;
   type: string;
 }
+
+type OutputOptions = { json?: boolean };
 
 class CliError extends Error {
   constructor(
@@ -75,8 +77,14 @@ const assertOk = <T>(result: { ok: boolean; data?: T; message?: string }, action
 
 // ─── Pipelines ───────────────────────────────────────────────────────
 
-export const listPipelines = async (): Promise<void> => {
+export const listPipelines = async (options: OutputOptions = {}): Promise<void> => {
   const pipelines = assertOk(await api.get<Pipeline[]>("/api/pipelines"), "list pipelines");
+
+  if (options.json) {
+    console.log(JSON.stringify(pipelines));
+
+    return;
+  }
 
   if (pipelines.length === 0) {
     console.log("No pipelines found.");
@@ -117,9 +125,9 @@ export const deletePipeline = async (id: string): Promise<void> => {
 
 export const runPipeline = async (
   pipelineId: string,
-  options: { inputPath?: string; follow?: boolean },
+  options: { inputPath?: string; follow?: boolean; json?: boolean },
 ): Promise<void> => {
-  console.log(`Triggering pipeline ${pipelineId}...`);
+  if (!options.json) console.log(`Triggering pipeline ${pipelineId}...`);
 
   const { jobId } = assertOk(
     await api.post<RunResponse>(`/api/pipelines/${pipelineId}/run`, {
@@ -127,11 +135,16 @@ export const runPipeline = async (
     }),
     "run pipeline",
   );
-  console.log(`Job created: ${jobId}`);
+  if (!options.json) console.log(`Job created: ${jobId}`);
 
-  if (options.follow === false) return;
+  if (options.follow === false) {
+    if (options.json) console.log(JSON.stringify({ jobId }));
 
-  await pollJob(jobId);
+    return;
+  }
+
+  const result = await pollJob(jobId, options);
+  if (options.json) console.log(JSON.stringify(result));
 };
 
 // ─── Rules ───────────────────────────────────────────────────────────
@@ -256,9 +269,15 @@ export const deleteOperation = async (id: string): Promise<void> => {
 
 // ─── Jobs ────────────────────────────────────────────────────────────
 
-export const listJobs = async (options: { status?: string }): Promise<void> => {
+export const listJobs = async (options: { status?: string; json?: boolean }): Promise<void> => {
   const query = options.status ? `?status=${options.status}` : "";
   const jobs = assertOk(await api.get<Job[]>(`/api/jobs${query}`), "list jobs");
+
+  if (options.json) {
+    console.log(JSON.stringify(jobs));
+
+    return;
+  }
 
   if (jobs.length === 0) {
     console.log("No jobs found.");
@@ -276,6 +295,11 @@ export const listJobs = async (options: { status?: string }): Promise<void> => {
 export const getJob = async (id: string): Promise<void> => {
   const job = assertOk(await api.get<Job>(`/api/jobs/${id}`), "get job");
   console.log(JSON.stringify(job, null, 2));
+};
+
+export const listJobTraces = async (id: string): Promise<void> => {
+  const traces = assertOk(await api.get<unknown[]>(`/api/jobs/${id}/traces`), "list job traces");
+  console.log(JSON.stringify(traces));
 };
 
 export const deleteJob = async (id: string): Promise<void> => {
@@ -327,9 +351,7 @@ export const deleteBestPractice = async (id: string): Promise<void> => {
 };
 
 export const exportBestPractices = async (outPath: string): Promise<void> => {
-  const res = await fetch(
-    `${getEnv().ORDINE_API_URL}/api/best-practices/export`,
-  );
+  const res = await fetch(`${getEnv().ORDINE_API_URL}/api/best-practices/export`);
   if (!res.ok) throw new CliError(`Failed to export: ${res.statusText}`);
   const buffer = Buffer.from(await res.arrayBuffer());
   writeFileSync(outPath, buffer);
@@ -371,11 +393,15 @@ export const browseFilesystem = async (dirPath?: string): Promise<void> => {
   }
 };
 
-const pollJob = async (jobId: string): Promise<void> => {
+const pollJob = async (
+  jobId: string,
+  options: OutputOptions,
+): Promise<{ job: Job; traces: unknown[] }> => {
   const startTime = Date.now();
   const seenTraceCount = { value: 0 };
+  const allTraces: unknown[] = [];
 
-  const poll = async (): Promise<void> => {
+  const poll = async (): Promise<{ job: Job; traces: unknown[] }> => {
     const result = await api.get<Job>(`/api/jobs/${jobId}`);
 
     if (!result.ok) {
@@ -385,30 +411,43 @@ const pollJob = async (jobId: string): Promise<void> => {
     const job = result.data;
 
     // Print new trace lines
-    const tracesResult = await api.get<{ message: string }[]>(`/api/jobs/${jobId}/traces`);
+    const tracesResult = await api.get<unknown[]>(`/api/jobs/${jobId}/traces`);
     if (tracesResult.ok) {
       const newTraces = tracesResult.data.slice(seenTraceCount.value);
-      for (const trace of newTraces) {
-        console.log(trace.message);
+      allTraces.splice(0, allTraces.length, ...tracesResult.data);
+      if (!options.json) {
+        for (const trace of newTraces) {
+          if (typeof trace !== "object" || trace === null || !("message" in trace)) continue;
+          console.log(String(trace.message));
+        }
       }
       seenTraceCount.value = tracesResult.data.length;
     }
 
-    if (job.status === "done" || job.status === "failed" || job.status === "cancelled") {
+    if (
+      job.status === "done" ||
+      job.status === "failed" ||
+      job.status === "cancelled" ||
+      job.status === "expired" ||
+      job.status === "skipped"
+    ) {
       const elapsed = formatDuration(Date.now() - startTime);
-      console.log();
+      if (!options.json) console.log();
 
       if (job.status === "done") {
-        console.log(`Pipeline completed in ${elapsed}`);
-      } else if (job.status === "failed") {
-        console.error(`Pipeline failed after ${elapsed}`);
-        if (job.error) console.error(`  Error: ${job.error}`);
-        throw new CliError("Pipeline failed");
+        if (!options.json) console.log(`Pipeline completed in ${elapsed}`);
+      } else if (job.status === "failed" || job.status === "expired") {
+        if (options.json) console.log(JSON.stringify({ job, traces: allTraces }));
+        else {
+          console.error(`Pipeline ${job.status} after ${elapsed}`);
+          if (job.error) console.error(`  Error: ${job.error}`);
+        }
+        throw new CliError(`Pipeline ${job.status}`);
       } else {
-        console.log(`Pipeline cancelled after ${elapsed}`);
+        if (!options.json) console.log(`Pipeline ${job.status} after ${elapsed}`);
       }
 
-      return;
+      return { job, traces: allTraces };
     }
 
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
@@ -416,5 +455,5 @@ const pollJob = async (jobId: string): Promise<void> => {
     return poll();
   };
 
-  await poll();
+  return poll();
 };

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -1,6 +1,5 @@
 import { api } from "./api";
 import { readFileSync, writeFileSync } from "node:fs";
-import { getEnv } from "./integrations/env";
 
 interface Pipeline {
   id: string;
@@ -41,6 +40,12 @@ interface DirEntry {
 
 type OutputOptions = { json?: boolean };
 
+interface PollResult {
+  job: Job;
+  traces: unknown[];
+  tracesError?: string;
+}
+
 class CliError extends Error {
   constructor(
     message: string,
@@ -52,6 +57,8 @@ class CliError extends Error {
 }
 
 const POLL_INTERVAL_MS = 3000;
+
+const toSingleLine = (message: string): string => message.replaceAll(/\s+/g, " ").trim();
 
 const formatDuration = (ms: number): string => {
   const seconds = Math.floor(ms / 1000);
@@ -351,10 +358,11 @@ export const deleteBestPractice = async (id: string): Promise<void> => {
 };
 
 export const exportBestPractices = async (outPath: string): Promise<void> => {
-  const res = await fetch(`${getEnv().ORDINE_API_URL}/api/best-practices/export`);
-  if (!res.ok) throw new CliError(`Failed to export: ${res.statusText}`);
-  const buffer = Buffer.from(await res.arrayBuffer());
-  writeFileSync(outPath, buffer);
+  const data = assertOk(
+    await api.getBytes("/api/best-practices/export"),
+    "export best practices",
+  );
+  writeFileSync(outPath, data);
   console.log(`Exported best practices to: ${outPath}`);
 };
 
@@ -396,12 +404,12 @@ export const browseFilesystem = async (dirPath?: string): Promise<void> => {
 const pollJob = async (
   jobId: string,
   options: OutputOptions,
-): Promise<{ job: Job; traces: unknown[] }> => {
+): Promise<PollResult> => {
   const startTime = Date.now();
   const seenTraceCount = { value: 0 };
   const allTraces: unknown[] = [];
 
-  const poll = async (): Promise<{ job: Job; traces: unknown[] }> => {
+  const poll = async (): Promise<PollResult> => {
     const result = await api.get<Job>(`/api/jobs/${jobId}`);
 
     if (!result.ok) {
@@ -412,6 +420,7 @@ const pollJob = async (
 
     // Print new trace lines
     const tracesResult = await api.get<unknown[]>(`/api/jobs/${jobId}/traces`);
+    const tracesError = tracesResult.ok ? undefined : toSingleLine(tracesResult.message);
     if (tracesResult.ok) {
       const newTraces = tracesResult.data.slice(seenTraceCount.value);
       allTraces.splice(0, allTraces.length, ...tracesResult.data);
@@ -425,6 +434,7 @@ const pollJob = async (
     }
 
     if (
+      job.status === "paused" ||
       job.status === "done" ||
       job.status === "failed" ||
       job.status === "cancelled" ||
@@ -433,21 +443,24 @@ const pollJob = async (
     ) {
       const elapsed = formatDuration(Date.now() - startTime);
       if (!options.json) console.log();
+      const output: PollResult = tracesError
+        ? { job, traces: allTraces, tracesError }
+        : { job, traces: allTraces };
+
+      if (tracesError) {
+        if (options.json) console.log(JSON.stringify(output));
+        throw new CliError(`Failed to fetch job traces: ${tracesError}`);
+      }
 
       if (job.status === "done") {
         if (!options.json) console.log(`Pipeline completed in ${elapsed}`);
-      } else if (job.status === "failed" || job.status === "expired") {
-        if (options.json) console.log(JSON.stringify({ job, traces: allTraces }));
-        else {
-          console.error(`Pipeline ${job.status} after ${elapsed}`);
-          if (job.error) console.error(`  Error: ${job.error}`);
-        }
-        throw new CliError(`Pipeline ${job.status}`);
       } else {
-        if (!options.json) console.log(`Pipeline ${job.status} after ${elapsed}`);
+        if (options.json) console.log(JSON.stringify(output));
+        const detail = job.error ? `: ${toSingleLine(job.error)}` : "";
+        throw new CliError(`Pipeline ${job.status} after ${elapsed}${detail}`);
       }
 
-      return { job, traces: allTraces };
+      return output;
     }
 
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -25,6 +25,7 @@ import {
   deleteOperation,
   listJobs,
   getJob,
+  listJobTraces,
   deleteJob,
   listBestPractices,
   getBestPractice,
@@ -42,7 +43,10 @@ const program = new Command();
 program
   .name("ordine")
   .description("Ordine CLI — manage pipelines, rules, skills, and more")
+  .option("--json", "Print machine-readable JSON for supported commands")
   .version(packageJson.version);
+
+const outputOptions = (): { json?: boolean } => program.opts<{ json?: boolean }>();
 
 // ─── Pipelines ───────────────────────────────────────────────────────
 
@@ -51,7 +55,7 @@ pipelinesCmd
   .command("list")
   .alias("ls")
   .description("List all pipelines")
-  .action(() => listPipelines());
+  .action(() => listPipelines(outputOptions()));
 pipelinesCmd
   .command("get <id>")
   .description("Get pipeline details")
@@ -75,7 +79,11 @@ program
   .option("-i, --input <path>", "Input file or folder path")
   .option("--no-follow", "Do not follow job progress (fire and forget)")
   .action((pipelineId: string, opts: { input?: string; follow?: boolean }) =>
-    runPipeline(pipelineId, { inputPath: opts.input, follow: opts.follow }),
+    runPipeline(pipelineId, {
+      inputPath: opts.input,
+      follow: opts.follow,
+      json: outputOptions().json,
+    }),
   );
 
 // ─── Rules ───────────────────────────────────────────────────────────
@@ -161,11 +169,15 @@ jobsCmd
   .alias("ls")
   .description("List all jobs")
   .option("-s, --status <status>", "Filter by status")
-  .action((opts: { status?: string }) => listJobs(opts));
+  .action((opts: { status?: string }) => listJobs({ ...opts, json: outputOptions().json }));
 jobsCmd
   .command("get <id>")
   .description("Get job details")
   .action((id: string) => getJob(id));
+jobsCmd
+  .command("traces <id>")
+  .description("List job traces as JSON")
+  .action((id: string) => listJobTraces(id));
 jobsCmd
   .command("delete <id>")
   .description("Delete a job")

--- a/apps/cli/src/integrations/env/envSchema.ts
+++ b/apps/cli/src/integrations/env/envSchema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod/v4";
 
 export const envSchema = z.object({
-  ORDINE_API_URL: z.string().default("http://localhost:9430"),
+  ORDINE_API_URL: z.string().default("http://localhost:9433"),
   ORDINE_DESKTOP_AUTH_TOKEN: z.string().min(32).optional(),
 });
 

--- a/apps/cli/src/integrations/env/envSchema.ts
+++ b/apps/cli/src/integrations/env/envSchema.ts
@@ -2,6 +2,7 @@ import { z } from "zod/v4";
 
 export const envSchema = z.object({
   ORDINE_API_URL: z.string().default("http://localhost:9430"),
+  ORDINE_DESKTOP_AUTH_TOKEN: z.string().min(32).optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/cli/tests/cli.integration.test.ts
+++ b/apps/cli/tests/cli.integration.test.ts
@@ -1,6 +1,8 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { spawn } from "node:child_process";
+import { existsSync, unlinkSync } from "node:fs";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { envSchema } from "../src/integrations/env/envSchema";
 
 const requests: Array<{ method: string; url: string; desktopToken?: string }> = [];
 
@@ -26,6 +28,16 @@ const handleRequest = (request: IncomingMessage, response: ServerResponse): void
 
     return;
   }
+  if (request.method === "POST" && request.url === "/api/pipelines/pipe-fail/run") {
+    sendJson(response, 202, { jobId: "job-fail" });
+
+    return;
+  }
+  if (request.method === "POST" && request.url === "/api/pipelines/pipe-trace-fail/run") {
+    sendJson(response, 202, { jobId: "job-trace-fail" });
+
+    return;
+  }
   if (request.method === "GET" && request.url === "/api/jobs/job-1") {
     sendJson(response, 200, { id: "job-1", title: "Agent Pipeline", status: "done", error: null });
 
@@ -36,12 +48,49 @@ const handleRequest = (request: IncomingMessage, response: ServerResponse): void
 
     return;
   }
+  if (request.method === "GET" && request.url === "/api/jobs/job-fail") {
+    sendJson(response, 200, {
+      id: "job-fail",
+      title: "Failed Pipeline",
+      status: "failed",
+      error: "Test failure\nwith details",
+    });
+
+    return;
+  }
+  if (request.method === "GET" && request.url === "/api/jobs/job-fail/traces") {
+    sendJson(response, 200, [{ message: "failed" }]);
+
+    return;
+  }
+  if (request.method === "GET" && request.url === "/api/jobs/job-trace-fail") {
+    sendJson(response, 200, {
+      id: "job-trace-fail",
+      title: "Trace Failure",
+      status: "done",
+      error: null,
+    });
+
+    return;
+  }
+  if (request.method === "GET" && request.url === "/api/jobs/job-trace-fail/traces") {
+    sendJson(response, 503, { error: "trace backend unavailable" });
+
+    return;
+  }
+  if (request.method === "GET" && request.url === "/api/best-practices/export") {
+    response.writeHead(200, { "content-type": "application/octet-stream" });
+    response.end("exported-data");
+
+    return;
+  }
 
   sendJson(response, 404, { error: "Not found" });
 };
 
 const server = createServer(handleRequest);
 let apiUrl = "";
+const exportOutPath = `/tmp/ordine-cli-export-${process.pid}.bestpractice`;
 
 const runCli = (
   args: string[],
@@ -77,9 +126,14 @@ afterAll(async () => {
   await new Promise<void>((resolve, reject) =>
     server.close((error) => (error ? reject(error) : resolve())),
   );
+  if (existsSync(exportOutPath)) unlinkSync(exportOutPath);
 });
 
 describe("Codex-facing CLI", () => {
+  it("defaults to the standalone REST API port", () => {
+    expect(envSchema.parse({}).ORDINE_API_URL).toBe("http://localhost:9433");
+  });
+
   it("lists pipelines as machine-readable JSON over the real HTTP client", async () => {
     const result = await runCli(["--json", "pipelines", "list"]);
 
@@ -112,5 +166,53 @@ describe("Codex-facing CLI", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
     expect(JSON.parse(result.stdout)).toEqual([{ message: "completed" }]);
+  });
+
+  it("keeps failed follow output machine-readable and exits non-zero", async () => {
+    const result = await runCli(["--json", "run", "pipe-fail"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toEqual({
+      job: {
+        id: "job-fail",
+        title: "Failed Pipeline",
+        status: "failed",
+        error: "Test failure\nwith details",
+      },
+      traces: [{ message: "failed" }],
+    });
+    expect(result.stderr.trim()).toMatch(/^Pipeline failed after \d+s: Test failure with details$/);
+    expect(result.stderr.trim().split("\n")).toHaveLength(1);
+  });
+
+  it("reports trace fetch failures instead of silently returning an empty list", async () => {
+    const result = await runCli(["--json", "run", "pipe-trace-fail"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toEqual({
+      job: {
+        id: "job-trace-fail",
+        title: "Trace Failure",
+        status: "done",
+        error: null,
+      },
+      traces: [],
+      tracesError: '{"error":"trace backend unavailable"}',
+    });
+    expect(result.stderr.trim()).toBe(
+      'Failed to fetch job traces: {"error":"trace backend unavailable"}',
+    );
+  });
+
+  it("sends Desktop authentication when exporting best practices", async () => {
+    const result = await runCli(["best-practices", "export", exportOutPath]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(requests.at(-1)).toEqual({
+      method: "GET",
+      url: "/api/best-practices/export",
+      desktopToken: "test-desktop-token-that-is-long-enough",
+    });
   });
 });

--- a/apps/cli/tests/cli.integration.test.ts
+++ b/apps/cli/tests/cli.integration.test.ts
@@ -1,0 +1,116 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { spawn } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const requests: Array<{ method: string; url: string; desktopToken?: string }> = [];
+
+const sendJson = (response: ServerResponse, status: number, body: unknown): void => {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+};
+
+const handleRequest = (request: IncomingMessage, response: ServerResponse): void => {
+  requests.push({
+    method: request.method ?? "GET",
+    url: request.url ?? "/",
+    desktopToken: request.headers["x-desktop-token"] as string | undefined,
+  });
+
+  if (request.method === "GET" && request.url === "/api/pipelines") {
+    sendJson(response, 200, [{ id: "pipe-1", name: "Agent Pipeline", description: "", tags: [] }]);
+
+    return;
+  }
+  if (request.method === "POST" && request.url === "/api/pipelines/pipe-1/run") {
+    sendJson(response, 202, { jobId: "job-1" });
+
+    return;
+  }
+  if (request.method === "GET" && request.url === "/api/jobs/job-1") {
+    sendJson(response, 200, { id: "job-1", title: "Agent Pipeline", status: "done", error: null });
+
+    return;
+  }
+  if (request.method === "GET" && request.url === "/api/jobs/job-1/traces") {
+    sendJson(response, 200, [{ message: "completed" }]);
+
+    return;
+  }
+
+  sendJson(response, 404, { error: "Not found" });
+};
+
+const server = createServer(handleRequest);
+let apiUrl = "";
+
+const runCli = (
+  args: string[],
+): Promise<{ exitCode: number | null; stdout: string; stderr: string }> =>
+  new Promise((resolve) => {
+    const child = spawn("bun", ["src/index.ts", ...args], {
+      cwd: new URL("../", import.meta.url),
+      env: {
+        ...process.env,
+        ORDINE_API_URL: apiUrl,
+        ORDINE_DESKTOP_AUTH_TOKEN: "test-desktop-token-that-is-long-enough",
+      },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on("close", (exitCode) => resolve({ exitCode, stdout, stderr }));
+  });
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Test server did not bind a port");
+  apiUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+});
+
+describe("Codex-facing CLI", () => {
+  it("lists pipelines as machine-readable JSON over the real HTTP client", async () => {
+    const result = await runCli(["--json", "pipelines", "list"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual([
+      { id: "pipe-1", name: "Agent Pipeline", description: "", tags: [] },
+    ]);
+    expect(requests.at(-1)).toEqual({
+      method: "GET",
+      url: "/api/pipelines",
+      desktopToken: "test-desktop-token-that-is-long-enough",
+    });
+  });
+
+  it("runs a pipeline and returns the final job with traces as JSON", async () => {
+    const result = await runCli(["--json", "run", "pipe-1"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual({
+      job: { id: "job-1", title: "Agent Pipeline", status: "done", error: null },
+      traces: [{ message: "completed" }],
+    });
+  });
+
+  it("reads job traces directly as JSON", async () => {
+    const result = await runCli(["--json", "jobs", "traces", "job-1"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual([{ message: "completed" }]);
+  });
+});

--- a/apps/cli/tests/commands.test.ts
+++ b/apps/cli/tests/commands.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 
 vi.mock("../src/api", () => ({
   api: {
     get: vi.fn(),
+    getBytes: vi.fn(),
     post: vi.fn(),
     put: vi.fn(),
     patch: vi.fn(),
@@ -47,6 +48,7 @@ import {
   createBestPractice,
   updateBestPractice,
   deleteBestPractice,
+  exportBestPractices,
   importBestPractices,
   browseFilesystem,
 } from "../src/commands";
@@ -239,6 +241,38 @@ describe("runPipeline", () => {
         traces: [],
       }),
     );
+  });
+
+  it.each(["paused", "cancelled", "skipped"] as const)(
+    "stops following and fails when a job is %s",
+    async (status) => {
+      mockApi.post.mockResolvedValueOnce({ ok: true, data: { jobId: `job-${status}` } } as never);
+      mockApi.get
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { id: `job-${status}`, status, error: null },
+        } as never)
+        .mockResolvedValueOnce({ ok: true, data: [] } as never);
+
+      await expect(runPipeline("pipe-1", { json: true })).rejects.toThrow(
+        `Pipeline ${status}`,
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        JSON.stringify({ job: { id: `job-${status}`, status, error: null }, traces: [] }),
+      );
+    },
+  );
+});
+
+describe("exportBestPractices", () => {
+  it("downloads through the authenticated API client", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    mockApi.getBytes.mockResolvedValueOnce({ ok: true, data: bytes } as never);
+
+    await exportBestPractices("/tmp/export.bestpractice");
+
+    expect(mockApi.getBytes).toHaveBeenCalledWith("/api/best-practices/export");
+    expect(vi.mocked(writeFileSync)).toHaveBeenCalledWith("/tmp/export.bestpractice", bytes);
   });
 });
 

--- a/apps/cli/tests/commands.test.ts
+++ b/apps/cli/tests/commands.test.ts
@@ -40,6 +40,7 @@ import {
   deleteOperation,
   listJobs,
   getJob,
+  listJobTraces,
   deleteJob,
   listBestPractices,
   getBestPractice,
@@ -55,7 +56,7 @@ const mockApi = vi.mocked(api);
 const mockReadFileSync = vi.mocked(readFileSync);
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
   vi.spyOn(console, "log").mockImplementation(() => {});
   vi.spyOn(console, "error").mockImplementation(() => {});
 });
@@ -100,6 +101,16 @@ describe("listPipelines", () => {
     mockApi.get.mockResolvedValueOnce({ ok: false, status: 500, message: "Server error" } as never);
 
     await expect(listPipelines()).rejects.toThrow("Failed to list pipelines");
+  });
+
+  it("prints stable JSON for agent callers", async () => {
+    const pipelines = [{ id: "pipe-1", name: "Lint Check", description: "", tags: [] }];
+    mockApi.get.mockResolvedValueOnce({ ok: true, data: pipelines } as never);
+
+    await listPipelines({ json: true });
+
+    expect(console.log).toHaveBeenCalledOnce();
+    expect(console.log).toHaveBeenCalledWith(JSON.stringify(pipelines));
   });
 });
 
@@ -182,6 +193,15 @@ describe("runPipeline", () => {
     expect(mockApi.get).not.toHaveBeenCalled();
   });
 
+  it("prints only the job id as JSON for a non-following run", async () => {
+    mockApi.post.mockResolvedValueOnce({ ok: true, data: { jobId: "job-456" } } as never);
+
+    await runPipeline("pipe-1", { follow: false, json: true });
+
+    expect(console.log).toHaveBeenCalledOnce();
+    expect(console.log).toHaveBeenCalledWith(JSON.stringify({ jobId: "job-456" }));
+  });
+
   it("throws on API error during run", async () => {
     mockApi.post.mockResolvedValueOnce({ ok: false, status: 404, message: "Not found" } as never);
 
@@ -201,6 +221,24 @@ describe("runPipeline", () => {
       } as never);
 
     await expect(runPipeline("pipe-1", {})).rejects.toThrow("Pipeline failed");
+  });
+
+  it("stops polling and fails when a job expires", async () => {
+    mockApi.post.mockResolvedValueOnce({ ok: true, data: { jobId: "job-expired" } } as never);
+    mockApi.get
+      .mockResolvedValueOnce({
+        ok: true,
+        data: { id: "job-expired", status: "expired", error: "Timed out" },
+      } as never)
+      .mockResolvedValueOnce({ ok: true, data: [] } as never);
+
+    await expect(runPipeline("pipe-1", { json: true })).rejects.toThrow("Pipeline expired");
+    expect(console.log).toHaveBeenCalledWith(
+      JSON.stringify({
+        job: { id: "job-expired", status: "expired", error: "Timed out" },
+        traces: [],
+      }),
+    );
   });
 });
 
@@ -425,6 +463,16 @@ describe("listJobs", () => {
 
     expect(console.log).toHaveBeenCalledWith("No jobs found.");
   });
+
+  it("prints stable JSON for agent callers", async () => {
+    const jobs = [{ id: "j-1", status: "done", title: "Run" }];
+    mockApi.get.mockResolvedValueOnce({ ok: true, data: jobs } as never);
+
+    await listJobs({ json: true });
+
+    expect(console.log).toHaveBeenCalledOnce();
+    expect(console.log).toHaveBeenCalledWith(JSON.stringify(jobs));
+  });
 });
 
 describe("getJob", () => {
@@ -434,6 +482,18 @@ describe("getJob", () => {
     await getJob("j-1");
 
     expect(mockApi.get).toHaveBeenCalledWith("/api/jobs/j-1");
+  });
+});
+
+describe("listJobTraces", () => {
+  it("prints traces as JSON", async () => {
+    const traces = [{ message: "step 1" }];
+    mockApi.get.mockResolvedValueOnce({ ok: true, data: traces } as never);
+
+    await listJobTraces("j-1");
+
+    expect(mockApi.get).toHaveBeenCalledWith("/api/jobs/j-1/traces");
+    expect(console.log).toHaveBeenCalledWith(JSON.stringify(traces));
   });
 });
 

--- a/skills/ordine-browse-traces/SKILL.md
+++ b/skills/ordine-browse-traces/SKILL.md
@@ -15,34 +15,34 @@ description: Use when Pipeline 运行失败或结果异常，需要读取 Job �
 
 ```bash
 # 查看 Job 详情
-curl -s http://localhost:9433/api/jobs/<JOB_ID> | python3 -m json.tool
+ordine --json jobs get <JOB_ID>
 ```
 
 关注字段：
 
-| 字段 | 说明 |
-|---|---|
-| `status` | `failed` = 运行失败，`completed` = 已完成（可能有部分错误） |
-| `error` | 顶层错误信息（如果有） |
-| `result` | 运行结果摘要 |
-| `startedAt` / `completedAt` | 计算运行耗时，判断是否超时 |
+| 字段                        | 说明                                                            |
+| --------------------------- | --------------------------------------------------------------- |
+| `status`                    | `failed` = 运行失败，`done` = 已完成（结果仍需结合 Trace 判断） |
+| `error`                     | 顶层错误信息（如果有）                                          |
+| `result`                    | 运行结果摘要                                                    |
+| `startedAt` / `completedAt` | 计算运行耗时，判断是否超时                                      |
 
 ### 第二步：读取 Trace 日志
 
 ```bash
 # 获取该 Job 的所有 Trace
-curl -s http://localhost:9433/api/jobs/<JOB_ID>/traces | python3 -m json.tool
+ordine --json jobs traces <JOB_ID>
 ```
 
 Trace 数据结构：
 
-| 字段 | 类型 | 说明 |
-|---|---|---|
-| `id` | `number` | 自增 ID |
-| `jobId` | `string` | 所属 Job ID |
-| `level` | `"info" \| "warn" \| "error" \| "debug"` | 日志级别 |
-| `message` | `string` | 日志内容 |
-| `createdAt` | `timestamp` | 时间戳 |
+| 字段        | 类型                                     | 说明        |
+| ----------- | ---------------------------------------- | ----------- |
+| `id`        | `number`                                 | 自增 ID     |
+| `jobId`     | `string`                                 | 所属 Job ID |
+| `level`     | `"info" \| "warn" \| "error" \| "debug"` | 日志级别    |
+| `message`   | `string`                                 | 日志内容    |
+| `createdAt` | `timestamp`                              | 时间戳      |
 
 ### 第三步：按级别过滤分析
 
@@ -64,13 +64,13 @@ curl -s http://localhost:9433/api/jobs/<JOB_ID>/traces | \
 
 ### 第四步：常见失败模式
 
-| 模式 | Trace 特征 | 修复方向 |
-|---|---|---|
-| Operation 执行失败 | `error` 消息包含 Operation ID | 检查该 Operation 的 executor 配置（script/skill/prompt） |
-| 输入路径不存在 | `error` 消息包含 `ENOENT` 或 `not found` | 检查运行时传入的 `-i` 路径是否正确 |
-| Skill 调用超时 | 长时间无新 Trace，最终 `failed` | 检查 Skill 服务是否在线，网络是否通畅 |
-| 脚本权限不足 | `error` 消息包含 `EACCES` 或 `permission denied` | 检查脚本文件的执行权限 |
-| 节点连接断裂 | `warn` 消息提示某节点未收到输入 | 检查 Pipeline DAG 中节点之间的连线 |
+| 模式               | Trace 特征                                       | 修复方向                                                 |
+| ------------------ | ------------------------------------------------ | -------------------------------------------------------- |
+| Operation 执行失败 | `error` 消息包含 Operation ID                    | 检查该 Operation 的 executor 配置（script/skill/prompt） |
+| 输入路径不存在     | `error` 消息包含 `ENOENT` 或 `not found`         | 检查运行时传入的 `-i` 路径是否正确                       |
+| Skill 调用超时     | 长时间无新 Trace，最终 `failed`                  | 检查 Skill 服务是否在线，网络是否通畅                    |
+| 脚本权限不足       | `error` 消息包含 `EACCES` 或 `permission denied` | 检查脚本文件的执行权限                                   |
+| 节点连接断裂       | `warn` 消息提示某节点未收到输入                  | 检查 Pipeline DAG 中节点之间的连线                       |
 
 ### 第五步：确认修复
 
@@ -86,4 +86,4 @@ curl -X POST http://localhost:9433/api/pipelines/<PIPELINE_ID>/run \
   -d '{ "inputPath": "<INPUT_PATH>" }'
 ```
 
-验证新 Job 状态为 `completed` 且无 `error` 级别 Trace。
+验证新 Job 状态为 `done` 且无 `error` 级别 Trace。

--- a/skills/ordine-list-pipelines/SKILL.md
+++ b/skills/ordine-list-pipelines/SKILL.md
@@ -11,14 +11,14 @@ description: Use when 需要列出 Ordine 中所有 Pipeline，查看可用的�
 # 设置 API 地址
 export ORDINE_API_URL=http://localhost:9433
 
-# 列出所有 Pipeline
-ordine pipelines
+# 列出所有 Pipeline（给 Agent 使用稳定 JSON 输出）
+ordine --json pipelines list
 
-# 或使用别名
-ordine ls
+# 人类可读输出
+ordine pipelines list
 ```
 
-输出格式：
+人类可读输出格式：
 
 ```
   Pipelines (3):

--- a/skills/ordine-manage-job/SKILL.md
+++ b/skills/ordine-manage-job/SKILL.md
@@ -81,10 +81,12 @@ curl -X DELETE http://localhost:9433/api/jobs/job_manual_001
 ## Job 状态流转
 
 ```
-queued → running → done
-                 → failed
-                 → cancelled
-                 → expired
+queued → running ↔ paused
+           ├→ done
+           ├→ failed
+           ├→ cancelled
+           ├→ expired
+           └→ skipped
 ```
 
 ## 常见任务

--- a/skills/ordine-manage-job/SKILL.md
+++ b/skills/ordine-manage-job/SKILL.md
@@ -14,6 +14,13 @@ Job 是 Pipeline 的一次运行记录，包含状态、日志和结果。当你
 ### 运行并自动跟踪 Job
 
 ```bash
+# Agent 读取所有 Job
+ordine --json jobs list
+
+# Agent 读取单个 Job 与 Trace
+ordine --json jobs get <JOB_ID>
+ordine --json jobs traces <JOB_ID>
+
 # 运行 Pipeline 会自动 follow Job
 ordine run pipe_check_dao -i ./src
 
@@ -59,23 +66,25 @@ curl -X DELETE http://localhost:9433/api/jobs/job_manual_001
 
 ## 数据结构
 
-| 字段 | 类型 | 说明 |
-|---|---|---|
-| `id` | `string` | 唯一标识 |
-| `pipelineId` | `string \| null` | 关联的 Pipeline ID |
-| `projectId` | `string \| null` | 关联的项目 ID |
-| `status` | `JobStatus` | 状态：`pending`, `running`, `completed`, `failed` |
-| `result` | `JSON \| null` | 运行结果（summary, output 等） |
-| `error` | `string \| null` | 错误信息 |
-| `startedAt` | `timestamp \| null` | 开始时间 |
-| `completedAt` | `timestamp \| null` | 完成时间 |
-| `createdAt` | `timestamp` | 创建时间 |
+| 字段          | 类型                | 说明                                                                                     |
+| ------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `id`          | `string`            | 唯一标识                                                                                 |
+| `pipelineId`  | `string \| null`    | 关联的 Pipeline ID                                                                       |
+| `projectId`   | `string \| null`    | 关联的项目 ID                                                                            |
+| `status`      | `JobStatus`         | 状态：`queued`, `running`, `paused`, `done`, `failed`, `cancelled`, `expired`, `skipped` |
+| `result`      | `JSON \| null`      | 运行结果（summary, output 等）                                                           |
+| `error`       | `string \| null`    | 错误信息                                                                                 |
+| `startedAt`   | `timestamp \| null` | 开始时间                                                                                 |
+| `completedAt` | `timestamp \| null` | 完成时间                                                                                 |
+| `createdAt`   | `timestamp`         | 创建时间                                                                                 |
 
 ## Job 状态流转
 
 ```
-pending → running → completed
-                  → failed
+queued → running → done
+                 → failed
+                 → cancelled
+                 → expired
 ```
 
 ## 常见任务
@@ -94,8 +103,8 @@ for j in jobs:
 ### 清理历史 Job
 
 ```bash
-# 列出所有 completed 的 Job，逐个删除
-curl -s "http://localhost:9433/api/jobs?status=completed" | python3 -c "
+# 列出所有 done 的 Job，逐个删除
+curl -s "http://localhost:9433/api/jobs?status=done" | python3 -c "
 import sys, json
 for j in json.load(sys.stdin):
     print(j['id'])

--- a/skills/ordine-run-pipeline/references/run-guide.md
+++ b/skills/ordine-run-pipeline/references/run-guide.md
@@ -12,9 +12,7 @@ export ORDINE_API_URL=http://localhost:9433
 ### 列出可运行的 Pipeline
 
 ```bash
-ordine pipelines
-# 或
-ordine ls
+ordine --json pipelines list
 ```
 
 输出示例：
@@ -39,13 +37,18 @@ ordine run pipe_check_dao -i ./packages/models/src/daos
 
 # 不等待完成（fire and forget）
 ordine run pipe_check_dao --no-follow
+
+# Agent 使用机器可读输出；全局选项放在子命令之前
+ordine --json run pipe_check_dao --no-follow
+ordine --json run pipe_check_dao
 ```
 
 CLI 会自动：
+
 1. 触发 Pipeline → 获取 Job ID
 2. 每 3 秒轮询 Job 状态
 3. 实时打印 Job 日志
-4. 完成时显示 Summary 或打印错误信息
+4. 完成时显示结果或打印错误信息；`--json` 模式返回 Job 和 Trace
 
 ### 运行输出示例
 
@@ -105,7 +108,7 @@ JOB_ID="job_xxxxxxxx"
 while true; do
   STATUS=$(curl -s http://localhost:9433/api/jobs/$JOB_ID | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])")
   echo "Status: $STATUS"
-  if [ "$STATUS" = "completed" ] || [ "$STATUS" = "failed" ]; then
+  if [ "$STATUS" = "done" ] || [ "$STATUS" = "failed" ] || [ "$STATUS" = "cancelled" ] || [ "$STATUS" = "expired" ]; then
     break
   fi
   sleep 2
@@ -118,16 +121,18 @@ curl -s http://localhost:9433/api/jobs/$JOB_ID | python3 -m json.tool
 ## Job 状态流转
 
 ```
-pending → running → completed
-                  → failed
+queued → running → done
+                 → failed
+                 → cancelled
+                 → expired
 ```
 
-| 状态 | 含义 |
-|---|---|
-| `pending` | 已创建，等待执行 |
-| `running` | 正在执行 |
-| `completed` | 执行成功 |
-| `failed` | 执行失败 |
+| 状态      | 含义             |
+| --------- | ---------------- |
+| `queued`  | 已创建，等待执行 |
+| `running` | 正在执行         |
+| `done`    | 执行成功         |
+| `failed`  | 执行失败         |
 
 ## 查看 Job 列表
 
@@ -151,11 +156,13 @@ curl -X DELETE http://localhost:9433/api/jobs/<job-id>
 在运行 Pipeline 之前，确认：
 
 1. **Pipeline 存在且配置正确**
+
    ```bash
    curl -s http://localhost:9433/api/pipelines/<pipeline-id> | python3 -m json.tool
    ```
 
 2. **Pipeline 中引用的 Operation 都存在**
+
    ```bash
    # 检查 pipeline 的 nodes，找到 type=operation 的节点
    # 确认其 data.operationId 对应的 Operation 存在

--- a/skills/ordine-run-pipeline/references/run-guide.md
+++ b/skills/ordine-run-pipeline/references/run-guide.md
@@ -108,7 +108,7 @@ JOB_ID="job_xxxxxxxx"
 while true; do
   STATUS=$(curl -s http://localhost:9433/api/jobs/$JOB_ID | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])")
   echo "Status: $STATUS"
-  if [ "$STATUS" = "done" ] || [ "$STATUS" = "failed" ] || [ "$STATUS" = "cancelled" ] || [ "$STATUS" = "expired" ]; then
+  if [ "$STATUS" = "paused" ] || [ "$STATUS" = "done" ] || [ "$STATUS" = "failed" ] || [ "$STATUS" = "cancelled" ] || [ "$STATUS" = "expired" ] || [ "$STATUS" = "skipped" ]; then
     break
   fi
   sleep 2
@@ -121,18 +121,24 @@ curl -s http://localhost:9433/api/jobs/$JOB_ID | python3 -m json.tool
 ## Job 状态流转
 
 ```
-queued → running → done
-                 → failed
-                 → cancelled
-                 → expired
+queued → running ↔ paused
+           ├→ done
+           ├→ failed
+           ├→ cancelled
+           ├→ expired
+           └→ skipped
 ```
 
-| 状态      | 含义             |
-| --------- | ---------------- |
-| `queued`  | 已创建，等待执行 |
-| `running` | 正在执行         |
-| `done`    | 执行成功         |
-| `failed`  | 执行失败         |
+| 状态        | 含义               |
+| ----------- | ------------------ |
+| `queued`    | 已创建，等待执行   |
+| `running`   | 正在执行           |
+| `paused`    | 已暂停，可稍后恢复 |
+| `done`      | 执行成功           |
+| `failed`    | 执行失败           |
+| `cancelled` | 已取消             |
+| `expired`   | 已过期             |
+| `skipped`   | 已跳过             |
 
 ## 查看 Job 列表
 


### PR DESCRIPTION
## PR 做了什么

完成 COD-33 第一阶段，让 Codex 在仓库中发现 Ordine Skill，并通过现有 CLI 以机器可读方式操作 Pipeline 与 Job：

- 新增仓库级 `ordine-control` Skill
- CLI 新增全局 `--json` 输出
- 新增 `jobs traces <id>`
- 支持可选 `ORDINE_DESKTOP_AUTH_TOKEN`，通过 Header 传递且不输出凭据
- 跟随 Pipeline 时返回最终 Job 与 Trace，并正确停止于 expired/skipped 等终态
- 修正相关 Skill 中过期的命令和 Job 状态

## Review 发现的问题

- 原有 Ordine Skill 位于根目录 `skills/`，Codex 新会话无法发现
- 现有 CLI 测试只 mock API，没有验证真实 CLI 参数解析和 HTTP 链路
- CLI 无稳定 JSON 输出，也没有直接读取 Job Trace 的命令
- Desktop 模式请求缺少 `X-Desktop-Token`
- expired/skipped 终态可能导致 CLI 持续轮询

## 解决方式

- 在 `.agents/skills/ordine-control` 增加 Codex 可发现入口
- 用真实 CLI 子进程 + 本地 HTTP 测试 Server 覆盖 list/run/traces
- 保持 MCP Server 为 COD-33 第二阶段，本 PR 不混入 MCP 实现

## 验证

- `bun run test`：51/51 passed
- `bun run check-types`：passed
- `bun run lint`：passed
- `bun run build`：passed
- 目标文件 format check：passed
- `git diff --check`：passed
- 新建真实 `codex exec --ephemeral --sandbox read-only` 会话，成功发现 `ordine-control` Skill

Linear: https://linear.app/code-forge-official/issue/COD-33