### PR TITLE
修复 Pipeline 创建时 Failed to fetch

### DIFF
--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -1,5 +1,6 @@
 VITE_APP_URL=http://localhost:9430
 VITE_MASTRA_API_URL=http://localhost:4111
+ORDINE_API_PROXY_TARGET=http://localhost:9433
 DATABASE_URL=postgresql://postgres:<password>@localhost:5432/ordine
 
 GITHUB_CLIENT_ID=

--- a/apps/app/e2e/agent-pipeline-workflow.e2e.spec.ts
+++ b/apps/app/e2e/agent-pipeline-workflow.e2e.spec.ts
@@ -9,7 +9,7 @@ const json = (route: Route, body: unknown, status = 200) =>
   });
 
 const mockPipelineAgent = async (page: Page, generatedPipelineId: string, pipelineName: string) => {
-  await page.route("http://localhost:9433/api/**", async (route) => {
+  await page.route("**/api/**", async (route) => {
     const request = route.request();
     const pathname = new URL(request.url()).pathname;
 
@@ -80,7 +80,7 @@ const mockPipelineAgent = async (page: Page, generatedPipelineId: string, pipeli
       return;
     }
 
-    await route.abort("failed");
+    await route.fallback();
   });
 };
 
@@ -94,6 +94,7 @@ test.describe("Agent-first Pipeline workflow", () => {
     const pipelineName = `Agent Pipeline ${runId}`;
     const pipelineId = `agent-pipeline-${runId}`;
 
+    await page.addInitScript(() => globalThis.localStorage.setItem("i18nextLng", "en"));
     await mockPipelineAgent(page, pipelineId, pipelineName);
     await navigateAndWait(page, "/");
     await page.getByRole("button", { name: "Projects" }).click();
@@ -103,7 +104,9 @@ test.describe("Agent-first Pipeline workflow", () => {
     await expect(page.getByRole("button", { name: "Projects" })).toContainText(projectName);
 
     await page.getByRole("button", { name: "New Pipeline" }).click();
-    await page.getByPlaceholder("Describe your goal and add any useful context...").fill("Build a review pipeline");
+    await page
+      .getByPlaceholder("Describe your goal and add any useful context...")
+      .fill("Build a review pipeline");
     await page.getByRole("button", { name: "Send" }).click();
     await expect(page.getByText(pipelineName, { exact: true })).toBeVisible();
     await page.getByRole("button", { name: "Approve plan" }).click();
@@ -111,7 +114,7 @@ test.describe("Agent-first Pipeline workflow", () => {
     await page.getByRole("button", { name: "Open in Canvas" }).click();
 
     await expect(page).toHaveURL(new RegExp(`/canvas\\?id=${pipelineId}$`));
-    await expect(page.getByTestId("canvas-v2-top-pill")).toContainText(pipelineName);
+    await expect(page.getByRole("textbox", { name: "Pipeline title" })).toHaveValue(pipelineName);
     await navigateAndWait(page, "/pipelines");
     await expect(page.getByRole("button", { name: "Projects" })).toContainText(projectName);
     await expect(page.getByText(pipelineName, { exact: true })).toBeVisible();

--- a/apps/app/src/integrations/server-env/envSchema.ts
+++ b/apps/app/src/integrations/server-env/envSchema.ts
@@ -4,6 +4,7 @@ export const serverEnvSchema = z
   .object({
     DATABASE_URL: z.string().optional(),
     PGLITE_DATA_DIR: z.string().optional(),
+    ORDINE_API_PROXY_TARGET: z.url().default("http://localhost:9433"),
     VITE_APP_URL: z.string().default("http://localhost:9430"),
     BETTER_AUTH_SECRET: z.string(),
     GITHUB_CLIENT_ID: z.string().optional(),

--- a/apps/app/src/lib/pipelineAgentSessionsClient.unit.test.ts
+++ b/apps/app/src/lib/pipelineAgentSessionsClient.unit.test.ts
@@ -197,11 +197,11 @@ describe("pipelineAgentSessionsClient.getGeneratedPipelineMaterialization", () =
 
     expect(globalThis.fetch).toHaveBeenNthCalledWith(
       1,
-      "http://localhost:9433/api/pipelines/pipeline-1",
+      "http://localhost:3000/api/pipelines/pipeline-1",
     );
     expect(globalThis.fetch).toHaveBeenNthCalledWith(
       2,
-      "http://localhost:9433/api/operations/operation-1",
+      "http://localhost:3000/api/operations/operation-1",
     );
     expect(result.pipeline.id).toBe("pipeline-1");
     expect(result.operations).toEqual([

--- a/apps/app/src/lib/proxyOrdineApiRequest.ts
+++ b/apps/app/src/lib/proxyOrdineApiRequest.ts
@@ -1,0 +1,35 @@
+import { ResultAsync } from "neverthrow";
+import { getServerEnv } from "@/integrations/server-env";
+
+const toProxyError = (error: unknown) =>
+  error instanceof Error ? error : new Error("Ordine API request failed");
+
+export const proxyOrdineApiRequest = async (request: Request) => {
+  const requestUrl = new URL(request.url);
+  const { ORDINE_API_PROXY_TARGET } = getServerEnv();
+  const upstreamUrl = new URL(
+    `${requestUrl.pathname}${requestUrl.search}`,
+    ORDINE_API_PROXY_TARGET,
+  );
+  const canHaveBody = request.method !== "GET" && request.method !== "HEAD";
+  const upstreamRequest = new Request(upstreamUrl, {
+    method: request.method,
+    headers: request.headers,
+    redirect: "manual",
+    ...(canHaveBody
+      ? ({ body: request.body, duplex: "half" } as RequestInit & { duplex: "half" })
+      : {}),
+  });
+  const result = await ResultAsync.fromPromise(fetch(upstreamRequest), toProxyError);
+
+  if (result.isErr()) {
+    return Response.json(
+      {
+        error: "Ordine API is unavailable. Start the API server and try again.",
+      },
+      { status: 503 },
+    );
+  }
+
+  return result.value;
+};

--- a/apps/app/src/lib/proxyOrdineApiRequest.unit.test.ts
+++ b/apps/app/src/lib/proxyOrdineApiRequest.unit.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/integrations/server-env", () => ({
+  getServerEnv: () => ({ ORDINE_API_PROXY_TARGET: "http://localhost:9433" }),
+}));
+
+import { proxyOrdineApiRequest } from "./proxyOrdineApiRequest";
+
+describe("proxyOrdineApiRequest", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("forwards the request path, query, method, and body to the API server", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(Response.json({ id: "session-1" }, { status: 201 }));
+    const request = new Request("http://localhost:9430/api/pipeline-agent-sessions?source=home", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode: "generate" }),
+    });
+
+    const response = await proxyOrdineApiRequest(request);
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+
+    expect(response.status).toBe(201);
+    expect(forwarded.url).toBe("http://localhost:9433/api/pipeline-agent-sessions?source=home");
+    expect(forwarded.method).toBe("POST");
+    expect(await forwarded.json()).toEqual({ mode: "generate" });
+  });
+
+  it("returns a structured 503 response when the API server cannot be reached", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("fetch failed"));
+
+    const response = await proxyOrdineApiRequest(
+      new Request("http://localhost:9430/api/pipeline-agent-sessions", { method: "POST" }),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "Ordine API is unavailable. Start the API server and try again.",
+    });
+  });
+});

--- a/apps/app/src/lib/resolveApiBaseUrl.ts
+++ b/apps/app/src/lib/resolveApiBaseUrl.ts
@@ -1,12 +1,9 @@
-const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
-
 interface BrowserLocation {
-  hostname: string;
   origin: string;
 }
 
 export const resolveApiBaseUrl = (location?: BrowserLocation) => {
-  if (!location || LOCAL_HOSTNAMES.has(location.hostname)) {
+  if (!location) {
     return "http://localhost:9433/api";
   }
 

--- a/apps/app/src/lib/resolveApiBaseUrl.unit.test.ts
+++ b/apps/app/src/lib/resolveApiBaseUrl.unit.test.ts
@@ -2,19 +2,16 @@ import { describe, expect, it } from "vitest";
 import { resolveApiBaseUrl } from "./resolveApiBaseUrl";
 
 describe("resolveApiBaseUrl", () => {
-  it.each(["localhost", "127.0.0.1", "::1", "[::1]"])(
-    "routes the local hostname %s to the standalone API server",
-    (hostname) => {
-      expect(resolveApiBaseUrl({ hostname, origin: `http://${hostname}:9430` })).toBe(
-        "http://localhost:9433/api",
-      );
-    },
-  );
+  it("uses the browser origin so requests go through the app server proxy", () => {
+    expect(resolveApiBaseUrl({ origin: "http://localhost:9430" })).toBe(
+      "http://localhost:9430/api",
+    );
+  });
 
   it("uses the current origin behind a production reverse proxy", () => {
-    expect(
-      resolveApiBaseUrl({ hostname: "ordine.example.com", origin: "https://ordine.example.com" }),
-    ).toBe("https://ordine.example.com/api");
+    expect(resolveApiBaseUrl({ origin: "https://ordine.example.com" })).toBe(
+      "https://ordine.example.com/api",
+    );
   });
 
   it("uses the local API server while rendering without a browser location", () => {

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as CanvasRouteImport } from './routes/canvas'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as LayoutIndexRouteImport } from './routes/_layout/index'
+import { Route as ApiPipelineAgentSessionsRouteImport } from './routes/api/pipeline-agent-sessions'
 import { Route as ApiLocalSessionRouteImport } from './routes/api/local-session'
 import { Route as LayoutUsageRouteImport } from './routes/_layout/usage'
 import { Route as LayoutSkillsRouteImport } from './routes/_layout/skills'
@@ -32,6 +33,9 @@ import { Route as LayoutPipelinesIndexRouteImport } from './routes/_layout/pipel
 import { Route as LayoutDistillationsIndexRouteImport } from './routes/_layout/distillations.index'
 import { Route as LayoutAgentsIndexRouteImport } from './routes/_layout/agents.index'
 import { Route as ApiTrpcSplatRouteImport } from './routes/api/trpc.$'
+import { Route as ApiPipelinesSplatRouteImport } from './routes/api/pipelines.$'
+import { Route as ApiPipelineAgentSessionsSplatRouteImport } from './routes/api/pipeline-agent-sessions.$'
+import { Route as ApiOperationsSplatRouteImport } from './routes/api/operations.$'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth.$'
 import { Route as LayoutPipelinesJobsRouteImport } from './routes/_layout/pipelines.jobs'
 import { Route as LayoutPipelinesPipelineIdRouteImport } from './routes/_layout/pipelines.$pipelineId'
@@ -73,6 +77,12 @@ const LayoutIndexRoute = LayoutIndexRouteImport.update({
   path: '/',
   getParentRoute: () => LayoutRoute,
 } as any)
+const ApiPipelineAgentSessionsRoute =
+  ApiPipelineAgentSessionsRouteImport.update({
+    id: '/api/pipeline-agent-sessions',
+    path: '/api/pipeline-agent-sessions',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiLocalSessionRoute = ApiLocalSessionRouteImport.update({
   id: '/api/local-session',
   path: '/api/local-session',
@@ -163,6 +173,22 @@ const LayoutAgentsIndexRoute = LayoutAgentsIndexRouteImport.update({
 const ApiTrpcSplatRoute = ApiTrpcSplatRouteImport.update({
   id: '/api/trpc/$',
   path: '/api/trpc/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiPipelinesSplatRoute = ApiPipelinesSplatRouteImport.update({
+  id: '/api/pipelines/$',
+  path: '/api/pipelines/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiPipelineAgentSessionsSplatRoute =
+  ApiPipelineAgentSessionsSplatRouteImport.update({
+    id: '/$',
+    path: '/$',
+    getParentRoute: () => ApiPipelineAgentSessionsRoute,
+  } as any)
+const ApiOperationsSplatRoute = ApiOperationsSplatRouteImport.update({
+  id: '/api/operations/$',
+  path: '/api/operations/$',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
@@ -277,11 +303,15 @@ export interface FileRoutesByFullPath {
   '/skills': typeof LayoutSkillsRoute
   '/usage': typeof LayoutUsageRoute
   '/api/local-session': typeof ApiLocalSessionRoute
+  '/api/pipeline-agent-sessions': typeof ApiPipelineAgentSessionsRouteWithChildren
   '/distillations/$distillationId': typeof LayoutDistillationsDistillationIdRoute
   '/distillations/new': typeof LayoutDistillationsNewRoute
   '/pipelines/$pipelineId': typeof LayoutPipelinesPipelineIdRoute
   '/pipelines/jobs': typeof LayoutPipelinesJobsRouteWithChildren
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/operations/$': typeof ApiOperationsSplatRoute
+  '/api/pipeline-agent-sessions/$': typeof ApiPipelineAgentSessionsSplatRoute
+  '/api/pipelines/$': typeof ApiPipelinesSplatRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
   '/agents/': typeof LayoutAgentsIndexRoute
   '/distillations/': typeof LayoutDistillationsIndexRoute
@@ -313,11 +343,15 @@ export interface FileRoutesByTo {
   '/skills': typeof LayoutSkillsRoute
   '/usage': typeof LayoutUsageRoute
   '/api/local-session': typeof ApiLocalSessionRoute
+  '/api/pipeline-agent-sessions': typeof ApiPipelineAgentSessionsRouteWithChildren
   '/': typeof LayoutIndexRoute
   '/distillations/$distillationId': typeof LayoutDistillationsDistillationIdRoute
   '/distillations/new': typeof LayoutDistillationsNewRoute
   '/pipelines/$pipelineId': typeof LayoutPipelinesPipelineIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/operations/$': typeof ApiOperationsSplatRoute
+  '/api/pipeline-agent-sessions/$': typeof ApiPipelineAgentSessionsSplatRoute
+  '/api/pipelines/$': typeof ApiPipelinesSplatRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
   '/agents': typeof LayoutAgentsIndexRoute
   '/distillations': typeof LayoutDistillationsIndexRoute
@@ -354,12 +388,16 @@ export interface FileRoutesById {
   '/_layout/skills': typeof LayoutSkillsRoute
   '/_layout/usage': typeof LayoutUsageRoute
   '/api/local-session': typeof ApiLocalSessionRoute
+  '/api/pipeline-agent-sessions': typeof ApiPipelineAgentSessionsRouteWithChildren
   '/_layout/': typeof LayoutIndexRoute
   '/_layout/distillations/$distillationId': typeof LayoutDistillationsDistillationIdRoute
   '/_layout/distillations/new': typeof LayoutDistillationsNewRoute
   '/_layout/pipelines/$pipelineId': typeof LayoutPipelinesPipelineIdRoute
   '/_layout/pipelines/jobs': typeof LayoutPipelinesJobsRouteWithChildren
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/operations/$': typeof ApiOperationsSplatRoute
+  '/api/pipeline-agent-sessions/$': typeof ApiPipelineAgentSessionsSplatRoute
+  '/api/pipelines/$': typeof ApiPipelinesSplatRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
   '/_layout/agents/': typeof LayoutAgentsIndexRoute
   '/_layout/distillations/': typeof LayoutDistillationsIndexRoute
@@ -397,11 +435,15 @@ export interface FileRouteTypes {
     | '/skills'
     | '/usage'
     | '/api/local-session'
+    | '/api/pipeline-agent-sessions'
     | '/distillations/$distillationId'
     | '/distillations/new'
     | '/pipelines/$pipelineId'
     | '/pipelines/jobs'
     | '/api/auth/$'
+    | '/api/operations/$'
+    | '/api/pipeline-agent-sessions/$'
+    | '/api/pipelines/$'
     | '/api/trpc/$'
     | '/agents/'
     | '/distillations/'
@@ -433,11 +475,15 @@ export interface FileRouteTypes {
     | '/skills'
     | '/usage'
     | '/api/local-session'
+    | '/api/pipeline-agent-sessions'
     | '/'
     | '/distillations/$distillationId'
     | '/distillations/new'
     | '/pipelines/$pipelineId'
     | '/api/auth/$'
+    | '/api/operations/$'
+    | '/api/pipeline-agent-sessions/$'
+    | '/api/pipelines/$'
     | '/api/trpc/$'
     | '/agents'
     | '/distillations'
@@ -473,12 +519,16 @@ export interface FileRouteTypes {
     | '/_layout/skills'
     | '/_layout/usage'
     | '/api/local-session'
+    | '/api/pipeline-agent-sessions'
     | '/_layout/'
     | '/_layout/distillations/$distillationId'
     | '/_layout/distillations/new'
     | '/_layout/pipelines/$pipelineId'
     | '/_layout/pipelines/jobs'
     | '/api/auth/$'
+    | '/api/operations/$'
+    | '/api/pipeline-agent-sessions/$'
+    | '/api/pipelines/$'
     | '/api/trpc/$'
     | '/_layout/agents/'
     | '/_layout/distillations/'
@@ -503,7 +553,10 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   SignUpRoute: typeof SignUpRoute
   ApiLocalSessionRoute: typeof ApiLocalSessionRoute
+  ApiPipelineAgentSessionsRoute: typeof ApiPipelineAgentSessionsRouteWithChildren
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
+  ApiOperationsSplatRoute: typeof ApiOperationsSplatRoute
+  ApiPipelinesSplatRoute: typeof ApiPipelinesSplatRoute
   ApiTrpcSplatRoute: typeof ApiTrpcSplatRoute
 }
 
@@ -543,6 +596,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof LayoutIndexRouteImport
       parentRoute: typeof LayoutRoute
+    }
+    '/api/pipeline-agent-sessions': {
+      id: '/api/pipeline-agent-sessions'
+      path: '/api/pipeline-agent-sessions'
+      fullPath: '/api/pipeline-agent-sessions'
+      preLoaderRoute: typeof ApiPipelineAgentSessionsRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/api/local-session': {
       id: '/api/local-session'
@@ -668,6 +728,27 @@ declare module '@tanstack/react-router' {
       path: '/api/trpc/$'
       fullPath: '/api/trpc/$'
       preLoaderRoute: typeof ApiTrpcSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/pipelines/$': {
+      id: '/api/pipelines/$'
+      path: '/api/pipelines/$'
+      fullPath: '/api/pipelines/$'
+      preLoaderRoute: typeof ApiPipelinesSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/pipeline-agent-sessions/$': {
+      id: '/api/pipeline-agent-sessions/$'
+      path: '/$'
+      fullPath: '/api/pipeline-agent-sessions/$'
+      preLoaderRoute: typeof ApiPipelineAgentSessionsSplatRouteImport
+      parentRoute: typeof ApiPipelineAgentSessionsRoute
+    }
+    '/api/operations/$': {
+      id: '/api/operations/$'
+      path: '/api/operations/$'
+      fullPath: '/api/operations/$'
+      preLoaderRoute: typeof ApiOperationsSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/auth/$': {
@@ -900,13 +981,30 @@ const LayoutRouteChildren: LayoutRouteChildren = {
 const LayoutRouteWithChildren =
   LayoutRoute._addFileChildren(LayoutRouteChildren)
 
+interface ApiPipelineAgentSessionsRouteChildren {
+  ApiPipelineAgentSessionsSplatRoute: typeof ApiPipelineAgentSessionsSplatRoute
+}
+
+const ApiPipelineAgentSessionsRouteChildren: ApiPipelineAgentSessionsRouteChildren =
+  {
+    ApiPipelineAgentSessionsSplatRoute: ApiPipelineAgentSessionsSplatRoute,
+  }
+
+const ApiPipelineAgentSessionsRouteWithChildren =
+  ApiPipelineAgentSessionsRoute._addFileChildren(
+    ApiPipelineAgentSessionsRouteChildren,
+  )
+
 const rootRouteChildren: RootRouteChildren = {
   LayoutRoute: LayoutRouteWithChildren,
   CanvasRoute: CanvasRoute,
   LoginRoute: LoginRoute,
   SignUpRoute: SignUpRoute,
   ApiLocalSessionRoute: ApiLocalSessionRoute,
+  ApiPipelineAgentSessionsRoute: ApiPipelineAgentSessionsRouteWithChildren,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
+  ApiOperationsSplatRoute: ApiOperationsSplatRoute,
+  ApiPipelinesSplatRoute: ApiPipelinesSplatRoute,
   ApiTrpcSplatRoute: ApiTrpcSplatRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/app/src/routes/api/operations.$.ts
+++ b/apps/app/src/routes/api/operations.$.ts
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { proxyOrdineApiRequest } from "@/lib/proxyOrdineApiRequest";
+
+export const Route = createFileRoute("/api/operations/$")({
+  server: {
+    handlers: {
+      GET: ({ request }) => proxyOrdineApiRequest(request),
+    },
+  },
+});

--- a/apps/app/src/routes/api/pipeline-agent-sessions.$.ts
+++ b/apps/app/src/routes/api/pipeline-agent-sessions.$.ts
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { proxyOrdineApiRequest } from "@/lib/proxyOrdineApiRequest";
+
+export const Route = createFileRoute("/api/pipeline-agent-sessions/$")({
+  server: {
+    handlers: {
+      GET: ({ request }) => proxyOrdineApiRequest(request),
+      POST: ({ request }) => proxyOrdineApiRequest(request),
+    },
+  },
+});

--- a/apps/app/src/routes/api/pipeline-agent-sessions.ts
+++ b/apps/app/src/routes/api/pipeline-agent-sessions.ts
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { proxyOrdineApiRequest } from "@/lib/proxyOrdineApiRequest";
+
+export const Route = createFileRoute("/api/pipeline-agent-sessions")({
+  server: {
+    handlers: {
+      POST: ({ request }) => proxyOrdineApiRequest(request),
+    },
+  },
+});

--- a/apps/app/src/routes/api/pipelines.$.ts
+++ b/apps/app/src/routes/api/pipelines.$.ts
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { proxyOrdineApiRequest } from "@/lib/proxyOrdineApiRequest";
+
+export const Route = createFileRoute("/api/pipelines/$")({
+  server: {
+    handlers: {
+      GET: ({ request }) => proxyOrdineApiRequest(request),
+    },
+  },
+});


### PR DESCRIPTION
## PR 做了什么

- 浏览器端 Pipeline Agent 请求统一走 Web 应用同源 API
- 新增受控 BFF 路由，将会话、Pipeline、Operation 请求代理到 Ordine API
- API 服务不可达时返回结构化 503，避免直接暴露 `Failed to fetch`
- 更新 Pipeline 创建 E2E，使 mock 匹配同源请求并适配当前 Canvas 标题控件

## Review 发现的问题

首页重构后，本地浏览器仍直接请求 `http://localhost:9433/api`。API 未启动、端口不一致或跨域链路异常时，浏览器只能产生无上下文的 `Failed to fetch`；原 E2E 又 mock 了这个固定地址，因此没有覆盖真实连接路径。

## 我怎么解决

- 浏览器请求改为 `${location.origin}/api`
- TanStack Start 增加最小范围代理，只开放 Pipeline 创建流程实际需要的 API 路由
- 通过 `ORDINE_API_PROXY_TARGET` 配置上游 API，默认 `http://localhost:9433`
- 上游不可达时返回清晰的 503 JSON 错误

## 验证结果

- 真实浏览器：同源 POST 创建 Session 返回 201，并进入真实 `/plan` 流程，无 `Failed to fetch`
- API 不可达：真实浏览器展示 `Ordine API is unavailable. Start the API server and try again.`
- Pipeline Agent E2E：1 passed（proposal、approve、materialize、Canvas、列表）
- App unit tests：129 files / 584 tests passed
- Typecheck：passed
- Lint：passed（保留 1 条已有 func-style warning）
- Build：passed
- `git diff --check`：passed
