### PR TITLE
fix: 修复 syncAll 误删 runtime(COD-336)

### DIFF
--- a/packages/services/src/agentRuntimesService/createAgentRuntimesService.ts
+++ b/packages/services/src/agentRuntimesService/createAgentRuntimesService.ts
@@ -1,5 +1,10 @@
 import { createAgentRuntimesDao, type DbConnection } from "@repo/models";
-import { mapWithMeta, withMeta, type AgentRuntimeConfig } from "@repo/schemas";
+import {
+  LOCAL_AGENT_RUNTIME_ID_PREFIX,
+  mapWithMeta,
+  withMeta,
+  type AgentRuntimeConfig,
+} from "@repo/schemas";
 
 export const createAgentRuntimesService = (db: DbConnection) => {
   const dao = createAgentRuntimesDao(db);
@@ -18,7 +23,16 @@ export const createAgentRuntimesService = (db: DbConnection) => {
 
       const toCreate = incoming.filter((r) => !existingIds.has(r.id));
       const toUpdate = incoming.filter((r) => existingIds.has(r.id));
-      const toDelete = existing.filter((r) => !incomingIds.has(r.id));
+      // syncAll 的调用方(daemon 定时推送、Web 端 scanAndSync)只上报本地扫描结果,
+      // 因此删除必须同时满足两个条件(COD-336):
+      // 1. 本轮上报非空 —— 空结果意味着扫描失败/PATH 漂移,清空列表会让 agent"时有时无";
+      // 2. 只删 local- 前缀的记录 —— 远程/手动添加的 runtime 永不被同步误删。
+      const toDelete =
+        incoming.length === 0
+          ? []
+          : existing.filter(
+              (r) => r.id.startsWith(LOCAL_AGENT_RUNTIME_ID_PREFIX) && !incomingIds.has(r.id),
+            );
 
       await Promise.all([
         ...toCreate.map((r) => dao.create(r)),

--- a/packages/services/src/agentRuntimesService/createAgentRuntimesService.unit.test.ts
+++ b/packages/services/src/agentRuntimesService/createAgentRuntimesService.unit.test.ts
@@ -141,4 +141,66 @@ describe("createAgentRuntimesService", () => {
     expect(mockDao.delete).not.toHaveBeenCalled();
     expect(result).toHaveLength(2);
   });
+
+  // COD-336 regression guards
+  const runtimeRecord = (id: string) => ({
+    id,
+    name: id,
+    type: "claude-code",
+    connection: { mode: "local" },
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  });
+
+  it("syncAll never deletes remote (non local-) runtimes missing from incoming", async () => {
+    mockDao.findMany
+      .mockResolvedValueOnce([runtimeRecord("remote-team-shared"), runtimeRecord("local-codex")])
+      .mockResolvedValueOnce([runtimeRecord("remote-team-shared"), runtimeRecord("local-codex")]);
+
+    const svc = createAgentRuntimesService({} as never);
+    await svc.syncAll([
+      {
+        id: "local-codex",
+        name: "Codex",
+        type: "codex",
+        connection: { mode: "local" },
+      },
+    ]);
+
+    expect(mockDao.delete).not.toHaveBeenCalled();
+  });
+
+  it("syncAll deletes stale local- runtimes while keeping remote ones", async () => {
+    mockDao.findMany
+      .mockResolvedValueOnce([
+        runtimeRecord("local-claude-code"),
+        runtimeRecord("local-codex"),
+        runtimeRecord("remote-team-shared"),
+      ])
+      .mockResolvedValueOnce([runtimeRecord("local-codex"), runtimeRecord("remote-team-shared")]);
+
+    const svc = createAgentRuntimesService({} as never);
+    await svc.syncAll([
+      {
+        id: "local-codex",
+        name: "Codex",
+        type: "codex",
+        connection: { mode: "local" },
+      },
+    ]);
+
+    expect(mockDao.delete).toHaveBeenCalledTimes(1);
+    expect(mockDao.delete).toHaveBeenCalledWith("local-claude-code");
+  });
+
+  it("syncAll with empty incoming deletes nothing (failed scan must not wipe the list)", async () => {
+    mockDao.findMany
+      .mockResolvedValueOnce([runtimeRecord("local-claude-code"), runtimeRecord("local-codex")])
+      .mockResolvedValueOnce([runtimeRecord("local-claude-code"), runtimeRecord("local-codex")]);
+
+    const svc = createAgentRuntimesService({} as never);
+    await svc.syncAll([]);
+
+    expect(mockDao.delete).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## 问题(COD-336)

`syncAll` 的 `toDelete` 未限定 `local-` 前缀:
1. daemon 每 15s 全量推送本地 runtime,手动添加的远程 runtime 被一并删除(数据丢失)
2. 某次扫描漏了一个(PATH 漂移/spawn 失败),该 runtime 立刻从 DB 消失
3. 空扫描结果直接清空列表

## 修复

`packages/services/src/agentRuntimesService/createAgentRuntimesService.ts`:
- `toDelete` 只作用于 `local-` 前缀记录,远程/手动添加的 runtime 永不被同步删除
- 本轮上报为空时不执行任何删除(扫描失败保护)

## 关于票的第三点(Web 端 runtimesPageSlice.ts)

该文件已不存在(Alan 风格 UI 重构中被移除),Web 端扫描走 `scanAndSync` → 同一个 service `syncAll`,本次修复已覆盖,无需另行处理。

## 测试

- 新增 3 条回归测试:远程 runtime 保留 / 过期 local- 记录仍被清理 / 空扫描不删
- `vitest run` 9/9 通过;tsc 无错误;oxlint 无新增警告

无视觉差异(纯后端逻辑)。