### PR TITLE
feat: 首页首条消息即跳转三栏工作区 (COD-345)

### DIFF
--- a/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationWorkspace.tsx
+++ b/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationWorkspace.tsx
@@ -24,6 +24,7 @@ import {
   type PipelineAgentSessionClientDetail,
 } from "@/lib/pipelineAgentSessionsClient";
 import { router } from "@/router";
+import { savePendingPipelinePrompt } from "@/lib/pendingPipelinePrompt";
 import {
   HOME_PIPELINE_AGENT_SESSION_KEY,
   usePipelineCreationSessionRecovery,
@@ -304,6 +305,16 @@ export const PipelineCreationWorkspace = ({
       if (runtimeConfigured === false) {
         setErrorMessage(t("pipelineAgentErrors.runtimeNotFound"));
       }
+
+      return;
+    }
+
+    // COD-345:首页首条消息不就地开聊,暂存 prompt 并跳转无 id 的 /canvas 三栏工作区,
+    // 对话由右侧 AgentPanel 接管(COD-346)。已有会话/附件时保持原流程,避免中断进行中的 session。
+    if (isHome && !sessionIdRef.current && messages.length === 0 && attachments.length === 0) {
+      savePendingPipelinePrompt(text);
+      setInputValue("");
+      void router.navigate({ to: "/canvas", search: { id: undefined } });
 
       return;
     }

--- a/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationWorkspace.unit.test.tsx
+++ b/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationWorkspace.unit.test.tsx
@@ -4,6 +4,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { render } from "@/test/test-wrapper";
 import { pipelineAgentSessionsClient } from "@/lib/pipelineAgentSessionsClient";
+import { router } from "@/router";
 import { PipelineCreationWorkspace } from "./PipelineCreationWorkspace";
 
 vi.mock("react-i18next", () => ({
@@ -38,6 +39,7 @@ const createClient = () => ({
 describe("PipelineCreationWorkspace", () => {
   beforeEach(() => {
     globalThis.localStorage.clear();
+    globalThis.sessionStorage.clear();
     vi.clearAllMocks();
   });
 
@@ -171,7 +173,7 @@ describe("PipelineCreationWorkspace", () => {
         active
         runtimeConfigured
         client={client as typeof pipelineAgentSessionsClient}
-        presentation="home"
+        presentation="dialog"
       />,
     );
     const composer = screen.getByRole("textbox", {
@@ -228,7 +230,7 @@ describe("PipelineCreationWorkspace", () => {
         runtimeConfigured
         client={client as typeof pipelineAgentSessionsClient}
         materializePipeline={materializePipeline}
-        presentation="home"
+        presentation="dialog"
         runtimeId="local-codex"
       />,
     );
@@ -333,5 +335,91 @@ describe("PipelineCreationWorkspace", () => {
     await user.click(screen.getByRole("button", { name: "newPipelineDialog.upload" }));
 
     expect(await screen.findByText("pipelineAgentErrors.network")).toBeInTheDocument();
+  });
+
+  it("stashes the first home message and jumps to the id-less canvas workspace", async () => {
+    const user = userEvent.setup();
+    const client = createClient();
+
+    render(
+      <PipelineCreationWorkspace
+        active
+        runtimeConfigured
+        client={client as typeof pipelineAgentSessionsClient}
+        presentation="home"
+      />,
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "newPipelineDialog.messagePlaceholder" }),
+      "Scout hackathons for me",
+    );
+    await user.click(screen.getByRole("button", { name: "newPipelineDialog.send" }));
+
+    expect(globalThis.sessionStorage.getItem("ordine.pendingPipelinePrompt")).toBe(
+      "Scout hackathons for me",
+    );
+    expect(router.navigate).toHaveBeenCalledWith({
+      to: "/canvas",
+      search: { id: undefined },
+    });
+    expect(client.createSession).not.toHaveBeenCalled();
+    expect(client.appendMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps the in-page flow when a home session already exists", async () => {
+    globalThis.localStorage.setItem("ordine.pipeline-agent.current-session-id", "session-live");
+    const user = userEvent.setup();
+    const client = createClient();
+    client.getSessionById.mockResolvedValue({
+      id: "session-live",
+      entrypoint: "new-pipeline-dialog",
+      mode: "generate",
+      status: "awaiting_user",
+      latestProposalId: null,
+      createdPipelineId: null,
+      messages: [
+        {
+          id: "message-1",
+          role: "user",
+          kind: "text",
+          content: "Build a pipeline",
+        },
+      ],
+      attachments: [],
+      proposals: [],
+    });
+    client.appendMessage.mockResolvedValue({
+      id: "message-2",
+      role: "user",
+      kind: "text",
+      content: "More details",
+    });
+    client.planSessionStream.mockImplementation(async (_sessionId, input) => {
+      input.onEvent({ type: "question", question: "What inputs?" });
+    });
+
+    render(
+      <PipelineCreationWorkspace
+        active
+        runtimeConfigured
+        client={client as typeof pipelineAgentSessionsClient}
+        presentation="home"
+      />,
+    );
+    await screen.findByText("Build a pipeline");
+    await user.type(
+      screen.getByRole("textbox", { name: "newPipelineDialog.messagePlaceholder" }),
+      "More details",
+    );
+    await user.click(screen.getByRole("button", { name: "newPipelineDialog.send" }));
+
+    expect(await screen.findByText("What inputs?")).toBeInTheDocument();
+    expect(client.appendMessage).toHaveBeenCalledWith(
+      "session-live",
+      expect.objectContaining({ content: "More details" }),
+      expect.anything(),
+    );
+    expect(router.navigate).not.toHaveBeenCalled();
+    expect(globalThis.sessionStorage.getItem("ordine.pendingPipelinePrompt")).toBeNull();
   });
 });

--- a/apps/app/src/integrations/trpc/services.ts
+++ b/apps/app/src/integrations/trpc/services.ts
@@ -30,6 +30,8 @@ export const agentsService = createAgentsService(db);
 export const agentRuntimesService = createAgentRuntimesService(db);
 export const capabilityHarvestService = createCapabilityHarvestService(db, {
   encryptionSecret: BETTER_AUTH_SECRET,
+  // vite SSR 的 module runner 里 process.env 不是普通对象,zod record 校验会拒收;摊开成纯对象
+  env: { ...process.env },
 });
 export const connectorsService = createConnectorsService(db, capabilityExecutionOptions);
 export const conversationMessagesService = createConversationMessagesService(db);

--- a/apps/app/src/lib/pendingPipelinePrompt.ts
+++ b/apps/app/src/lib/pendingPipelinePrompt.ts
@@ -1,0 +1,25 @@
+const PENDING_PIPELINE_PROMPT_KEY = "ordine.pendingPipelinePrompt";
+
+/**
+ * COD-345:首页首条消息跳转无 id 的 /canvas 前,把 prompt 暂存到 sessionStorage;
+ * COD-346 的 AgentPanel 在 CanvasPage 挂载后取出并自动首发。
+ * 一次性语义:take 即删。key 与 packages/views 侧消费方保持同名,勿单边改。
+ */
+export const savePendingPipelinePrompt = (prompt: string) => {
+  if (globalThis.sessionStorage === undefined) {
+    return;
+  }
+
+  globalThis.sessionStorage.setItem(PENDING_PIPELINE_PROMPT_KEY, prompt);
+};
+
+export const takePendingPipelinePrompt = (): string | null => {
+  if (globalThis.sessionStorage === undefined) {
+    return null;
+  }
+
+  const prompt = globalThis.sessionStorage.getItem(PENDING_PIPELINE_PROMPT_KEY);
+  globalThis.sessionStorage.removeItem(PENDING_PIPELINE_PROMPT_KEY);
+
+  return prompt;
+};

--- a/apps/app/src/lib/pendingPipelinePrompt.unit.test.ts
+++ b/apps/app/src/lib/pendingPipelinePrompt.unit.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { savePendingPipelinePrompt, takePendingPipelinePrompt } from "./pendingPipelinePrompt";
+
+describe("pendingPipelinePrompt", () => {
+  beforeEach(() => {
+    globalThis.sessionStorage.clear();
+  });
+
+  it("takes a saved prompt exactly once", () => {
+    savePendingPipelinePrompt("build a hackathon scout");
+
+    expect(takePendingPipelinePrompt()).toBe("build a hackathon scout");
+    expect(takePendingPipelinePrompt()).toBeNull();
+  });
+
+  it("returns null when nothing was saved", () => {
+    expect(takePendingPipelinePrompt()).toBeNull();
+  });
+
+  it("overwrites a previous pending prompt with the latest one", () => {
+    savePendingPipelinePrompt("first");
+    savePendingPipelinePrompt("second");
+
+    expect(takePendingPipelinePrompt()).toBe("second");
+    expect(takePendingPipelinePrompt()).toBeNull();
+  });
+});


### PR DESCRIPTION
## 背景

Linear: COD-345(阻塞 COD-346)

首页 PipelineCreationWorkspace 原本是居中聊天,方案同意后才建 pipeline 才跳 /canvas。目标设计:首条消息一发出立即进入「左侧 sidebar + 中间空 canvas + 右侧 AgentPanel」三栏工作区,对话在右侧继续(COD-346 接管)。

## 改动

- `apps/app/src/lib/pendingPipelinePrompt.ts`(新增):sessionStorage 一次性 token 存取,供 COD-346 的 AgentPanel 消费首发
- `PipelineCreationWorkspace.handleSend`:home 首条发送(无会话/无附件/无消息)时暂存 prompt + 跳转无 id /canvas;已有会话时保持原流程不中断
- `services.ts`(独立 commit):修复 vite SSR 下 process.env 非纯对象导致 capabilityHarvestService zod 校验 500、首页发送按钮被禁用的环境 bug
- 单测:lib 3 条 + workspace 新增 2 条(首条跳转/已有会话不跳),2 条旧用例从 home 改为 dialog presentation(旧流程在 dialog 保留)

## 验证

- bun run compile / lint / format:check / test(137 文件 639 用例)全绿
- 真实浏览器验证:首页输入首条消息发送 → URL 变为 /canvas(无 id),sessionStorage 读出暂存 prompt,页面呈现三栏(左侧组件栏 + 中间空画布 + 右侧 AI 助手默认展开),控制台零报错
- 「新建流水线」按钮在 develop 上是重置首页 composer(newPipelineWorkspaceVersion),不走 dialog,行为未变

## 视觉说明

首页视觉未改,仅首条发送的行为路径变化;跳转后的 /canvas 三栏为既有页面。浏览器验证截图(发送后跳转的三栏工作区:空画布 + 右侧 AgentPanel)见本地 pr-assets/cod345-after-send.png(该目录在 gitignore 内,需要的话我可以传到 PR 评论)。