### PR TITLE
style: 修复 develop 格式检查(#170 带入)

### DIFF
--- a/packages/db-schema/src/tables/agents_table.ts
+++ b/packages/db-schema/src/tables/agents_table.ts
@@ -15,18 +15,9 @@ export const agentsTable = pgTable(
     defaultRuntime: text("default_runtime").$type<AgentRuntime | null>(),
     defaultModel: text("default_model"),
     systemPrompt: text("system_prompt"),
-    capabilities: jsonb("capabilities")
-      .$type<AgentCapability[]>()
-      .notNull()
-      .default([]),
-    allowedTools: jsonb("allowed_tools")
-      .$type<string[]>()
-      .notNull()
-      .default([]),
-    allowedSkillIds: jsonb("allowed_skill_ids")
-      .$type<string[]>()
-      .notNull()
-      .default([]),
+    capabilities: jsonb("capabilities").$type<AgentCapability[]>().notNull().default([]),
+    allowedTools: jsonb("allowed_tools").$type<string[]>().notNull().default([]),
+    allowedSkillIds: jsonb("allowed_skill_ids").$type<string[]>().notNull().default([]),
     tags: jsonb("tags").$type<string[]>().notNull().default([]),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/packages/views/src/pages/RuntimesPage/_store/runtimesPageSlice.ts
+++ b/packages/views/src/pages/RuntimesPage/_store/runtimesPageSlice.ts
@@ -36,8 +36,7 @@ const hasDetectionChanged = (
 
   const modelsChanged =
     detected.connection.models !== undefined &&
-    JSON.stringify(existing.connection.models ?? []) !==
-      JSON.stringify(detected.connection.models);
+    JSON.stringify(existing.connection.models ?? []) !== JSON.stringify(detected.connection.models);
 
   return (
     existing.type !== detected.type ||


### PR DESCRIPTION
#170 合并时 CI 格式检查未过(此前 develop 一直红,没暴露)。对两个文件跑 oxfmt:

- packages/db-schema/src/tables/agents_table.ts
- packages/views/src/pages/RuntimesPage/_store/runtimesPageSlice.ts

纯格式化,无逻辑改动。