### PR TITLE
feat: 添加统一能力目录与保存校验 (COD-340)

### DIFF
--- a/apps/app/drizzle/0032_capability_risk_overrides.sql
+++ b/apps/app/drizzle/0032_capability_risk_overrides.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "capability_risk_overrides" (
+	"capability_id" text PRIMARY KEY NOT NULL,
+	"risk_tier" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+UPDATE "skills"
+SET "origin" = 'builtin'
+WHERE "id" IN (
+	'skill-001', 'skill-002', 'skill-003', 'skill-004',
+	'skill-005', 'skill-006', 'skill-007', 'skill-008',
+	'skill-009', 'skill-010', 'skill-011', 'skill-012'
+)
+AND "origin" = 'manual'
+AND "sources" = '[]'::jsonb;

--- a/apps/app/drizzle/meta/_journal.json
+++ b/apps/app/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1786607704000,
       "tag": "0031_add_agent_default_model",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1786613376495,
+      "tag": "0032_capability_risk_overrides",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/app/src/integrations/trpc/router.ts
+++ b/apps/app/src/integrations/trpc/router.ts
@@ -2,6 +2,7 @@ import { router } from "./init";
 import { agentsRouter } from "./routers/agents";
 import { agentRuntimesRouter } from "./routers/agentRuntimes";
 import { connectorsRouter } from "./routers/connectors";
+import { capabilityCatalogRouter } from "./routers/capabilityCatalog";
 import { conversationsRouter } from "./routers/conversations";
 import { distillationsRouter } from "./routers/distillations";
 import { filesystemRouter } from "./routers/filesystem";
@@ -21,6 +22,7 @@ import { usageRouter } from "./routers/usage";
 export const appRouter = router({
   agents: agentsRouter,
   agentRuntimes: agentRuntimesRouter,
+  capabilityCatalog: capabilityCatalogRouter,
   connectors: connectorsRouter,
   conversations: conversationsRouter,
   filesystem: filesystemRouter,

--- a/apps/app/src/integrations/trpc/routers/capabilityCatalog.ts
+++ b/apps/app/src/integrations/trpc/routers/capabilityCatalog.ts
@@ -1,0 +1,19 @@
+import {
+  GetCapabilityCatalogInputSchema,
+  SetCapabilityRiskTierOverrideInputSchema,
+} from "@repo/schemas";
+import { authedProcedure, publicProcedure, router } from "../init";
+import { capabilityCatalogService } from "../services";
+import { unwrapResult } from "./result";
+
+export const capabilityCatalogRouter = router({
+  getMany: publicProcedure
+    .input(GetCapabilityCatalogInputSchema.optional())
+    .query(async ({ input }) => unwrapResult(await capabilityCatalogService.getMany(input ?? {}))),
+
+  setRiskTierOverride: authedProcedure
+    .input(SetCapabilityRiskTierOverrideInputSchema)
+    .mutation(async ({ input }) =>
+      unwrapResult(await capabilityCatalogService.setRiskTierOverride(input)),
+    ),
+});

--- a/apps/app/src/integrations/trpc/routers/operations.ts
+++ b/apps/app/src/integrations/trpc/routers/operations.ts
@@ -2,6 +2,7 @@ import { z } from "zod/v4";
 import { publicProcedure, router } from "../init";
 import { operationsService, operationRunnerService } from "../services";
 import { AgentRuntimeSchema, ObjectNodeTypeSchema, OperationConfigSchema } from "@repo/schemas";
+import { unwrapResult } from "./result";
 
 export const operationsRouter = router({
   getMany: publicProcedure.query(() => operationsService.getAll()),
@@ -23,7 +24,7 @@ export const operationsRouter = router({
         sourceSkillId: z.string().optional(),
       }),
     )
-    .mutation(({ input }) => operationsService.create(input)),
+    .mutation(async ({ input }) => unwrapResult(await operationsService.create(input))),
 
   update: publicProcedure
     .input(
@@ -35,10 +36,10 @@ export const operationsRouter = router({
         acceptedObjectTypes: z.array(ObjectNodeTypeSchema).optional(),
       }),
     )
-    .mutation(({ input }) => {
+    .mutation(async ({ input }) => {
       const { id, ...rest } = input;
 
-      return operationsService.update(id, rest);
+      return unwrapResult(await operationsService.update(id, rest));
     }),
 
   delete: publicProcedure

--- a/apps/app/src/integrations/trpc/routers/operations.ts
+++ b/apps/app/src/integrations/trpc/routers/operations.ts
@@ -1,7 +1,11 @@
 import { z } from "zod/v4";
 import { publicProcedure, router } from "../init";
 import { operationsService, operationRunnerService } from "../services";
-import { AgentRuntimeSchema, ObjectNodeTypeSchema, OperationConfigSchema } from "@repo/schemas";
+import {
+  AgentRuntimeSchema,
+  ObjectNodeTypeSchema,
+  StrictOperationConfigSchema,
+} from "@repo/schemas";
 import { unwrapResult } from "./result";
 
 export const operationsRouter = router({
@@ -17,7 +21,7 @@ export const operationsRouter = router({
         id: z.string(),
         name: z.string(),
         description: z.string().nullable().default(null),
-        config: OperationConfigSchema.optional(),
+        config: StrictOperationConfigSchema.optional(),
         acceptedObjectTypes: z
           .array(ObjectNodeTypeSchema)
           .default(["file", "folder", "github-project"]),
@@ -32,8 +36,9 @@ export const operationsRouter = router({
         id: z.string(),
         name: z.string().optional(),
         description: z.string().nullable().optional(),
-        config: OperationConfigSchema.optional(),
+        config: StrictOperationConfigSchema.optional(),
         acceptedObjectTypes: z.array(ObjectNodeTypeSchema).optional(),
+        sourceSkillId: z.string().nullable().optional(),
       }),
     )
     .mutation(async ({ input }) => {

--- a/apps/app/src/integrations/trpc/routers/pipelines.ts
+++ b/apps/app/src/integrations/trpc/routers/pipelines.ts
@@ -23,36 +23,27 @@ export const pipelinesRouter = router({
     .input(
       z.object({
         pipeline: PipelineSchema.omit({ createdAt: true, updatedAt: true }),
-        pendingOperations: z
-          .array(
-            z.object({
-              id: z.string(),
-              name: z.string(),
-              description: z.string(),
-              config: z.record(z.string(), z.unknown()),
-              acceptedObjectTypes: z.array(z.string()),
-              sourceSkillId: z.string().optional(),
-            }),
-          )
-          .optional(),
+        pendingOperations: z.array(ProposePendingOperationSchema).optional(),
       }),
     )
     .mutation(async ({ input }) => {
+      const pipeline = {
+        ...input.pipeline,
+        nodes: input.pipeline.nodes as never,
+        edges: input.pipeline.edges as never,
+      };
       if (input.pendingOperations && input.pendingOperations.length > 0) {
-        unwrapResult(
-          await pipelinesService.createPendingOperations(
+        return unwrapResult(
+          await pipelinesService.createWithPendingOperations(
+            pipeline,
             input.pendingOperations as Parameters<
-              typeof pipelinesService.createPendingOperations
-            >[0],
+              typeof pipelinesService.createWithPendingOperations
+            >[1],
           ),
         );
       }
 
-      return pipelinesService.create({
-        ...input.pipeline,
-        nodes: input.pipeline.nodes as never,
-        edges: input.pipeline.edges as never,
-      });
+      return pipelinesService.create(pipeline);
     }),
 
   update: publicProcedure

--- a/apps/app/src/integrations/trpc/routers/pipelines.ts
+++ b/apps/app/src/integrations/trpc/routers/pipelines.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import { authedProcedure, publicProcedure, router } from "../init";
 import { pipelinesService, pipelineRunnerService } from "../services";
 import { getProposeProgress, setProposeProgress } from "@repo/services";
+import { unwrapResult } from "./result";
 import {
   AgentContextPayloadSchema,
   PipelineGraphSnapshotSchema,
@@ -38,8 +39,12 @@ export const pipelinesRouter = router({
     )
     .mutation(async ({ input }) => {
       if (input.pendingOperations && input.pendingOperations.length > 0) {
-        await pipelinesService.createPendingOperations(
-          input.pendingOperations as Parameters<typeof pipelinesService.createPendingOperations>[0],
+        unwrapResult(
+          await pipelinesService.createPendingOperations(
+            input.pendingOperations as Parameters<
+              typeof pipelinesService.createPendingOperations
+            >[0],
+          ),
         );
       }
 
@@ -144,8 +149,10 @@ export const pipelinesRouter = router({
   createPendingOperations: publicProcedure
     .input(z.object({ operations: z.array(ProposePendingOperationSchema) }))
     .mutation(async ({ input }) => {
-      await pipelinesService.createPendingOperations(
-        input.operations as Parameters<typeof pipelinesService.createPendingOperations>[0],
+      unwrapResult(
+        await pipelinesService.createPendingOperations(
+          input.operations as Parameters<typeof pipelinesService.createPendingOperations>[0],
+        ),
       );
 
       return { created: input.operations.length };

--- a/apps/app/src/integrations/trpc/routers/result.ts
+++ b/apps/app/src/integrations/trpc/routers/result.ts
@@ -2,6 +2,9 @@ import { TRPCError } from "@trpc/server";
 import type { Result } from "neverthrow";
 
 const codeForError = (error: unknown) => {
+  if (error instanceof Error && error.name === "CapabilityCatalogValidationError") {
+    return "BAD_REQUEST";
+  }
   if (error instanceof Error && error.name.endsWith("NotFoundError")) return "NOT_FOUND";
   if (error instanceof Error && error.name === "ConflictError") return "CONFLICT";
   if (error instanceof Error && error.name === "InvalidJobStatusError") return "CONFLICT";

--- a/apps/app/src/integrations/trpc/routers/result.ts
+++ b/apps/app/src/integrations/trpc/routers/result.ts
@@ -2,7 +2,11 @@ import { TRPCError } from "@trpc/server";
 import type { Result } from "neverthrow";
 
 const codeForError = (error: unknown) => {
-  if (error instanceof Error && error.name === "CapabilityCatalogValidationError") {
+  if (
+    error instanceof Error &&
+    (error.name === "CapabilityCatalogValidationError" ||
+      error.name === "OperationConfigValidationError")
+  ) {
     return "BAD_REQUEST";
   }
   if (error instanceof Error && error.name.endsWith("NotFoundError")) return "NOT_FOUND";

--- a/apps/app/src/integrations/trpc/services.ts
+++ b/apps/app/src/integrations/trpc/services.ts
@@ -3,6 +3,7 @@ import {
   createAgentsService,
   createAgentRuntimesService,
   createCapabilityHarvestService,
+  createCapabilityCatalogService,
   createConnectorsService,
   createConversationMessagesService,
   createDistillationsService,
@@ -31,6 +32,7 @@ export const agentRuntimesService = createAgentRuntimesService(db);
 export const capabilityHarvestService = createCapabilityHarvestService(db, {
   encryptionSecret: BETTER_AUTH_SECRET,
 });
+export const capabilityCatalogService = createCapabilityCatalogService(db);
 export const connectorsService = createConnectorsService(db, capabilityExecutionOptions);
 export const conversationMessagesService = createConversationMessagesService(db);
 export const distillationsService = createDistillationsService(db);

--- a/apps/create/migrations/0005_capability_risk_overrides.sql
+++ b/apps/create/migrations/0005_capability_risk_overrides.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "capability_risk_overrides" (
+	"capability_id" text PRIMARY KEY NOT NULL,
+	"risk_tier" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+UPDATE "skills"
+SET "origin" = 'builtin'
+WHERE "id" IN (
+	'skill-001', 'skill-002', 'skill-003', 'skill-004',
+	'skill-005', 'skill-006', 'skill-007', 'skill-008',
+	'skill-009', 'skill-010', 'skill-011', 'skill-012'
+)
+AND "origin" = 'manual'
+AND "sources" = '[]'::jsonb;

--- a/apps/create/tests/migrations.test.ts
+++ b/apps/create/tests/migrations.test.ts
@@ -59,7 +59,7 @@ describe("runMigrations", () => {
     const result = await runMigrations(db, migrationsDir);
 
     expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toBe(4);
+    expect(result._unsafeUnwrap()).toBe(5);
     const migrations = await db.query<{ name: string }>(
       `SELECT name FROM _ordine_migrations ORDER BY name`,
     );
@@ -69,6 +69,7 @@ describe("runMigrations", () => {
       "0002_routines_claude_spec.sql",
       "0003_harvest_capabilities.sql",
       "0004_add_agent_default_model.sql",
+      "0005_capability_risk_overrides.sql",
     ]);
     const projects = await db.query<{ table_name: string }>(
       `SELECT table_name FROM information_schema.tables WHERE table_name = 'projects'`,
@@ -85,7 +86,7 @@ describe("runMigrations", () => {
     const result = await runMigrations(db, migrationsDir);
 
     expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toBe(4);
+    expect(result._unsafeUnwrap()).toBe(5);
 
     const migrations = await db.query<{ name: string }>(
       `SELECT name FROM _ordine_migrations ORDER BY name`,
@@ -96,6 +97,7 @@ describe("runMigrations", () => {
       "0002_routines_claude_spec.sql",
       "0003_harvest_capabilities.sql",
       "0004_add_agent_default_model.sql",
+      "0005_capability_risk_overrides.sql",
     ]);
 
     const columns = await db.query<{ column_name: string; table_name: string }>(

--- a/apps/server/src/routes/operations.ts
+++ b/apps/server/src/routes/operations.ts
@@ -1,14 +1,13 @@
 import { Hono } from "hono";
 import { ResultAsync } from "neverthrow";
-import type { AgentRuntime, CapabilityCatalogValidationIssue } from "@repo/schemas";
+import type { AgentRuntime } from "@repo/schemas";
 import { operationsService, operationRunnerService } from "../services.js";
 
 export const operationsRoutes = new Hono();
 
-const isCapabilityCatalogValidationError = (
-  error: Error,
-): error is Error & { issues: CapabilityCatalogValidationIssue[] } =>
-  error.name === "CapabilityCatalogValidationError";
+const isOperationValidationError = (error: Error): error is Error & { issues: unknown[] } =>
+  error.name === "CapabilityCatalogValidationError" ||
+  error.name === "OperationConfigValidationError";
 
 operationsRoutes.get("/", async (c) => {
   const operations = await operationsService.getAll();
@@ -20,7 +19,7 @@ operationsRoutes.post("/", async (c) => {
   const body = await c.req.json();
   const result = await operationsService.create(body);
   if (result.isErr()) {
-    return isCapabilityCatalogValidationError(result.error)
+    return isOperationValidationError(result.error)
       ? c.json({ error: result.error.message, issues: result.error.issues }, 422)
       : c.json({ error: "Failed to create operation" }, 500);
   }
@@ -35,7 +34,7 @@ operationsRoutes.put("/", async (c) => {
     const { id: _, ...patch } = body;
     const result = await operationsService.update(body.id, patch);
     if (result.isErr()) {
-      return isCapabilityCatalogValidationError(result.error)
+      return isOperationValidationError(result.error)
         ? c.json({ error: result.error.message, issues: result.error.issues }, 422)
         : c.json({ error: "Failed to update operation" }, 500);
     }
@@ -44,7 +43,7 @@ operationsRoutes.put("/", async (c) => {
   }
   const result = await operationsService.create(body);
   if (result.isErr()) {
-    return isCapabilityCatalogValidationError(result.error)
+    return isOperationValidationError(result.error)
       ? c.json({ error: result.error.message, issues: result.error.issues }, 422)
       : c.json({ error: "Failed to create operation" }, 500);
   }
@@ -65,7 +64,7 @@ operationsRoutes.patch("/:id", async (c) => {
   const body = await c.req.json();
   const result = await operationsService.update(id, body);
   if (result.isErr()) {
-    return isCapabilityCatalogValidationError(result.error)
+    return isOperationValidationError(result.error)
       ? c.json({ error: result.error.message, issues: result.error.issues }, 422)
       : c.json({ error: "Failed to update operation" }, 500);
   }

--- a/apps/server/src/routes/operations.ts
+++ b/apps/server/src/routes/operations.ts
@@ -1,9 +1,14 @@
 import { Hono } from "hono";
 import { ResultAsync } from "neverthrow";
-import type { AgentRuntime } from "@repo/schemas";
+import type { AgentRuntime, CapabilityCatalogValidationIssue } from "@repo/schemas";
 import { operationsService, operationRunnerService } from "../services.js";
 
 export const operationsRoutes = new Hono();
+
+const isCapabilityCatalogValidationError = (
+  error: Error,
+): error is Error & { issues: CapabilityCatalogValidationIssue[] } =>
+  error.name === "CapabilityCatalogValidationError";
 
 operationsRoutes.get("/", async (c) => {
   const operations = await operationsService.getAll();
@@ -13,9 +18,14 @@ operationsRoutes.get("/", async (c) => {
 
 operationsRoutes.post("/", async (c) => {
   const body = await c.req.json();
-  const operation = await operationsService.create(body);
+  const result = await operationsService.create(body);
+  if (result.isErr()) {
+    return isCapabilityCatalogValidationError(result.error)
+      ? c.json({ error: result.error.message, issues: result.error.issues }, 422)
+      : c.json({ error: "Failed to create operation" }, 500);
+  }
 
-  return c.json(operation, 201);
+  return c.json(result.value, 201);
 });
 
 operationsRoutes.put("/", async (c) => {
@@ -23,13 +33,23 @@ operationsRoutes.put("/", async (c) => {
   const existing = await operationsService.getById(body.id);
   if (existing) {
     const { id: _, ...patch } = body;
-    const updated = await operationsService.update(body.id, patch);
+    const result = await operationsService.update(body.id, patch);
+    if (result.isErr()) {
+      return isCapabilityCatalogValidationError(result.error)
+        ? c.json({ error: result.error.message, issues: result.error.issues }, 422)
+        : c.json({ error: "Failed to update operation" }, 500);
+    }
 
-    return c.json(updated);
+    return c.json(result.value);
   }
-  const operation = await operationsService.create(body);
+  const result = await operationsService.create(body);
+  if (result.isErr()) {
+    return isCapabilityCatalogValidationError(result.error)
+      ? c.json({ error: result.error.message, issues: result.error.issues }, 422)
+      : c.json({ error: "Failed to create operation" }, 500);
+  }
 
-  return c.json(operation, 201);
+  return c.json(result.value, 201);
 });
 
 operationsRoutes.get("/:id", async (c) => {
@@ -43,9 +63,14 @@ operationsRoutes.get("/:id", async (c) => {
 operationsRoutes.patch("/:id", async (c) => {
   const id = c.req.param("id");
   const body = await c.req.json();
-  const operation = await operationsService.update(id, body);
+  const result = await operationsService.update(id, body);
+  if (result.isErr()) {
+    return isCapabilityCatalogValidationError(result.error)
+      ? c.json({ error: result.error.message, issues: result.error.issues }, 422)
+      : c.json({ error: "Failed to update operation" }, 500);
+  }
 
-  return c.json(operation);
+  return c.json(result.value);
 });
 
 operationsRoutes.delete("/:id", async (c) => {

--- a/apps/server/src/routes/pipelines.ts
+++ b/apps/server/src/routes/pipelines.ts
@@ -1,10 +1,19 @@
 import { Hono } from "hono";
 import { ResultAsync } from "neverthrow";
 import { z } from "zod/v4";
-import { PipelineGraphSnapshotSchema, ProposeAttachmentSchema } from "@repo/schemas";
+import {
+  PipelineGraphSnapshotSchema,
+  ProposeAttachmentSchema,
+  type CapabilityCatalogValidationIssue,
+} from "@repo/schemas";
 import { pipelinesService, pipelineRunnerService } from "../services.js";
 
 export const pipelinesRoutes = new Hono();
+
+const isCapabilityCatalogValidationError = (
+  error: Error,
+): error is Error & { issues: CapabilityCatalogValidationIssue[] } =>
+  error.name === "CapabilityCatalogValidationError";
 
 const proposeActionsBodySchema = z.object({
   attachments: z.array(ProposeAttachmentSchema).optional(),
@@ -27,7 +36,12 @@ pipelinesRoutes.post("/", async (c) => {
   const body = await c.req.json();
   const { pendingOperations, ...pipelineData } = body;
   if (Array.isArray(pendingOperations) && pendingOperations.length > 0) {
-    await pipelinesService.createPendingOperations(pendingOperations);
+    const result = await pipelinesService.createPendingOperations(pendingOperations);
+    if (result.isErr()) {
+      return isCapabilityCatalogValidationError(result.error)
+        ? c.json({ error: result.error.message, issues: result.error.issues }, 422)
+        : c.json({ error: "Failed to create pending operations" }, 500);
+    }
   }
   const pipeline = await pipelinesService.create(pipelineData);
 

--- a/apps/server/src/routes/pipelines.ts
+++ b/apps/server/src/routes/pipelines.ts
@@ -4,16 +4,15 @@ import { z } from "zod/v4";
 import {
   PipelineGraphSnapshotSchema,
   ProposeAttachmentSchema,
-  type CapabilityCatalogValidationIssue,
+  ProposePendingOperationSchema,
 } from "@repo/schemas";
 import { pipelinesService, pipelineRunnerService } from "../services.js";
 
 export const pipelinesRoutes = new Hono();
 
-const isCapabilityCatalogValidationError = (
-  error: Error,
-): error is Error & { issues: CapabilityCatalogValidationIssue[] } =>
-  error.name === "CapabilityCatalogValidationError";
+const isOperationValidationError = (error: Error): error is Error & { issues: unknown[] } =>
+  error.name === "CapabilityCatalogValidationError" ||
+  error.name === "OperationConfigValidationError";
 
 const proposeActionsBodySchema = z.object({
   attachments: z.array(ProposeAttachmentSchema).optional(),
@@ -35,13 +34,31 @@ pipelinesRoutes.get("/", async (c) => {
 pipelinesRoutes.post("/", async (c) => {
   const body = await c.req.json();
   const { pendingOperations, ...pipelineData } = body;
-  if (Array.isArray(pendingOperations) && pendingOperations.length > 0) {
-    const result = await pipelinesService.createPendingOperations(pendingOperations);
+  const parsedPendingOperations = z
+    .array(ProposePendingOperationSchema)
+    .optional()
+    .safeParse(pendingOperations);
+  if (!parsedPendingOperations.success) {
+    return c.json(
+      {
+        error: "Invalid pending operations",
+        issues: parsedPendingOperations.error.issues,
+      },
+      422,
+    );
+  }
+  if (parsedPendingOperations.data && parsedPendingOperations.data.length > 0) {
+    const result = await pipelinesService.createWithPendingOperations(
+      pipelineData,
+      parsedPendingOperations.data,
+    );
     if (result.isErr()) {
-      return isCapabilityCatalogValidationError(result.error)
+      return isOperationValidationError(result.error)
         ? c.json({ error: result.error.message, issues: result.error.issues }, 422)
-        : c.json({ error: "Failed to create pending operations" }, 500);
+        : c.json({ error: "Failed to create pipeline" }, 500);
     }
+
+    return c.json(result.value, 201);
   }
   const pipeline = await pipelinesService.create(pipelineData);
 

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -250,7 +250,7 @@ describe("Operations API", () => {
   });
 
   it("POST /api/operations creates operation", async () => {
-    mockOperationsService.create.mockResolvedValueOnce(mockOp as never);
+    mockOperationsService.create.mockResolvedValueOnce(ok(mockOp) as never);
     const res = await app.request("/api/operations", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -261,7 +261,7 @@ describe("Operations API", () => {
 
   it("PUT /api/operations upserts - creates when new", async () => {
     mockOperationsService.getById.mockResolvedValueOnce(null as never);
-    mockOperationsService.create.mockResolvedValueOnce(mockOp as never);
+    mockOperationsService.create.mockResolvedValueOnce(ok(mockOp) as never);
     const res = await app.request("/api/operations", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -284,7 +284,7 @@ describe("Operations API", () => {
   });
 
   it("PATCH /api/operations/:id updates operation", async () => {
-    mockOperationsService.update.mockResolvedValueOnce({ ...mockOp, name: "Updated" } as never);
+    mockOperationsService.update.mockResolvedValueOnce(ok({ ...mockOp, name: "Updated" }) as never);
     const res = await app.request("/api/operations/op-1", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -6,6 +6,7 @@ vi.mock("../src/services.js", () => ({
     getAll: vi.fn(),
     getById: vi.fn(),
     create: vi.fn(),
+    createWithPendingOperations: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
   },
@@ -103,6 +104,58 @@ describe("Pipelines API", () => {
     });
     expect(res.status).toBe(201);
     expect(mockPipelinesService.create).toHaveBeenCalledOnce();
+  });
+
+  it("POST /api/pipelines creates pending operations and pipeline atomically", async () => {
+    mockPipelinesService.createWithPendingOperations.mockResolvedValueOnce(
+      ok(mockPipeline) as never,
+    );
+    const res = await app.request("/api/pipelines", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Test",
+        nodes: [],
+        edges: [],
+        pendingOperations: [
+          {
+            id: "op-1",
+            name: "Read",
+            description: "Read input",
+            config: { executor: { type: "agent" } },
+            acceptedObjectTypes: ["file"],
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(mockPipelinesService.createWithPendingOperations).toHaveBeenCalledOnce();
+    expect(mockPipelinesService.create).not.toHaveBeenCalled();
+  });
+
+  it("POST /api/pipelines rejects malformed pending operation configs", async () => {
+    const res = await app.request("/api/pipelines", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Test",
+        nodes: [],
+        edges: [],
+        pendingOperations: [
+          {
+            id: "op-1",
+            name: "Broken",
+            description: "Broken config",
+            config: { executor: { type: "agent", allowedTools: [42] } },
+            acceptedObjectTypes: ["file"],
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(422);
+    expect(mockPipelinesService.createWithPendingOperations).not.toHaveBeenCalled();
   });
 
   it("GET /api/pipelines/:id returns pipeline", async () => {

--- a/packages/db-schema/src/migrations/cod339_migration.unit.test.ts
+++ b/packages/db-schema/src/migrations/cod339_migration.unit.test.ts
@@ -35,10 +35,14 @@ describe("COD-339 migration", () => {
       entries: Array<{ idx: number; tag: string }>;
     };
 
-    expect(journal.entries.at(-1)).toMatchObject({
-      idx: 30,
-      tag: "0030_harvest_capabilities",
-    });
+    expect(journal.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          idx: 30,
+          tag: "0030_harvest_capabilities",
+        }),
+      ]),
+    );
   });
 
   it("adds provenance and encrypted credential columns plus the signature index", async () => {

--- a/packages/db-schema/src/tables/capability_risk_overrides_table.ts
+++ b/packages/db-schema/src/tables/capability_risk_overrides_table.ts
@@ -1,0 +1,11 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import type { CapabilityRiskTier } from "@repo/schemas";
+
+export const capabilityRiskOverridesTable = pgTable("capability_risk_overrides", {
+  capabilityId: text("capability_id").primaryKey(),
+  riskTier: text("risk_tier").$type<CapabilityRiskTier>().notNull(),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+export type CapabilityRiskOverrideRecord = typeof capabilityRiskOverridesTable.$inferSelect;

--- a/packages/db-schema/src/tables/index.ts
+++ b/packages/db-schema/src/tables/index.ts
@@ -3,6 +3,7 @@ export * from "./agents_table";
 export * from "./agent_raw_exports_table";
 export * from "./agent_runtimes_table";
 export * from "./agent_spans_table";
+export * from "./capability_risk_overrides_table";
 export * from "./connectors_table";
 export * from "./conversation_messages_table";
 export * from "./distillation_runs_table";

--- a/packages/models/src/daos/capabilityRiskOverridesDao/capabilityRiskOverridesDao.ts
+++ b/packages/models/src/daos/capabilityRiskOverridesDao/capabilityRiskOverridesDao.ts
@@ -1,0 +1,38 @@
+import { desc, eq } from "drizzle-orm";
+import { capabilityRiskOverridesTable } from "@repo/db-schema";
+import type { CapabilityRiskTier } from "@repo/schemas";
+import type { DbExecutor } from "../../types";
+
+export class CapabilityRiskOverridesDao {
+  constructor(readonly executor: DbExecutor) {}
+
+  async findMany() {
+    return this.executor
+      .select()
+      .from(capabilityRiskOverridesTable)
+      .orderBy(desc(capabilityRiskOverridesTable.updatedAt));
+  }
+
+  async upsert(capabilityId: string, riskTier: CapabilityRiskTier) {
+    const now = new Date();
+    const [record] = await this.executor
+      .insert(capabilityRiskOverridesTable)
+      .values({ capabilityId, riskTier, createdAt: now, updatedAt: now })
+      .onConflictDoUpdate({
+        target: capabilityRiskOverridesTable.capabilityId,
+        set: { riskTier, updatedAt: now },
+      })
+      .returning();
+
+    return record!;
+  }
+
+  async delete(capabilityId: string) {
+    await this.executor
+      .delete(capabilityRiskOverridesTable)
+      .where(eq(capabilityRiskOverridesTable.capabilityId, capabilityId));
+  }
+}
+
+export const createCapabilityRiskOverridesDao = (executor: DbExecutor) =>
+  new CapabilityRiskOverridesDao(executor);

--- a/packages/models/src/daos/capabilityRiskOverridesDao/index.ts
+++ b/packages/models/src/daos/capabilityRiskOverridesDao/index.ts
@@ -1,0 +1,1 @@
+export * from "./capabilityRiskOverridesDao";

--- a/packages/models/src/daos/index.ts
+++ b/packages/models/src/daos/index.ts
@@ -2,6 +2,7 @@ export * from "./agentsDao";
 export * from "./agentRawExportsDao";
 export * from "./agentRuntimesDao";
 export * from "./agentSpansDao";
+export * from "./capabilityRiskOverridesDao";
 export * from "./connectorsDao";
 export * from "./conversationMessagesDao";
 export * from "./distillationRunsDao";

--- a/packages/models/src/daos/skillsDao/skillsDao.ts
+++ b/packages/models/src/daos/skillsDao/skillsDao.ts
@@ -171,6 +171,7 @@ export class SkillsDao {
     const now = new Date();
     const rows = seedData.map((s) => ({
       ...s,
+      origin: "builtin" as const,
       createdAt: now,
       updatedAt: now,
     }));

--- a/packages/models/src/daos/skillsDao/skillsDao.unit.test.ts
+++ b/packages/models/src/daos/skillsDao/skillsDao.unit.test.ts
@@ -130,6 +130,7 @@ describe("skillsDao", () => {
         expect.objectContaining({
           name: "error-handling-best-practice",
           description: expect.stringContaining("neverthrow"),
+          origin: "builtin",
           tags: expect.arrayContaining(["Neverthrow"]),
         }),
       ]),

--- a/packages/schemas/src/capability/CapabilityCatalogSchema.ts
+++ b/packages/schemas/src/capability/CapabilityCatalogSchema.ts
@@ -58,6 +58,7 @@ export const CapabilityCatalogValidationIssueSchema = z.object({
   path: z.string().min(1),
   reference: z.string().min(1),
   expectedKinds: z.array(CapabilityCatalogKindSchema).min(1),
+  runtime: AgentRuntimeSchema.optional(),
 });
 export type CapabilityCatalogValidationIssue = z.infer<
   typeof CapabilityCatalogValidationIssueSchema

--- a/packages/schemas/src/capability/CapabilityCatalogSchema.ts
+++ b/packages/schemas/src/capability/CapabilityCatalogSchema.ts
@@ -1,0 +1,64 @@
+import { z } from "zod/v4";
+import { AgentRuntimeSchema } from "../agent-runtime/AgentRuntimeSchema";
+
+export const CapabilityCatalogKindSchema = z.enum(["builtin-tool", "skill", "mcp-tool"]);
+export type CapabilityCatalogKind = z.infer<typeof CapabilityCatalogKindSchema>;
+
+export const CapabilityCatalogSourceSchema = z.enum(["builtin", "manual", "scanned"]);
+export type CapabilityCatalogSource = z.infer<typeof CapabilityCatalogSourceSchema>;
+
+export const CapabilityRiskTierSchema = z.enum(["readonly", "write", "irreversible"]);
+export type CapabilityRiskTier = z.infer<typeof CapabilityRiskTierSchema>;
+
+export const CapabilityRiskSourceSchema = z.enum(["rule", "override"]);
+export type CapabilityRiskSource = z.infer<typeof CapabilityRiskSourceSchema>;
+
+const CapabilityCatalogEntryBaseSchema = z.object({
+  id: z.string().min(1),
+  reference: z.string().min(1),
+  displayName: z.string().min(1),
+  description: z.string(),
+  source: CapabilityCatalogSourceSchema,
+  supportedRuntimes: z.array(AgentRuntimeSchema),
+  riskTier: CapabilityRiskTierSchema,
+  inferredRiskTier: CapabilityRiskTierSchema,
+  riskTierSource: CapabilityRiskSourceSchema,
+});
+
+export const CapabilityCatalogEntrySchema = z.discriminatedUnion("kind", [
+  CapabilityCatalogEntryBaseSchema.extend({
+    kind: z.literal("builtin-tool"),
+  }),
+  CapabilityCatalogEntryBaseSchema.extend({
+    kind: z.literal("skill"),
+    skillId: z.string().min(1),
+  }),
+  CapabilityCatalogEntryBaseSchema.extend({
+    kind: z.literal("mcp-tool"),
+    connectorId: z.string().min(1),
+  }),
+]);
+export type CapabilityCatalogEntry = z.infer<typeof CapabilityCatalogEntrySchema>;
+
+export const GetCapabilityCatalogInputSchema = z.object({
+  runtime: AgentRuntimeSchema.optional(),
+  kinds: z.array(CapabilityCatalogKindSchema).optional(),
+});
+export type GetCapabilityCatalogInput = z.infer<typeof GetCapabilityCatalogInputSchema>;
+
+export const SetCapabilityRiskTierOverrideInputSchema = z.object({
+  id: z.string().min(1),
+  riskTier: CapabilityRiskTierSchema.nullable(),
+});
+export type SetCapabilityRiskTierOverrideInput = z.infer<
+  typeof SetCapabilityRiskTierOverrideInputSchema
+>;
+
+export const CapabilityCatalogValidationIssueSchema = z.object({
+  path: z.string().min(1),
+  reference: z.string().min(1),
+  expectedKinds: z.array(CapabilityCatalogKindSchema).min(1),
+});
+export type CapabilityCatalogValidationIssue = z.infer<
+  typeof CapabilityCatalogValidationIssueSchema
+>;

--- a/packages/schemas/src/capability/CapabilitySourceSchema.ts
+++ b/packages/schemas/src/capability/CapabilitySourceSchema.ts
@@ -7,7 +7,7 @@ export type CapabilitySourceId = z.infer<typeof CapabilitySourceIdSchema>;
 export const CapabilitySourceScopeSchema = z.enum(["global", "workspace"]);
 export type CapabilitySourceScope = z.infer<typeof CapabilitySourceScopeSchema>;
 
-export const CapabilityOriginSchema = z.enum(["manual", "harvested"]);
+export const CapabilityOriginSchema = z.enum(["manual", "harvested", "builtin"]);
 export type CapabilityOrigin = z.infer<typeof CapabilityOriginSchema>;
 
 export const CapabilityCredentialReferencesSchema = z.object({

--- a/packages/schemas/src/capability/index.ts
+++ b/packages/schemas/src/capability/index.ts
@@ -1,1 +1,2 @@
+export * from "./CapabilityCatalogSchema";
 export * from "./CapabilitySourceSchema";

--- a/packages/schemas/src/operation/OperationConfigSchema.ts
+++ b/packages/schemas/src/operation/OperationConfigSchema.ts
@@ -10,3 +10,8 @@ export const OperationConfigSchema = z.object({
 });
 export type OperationConfig = z.infer<typeof OperationConfigSchema>;
 export type OperationConfigInput = z.input<typeof OperationConfigSchema>;
+
+/** User-save boundary: reject unknown root/executor fields instead of stripping them. */
+export const StrictOperationConfigSchema = OperationConfigSchema.extend({
+  executor: OperationExecutorConfigSchema.strict().optional(),
+}).strict();

--- a/packages/schemas/src/pipeline/ProposeActionsResponseSchema.ts
+++ b/packages/schemas/src/pipeline/ProposeActionsResponseSchema.ts
@@ -1,4 +1,6 @@
 import { z } from "zod/v4";
+import { ObjectNodeTypeSchema } from "./node/ObjectNodeTypeSchema";
+import { StrictOperationConfigSchema } from "../operation/OperationConfigSchema";
 import { PipelineActionDiagnosticSchema } from "./PipelineActionDiagnosticSchema";
 import { PipelineActionProposalSchema } from "./PipelineActionProposalSchema";
 
@@ -20,11 +22,12 @@ export type ProposeActionsErrorCode = z.infer<typeof ProposeActionsErrorCodeSche
 
 /** Operation drafted by the agent because no existing one matched. */
 export const ProposePendingOperationSchema = z.object({
-  acceptedObjectTypes: z.array(z.string()),
-  config: z.record(z.string(), z.unknown()),
+  acceptedObjectTypes: z.array(ObjectNodeTypeSchema),
+  config: StrictOperationConfigSchema,
   description: z.string(),
   id: z.string(),
   name: z.string(),
+  sourceSkillId: z.string().optional(),
 });
 export type ProposePendingOperation = z.infer<typeof ProposePendingOperationSchema>;
 

--- a/packages/services/src/capabilityCatalogService/catalogProjection.ts
+++ b/packages/services/src/capabilityCatalogService/catalogProjection.ts
@@ -44,7 +44,6 @@ const MCP_SUPPORTED_RUNTIMES = ["claude-code", "codex"] as const satisfies reado
 const SKILL_SUPPORTED_RUNTIMES = [
   "claude-code",
   "codex",
-  "hermes",
   "mastra",
   "openclaw",
   "pi-agent",

--- a/packages/services/src/capabilityCatalogService/catalogProjection.ts
+++ b/packages/services/src/capabilityCatalogService/catalogProjection.ts
@@ -1,0 +1,166 @@
+import { ToolNameSchema } from "@repo/agent";
+import type {
+  AgentRuntime,
+  CapabilityCatalogEntry,
+  CapabilityOrigin,
+  CapabilityRiskTier,
+  CapabilitySource,
+  ConnectorConfig,
+} from "@repo/schemas";
+import { resolveMcpConnectorTools } from "../connectorsService/buildClaudeMcpInjection";
+import { inferCapabilityRiskTier } from "./inferCapabilityRiskTier";
+
+export type CatalogConnector = {
+  id: string;
+  name: string;
+  method: string;
+  status: string;
+  config: ConnectorConfig;
+  origin: CapabilityOrigin;
+};
+
+export type CatalogSkill = {
+  id: string;
+  name: string;
+  label: string;
+  description: string;
+  origin: CapabilityOrigin;
+  sources: CapabilitySource[];
+};
+
+export type CatalogRiskOverride = {
+  capabilityId: string;
+  riskTier: CapabilityRiskTier;
+};
+
+export type CapabilityCatalogProjectionInput = {
+  connectors: CatalogConnector[];
+  skills: CatalogSkill[];
+  overrides: CatalogRiskOverride[];
+};
+
+const BUILTIN_SUPPORTED_RUNTIMES = ["claude-code"] as const satisfies readonly AgentRuntime[];
+const MCP_SUPPORTED_RUNTIMES = ["claude-code", "codex"] as const satisfies readonly AgentRuntime[];
+const SKILL_SUPPORTED_RUNTIMES = [
+  "claude-code",
+  "codex",
+  "hermes",
+  "mastra",
+  "openclaw",
+  "pi-agent",
+  "opencode",
+  "kimi-code",
+] as const satisfies readonly AgentRuntime[];
+
+const BUILTIN_RISK_TIERS = {
+  Read: "readonly",
+  "Bash(find:*)": "readonly",
+  "Bash(grep:*)": "readonly",
+  "Bash(rg:*)": "readonly",
+  "Bash(cat:*)": "readonly",
+  "Bash(head:*)": "readonly",
+  "Bash(tail:*)": "readonly",
+  "Bash(wc:*)": "readonly",
+  "Bash(ls:*)": "readonly",
+  "Bash(tree:*)": "readonly",
+  Edit: "write",
+  Write: "write",
+  "Bash(sed:*)": "write",
+  "Bash(curl:*)": "irreversible",
+  "Bash(python3:*)": "irreversible",
+  WebSearch: "readonly",
+  WebFetch: "readonly",
+  "Bash(gh:*)": "irreversible",
+} as const satisfies Record<(typeof ToolNameSchema.options)[number], CapabilityRiskTier>;
+
+const toCatalogSource = (origin: CapabilityOrigin): CapabilityCatalogEntry["source"] => {
+  if (origin === "builtin") return "builtin";
+  if (origin === "harvested") return "scanned";
+
+  return "manual";
+};
+
+const withRisk = <T extends Omit<CapabilityCatalogEntry, "riskTier" | "riskTierSource">>(
+  entry: T,
+  overrideById: ReadonlyMap<string, CapabilityRiskTier>,
+): T & Pick<CapabilityCatalogEntry, "riskTier" | "riskTierSource"> => {
+  const override = overrideById.get(entry.id);
+
+  return {
+    ...entry,
+    riskTier: override ?? entry.inferredRiskTier,
+    riskTierSource: override ? "override" : "rule",
+  };
+};
+
+export const projectCapabilityCatalog = ({
+  connectors,
+  skills,
+  overrides,
+}: CapabilityCatalogProjectionInput): CapabilityCatalogEntry[] => {
+  const overrideById = new Map(
+    overrides.map((override) => [override.capabilityId, override.riskTier]),
+  );
+
+  const builtinEntries = ToolNameSchema.options.map((reference) => {
+    const inferredRiskTier = BUILTIN_RISK_TIERS[reference];
+
+    return withRisk(
+      {
+        kind: "builtin-tool" as const,
+        source: "builtin" as const,
+        id: `builtin:${reference}`,
+        reference,
+        displayName: reference,
+        description: `Built-in ${reference} execution tool`,
+        supportedRuntimes: [...BUILTIN_SUPPORTED_RUNTIMES],
+        inferredRiskTier,
+      },
+      overrideById,
+    );
+  });
+
+  const skillEntries = skills.map((skill) => {
+    const inferredRiskTier = inferCapabilityRiskTier(`${skill.name} ${skill.label}`);
+
+    return withRisk(
+      {
+        kind: "skill" as const,
+        source: toCatalogSource(skill.origin),
+        id: `skill:${skill.id}`,
+        reference: skill.id,
+        displayName: skill.label,
+        description: skill.description,
+        supportedRuntimes: [...SKILL_SUPPORTED_RUNTIMES],
+        inferredRiskTier,
+        skillId: skill.id,
+      },
+      overrideById,
+    );
+  });
+
+  const connectorById = new Map(connectors.map((connector) => [connector.id, connector]));
+  const mcpEntries = resolveMcpConnectorTools(connectors).map((tool) => {
+    const connector = connectorById.get(tool.connector.id)!;
+    const inferredRiskTier = inferCapabilityRiskTier(tool.toolName);
+
+    return withRisk(
+      {
+        kind: "mcp-tool" as const,
+        source: toCatalogSource(connector.origin),
+        id: `mcp:${tool.connector.id}:${tool.toolName}`,
+        reference: tool.reference,
+        displayName: tool.toolName,
+        description: tool.description,
+        supportedRuntimes: [...MCP_SUPPORTED_RUNTIMES],
+        inferredRiskTier,
+        connectorId: tool.connector.id,
+      },
+      overrideById,
+    );
+  });
+
+  return [...builtinEntries, ...skillEntries, ...mcpEntries].sort((a, b) =>
+    a.id.localeCompare(b.id),
+  );
+};

--- a/packages/services/src/capabilityCatalogService/catalogProjection.unit.test.ts
+++ b/packages/services/src/capabilityCatalogService/catalogProjection.unit.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { buildMcpConnectorInjection } from "../connectorsService/buildClaudeMcpInjection";
+import {
+  projectCapabilityCatalog,
+  type CatalogConnector,
+  type CatalogSkill,
+} from "./catalogProjection";
+
+const connector = (
+  id: string,
+  name: string,
+  config: CatalogConnector["config"],
+  status = "connected",
+): CatalogConnector => ({
+  id,
+  name,
+  method: "mcp",
+  status,
+  config,
+  origin: "harvested",
+});
+
+const skill = (id: string, origin: CatalogSkill["origin"]): CatalogSkill => ({
+  id,
+  name: `${id}-skill`,
+  label: `${id} skill`,
+  description: `${id} description`,
+  origin,
+  sources: [],
+});
+
+describe("projectCapabilityCatalog", () => {
+  it("projects builtin, manual/scanned/builtin skills, and connected concrete MCP tools", () => {
+    const entries = projectCapabilityCatalog({
+      connectors: [
+        connector("connector-a", "github", {
+          transport: "stdio",
+          command: "github-first",
+          tools: [{ name: "read_issue", description: "Read an issue" }],
+        }),
+        connector("connector-b", "github", {
+          transport: "stdio",
+          command: "github-second",
+          tools: [{ name: "create_issue" }],
+        }),
+        connector(
+          "connector-c",
+          "offline",
+          {
+            transport: "stdio",
+            command: "offline",
+            tools: [{ name: "delete_issue" }],
+          },
+          "needs_setup",
+        ),
+        connector("connector-d", "empty", { transport: "stdio", command: "empty" }),
+      ],
+      skills: [
+        skill("manual", "manual"),
+        skill("scanned", "harvested"),
+        skill("seed", "builtin"),
+      ],
+      overrides: [],
+    });
+
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "builtin:Read",
+          kind: "builtin-tool",
+          source: "builtin",
+          reference: "Read",
+          riskTier: "readonly",
+        }),
+        expect.objectContaining({ id: "skill:manual", kind: "skill", source: "manual" }),
+        expect.objectContaining({ id: "skill:scanned", kind: "skill", source: "scanned" }),
+        expect.objectContaining({ id: "skill:seed", kind: "skill", source: "builtin" }),
+        expect.objectContaining({
+          id: "mcp:connector-a:read_issue",
+          kind: "mcp-tool",
+          reference: "mcp__github__read_issue",
+          riskTier: "readonly",
+        }),
+        expect.objectContaining({
+          id: "mcp:connector-b:create_issue",
+          reference: "mcp__github___create_issue",
+          riskTier: "write",
+        }),
+      ]),
+    );
+    expect(entries.some((entry) => entry.id.includes("connector-c"))).toBe(false);
+    expect(entries.some((entry) => entry.id.includes("connector-d"))).toBe(false);
+
+    const mcpReferences = entries
+      .filter((entry) => entry.kind === "mcp-tool")
+      .map((entry) => entry.reference);
+    expect(
+      buildMcpConnectorInjection(
+        [
+          connector("connector-a", "github", {
+            transport: "stdio",
+            command: "github-first",
+            tools: [{ name: "read_issue" }],
+          }),
+          connector("connector-b", "github", {
+            transport: "stdio",
+            command: "github-second",
+            tools: [{ name: "create_issue" }],
+          }),
+        ],
+        mcpReferences,
+      )?.toolNames,
+    ).toEqual(mcpReferences);
+  });
+
+  it("applies a risk override while preserving the inferred tier", () => {
+    const entries = projectCapabilityCatalog({
+      connectors: [],
+      skills: [],
+      overrides: [{ capabilityId: "builtin:Read", riskTier: "irreversible" }],
+    });
+
+    expect(entries.find((entry) => entry.id === "builtin:Read")).toMatchObject({
+      inferredRiskTier: "readonly",
+      riskTier: "irreversible",
+      riskTierSource: "override",
+    });
+  });
+});

--- a/packages/services/src/capabilityCatalogService/catalogProjection.unit.test.ts
+++ b/packages/services/src/capabilityCatalogService/catalogProjection.unit.test.ts
@@ -55,11 +55,7 @@ describe("projectCapabilityCatalog", () => {
         ),
         connector("connector-d", "empty", { transport: "stdio", command: "empty" }),
       ],
-      skills: [
-        skill("manual", "manual"),
-        skill("scanned", "harvested"),
-        skill("seed", "builtin"),
-      ],
+      skills: [skill("manual", "manual"), skill("scanned", "harvested"), skill("seed", "builtin")],
       overrides: [],
     });
 

--- a/packages/services/src/capabilityCatalogService/catalogProjection.unit.test.ts
+++ b/packages/services/src/capabilityCatalogService/catalogProjection.unit.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildMcpConnectorInjection } from "../connectorsService/buildClaudeMcpInjection";
+import {
+  buildMcpConnectorInjection,
+  buildMcpServerKey,
+  buildMcpToolReference,
+} from "../connectorsService/buildClaudeMcpInjection";
 import {
   projectCapabilityCatalog,
   type CatalogConnector,
@@ -74,12 +78,12 @@ describe("projectCapabilityCatalog", () => {
         expect.objectContaining({
           id: "mcp:connector-a:read_issue",
           kind: "mcp-tool",
-          reference: "mcp__github__read_issue",
+          reference: buildMcpToolReference(buildMcpServerKey("connector-a"), "read_issue"),
           riskTier: "readonly",
         }),
         expect.objectContaining({
           id: "mcp:connector-b:create_issue",
-          reference: "mcp__github___create_issue",
+          reference: buildMcpToolReference(buildMcpServerKey("connector-b"), "create_issue"),
           riskTier: "write",
         }),
       ]),

--- a/packages/services/src/capabilityCatalogService/createCapabilityCatalogService.ts
+++ b/packages/services/src/capabilityCatalogService/createCapabilityCatalogService.ts
@@ -4,13 +4,13 @@ import {
   createSkillsDao,
   type DbConnection,
 } from "@repo/models";
-import type {
-  AgentRuntime,
-  CapabilityCatalogEntry,
-  CapabilityCatalogKind,
-  CapabilityCatalogValidationIssue,
-  CapabilityRiskTier,
-  OperationConfigInput,
+import {
+  AgentRuntimeSchema,
+  type CapabilityCatalogEntry,
+  type CapabilityCatalogValidationIssue,
+  type GetCapabilityCatalogInput,
+  type OperationConfigInput,
+  type SetCapabilityRiskTierOverrideInput,
 } from "@repo/schemas";
 import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import { NotFoundError, ServiceError, toServiceError } from "../serviceErrors";
@@ -30,18 +30,23 @@ export interface CapabilityCatalogServiceOptions {
   dependencies?: CapabilityCatalogServiceDependencies;
 }
 
-export interface GetCapabilityCatalogInput {
-  runtime?: AgentRuntime;
-  kinds?: CapabilityCatalogKind[];
-}
+const capabilityValidationMessage = (issues: CapabilityCatalogValidationIssue[]): string => {
+  const summaries = issues
+    .slice(0, 3)
+    .map((issue) =>
+      issue.runtime
+        ? `${issue.path}: ${issue.reference} is not available for ${issue.runtime}`
+        : `${issue.path}: ${issue.reference}`,
+    );
+  const remainder =
+    issues.length > summaries.length ? `; +${issues.length - summaries.length} more` : "";
+
+  return `Invalid capability reference${issues.length === 1 ? "" : "s"}: ${summaries.join("; ")}${remainder}`;
+};
 
 export class CapabilityCatalogValidationError extends ServiceError {
   constructor(readonly issues: CapabilityCatalogValidationIssue[]) {
-    super(
-      issues.length === 1
-        ? `Invalid capability reference at ${issues[0]!.path}: ${issues[0]!.reference}`
-        : `Invalid capability references (${issues.length})`,
-    );
+    super(capabilityValidationMessage(issues));
     this.name = "CapabilityCatalogValidationError";
   }
 }
@@ -69,15 +74,23 @@ const extractValidationIssues = (
 
   const executorConfig = executor as Record<string, unknown>;
   const issues: CapabilityCatalogValidationIssue[] = [];
+  const runtimeResult = AgentRuntimeSchema.safeParse(executorConfig.agent);
+  const runtime = runtimeResult.success ? runtimeResult.data : undefined;
   const skillId = executorConfig.skillId;
   if (
     typeof skillId === "string" &&
-    !entries.some((entry) => entry.kind === "skill" && entry.reference === skillId)
+    !entries.some(
+      (entry) =>
+        entry.kind === "skill" &&
+        entry.reference === skillId &&
+        (!runtime || entry.supportedRuntimes.includes(runtime)),
+    )
   ) {
     issues.push({
       path: `${pathPrefix}.executor.skillId`,
       reference: skillId,
       expectedKinds: ["skill"],
+      ...(runtime ? { runtime } : {}),
     });
   }
 
@@ -89,7 +102,8 @@ const extractValidationIssues = (
         entries.some(
           (entry) =>
             (entry.kind === "builtin-tool" || entry.kind === "mcp-tool") &&
-            entry.reference === reference,
+            entry.reference === reference &&
+            (!runtime || entry.supportedRuntimes.includes(runtime)),
         )
       ) {
         return;
@@ -99,6 +113,7 @@ const extractValidationIssues = (
         path: `${pathPrefix}.executor.allowedTools[${index}]`,
         reference,
         expectedKinds: ["builtin-tool", "mcp-tool"],
+        ...(runtime ? { runtime } : {}),
       });
     });
   }
@@ -163,10 +178,7 @@ export const createCapabilityCatalogService = (
   const setRiskTierOverride = ({
     id,
     riskTier,
-  }: {
-    id: string;
-    riskTier: CapabilityRiskTier | null;
-  }): ResultAsync<CapabilityCatalogEntry, Error> =>
+  }: SetCapabilityRiskTierOverrideInput): ResultAsync<CapabilityCatalogEntry, Error> =>
     loadEntries().andThen((entries) => {
       const entry = entries.find((candidate) => candidate.id === id);
       if (!entry) return errAsync(new NotFoundError("Capability", id));

--- a/packages/services/src/capabilityCatalogService/createCapabilityCatalogService.ts
+++ b/packages/services/src/capabilityCatalogService/createCapabilityCatalogService.ts
@@ -2,14 +2,14 @@ import {
   createCapabilityRiskOverridesDao,
   createConnectorsDao,
   createSkillsDao,
-  type DbConnection,
+  type DbExecutor,
 } from "@repo/models";
 import {
-  AgentRuntimeSchema,
+  StrictOperationConfigSchema,
   type CapabilityCatalogEntry,
   type CapabilityCatalogValidationIssue,
   type GetCapabilityCatalogInput,
-  type OperationConfigInput,
+  type OperationConfig,
   type SetCapabilityRiskTierOverrideInput,
 } from "@repo/schemas";
 import { errAsync, okAsync, ResultAsync } from "neverthrow";
@@ -28,6 +28,16 @@ export interface CapabilityCatalogServiceDependencies {
 
 export interface CapabilityCatalogServiceOptions {
   dependencies?: CapabilityCatalogServiceDependencies;
+}
+
+export interface OperationCapabilityValidationInput {
+  config?: unknown;
+  sourceSkillId?: unknown;
+}
+
+export interface OperationConfigShapeValidationIssue {
+  path: string;
+  message: string;
 }
 
 const capabilityValidationMessage = (issues: CapabilityCatalogValidationIssue[]): string => {
@@ -51,6 +61,23 @@ export class CapabilityCatalogValidationError extends ServiceError {
   }
 }
 
+const operationConfigValidationMessage = (
+  issues: OperationConfigShapeValidationIssue[],
+): string => {
+  const summaries = issues.slice(0, 3).map((issue) => `${issue.path}: ${issue.message}`);
+  const remainder =
+    issues.length > summaries.length ? `; +${issues.length - summaries.length} more` : "";
+
+  return `Invalid operation config${issues.length === 1 ? "" : "s"}: ${summaries.join("; ")}${remainder}`;
+};
+
+export class OperationConfigValidationError extends ServiceError {
+  constructor(readonly issues: OperationConfigShapeValidationIssue[]) {
+    super(operationConfigValidationMessage(issues));
+    this.name = "OperationConfigValidationError";
+  }
+}
+
 const filterCatalogEntries = (
   entries: CapabilityCatalogEntry[],
   input: GetCapabilityCatalogInput,
@@ -65,18 +92,16 @@ const filterCatalogEntries = (
 };
 
 const extractValidationIssues = (
-  config: OperationConfigInput | Record<string, unknown>,
+  config: OperationConfig,
   entries: CapabilityCatalogEntry[],
   pathPrefix = "config",
 ): CapabilityCatalogValidationIssue[] => {
   const executor = config.executor;
-  if (!executor || typeof executor !== "object" || Array.isArray(executor)) return [];
+  if (!executor) return [];
 
-  const executorConfig = executor as Record<string, unknown>;
   const issues: CapabilityCatalogValidationIssue[] = [];
-  const runtimeResult = AgentRuntimeSchema.safeParse(executorConfig.agent);
-  const runtime = runtimeResult.success ? runtimeResult.data : undefined;
-  const skillId = executorConfig.skillId;
+  const runtime = executor.agent;
+  const skillId = executor.skillId;
   if (
     typeof skillId === "string" &&
     !entries.some(
@@ -94,10 +119,8 @@ const extractValidationIssues = (
     });
   }
 
-  const allowedTools = executorConfig.allowedTools;
-  if (Array.isArray(allowedTools)) {
-    allowedTools.forEach((reference, index) => {
-      if (typeof reference !== "string") return;
+  if (executor.allowedTools) {
+    executor.allowedTools.forEach((reference, index) => {
       if (
         entries.some(
           (entry) =>
@@ -121,8 +144,79 @@ const extractValidationIssues = (
   return issues;
 };
 
+const sourceSkillValidationIssues = (
+  sourceSkillId: unknown,
+  entries: CapabilityCatalogEntry[],
+  path: string,
+): CapabilityCatalogValidationIssue[] => {
+  if (
+    typeof sourceSkillId !== "string" ||
+    entries.some((entry) => entry.kind === "skill" && entry.reference === sourceSkillId)
+  ) {
+    return [];
+  }
+
+  return [{ path, reference: sourceSkillId, expectedKinds: ["skill"] }];
+};
+
+type ValidationTarget = {
+  config?: unknown;
+  configPath?: string;
+  sourceSkillId?: unknown;
+  sourceSkillIdPath?: string;
+};
+
+type ParsedValidationTarget = Omit<ValidationTarget, "config"> & {
+  config?: OperationConfig;
+};
+
+const appendZodPath = (prefix: string, segments: PropertyKey[]): string =>
+  segments.reduce<string>(
+    (path, segment) =>
+      typeof segment === "number" ? `${path}[${segment}]` : `${path}.${String(segment)}`,
+    prefix,
+  );
+
+const parseValidationTargets = (
+  targets: ValidationTarget[],
+): { parsedTargets: ParsedValidationTarget[]; issues: OperationConfigShapeValidationIssue[] } => {
+  const issues: OperationConfigShapeValidationIssue[] = [];
+  const parsedTargets = targets.map((target) => {
+    const parsedTarget: ParsedValidationTarget = { ...target, config: undefined };
+    if (target.configPath) {
+      const parsed = StrictOperationConfigSchema.safeParse(target.config);
+      if (parsed.success) {
+        parsedTarget.config = parsed.data;
+      } else {
+        issues.push(
+          ...parsed.error.issues.map((issue) => ({
+            path: appendZodPath(target.configPath!, issue.path),
+            message: issue.message,
+          })),
+        );
+      }
+    }
+
+    if (
+      target.sourceSkillIdPath &&
+      target.sourceSkillId !== undefined &&
+      target.sourceSkillId !== null &&
+      typeof target.sourceSkillId !== "string"
+    ) {
+      issues.push({
+        path: target.sourceSkillIdPath,
+        message: "Expected a skill id string",
+      });
+    }
+
+    return parsedTarget;
+  });
+
+  return { parsedTargets, issues };
+};
+
 export const createCapabilityCatalogService = (
-  db: DbConnection,
+  db: DbExecutor,
   options: CapabilityCatalogServiceOptions = {},
 ) => {
   const dependencies =
@@ -151,29 +245,72 @@ export const createCapabilityCatalogService = (
   const getMany = (input: GetCapabilityCatalogInput = {}) =>
     loadEntries().map((entries) => filterCatalogEntries(entries, input));
 
-  const validateOperationConfigs = (
-    configs: ReadonlyArray<OperationConfigInput | Record<string, unknown>>,
-  ): ResultAsync<void, Error> =>
-    loadEntries().andThen((entries) => {
-      const issues = configs.flatMap((config, index) =>
-        extractValidationIssues(config, entries, `configs[${index}]`),
-      );
+  const validateTargets = (targets: ValidationTarget[]): ResultAsync<void, Error> => {
+    const { parsedTargets, issues: shapeIssues } = parseValidationTargets(targets);
+    if (shapeIssues.length > 0) {
+      return errAsync(new OperationConfigValidationError(shapeIssues));
+    }
+
+    return loadEntries().andThen((entries) => {
+      const issues = parsedTargets.flatMap((target) => [
+        ...(target.config && target.configPath
+          ? extractValidationIssues(target.config, entries, target.configPath)
+          : []),
+        ...(target.sourceSkillIdPath
+          ? sourceSkillValidationIssues(target.sourceSkillId, entries, target.sourceSkillIdPath)
+          : []),
+      ]);
 
       return issues.length > 0
         ? errAsync(new CapabilityCatalogValidationError(issues))
         : okAsync(undefined);
     });
+  };
 
-  const validateOperationConfig = (
-    config: OperationConfigInput | Record<string, unknown>,
+  const validateOperationConfigs = (configs: ReadonlyArray<unknown>): ResultAsync<void, Error> =>
+    validateTargets(configs.map((config, index) => ({ config, configPath: `configs[${index}]` })));
+
+  const validateOperationConfig = (config: unknown): ResultAsync<void, Error> =>
+    validateTargets([{ config, configPath: "config" }]);
+
+  const validateOperationInput = (
+    input: OperationCapabilityValidationInput,
   ): ResultAsync<void, Error> =>
-    loadEntries().andThen((entries) => {
-      const issues = extractValidationIssues(config, entries);
+    validateTargets([
+      {
+        config: input.config,
+        configPath: "config",
+        sourceSkillId: input.sourceSkillId,
+        sourceSkillIdPath: "sourceSkillId",
+      },
+    ]);
 
-      return issues.length > 0
-        ? errAsync(new CapabilityCatalogValidationError(issues))
-        : okAsync(undefined);
-    });
+  const validateOperationInputs = (
+    inputs: ReadonlyArray<OperationCapabilityValidationInput>,
+  ): ResultAsync<void, Error> =>
+    validateTargets(
+      inputs.map((input, index) => ({
+        config: input.config,
+        configPath: `operations[${index}].config`,
+        sourceSkillId: input.sourceSkillId,
+        sourceSkillIdPath: `operations[${index}].sourceSkillId`,
+      })),
+    );
+
+  const validateOperationPatch = (
+    patch: OperationCapabilityValidationInput,
+  ): ResultAsync<void, Error> =>
+    validateTargets([
+      {
+        ...(Object.hasOwn(patch, "config") ? { config: patch.config, configPath: "config" } : {}),
+        ...(Object.hasOwn(patch, "sourceSkillId")
+          ? {
+              sourceSkillId: patch.sourceSkillId,
+              sourceSkillIdPath: "sourceSkillId",
+            }
+          : {}),
+      },
+    ]);
 
   const setRiskTierOverride = ({
     id,
@@ -201,5 +338,8 @@ export const createCapabilityCatalogService = (
     setRiskTierOverride,
     validateOperationConfig,
     validateOperationConfigs,
+    validateOperationInput,
+    validateOperationInputs,
+    validateOperationPatch,
   };
 };

--- a/packages/services/src/capabilityCatalogService/createCapabilityCatalogService.ts
+++ b/packages/services/src/capabilityCatalogService/createCapabilityCatalogService.ts
@@ -1,0 +1,193 @@
+import {
+  createCapabilityRiskOverridesDao,
+  createConnectorsDao,
+  createSkillsDao,
+  type DbConnection,
+} from "@repo/models";
+import type {
+  AgentRuntime,
+  CapabilityCatalogEntry,
+  CapabilityCatalogKind,
+  CapabilityCatalogValidationIssue,
+  CapabilityRiskTier,
+  OperationConfigInput,
+} from "@repo/schemas";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
+import { NotFoundError, ServiceError, toServiceError } from "../serviceErrors";
+import { projectCapabilityCatalog } from "./catalogProjection";
+
+type ConnectorsDao = ReturnType<typeof createConnectorsDao>;
+type SkillsDao = ReturnType<typeof createSkillsDao>;
+type RiskOverridesDao = ReturnType<typeof createCapabilityRiskOverridesDao>;
+
+export interface CapabilityCatalogServiceDependencies {
+  connectorsDao: Pick<ConnectorsDao, "findMany">;
+  skillsDao: Pick<SkillsDao, "findMany" | "seedIfEmpty">;
+  riskOverridesDao: Pick<RiskOverridesDao, "delete" | "findMany" | "upsert">;
+}
+
+export interface CapabilityCatalogServiceOptions {
+  dependencies?: CapabilityCatalogServiceDependencies;
+}
+
+export interface GetCapabilityCatalogInput {
+  runtime?: AgentRuntime;
+  kinds?: CapabilityCatalogKind[];
+}
+
+export class CapabilityCatalogValidationError extends ServiceError {
+  constructor(readonly issues: CapabilityCatalogValidationIssue[]) {
+    super(
+      issues.length === 1
+        ? `Invalid capability reference at ${issues[0]!.path}: ${issues[0]!.reference}`
+        : `Invalid capability references (${issues.length})`,
+    );
+    this.name = "CapabilityCatalogValidationError";
+  }
+}
+
+const filterCatalogEntries = (
+  entries: CapabilityCatalogEntry[],
+  input: GetCapabilityCatalogInput,
+): CapabilityCatalogEntry[] => {
+  const kinds = input.kinds ? new Set(input.kinds) : null;
+
+  return entries.filter(
+    (entry) =>
+      (!input.runtime || entry.supportedRuntimes.includes(input.runtime)) &&
+      (!kinds || kinds.has(entry.kind)),
+  );
+};
+
+const extractValidationIssues = (
+  config: OperationConfigInput | Record<string, unknown>,
+  entries: CapabilityCatalogEntry[],
+  pathPrefix = "config",
+): CapabilityCatalogValidationIssue[] => {
+  const executor = config.executor;
+  if (!executor || typeof executor !== "object" || Array.isArray(executor)) return [];
+
+  const executorConfig = executor as Record<string, unknown>;
+  const issues: CapabilityCatalogValidationIssue[] = [];
+  const skillId = executorConfig.skillId;
+  if (
+    typeof skillId === "string" &&
+    !entries.some((entry) => entry.kind === "skill" && entry.reference === skillId)
+  ) {
+    issues.push({
+      path: `${pathPrefix}.executor.skillId`,
+      reference: skillId,
+      expectedKinds: ["skill"],
+    });
+  }
+
+  const allowedTools = executorConfig.allowedTools;
+  if (Array.isArray(allowedTools)) {
+    allowedTools.forEach((reference, index) => {
+      if (typeof reference !== "string") return;
+      if (
+        entries.some(
+          (entry) =>
+            (entry.kind === "builtin-tool" || entry.kind === "mcp-tool") &&
+            entry.reference === reference,
+        )
+      ) {
+        return;
+      }
+
+      issues.push({
+        path: `${pathPrefix}.executor.allowedTools[${index}]`,
+        reference,
+        expectedKinds: ["builtin-tool", "mcp-tool"],
+      });
+    });
+  }
+
+  return issues;
+};
+
+export const createCapabilityCatalogService = (
+  db: DbConnection,
+  options: CapabilityCatalogServiceOptions = {},
+) => {
+  const dependencies =
+    options.dependencies ??
+    ({
+      connectorsDao: createConnectorsDao(db),
+      skillsDao: createSkillsDao(db),
+      riskOverridesDao: createCapabilityRiskOverridesDao(db),
+    } satisfies CapabilityCatalogServiceDependencies);
+
+  const loadEntries = (): ResultAsync<CapabilityCatalogEntry[], Error> =>
+    ResultAsync.fromPromise(
+      (async () => {
+        await dependencies.skillsDao.seedIfEmpty();
+        const [connectors, skills, overrides] = await Promise.all([
+          dependencies.connectorsDao.findMany(),
+          dependencies.skillsDao.findMany(),
+          dependencies.riskOverridesDao.findMany(),
+        ]);
+
+        return projectCapabilityCatalog({ connectors, skills, overrides });
+      })(),
+      (error) => toServiceError(error, "Load capability catalog"),
+    );
+
+  const getMany = (input: GetCapabilityCatalogInput = {}) =>
+    loadEntries().map((entries) => filterCatalogEntries(entries, input));
+
+  const validateOperationConfigs = (
+    configs: ReadonlyArray<OperationConfigInput | Record<string, unknown>>,
+  ): ResultAsync<void, Error> =>
+    loadEntries().andThen((entries) => {
+      const issues = configs.flatMap((config, index) =>
+        extractValidationIssues(config, entries, `configs[${index}]`),
+      );
+
+      return issues.length > 0
+        ? errAsync(new CapabilityCatalogValidationError(issues))
+        : okAsync(undefined);
+    });
+
+  const validateOperationConfig = (
+    config: OperationConfigInput | Record<string, unknown>,
+  ): ResultAsync<void, Error> =>
+    loadEntries().andThen((entries) => {
+      const issues = extractValidationIssues(config, entries);
+
+      return issues.length > 0
+        ? errAsync(new CapabilityCatalogValidationError(issues))
+        : okAsync(undefined);
+    });
+
+  const setRiskTierOverride = ({
+    id,
+    riskTier,
+  }: {
+    id: string;
+    riskTier: CapabilityRiskTier | null;
+  }): ResultAsync<CapabilityCatalogEntry, Error> =>
+    loadEntries().andThen((entries) => {
+      const entry = entries.find((candidate) => candidate.id === id);
+      if (!entry) return errAsync(new NotFoundError("Capability", id));
+
+      const mutation: Promise<void> = riskTier
+        ? dependencies.riskOverridesDao.upsert(id, riskTier).then(() => undefined)
+        : dependencies.riskOverridesDao.delete(id);
+
+      return ResultAsync.fromPromise(mutation, (error) =>
+        toServiceError(error, "Set capability risk override"),
+      ).map(() => ({
+        ...entry,
+        riskTier: riskTier ?? entry.inferredRiskTier,
+        riskTierSource: riskTier ? ("override" as const) : ("rule" as const),
+      }));
+    });
+
+  return {
+    getMany,
+    setRiskTierOverride,
+    validateOperationConfig,
+    validateOperationConfigs,
+  };
+};

--- a/packages/services/src/capabilityCatalogService/createCapabilityCatalogService.unit.test.ts
+++ b/packages/services/src/capabilityCatalogService/createCapabilityCatalogService.unit.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCapabilityCatalogService } from "./createCapabilityCatalogService";
+
+const connectorsDao = {
+  findMany: vi.fn(),
+};
+const skillsDao = {
+  findMany: vi.fn(),
+  seedIfEmpty: vi.fn(),
+};
+const riskOverridesDao = {
+  delete: vi.fn(),
+  findMany: vi.fn(),
+  upsert: vi.fn(),
+};
+
+const dependencies = { connectorsDao, skillsDao, riskOverridesDao };
+
+describe("createCapabilityCatalogService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connectorsDao.findMany.mockResolvedValue([]);
+    skillsDao.findMany.mockResolvedValue([
+      {
+        id: "skill-1",
+        name: "read-repository",
+        label: "Read repository",
+        description: "Read source files",
+        origin: "manual",
+        sources: [],
+      },
+    ]);
+    skillsDao.seedIfEmpty.mockResolvedValue(undefined);
+    riskOverridesDao.findMany.mockResolvedValue([]);
+    riskOverridesDao.delete.mockResolvedValue(undefined);
+    riskOverridesDao.upsert.mockResolvedValue({ capabilityId: "builtin:Read" });
+  });
+
+  const createService = () =>
+    createCapabilityCatalogService({} as never, { dependencies: dependencies as never });
+
+  it("filters the public projection by runtime and kinds", async () => {
+    const result = await createService().getMany({
+      runtime: "codex",
+      kinds: ["skill"],
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toEqual([
+      expect.objectContaining({ id: "skill:skill-1", kind: "skill", reference: "skill-1" }),
+    ]);
+  });
+
+  it("sets and clears a risk override", async () => {
+    const service = createService();
+    const setResult = await service.setRiskTierOverride({
+      id: "builtin:Read",
+      riskTier: "irreversible",
+    });
+    expect(setResult._unsafeUnwrap()).toMatchObject({
+      riskTier: "irreversible",
+      riskTierSource: "override",
+      inferredRiskTier: "readonly",
+    });
+    expect(riskOverridesDao.upsert).toHaveBeenCalledWith("builtin:Read", "irreversible");
+
+    const clearResult = await service.setRiskTierOverride({ id: "builtin:Read", riskTier: null });
+    expect(clearResult._unsafeUnwrap()).toMatchObject({
+      riskTier: "readonly",
+      riskTierSource: "rule",
+    });
+    expect(riskOverridesDao.delete).toHaveBeenCalledWith("builtin:Read");
+  });
+
+  it("validates skill, builtin, and MCP references with structured paths", async () => {
+    connectorsDao.findMany.mockResolvedValue([
+      {
+        id: "github",
+        name: "github",
+        method: "mcp",
+        status: "connected",
+        origin: "harvested",
+        config: {
+          transport: "stdio",
+          command: "github-mcp",
+          tools: [{ name: "create_issue" }],
+        },
+      },
+    ]);
+    const service = createService();
+
+    const valid = await service.validateOperationConfig({
+      executor: {
+        type: "agent",
+        skillId: "skill-1",
+        allowedTools: ["Read", "mcp__github__create_issue"],
+      },
+    });
+    expect(valid.isOk()).toBe(true);
+
+    const invalid = await service.validateOperationConfig({
+      executor: {
+        type: "agent",
+        skillId: "missing-skill",
+        allowedTools: ["unknown-tool"],
+      },
+    });
+    expect(invalid.isErr()).toBe(true);
+    expect(invalid._unsafeUnwrapErr()).toMatchObject({
+      name: "CapabilityCatalogValidationError",
+      issues: [
+        {
+          path: "config.executor.skillId",
+          reference: "missing-skill",
+          expectedKinds: ["skill"],
+        },
+        {
+          path: "config.executor.allowedTools[0]",
+          reference: "unknown-tool",
+          expectedKinds: ["builtin-tool", "mcp-tool"],
+        },
+      ],
+    });
+  });
+
+  it("fails closed when catalog loading fails", async () => {
+    connectorsDao.findMany.mockRejectedValue(new Error("database password leaked"));
+    const result = await createService().validateOperationConfig({
+      executor: { type: "agent", allowedTools: ["Read"] },
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr().message).toBe("Load capability catalog failed");
+    expect(result._unsafeUnwrapErr().message).not.toContain("password");
+  });
+});

--- a/packages/services/src/capabilityCatalogService/createCapabilityCatalogService.unit.test.ts
+++ b/packages/services/src/capabilityCatalogService/createCapabilityCatalogService.unit.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildMcpServerKey,
+  buildMcpToolReference,
+} from "../connectorsService/buildClaudeMcpInjection";
 import { createCapabilityCatalogService } from "./createCapabilityCatalogService";
 
 const connectorsDao = {
@@ -94,12 +98,13 @@ describe("createCapabilityCatalogService", () => {
       },
     ]);
     const service = createService();
+    const createIssueReference = buildMcpToolReference(buildMcpServerKey("github"), "create_issue");
 
     const valid = await service.validateOperationConfig({
       executor: {
         type: "agent",
         skillId: "skill-1",
-        allowedTools: ["Read", "mcp__github__create_issue"],
+        allowedTools: ["Read", createIssueReference],
       },
     });
     expect(valid.isOk()).toBe(true);
@@ -145,6 +150,44 @@ describe("createCapabilityCatalogService", () => {
         },
       ],
     });
+
+    const malformed = await service.validateOperationConfig({
+      executor: {
+        type: "agent",
+        agent: "not-a-runtime",
+        allowedTools: [42],
+        hiddenToolPermission: "shell",
+      },
+    });
+    expect(malformed._unsafeUnwrapErr()).toMatchObject({
+      name: "OperationConfigValidationError",
+      issues: expect.arrayContaining([
+        expect.objectContaining({ path: "config.executor.agent" }),
+        expect.objectContaining({ path: "config.executor.allowedTools[0]" }),
+        expect.objectContaining({ path: "config.executor" }),
+      ]),
+    });
+
+    const missingSourceSkill = await service.validateOperationInput({
+      config: {},
+      sourceSkillId: "missing-source-skill",
+    });
+    expect(missingSourceSkill._unsafeUnwrapErr()).toMatchObject({
+      name: "CapabilityCatalogValidationError",
+      issues: [
+        {
+          path: "sourceSkillId",
+          reference: "missing-source-skill",
+          expectedKinds: ["skill"],
+        },
+      ],
+    });
+
+    const validSourceSkill = await service.validateOperationInput({
+      config: {},
+      sourceSkillId: "skill-1",
+    });
+    expect(validSourceSkill.isOk()).toBe(true);
   });
 
   it("fails closed when catalog loading fails", async () => {

--- a/packages/services/src/capabilityCatalogService/createCapabilityCatalogService.unit.test.ts
+++ b/packages/services/src/capabilityCatalogService/createCapabilityCatalogService.unit.test.ts
@@ -49,6 +49,12 @@ describe("createCapabilityCatalogService", () => {
     expect(result._unsafeUnwrap()).toEqual([
       expect.objectContaining({ id: "skill:skill-1", kind: "skill", reference: "skill-1" }),
     ]);
+
+    const hermesResult = await createService().getMany({
+      runtime: "hermes",
+      kinds: ["skill"],
+    });
+    expect(hermesResult._unsafeUnwrap()).toEqual([]);
   });
 
   it("sets and clears a risk override", async () => {
@@ -118,6 +124,24 @@ describe("createCapabilityCatalogService", () => {
           path: "config.executor.allowedTools[0]",
           reference: "unknown-tool",
           expectedKinds: ["builtin-tool", "mcp-tool"],
+        },
+      ],
+    });
+
+    const incompatibleRuntime = await service.validateOperationConfig({
+      executor: {
+        type: "agent",
+        agent: "hermes",
+        skillId: "skill-1",
+      },
+    });
+    expect(incompatibleRuntime._unsafeUnwrapErr()).toMatchObject({
+      issues: [
+        {
+          path: "config.executor.skillId",
+          reference: "skill-1",
+          expectedKinds: ["skill"],
+          runtime: "hermes",
         },
       ],
     });

--- a/packages/services/src/capabilityCatalogService/index.ts
+++ b/packages/services/src/capabilityCatalogService/index.ts
@@ -1,0 +1,3 @@
+export * from "./catalogProjection";
+export * from "./createCapabilityCatalogService";
+export * from "./inferCapabilityRiskTier";

--- a/packages/services/src/capabilityCatalogService/inferCapabilityRiskTier.ts
+++ b/packages/services/src/capabilityCatalogService/inferCapabilityRiskTier.ts
@@ -43,6 +43,8 @@ const IRREVERSIBLE_KEYWORDS = new Set([
   "destroy",
   "drop",
   "pay",
+  "payment",
+  "payments",
   "charge",
   "refund",
   "transfer",
@@ -62,6 +64,18 @@ export const tokenizeCapabilityName = (value: string): string[] =>
 
 export const inferCapabilityRiskTier = (value: string): CapabilityRiskTier => {
   const tokens = tokenizeCapabilityName(value);
+  const hasActionSequence = tokens.some((token) => token === "and" || token === "then");
+  const firstRecognizedAction = tokens.find(
+    (token) =>
+      READONLY_KEYWORDS.has(token) || WRITE_KEYWORDS.has(token) || IRREVERSIBLE_KEYWORDS.has(token),
+  );
+
+  // A leading read verb describes the operation; later words such as
+  // "release" are commonly the object (get_release), not a second action.
+  // Explicit multi-action names still use the highest matched risk.
+  if (firstRecognizedAction && READONLY_KEYWORDS.has(firstRecognizedAction) && !hasActionSequence) {
+    return "readonly";
+  }
 
   if (tokens.some((token) => IRREVERSIBLE_KEYWORDS.has(token))) return "irreversible";
   if (tokens.some((token) => WRITE_KEYWORDS.has(token))) return "write";

--- a/packages/services/src/capabilityCatalogService/inferCapabilityRiskTier.ts
+++ b/packages/services/src/capabilityCatalogService/inferCapabilityRiskTier.ts
@@ -1,0 +1,71 @@
+import type { CapabilityRiskTier } from "@repo/schemas";
+
+const READONLY_KEYWORDS = new Set([
+  "get",
+  "list",
+  "read",
+  "query",
+  "search",
+  "find",
+  "fetch",
+  "view",
+  "inspect",
+  "describe",
+  "preview",
+  "check",
+  "status",
+]);
+
+const WRITE_KEYWORDS = new Set([
+  "create",
+  "add",
+  "update",
+  "modify",
+  "edit",
+  "write",
+  "set",
+  "upsert",
+  "patch",
+  "upload",
+  "import",
+  "copy",
+  "move",
+  "connect",
+  "disconnect",
+  "archive",
+  "restore",
+]);
+
+const IRREVERSIBLE_KEYWORDS = new Set([
+  "publish",
+  "delete",
+  "remove",
+  "destroy",
+  "drop",
+  "pay",
+  "charge",
+  "refund",
+  "transfer",
+  "send",
+  "deploy",
+  "release",
+  "execute",
+]);
+
+export const tokenizeCapabilityName = (value: string): string[] =>
+  value
+    .replaceAll(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replaceAll(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+
+export const inferCapabilityRiskTier = (value: string): CapabilityRiskTier => {
+  const tokens = tokenizeCapabilityName(value);
+
+  if (tokens.some((token) => IRREVERSIBLE_KEYWORDS.has(token))) return "irreversible";
+  if (tokens.some((token) => WRITE_KEYWORDS.has(token))) return "write";
+  if (tokens.some((token) => READONLY_KEYWORDS.has(token))) return "readonly";
+
+  return "write";
+};

--- a/packages/services/src/capabilityCatalogService/inferCapabilityRiskTier.unit.test.ts
+++ b/packages/services/src/capabilityCatalogService/inferCapabilityRiskTier.unit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { inferCapabilityRiskTier, tokenizeCapabilityName } from "./inferCapabilityRiskTier";
+
+describe("inferCapabilityRiskTier", () => {
+  it.each([
+    ["getIssue", "readonly"],
+    ["list_issues", "readonly"],
+    ["search-issues", "readonly"],
+    ["createIssue", "write"],
+    ["update_issue", "write"],
+    ["upload-file", "write"],
+    ["deleteIssue", "irreversible"],
+    ["send_message", "irreversible"],
+    ["deploy-release", "irreversible"],
+  ] as const)("infers %s as %s", (name, expected) => {
+    expect(inferCapabilityRiskTier(name)).toBe(expected);
+  });
+
+  it("uses the highest matched risk", () => {
+    expect(inferCapabilityRiskTier("getAndDeleteIssue")).toBe("irreversible");
+    expect(inferCapabilityRiskTier("read_then_update_record")).toBe("write");
+  });
+
+  it("defaults unknown names to write", () => {
+    expect(inferCapabilityRiskTier("summarize_content")).toBe("write");
+  });
+
+  it("splits camelCase, acronyms, snake_case, and kebab-case", () => {
+    expect(tokenizeCapabilityName("HTTPFetch_create-item")).toEqual([
+      "http",
+      "fetch",
+      "create",
+      "item",
+    ]);
+  });
+});

--- a/packages/services/src/capabilityCatalogService/inferCapabilityRiskTier.unit.test.ts
+++ b/packages/services/src/capabilityCatalogService/inferCapabilityRiskTier.unit.test.ts
@@ -7,11 +7,15 @@ describe("inferCapabilityRiskTier", () => {
     ["list_issues", "readonly"],
     ["search-issues", "readonly"],
     ["createIssue", "write"],
+    ["modify_record", "write"],
     ["update_issue", "write"],
     ["upload-file", "write"],
+    ["create_payment", "irreversible"],
     ["deleteIssue", "irreversible"],
+    ["publish_draft", "irreversible"],
     ["send_message", "irreversible"],
     ["deploy-release", "irreversible"],
+    ["get_release", "readonly"],
   ] as const)("infers %s as %s", (name, expected) => {
     expect(inferCapabilityRiskTier(name)).toBe(expected);
   });

--- a/packages/services/src/connectorsService/buildClaudeMcpInjection.ts
+++ b/packages/services/src/connectorsService/buildClaudeMcpInjection.ts
@@ -3,12 +3,24 @@ import { isMcpConnectorConfig, type ConnectorConfig, type McpConnectorConfig } f
 
 export type ClaudeMcpInjection = McpConnectorInjection;
 
-type ConnectorLike = {
+export type ConnectorLike = {
   id: string;
   name: string;
   method: string;
   status: string;
   config: ConnectorConfig;
+};
+
+export type ResolvedMcpConnector = {
+  connector: ConnectorLike;
+  config: McpConnectorConfig;
+  serverKey: string;
+};
+
+export type ResolvedMcpTool = ResolvedMcpConnector & {
+  toolName: string;
+  description: string;
+  reference: string;
 };
 
 /**
@@ -22,6 +34,44 @@ export const sanitizeServerKey = (name: string): string =>
 const uniqueServerKey = (base: string, taken: Record<string, unknown>): string =>
   base in taken ? uniqueServerKey(`${base}_`, taken) : base;
 
+export const buildMcpToolReference = (serverKey: string, toolName: string): string =>
+  `mcp__${serverKey}__${toolName}`;
+
+/**
+ * Resolve every connected, structurally valid MCP connector in stable id
+ * order. Runtime injection and the capability catalog both consume this
+ * function so server-key disambiguation cannot drift between the two paths.
+ */
+export const resolveMcpConnectors = (connectors: ConnectorLike[]): ResolvedMcpConnector[] => {
+  const takenServerKeys: Record<string, unknown> = {};
+
+  return connectors
+    .filter(
+      (connector): connector is ConnectorLike & { config: McpConnectorConfig } =>
+        connector.method === "mcp" &&
+        connector.status === "connected" &&
+        isMcpConnectorConfig(connector.config),
+    )
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map((connector) => {
+      const serverKey = uniqueServerKey(sanitizeServerKey(connector.name), takenServerKeys);
+      takenServerKeys[serverKey] = true;
+
+      return { connector, config: connector.config, serverKey };
+    });
+};
+
+/** Only handshake-discovered concrete tools belong in the public catalog. */
+export const resolveMcpConnectorTools = (connectors: ConnectorLike[]): ResolvedMcpTool[] =>
+  resolveMcpConnectors(connectors).flatMap((resolved) =>
+    (resolved.config.tools ?? []).map((tool) => ({
+      ...resolved,
+      toolName: tool.name,
+      description: tool.description ?? "",
+      reference: buildMcpToolReference(resolved.serverKey, tool.name),
+    })),
+  );
+
 const selectedMcpToolNames = ({
   serverKey,
   config,
@@ -34,7 +84,7 @@ const selectedMcpToolNames = ({
   const serverToolPrefix = `mcp__${serverKey}`;
   const availableToolNames =
     config.tools && config.tools.length > 0
-      ? config.tools.map((tool) => `${serverToolPrefix}__${tool.name}`)
+      ? config.tools.map((tool) => buildMcpToolReference(serverKey, tool.name))
       : [serverToolPrefix];
 
   return selectedTools
@@ -58,26 +108,9 @@ export const buildMcpConnectorInjection = (
   const toolNames: string[] = [];
   const selectedTools = selectedToolNames ? new Set(selectedToolNames) : null;
   const selectedToolOwners = new Map<string, string>();
-  const takenServerKeys: Record<string, unknown> = {};
-  const eligibleConnectors = connectors
-    .map((connector) => ({ connector }))
-    .filter(({ connector }) => {
-      if (connector.method !== "mcp") return false;
-      if (connector.status !== "connected") return false;
+  const eligibleConnectors = resolveMcpConnectors(connectors);
 
-      return isMcpConnectorConfig(connector.config);
-    })
-    .sort((a, b) => a.connector.id.localeCompare(b.connector.id))
-    .map(({ connector }) => {
-      const key = uniqueServerKey(sanitizeServerKey(connector.name), takenServerKeys);
-      takenServerKeys[key] = true;
-
-      return { connector, key };
-    });
-
-  for (const { connector, key } of eligibleConnectors) {
-    const config = connector.config;
-    if (!isMcpConnectorConfig(config)) continue;
+  for (const { config, serverKey: key } of eligibleConnectors) {
 
     const selectedServerTools = selectedMcpToolNames({ serverKey: key, config, selectedTools });
     if (selectedServerTools.length === 0) continue;

--- a/packages/services/src/connectorsService/buildClaudeMcpInjection.ts
+++ b/packages/services/src/connectorsService/buildClaudeMcpInjection.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import type { McpConnectorInjection, McpServerEntry } from "@repo/agent";
 import {
   McpConnectorConfigSchema,
@@ -28,15 +29,16 @@ export type ResolvedMcpTool = ResolvedMcpConnector & {
 };
 
 /**
- * Server keys keep only [A-Za-z0-9_-]; everything else becomes _
- * (matches claude's mcp__<server>__ naming).
+ * MCP references are persisted on operations, so their server component must
+ * not depend on connector display names or on which other connectors happen
+ * to be connected. Hex is injective for the UTF-8 connector id and cannot
+ * contain the `__` separator used by Claude/Codex tool references.
  */
-export const sanitizeServerKey = (name: string): string =>
-  name.replaceAll(/[^A-Za-z0-9_-]/g, "_").replaceAll(/^_+|_+$/g, "") || "server";
+export const buildMcpServerKey = (connectorId: string): string => {
+  if (connectorId.length === 0) throw new Error("MCP connector id must be non-empty");
 
-/** Dedupe same-named keys: append `_` until unique. */
-const uniqueServerKey = (base: string, taken: Record<string, unknown>): string =>
-  base in taken ? uniqueServerKey(`${base}_`, taken) : base;
+  return `connector_${Buffer.from(connectorId, "utf8").toString("hex")}`;
+};
 
 export const buildMcpToolReference = (serverKey: string, toolName: string): string =>
   `mcp__${serverKey}__${toolName}`;
@@ -47,8 +49,6 @@ export const buildMcpToolReference = (serverKey: string, toolName: string): stri
  * function so server-key disambiguation cannot drift between the two paths.
  */
 export const resolveMcpConnectors = (connectors: ConnectorLike[]): ResolvedMcpConnector[] => {
-  const takenServerKeys: Record<string, unknown> = {};
-
   return connectors
     .flatMap((connector) => {
       if (connector.method !== "mcp" || connector.status !== "connected") return [];
@@ -57,24 +57,32 @@ export const resolveMcpConnectors = (connectors: ConnectorLike[]): ResolvedMcpCo
       return parsed.success ? [{ connector, config: parsed.data }] : [];
     })
     .sort((a, b) => a.connector.id.localeCompare(b.connector.id))
-    .map(({ connector, config }) => {
-      const serverKey = uniqueServerKey(sanitizeServerKey(connector.name), takenServerKeys);
-      takenServerKeys[serverKey] = true;
-
-      return { connector, config, serverKey };
-    });
+    .map(({ connector, config }) => ({
+      connector,
+      config,
+      serverKey: buildMcpServerKey(connector.id),
+    }));
 };
 
 /** Only handshake-discovered concrete tools belong in the public catalog. */
 export const resolveMcpConnectorTools = (connectors: ConnectorLike[]): ResolvedMcpTool[] =>
-  resolveMcpConnectors(connectors).flatMap((resolved) =>
-    (resolved.config.tools ?? []).map((tool) => ({
-      ...resolved,
-      toolName: tool.name,
-      description: tool.description ?? "",
-      reference: buildMcpToolReference(resolved.serverKey, tool.name),
-    })),
-  );
+  resolveMcpConnectors(connectors).flatMap((resolved) => {
+    const seenToolNames = new Set<string>();
+
+    return (resolved.config.tools ?? []).flatMap((tool) => {
+      if (seenToolNames.has(tool.name)) return [];
+      seenToolNames.add(tool.name);
+
+      return [
+        {
+          ...resolved,
+          toolName: tool.name,
+          description: tool.description ?? "",
+          reference: buildMcpToolReference(resolved.serverKey, tool.name),
+        },
+      ];
+    });
+  });
 
 const selectedMcpToolNames = ({
   serverKey,
@@ -88,7 +96,7 @@ const selectedMcpToolNames = ({
   const serverToolPrefix = `mcp__${serverKey}`;
   const availableToolNames =
     config.tools && config.tools.length > 0
-      ? config.tools.map((tool) => buildMcpToolReference(serverKey, tool.name))
+      ? [...new Set(config.tools.map((tool) => buildMcpToolReference(serverKey, tool.name)))]
       : [serverToolPrefix];
 
   return selectedTools

--- a/packages/services/src/connectorsService/buildClaudeMcpInjection.ts
+++ b/packages/services/src/connectorsService/buildClaudeMcpInjection.ts
@@ -1,5 +1,9 @@
 import type { McpConnectorInjection, McpServerEntry } from "@repo/agent";
-import { isMcpConnectorConfig, type ConnectorConfig, type McpConnectorConfig } from "@repo/schemas";
+import {
+  McpConnectorConfigSchema,
+  type ConnectorConfig,
+  type McpConnectorConfig,
+} from "@repo/schemas";
 
 export type ClaudeMcpInjection = McpConnectorInjection;
 
@@ -46,18 +50,18 @@ export const resolveMcpConnectors = (connectors: ConnectorLike[]): ResolvedMcpCo
   const takenServerKeys: Record<string, unknown> = {};
 
   return connectors
-    .filter(
-      (connector): connector is ConnectorLike & { config: McpConnectorConfig } =>
-        connector.method === "mcp" &&
-        connector.status === "connected" &&
-        isMcpConnectorConfig(connector.config),
-    )
-    .sort((a, b) => a.id.localeCompare(b.id))
-    .map((connector) => {
+    .flatMap((connector) => {
+      if (connector.method !== "mcp" || connector.status !== "connected") return [];
+      const parsed = McpConnectorConfigSchema.safeParse(connector.config);
+
+      return parsed.success ? [{ connector, config: parsed.data }] : [];
+    })
+    .sort((a, b) => a.connector.id.localeCompare(b.connector.id))
+    .map(({ connector, config }) => {
       const serverKey = uniqueServerKey(sanitizeServerKey(connector.name), takenServerKeys);
       takenServerKeys[serverKey] = true;
 
-      return { connector, config: connector.config, serverKey };
+      return { connector, config, serverKey };
     });
 };
 
@@ -111,7 +115,6 @@ export const buildMcpConnectorInjection = (
   const eligibleConnectors = resolveMcpConnectors(connectors);
 
   for (const { config, serverKey: key } of eligibleConnectors) {
-
     const selectedServerTools = selectedMcpToolNames({ serverKey: key, config, selectedTools });
     if (selectedServerTools.length === 0) continue;
 

--- a/packages/services/src/connectorsService/buildClaudeMcpInjection.unit.test.ts
+++ b/packages/services/src/connectorsService/buildClaudeMcpInjection.unit.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildMcpConnectorInjection, sanitizeServerKey } from "./buildClaudeMcpInjection";
+import {
+  buildMcpConnectorInjection,
+  resolveMcpConnectorTools,
+  sanitizeServerKey,
+} from "./buildClaudeMcpInjection";
 
 const connected = (
   name: string,
@@ -140,5 +144,56 @@ describe("buildMcpConnectorInjection", () => {
         ["mcp__api_x___read"],
       ),
     ).toThrow("Ambiguous MCP tool selection mcp__api_x___read");
+  });
+});
+
+describe("resolveMcpConnectorTools", () => {
+  it("uses the exact runtime references and stable connector-name disambiguation", () => {
+    const connectors = [
+      connected(
+        "github",
+        {
+          transport: "stdio",
+          command: "github-second",
+          tools: [{ name: "create_issue", description: "Create an issue" }],
+        },
+        "connected",
+        "mcp",
+        "connector-b",
+      ),
+      connected(
+        "github",
+        {
+          transport: "stdio",
+          command: "github-first",
+          tools: [{ name: "read_issue" }],
+        },
+        "connected",
+        "mcp",
+        "connector-a",
+      ),
+    ];
+
+    const tools = resolveMcpConnectorTools(connectors);
+    expect(tools.map((tool) => tool.reference)).toEqual([
+      "mcp__github__read_issue",
+      "mcp__github___create_issue",
+    ]);
+    expect(
+      buildMcpConnectorInjection(
+        connectors,
+        tools.map((tool) => tool.reference),
+      )?.toolNames,
+    ).toEqual(tools.map((tool) => tool.reference));
+  });
+
+  it("excludes disconnected, invalid, and tool-less connectors", () => {
+    expect(
+      resolveMcpConnectorTools([
+        connected("pending", { transport: "stdio", command: "x", tools: [{ name: "read" }] }, "needs_setup"),
+        connected("invalid", {}),
+        connected("empty", { transport: "stdio", command: "x" }),
+      ]),
+    ).toEqual([]);
   });
 });

--- a/packages/services/src/connectorsService/buildClaudeMcpInjection.unit.test.ts
+++ b/packages/services/src/connectorsService/buildClaudeMcpInjection.unit.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildMcpConnectorInjection,
+  buildMcpServerKey,
+  buildMcpToolReference,
   resolveMcpConnectorTools,
-  sanitizeServerKey,
 } from "./buildClaudeMcpInjection";
 
 const connected = (
@@ -13,12 +14,8 @@ const connected = (
   id = `connector-${name}`,
 ) => ({ id, name, method, status, config }) as never;
 
-describe("sanitizeServerKey", () => {
-  it("keeps word chars, replaces the rest", () => {
-    expect(sanitizeServerKey("GitHub MCP!")).toBe("GitHub_MCP");
-    expect(sanitizeServerKey("###")).toBe("server");
-  });
-});
+const toolReference = (connectorId: string, toolName: string): string =>
+  buildMcpToolReference(buildMcpServerKey(connectorId), toolName);
 
 describe("buildMcpConnectorInjection", () => {
   it("returns null when there are no connected mcp connectors", () => {
@@ -41,6 +38,8 @@ describe("buildMcpConnectorInjection", () => {
   });
 
   it("builds stdio server entry + per-tool allow names", () => {
+    const connectorId = "connector-fs";
+    const serverKey = buildMcpServerKey(connectorId);
     const out = buildMcpConnectorInjection([
       connected("fs", {
         transport: "stdio",
@@ -52,29 +51,36 @@ describe("buildMcpConnectorInjection", () => {
       }),
     ]);
     expect(out).not.toBeNull();
-    expect(out!.mcpServers.fs).toEqual({
+    expect(out!.mcpServers[serverKey]).toEqual({
       command: "npx",
       args: ["-y", "server-fs"],
       cwd: "/workspace",
       env: { TOKEN: "x" },
     });
-    expect(out!.toolNames).toEqual(["mcp__fs__read_file", "mcp__fs__write_file"]);
+    expect(out!.toolNames).toEqual([
+      toolReference(connectorId, "read_file"),
+      toolReference(connectorId, "write_file"),
+    ]);
   });
 
   it("builds http entry and whole-server allow when no tools discovered", () => {
+    const connectorId = "connector-remote api";
+    const serverKey = buildMcpServerKey(connectorId);
     const out = buildMcpConnectorInjection([
       connected("remote api", { transport: "http", url: "https://x/sse" }),
     ]);
-    expect(out!.mcpServers.remote_api).toEqual({ type: "http", url: "https://x/sse" });
-    expect(out!.toolNames).toEqual(["mcp__remote_api"]);
+    expect(out!.mcpServers[serverKey]).toEqual({ type: "http", url: "https://x/sse" });
+    expect(out!.toolNames).toEqual([`mcp__${serverKey}`]);
   });
 
-  it("dedupes server keys with the same sanitized name", () => {
+  it("uses stable connector ids when display names collide", () => {
     const out = buildMcpConnectorInjection([
-      connected("api x", { transport: "stdio", command: "a" }),
-      connected("api!x", { transport: "stdio", command: "b" }),
+      connected("api", { transport: "stdio", command: "a" }, "connected", "mcp", "a"),
+      connected("api", { transport: "stdio", command: "b" }, "connected", "mcp", "b"),
     ]);
-    expect(Object.keys(out!.mcpServers).sort()).toEqual(["api_x", "api_x_"]);
+    expect(Object.keys(out!.mcpServers).sort()).toEqual(
+      [buildMcpServerKey("a"), buildMcpServerKey("b")].sort(),
+    );
   });
 
   it("only includes connectors selected for the current run", () => {
@@ -91,16 +97,16 @@ describe("buildMcpConnectorInjection", () => {
           tools: [{ name: "create_issue" }],
         }),
       ],
-      ["mcp__github__read_issue"],
+      [toolReference("connector-github", "read_issue")],
     );
 
     expect(out).toEqual({
-      mcpServers: { github: { command: "github-mcp" } },
-      toolNames: ["mcp__github__read_issue"],
+      mcpServers: { [buildMcpServerKey("connector-github")]: { command: "github-mcp" } },
+      toolNames: [toolReference("connector-github", "read_issue")],
     });
   });
 
-  it("uses connector id order for stable deduped keys", () => {
+  it("does not drift an existing reference when a same-name connector is added", () => {
     const connectors = [
       connected(
         "api",
@@ -117,38 +123,55 @@ describe("buildMcpConnectorInjection", () => {
         "connector-a",
       ),
     ];
+    const existingReference = toolReference("connector-b", "read");
 
-    for (const orderedConnectors of [connectors, [...connectors].reverse()]) {
-      expect(buildMcpConnectorInjection(orderedConnectors, ["mcp__api___read"])).toEqual({
-        mcpServers: { api_: { command: "second-mcp" } },
-        toolNames: ["mcp__api___read"],
+    for (const orderedConnectors of [
+      connectors.slice(0, 1),
+      connectors,
+      [...connectors].reverse(),
+    ]) {
+      expect(buildMcpConnectorInjection(orderedConnectors, [existingReference])).toEqual({
+        mcpServers: {
+          [buildMcpServerKey("connector-b")]: { command: "second-mcp" },
+        },
+        toolNames: [existingReference],
       });
     }
   });
 
-  it("fails closed when a selected tool name maps to multiple servers", () => {
-    expect(() =>
-      buildMcpConnectorInjection(
-        [
-          connected("api x", {
-            transport: "stdio",
-            command: "first-mcp",
-            tools: [{ name: "_read" }],
-          }),
-          connected("api!x", {
-            transport: "stdio",
-            command: "second-mcp",
-            tools: [{ name: "read" }],
-          }),
-        ],
-        ["mcp__api_x___read"],
-      ),
-    ).toThrow("Ambiguous MCP tool selection mcp__api_x___read");
+  it("keeps formerly ambiguous connector/tool pairs unique at runtime", () => {
+    const first = connected(
+      "api x",
+      { transport: "stdio", command: "first-mcp", tools: [{ name: "_read" }] },
+      "connected",
+      "mcp",
+      "connector-a",
+    );
+    const second = connected(
+      "api!x",
+      { transport: "stdio", command: "second-mcp", tools: [{ name: "read" }] },
+      "connected",
+      "mcp",
+      "connector-b",
+    );
+    const references = [
+      toolReference("connector-a", "_read"),
+      toolReference("connector-b", "read"),
+    ];
+
+    expect(new Set(references).size).toBe(2);
+    expect(buildMcpConnectorInjection([first, second], references)).toEqual({
+      mcpServers: {
+        [buildMcpServerKey("connector-a")]: { command: "first-mcp" },
+        [buildMcpServerKey("connector-b")]: { command: "second-mcp" },
+      },
+      toolNames: references,
+    });
   });
 });
 
 describe("resolveMcpConnectorTools", () => {
-  it("uses the exact runtime references and stable connector-name disambiguation", () => {
+  it("uses the exact runtime references and stable connector identity", () => {
     const connectors = [
       connected(
         "github",
@@ -176,8 +199,8 @@ describe("resolveMcpConnectorTools", () => {
 
     const tools = resolveMcpConnectorTools(connectors);
     expect(tools.map((tool) => tool.reference)).toEqual([
-      "mcp__github__read_issue",
-      "mcp__github___create_issue",
+      toolReference("connector-a", "read_issue"),
+      toolReference("connector-b", "create_issue"),
     ]);
     expect(
       buildMcpConnectorInjection(

--- a/packages/services/src/connectorsService/buildClaudeMcpInjection.unit.test.ts
+++ b/packages/services/src/connectorsService/buildClaudeMcpInjection.unit.test.ts
@@ -190,8 +190,12 @@ describe("resolveMcpConnectorTools", () => {
   it("excludes disconnected, invalid, and tool-less connectors", () => {
     expect(
       resolveMcpConnectorTools([
-        connected("pending", { transport: "stdio", command: "x", tools: [{ name: "read" }] }, "needs_setup"),
-        connected("invalid", {}),
+        connected(
+          "pending",
+          { transport: "stdio", command: "x", tools: [{ name: "read" }] },
+          "needs_setup",
+        ),
+        connected("invalid", { transport: "stdio", tools: [{ name: "read" }] }),
         connected("empty", { transport: "stdio", command: "x" }),
       ]),
     ).toEqual([]);

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./agentsService";
 export * from "./agentRuntimesService";
 export * from "./capabilityHarvestService";
+export * from "./capabilityCatalogService";
 export * from "./connectorsService";
 export * from "./conversationMessagesService";
 export * from "./distillationsService";

--- a/packages/services/src/operationsService/createOperationsService.ts
+++ b/packages/services/src/operationsService/createOperationsService.ts
@@ -1,14 +1,56 @@
 import { createOperationsDao, type DbConnection } from "@repo/models";
 import { mapWithMeta, withMeta } from "@repo/schemas";
+import { okAsync, ResultAsync } from "neverthrow";
+import {
+  createCapabilityCatalogService,
+  type CapabilityCatalogServiceOptions,
+} from "../capabilityCatalogService";
+import { toServiceError } from "../serviceErrors";
 
-export const createOperationsService = (db: DbConnection) => {
+export interface OperationsServiceOptions {
+  capabilityCatalog?: ReturnType<typeof createCapabilityCatalogService>;
+  capabilityCatalogOptions?: CapabilityCatalogServiceOptions;
+}
+
+export const createOperationsService = (
+  db: DbConnection,
+  options: OperationsServiceOptions = {},
+) => {
   const dao = createOperationsDao(db);
+  const capabilityCatalog =
+    options.capabilityCatalog ??
+    createCapabilityCatalogService(db, options.capabilityCatalogOptions);
+
+  const create = (data: Parameters<typeof dao.create>[0]) =>
+    capabilityCatalog
+      .validateOperationConfig(data.config ?? {})
+      .andThen(() =>
+        ResultAsync.fromPromise(dao.create(data), (error) =>
+          toServiceError(error, "Create operation"),
+        ),
+      )
+      .map(withMeta);
+
+  const update = (id: string, patch: Parameters<typeof dao.update>[1]) => {
+    const validation =
+      patch.config === undefined
+        ? okAsync(undefined)
+        : capabilityCatalog.validateOperationConfig(patch.config);
+
+    return validation
+      .andThen(() =>
+        ResultAsync.fromPromise(dao.update(id, patch), (error) =>
+          toServiceError(error, "Update operation"),
+        ),
+      )
+      .map(withMeta);
+  };
 
   return {
     getAll: async () => mapWithMeta(await dao.findMany()),
     getById: async (id: string) => withMeta(await dao.findById(id)),
-    create: async (...args: Parameters<typeof dao.create>) => withMeta(await dao.create(...args)),
-    update: async (...args: Parameters<typeof dao.update>) => withMeta(await dao.update(...args)),
+    create,
+    update,
     delete: (id: string) => dao.delete(id),
   };
 };

--- a/packages/services/src/operationsService/createOperationsService.ts
+++ b/packages/services/src/operationsService/createOperationsService.ts
@@ -23,7 +23,10 @@ export const createOperationsService = (
 
   const create = (data: Parameters<typeof dao.create>[0]) =>
     capabilityCatalog
-      .validateOperationConfig(data.config ?? {})
+      .validateOperationInput({
+        config: data.config === undefined ? {} : data.config,
+        sourceSkillId: data.sourceSkillId,
+      })
       .andThen(() =>
         ResultAsync.fromPromise(dao.create(data), (error) =>
           toServiceError(error, "Create operation"),
@@ -33,9 +36,14 @@ export const createOperationsService = (
 
   const update = (id: string, patch: Parameters<typeof dao.update>[1]) => {
     const validation =
-      patch.config === undefined
+      !Object.hasOwn(patch, "config") && !Object.hasOwn(patch, "sourceSkillId")
         ? okAsync(undefined)
-        : capabilityCatalog.validateOperationConfig(patch.config);
+        : capabilityCatalog.validateOperationPatch({
+            ...(Object.hasOwn(patch, "config") ? { config: patch.config } : {}),
+            ...(Object.hasOwn(patch, "sourceSkillId")
+              ? { sourceSkillId: patch.sourceSkillId }
+              : {}),
+          });
 
     return validation
       .andThen(() =>

--- a/packages/services/src/operationsService/createOperationsService.unit.test.ts
+++ b/packages/services/src/operationsService/createOperationsService.unit.test.ts
@@ -1,15 +1,23 @@
 import { describe, it, expect, vi } from "vitest";
 
 const mockDao = {
-  findMany: vi.fn().mockResolvedValue([{ id: "o1" , createdAt: new Date(0), updatedAt: new Date(0) }]),
-  findById: vi.fn().mockResolvedValue({ id: "o1" , createdAt: new Date(0), updatedAt: new Date(0) }),
-  create: vi.fn().mockResolvedValue({ id: "o1" , createdAt: new Date(0), updatedAt: new Date(0) }),
-  update: vi.fn().mockResolvedValue({ id: "o1" , createdAt: new Date(0), updatedAt: new Date(0) }),
+  findMany: vi
+    .fn()
+    .mockResolvedValue([{ id: "o1", createdAt: new Date(0), updatedAt: new Date(0) }]),
+  findById: vi.fn().mockResolvedValue({ id: "o1", createdAt: new Date(0), updatedAt: new Date(0) }),
+  create: vi.fn().mockResolvedValue({ id: "o1", createdAt: new Date(0), updatedAt: new Date(0) }),
+  update: vi.fn().mockResolvedValue({ id: "o1", createdAt: new Date(0), updatedAt: new Date(0) }),
   delete: vi.fn().mockResolvedValue(undefined),
 };
 
 vi.mock("@repo/models", () => ({
+  createCapabilityRiskOverridesDao: () => ({ findMany: vi.fn().mockResolvedValue([]) }),
+  createConnectorsDao: () => ({ findMany: vi.fn().mockResolvedValue([]) }),
   createOperationsDao: () => mockDao,
+  createSkillsDao: () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    seedIfEmpty: vi.fn().mockResolvedValue(undefined),
+  }),
 }));
 
 import { createOperationsService } from "./createOperationsService";
@@ -19,7 +27,9 @@ describe("createOperationsService", () => {
     const svc = createOperationsService({} as never);
     const result = await svc.getAll();
     expect(mockDao.findMany).toHaveBeenCalled();
-    expect(result).toEqual([{ id: "o1" , meta: { createdAt: new Date(0), updatedAt: new Date(0) } }]);
+    expect(result).toEqual([
+      { id: "o1", meta: { createdAt: new Date(0), updatedAt: new Date(0) } },
+    ]);
   });
 
   it("getById delegates to dao.findById", async () => {

--- a/packages/services/src/operationsService/createOperationsService.unit.test.ts
+++ b/packages/services/src/operationsService/createOperationsService.unit.test.ts
@@ -45,6 +45,30 @@ describe("createOperationsService", () => {
     expect(mockDao.create).toHaveBeenCalledWith(data);
   });
 
+  it("rejects malformed configs and catalog-missing source skills before insert", async () => {
+    const svc = createOperationsService({} as never);
+    mockDao.create.mockClear();
+
+    const malformed = await svc.create({
+      name: "broken",
+      config: { executor: { type: "agent", agent: "not-a-runtime" } },
+    } as never);
+    expect(malformed._unsafeUnwrapErr()).toMatchObject({
+      name: "OperationConfigValidationError",
+    });
+
+    const missingSourceSkill = await svc.create({
+      name: "broken source",
+      config: {},
+      sourceSkillId: "missing-skill",
+    } as never);
+    expect(missingSourceSkill._unsafeUnwrapErr()).toMatchObject({
+      name: "CapabilityCatalogValidationError",
+      issues: [expect.objectContaining({ path: "sourceSkillId" })],
+    });
+    expect(mockDao.create).not.toHaveBeenCalled();
+  });
+
   it("update delegates to dao.update", async () => {
     const svc = createOperationsService({} as never);
     await svc.update("o1", { name: "updated" } as never);

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
@@ -826,12 +826,13 @@ export const createPipelineAgentSessionsService = (db: DbConnection) => {
       }
 
       if (proposal.proposal.mode === "edit" && proposal.proposal.pendingOperations?.length > 0) {
-        await pipelinesService.createPendingOperations(
+        const createPendingResult = await pipelinesService.createPendingOperations(
           proposal.proposal.pendingOperations.map((op) => ({
             ...op,
             acceptedObjectTypes: op.acceptedObjectTypes as ObjectNodeType[],
           })),
         );
+        if (createPendingResult.isErr()) throw createPendingResult.error;
       }
 
       await proposalsDao.update(proposalId, {
@@ -1276,9 +1277,11 @@ export const createPipelineAgentSessionsService = (db: DbConnection) => {
             const transactionalSessionsDao = createPipelineAgentSessionsDao(tx);
             assertActivityActive(sessionId, activity);
             if (generated.pendingOperations && generated.pendingOperations.length > 0) {
-              await transactionalPipelinesService.createPendingOperations(
-                generated.pendingOperations,
-              );
+              const createPendingResult =
+                await transactionalPipelinesService.createPendingOperations(
+                  generated.pendingOperations,
+                );
+              if (createPendingResult.isErr()) throw createPendingResult.error;
               assertActivityActive(sessionId, activity);
             }
 

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
@@ -796,55 +796,59 @@ export const createPipelineAgentSessionsService = (db: DbConnection) => {
       return proposal;
     },
 
-    approveProposal: async (sessionId: string, proposalId: string) => {
-      const session = await sessionsDao.findById(sessionId);
-      if (!session) {
-        throw new Error(`Pipeline agent session not found: ${sessionId}`);
-      }
+    approveProposal: (sessionId: string, proposalId: string) =>
+      db.transaction(async (transaction) => {
+        const transactionalSessionsDao = createPipelineAgentSessionsDao(transaction);
+        const transactionalProposalsDao = createPipelineAgentProposalsDao(transaction);
+        const transactionalPipelinesService = createPipelinesService(transaction);
+        const session = await transactionalSessionsDao.findById(sessionId);
+        if (!session) {
+          throw new Error(`Pipeline agent session not found: ${sessionId}`);
+        }
 
-      const proposal = await proposalsDao.findById(proposalId);
-      if (!proposal) {
-        throw new Error(`Pipeline agent proposal not found: ${proposalId}`);
-      }
-      if (proposal.sessionId !== sessionId) {
-        throw new Error(
-          `Pipeline agent proposal ${proposalId} does not belong to session ${sessionId}`,
-        );
-      }
-      if (proposal.mode !== session.mode) {
-        throw new Error(
-          `Pipeline agent proposal ${proposalId} mode does not match session ${sessionId}`,
-        );
-      }
-      if (proposal.status !== "proposal_ready") {
-        throw new Error(
-          `Pipeline agent proposal ${proposalId} cannot be approved from status ${proposal.status}`,
-        );
-      }
-      if (proposal.proposal.readiness !== "ready_for_generation") {
-        throw new Error(`Pipeline agent proposal ${proposalId} is not ready for approval`);
-      }
+        const proposal = await transactionalProposalsDao.findById(proposalId);
+        if (!proposal) {
+          throw new Error(`Pipeline agent proposal not found: ${proposalId}`);
+        }
+        if (proposal.sessionId !== sessionId) {
+          throw new Error(
+            `Pipeline agent proposal ${proposalId} does not belong to session ${sessionId}`,
+          );
+        }
+        if (proposal.mode !== session.mode) {
+          throw new Error(
+            `Pipeline agent proposal ${proposalId} mode does not match session ${sessionId}`,
+          );
+        }
+        if (proposal.status !== "proposal_ready") {
+          throw new Error(
+            `Pipeline agent proposal ${proposalId} cannot be approved from status ${proposal.status}`,
+          );
+        }
+        if (proposal.proposal.readiness !== "ready_for_generation") {
+          throw new Error(`Pipeline agent proposal ${proposalId} is not ready for approval`);
+        }
 
-      if (proposal.proposal.mode === "edit" && proposal.proposal.pendingOperations?.length > 0) {
-        const createPendingResult = await pipelinesService.createPendingOperations(
-          proposal.proposal.pendingOperations.map((op) => ({
-            ...op,
-            acceptedObjectTypes: op.acceptedObjectTypes as ObjectNodeType[],
-          })),
-        );
-        if (createPendingResult.isErr()) throw createPendingResult.error;
-      }
+        if (proposal.proposal.mode === "edit" && proposal.proposal.pendingOperations?.length > 0) {
+          const createPendingResult = await transactionalPipelinesService.createPendingOperations(
+            proposal.proposal.pendingOperations.map((operation) => ({
+              ...operation,
+              acceptedObjectTypes: operation.acceptedObjectTypes as ObjectNodeType[],
+            })),
+          );
+          if (createPendingResult.isErr()) throw createPendingResult.error;
+        }
 
-      await proposalsDao.update(proposalId, {
-        status: "approved",
-        approvedAt: new Date(),
-      });
+        await transactionalProposalsDao.update(proposalId, {
+          status: "approved",
+          approvedAt: new Date(),
+        });
 
-      await sessionsDao.update(sessionId, {
-        status: "approved",
-        approvedProposalId: proposalId,
-      });
-    },
+        await transactionalSessionsDao.update(sessionId, {
+          status: "approved",
+          approvedProposalId: proposalId,
+        });
+      }),
 
     supersedeProposal: async (sessionId: string, proposalId: string) => {
       const proposal = await proposalsDao.findById(proposalId);

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import JSZip from "jszip";
+import { ok } from "neverthrow";
 
 const mockSessionsDao = {
   create: vi.fn(),
@@ -220,7 +221,7 @@ describe("createPipelineAgentSessionsService", () => {
       nodes: [],
       edges: [],
     });
-    mockPipelinesService.createPendingOperations.mockResolvedValue(undefined);
+    mockPipelinesService.createPendingOperations.mockResolvedValue(ok(undefined));
     mockPipelinesService.delete.mockResolvedValue(undefined);
     mockPipelinesService.create.mockImplementation(async (data) => ({
       id: data.id ?? "pipeline-1",

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
@@ -81,12 +81,14 @@ vi.mock("@repo/models", () => ({
   createAgentRuntimesDao: () => mockAgentRuntimesDao,
   createOperationsDao: () => mockOperationsDao,
   createPipelinesDao: () => mockPipelinesDao,
-  createPipelineAgentSessionsDao: () => mockSessionsDao,
+  createPipelineAgentSessionsDao: (executor: { sessionsDao?: typeof mockSessionsDao }) =>
+    executor?.sessionsDao ?? mockSessionsDao,
   createPipelineAgentMessagesDao: () => mockMessagesDao,
   createPipelineAgentAttachmentsDao: () => mockAttachmentsDao,
   createPipelineAgentAttachmentsRepository: () => mockAttachmentsRepository,
   createPipelineAgentContextArtifactsDao: () => mockContextArtifactsDao,
-  createPipelineAgentProposalsDao: () => mockProposalsDao,
+  createPipelineAgentProposalsDao: (executor: { proposalsDao?: typeof mockProposalsDao }) =>
+    executor?.proposalsDao ?? mockProposalsDao,
   createRoutinesDao: () => mockRoutinesDao,
   createSettingsDao: () => mockSettingsDao,
 }));
@@ -100,7 +102,8 @@ vi.mock("../pipelineRunnerService/agentRunner/agentRunner", () => ({
 }));
 
 vi.mock("../pipelinesService/createPipelinesService", () => ({
-  createPipelinesService: () => mockPipelinesService,
+  createPipelinesService: (executor: { pipelinesService?: typeof mockPipelinesService }) =>
+    executor?.pipelinesService ?? mockPipelinesService,
 }));
 
 import { createPipelineAgentSessionsService as createPipelineAgentSessionsServiceFactory } from "./createPipelineAgentSessionsService";
@@ -114,6 +117,7 @@ const createPipelineAgentSessionsService = (_db: never) =>
 describe("createPipelineAgentSessionsService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDb.transaction.mockImplementation(async (callback) => callback({}));
 
     mockSessionsDao.create.mockImplementation(async (data) => ({
       id: data.id ?? "session-1",
@@ -401,6 +405,7 @@ describe("createPipelineAgentSessionsService", () => {
         approvedProposalId: "proposal-1",
       }),
     );
+    expect(mockDb.transaction).toHaveBeenCalledOnce();
   });
 
   it("materializes pendingOperations when approving an edit-mode proposal", async () => {
@@ -465,6 +470,80 @@ describe("createPipelineAgentSessionsService", () => {
       "session-1",
       expect.objectContaining({ status: "approved" }),
     );
+  });
+
+  it("rolls back approval state and pending operations when the final session update fails", async () => {
+    const committed = {
+      operations: [] as string[],
+      proposalStatus: "proposal_ready",
+      sessionStatus: "proposal_ready",
+    };
+    const session = {
+      id: "session-1",
+      mode: "edit",
+      status: "proposal_ready",
+    };
+    const proposal = {
+      id: "proposal-edit-1",
+      sessionId: "session-1",
+      mode: "edit",
+      status: "proposal_ready",
+      proposal: {
+        mode: "edit",
+        readiness: "ready_for_generation",
+        pendingOperations: [
+          {
+            id: "op-new",
+            name: "New operation",
+            description: "new",
+            config: { executor: { type: "agent" } },
+            acceptedObjectTypes: ["file"],
+          },
+        ],
+      },
+    };
+    mockDb.transaction.mockImplementationOnce(async (callback) => {
+      const staged = {
+        operations: [...committed.operations],
+        proposalStatus: committed.proposalStatus,
+        sessionStatus: committed.sessionStatus,
+      };
+      const value = await callback({
+        pipelinesService: {
+          ...mockPipelinesService,
+          createPendingOperations: vi.fn(async (operations: Array<{ id: string }>) => {
+            staged.operations.push(...operations.map((operation) => operation.id));
+
+            return ok(undefined);
+          }),
+        },
+        proposalsDao: {
+          ...mockProposalsDao,
+          findById: vi.fn().mockResolvedValue(proposal),
+          update: vi.fn(async () => {
+            staged.proposalStatus = "approved";
+          }),
+        },
+        sessionsDao: {
+          ...mockSessionsDao,
+          findById: vi.fn().mockResolvedValue(session),
+          update: vi.fn().mockRejectedValue(new Error("injected session update failure")),
+        },
+      });
+      Object.assign(committed, staged);
+
+      return value;
+    });
+    const service = createPipelineAgentSessionsService({} as never);
+
+    await expect(service.approveProposal("session-1", "proposal-edit-1")).rejects.toThrow(
+      "injected session update failure",
+    );
+    expect(committed).toEqual({
+      operations: [],
+      proposalStatus: "proposal_ready",
+      sessionStatus: "proposal_ready",
+    });
   });
 
   it("does not call createPendingOperations for proposals without pendingOperations", async () => {

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
@@ -19,35 +19,44 @@ const {
   mockPipelinesDao,
   mockAgentRuntimesDao,
   mockMcpInjections,
+  mockMcpServerKey,
+  mockMcpToolReference,
   mockPipelineRunExecutorRun,
-} = vi.hoisted(() => ({
-  mockMcpInjections: [] as unknown[],
-  mockJobsDao: {
-    findById: vi.fn(),
-    updateStatus: vi.fn().mockResolvedValue(undefined),
-    create: vi.fn().mockResolvedValue(undefined),
-    setNodeStatuses: vi.fn().mockResolvedValue(undefined),
-  },
-  mockConnectorsDao: {
-    findMany: vi.fn().mockResolvedValue([]),
-  },
-  mockPipelinesDao: {
-    findById: vi.fn(),
-  },
-  mockAgentRuntimesDao: {
-    findMany: vi.fn().mockResolvedValue([
-      {
-        id: "runtime-codex",
-        name: "Codex Local",
-        type: "codex",
-        connection: { mode: "local" },
-      },
-    ]),
-  },
-  mockPipelineRunExecutorRun: vi.fn(async (opts: PipelineRunOptionsMock) => {
-    await opts.engineDeps.runSkill({ allowedTools: ["mcp__github__read_issue"] } as never);
-  }),
-}));
+} = vi.hoisted(() => {
+  const mockMcpServerKey = "connector_636f6e6e6563746f722d676974687562";
+  const mockMcpToolReference = `mcp__${mockMcpServerKey}__read_issue`;
+
+  return {
+    mockMcpInjections: [] as unknown[],
+    mockMcpServerKey,
+    mockMcpToolReference,
+    mockJobsDao: {
+      findById: vi.fn(),
+      updateStatus: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn().mockResolvedValue(undefined),
+      setNodeStatuses: vi.fn().mockResolvedValue(undefined),
+    },
+    mockConnectorsDao: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    mockPipelinesDao: {
+      findById: vi.fn(),
+    },
+    mockAgentRuntimesDao: {
+      findMany: vi.fn().mockResolvedValue([
+        {
+          id: "runtime-codex",
+          name: "Codex Local",
+          type: "codex",
+          connection: { mode: "local" },
+        },
+      ]),
+    },
+    mockPipelineRunExecutorRun: vi.fn(async (opts: PipelineRunOptionsMock) => {
+      await opts.engineDeps.runSkill({ allowedTools: [mockMcpToolReference] } as never);
+    }),
+  };
+});
 
 vi.mock("@repo/obs", () => ({
   initObs: vi.fn(),
@@ -79,7 +88,7 @@ vi.mock("../engineDeps", () => ({
     build: vi.fn((opts: EngineDepsBuildOptionsMock) => ({
       runPrompt: vi.fn(),
       runSkill: vi.fn(async () => {
-        mockMcpInjections.push(await opts.getMcpConnectorInjection?.(["mcp__github__read_issue"]));
+        mockMcpInjections.push(await opts.getMcpConnectorInjection?.([mockMcpToolReference]));
       }),
       structuredJsonToMarkdown: vi.fn(),
       evaluateLoopCondition: vi.fn(),
@@ -300,13 +309,13 @@ describe("createPipelineRunnerService run controls", () => {
     expect(mockMcpInjections).toEqual([
       {
         mcpServers: {
-          github: {
+          [mockMcpServerKey]: {
             type: "http",
             url: "https://example.test/mcp",
             headers: { Authorization: "Bearer pipeline-runtime-value" },
           },
         },
-        toolNames: ["mcp__github__read_issue"],
+        toolNames: [mockMcpToolReference],
       },
     ]);
   });

--- a/packages/services/src/pipelinesService/createPipelinesService.ts
+++ b/packages/services/src/pipelinesService/createPipelinesService.ts
@@ -14,7 +14,7 @@ import {
   createPipelineRunsDao,
   createPipelinesDao,
   createSettingsDao,
-  type DbConnection,
+  type DbExecutor,
 } from "@repo/models";
 import { ResultAsync } from "neverthrow";
 import { logger } from "@repo/logger";
@@ -141,7 +141,16 @@ export interface PipelinesServiceOptions {
   capabilityCatalogOptions?: CapabilityCatalogServiceOptions;
 }
 
-export const createPipelinesService = (db: DbConnection, options: PipelinesServiceOptions = {}) => {
+export interface PendingOperationInput {
+  id: string;
+  name: string;
+  description: string;
+  config: Record<string, unknown>;
+  acceptedObjectTypes: ObjectNodeType[];
+  sourceSkillId?: string;
+}
+
+export const createPipelinesService = (db: DbExecutor, options: PipelinesServiceOptions = {}) => {
   const agentRuntimesDao = createAgentRuntimesDao(db);
   const conversationMessagesDao = createConversationMessagesDao(db);
   const dao = createPipelinesDao(db);
@@ -151,42 +160,48 @@ export const createPipelinesService = (db: DbConnection, options: PipelinesServi
   const jobTracesDao = createJobTracesDao(db);
   const operationsDao = createOperationsDao(db);
   const settingsDao = createSettingsDao(db);
-  const capabilityCatalogRef = { current: options.capabilityCatalog };
-  const getCapabilityCatalog = () => {
-    capabilityCatalogRef.current ??= createCapabilityCatalogService(
-      db,
-      options.capabilityCatalogOptions,
+  const getCapabilityCatalog = (executor: DbExecutor) =>
+    options.capabilityCatalog ??
+    createCapabilityCatalogService(executor, options.capabilityCatalogOptions);
+  const insertPendingOperations = async (
+    executor: DbExecutor,
+    pendingOperations: PendingOperationInput[],
+  ): Promise<void> => {
+    const validation =
+      await getCapabilityCatalog(executor).validateOperationInputs(pendingOperations);
+    if (validation.isErr()) throw validation.error;
+
+    const transactionalOperationsDao = createOperationsDao(executor);
+    for (const operation of pendingOperations) {
+      await transactionalOperationsDao.create(operation);
+    }
+  };
+
+  const createPendingOperations = (pendingOperations: PendingOperationInput[]) =>
+    ResultAsync.fromPromise(
+      db.transaction((transaction) => insertPendingOperations(transaction, pendingOperations)),
+      (error) => toServiceError(error, "Create pending operations"),
     );
 
-    return capabilityCatalogRef.current;
-  };
+  const createWithPendingOperations = (
+    pipeline: Parameters<typeof dao.create>[0],
+    pendingOperations: PendingOperationInput[],
+  ) =>
+    ResultAsync.fromPromise(
+      db.transaction(async (transaction) => {
+        await insertPendingOperations(transaction, pendingOperations);
+
+        return createPipelinesDao(transaction).create(pipeline);
+      }),
+      (error) => toServiceError(error, "Create pipeline with pending operations"),
+    );
 
   return {
     getAll: () => dao.findMany(),
     getById: (id: string) => dao.findById(id),
     create: (...args: Parameters<typeof dao.create>) => dao.create(...args),
-    createPendingOperations: (
-      pendingOperations: Array<{
-        id: string;
-        name: string;
-        description: string;
-        config: Record<string, unknown>;
-        acceptedObjectTypes: ObjectNodeType[];
-        sourceSkillId?: string;
-      }>,
-    ) =>
-      getCapabilityCatalog()
-        .validateOperationConfigs(pendingOperations.map((operation) => operation.config))
-        .andThen(() =>
-          ResultAsync.fromPromise(
-            (async () => {
-              for (const operation of pendingOperations) {
-                await operationsDao.create(operation);
-              }
-            })(),
-            (error) => toServiceError(error, "Create pending operations"),
-          ),
-        ),
+    createPendingOperations,
+    createWithPendingOperations,
     update: (...args: Parameters<typeof dao.update>) => dao.update(...args),
     delete: async (id: string) => {
       await pipelineRunsDao.deleteByPipelineId(id);

--- a/packages/services/src/pipelinesService/createPipelinesService.ts
+++ b/packages/services/src/pipelinesService/createPipelinesService.ts
@@ -16,6 +16,7 @@ import {
   createSettingsDao,
   type DbConnection,
 } from "@repo/models";
+import { ResultAsync } from "neverthrow";
 import { logger } from "@repo/logger";
 import {
   PipelineSchema,
@@ -26,6 +27,11 @@ import {
 import { isConnectionAllowed } from "@repo/pipeline-engine/schemas";
 import { runStructuredAgent } from "../pipelineRunnerService/agentRunner/runStructuredAgent";
 import { normalizeSettingsRecord } from "../settingsService/normalizeSettingsRecord";
+import {
+  createCapabilityCatalogService,
+  type CapabilityCatalogServiceOptions,
+} from "../capabilityCatalogService";
+import { toServiceError } from "../serviceErrors";
 import { MAX_SNAPSHOT_CHARS, truncate } from "./promptText";
 import { proposeActions, type ProposeActionsOptions } from "./proposeActions";
 import {
@@ -130,7 +136,12 @@ const sanitizeGeneratedGraph = (value: unknown): unknown => {
   };
 };
 
-export const createPipelinesService = (db: DbConnection) => {
+export interface PipelinesServiceOptions {
+  capabilityCatalog?: ReturnType<typeof createCapabilityCatalogService>;
+  capabilityCatalogOptions?: CapabilityCatalogServiceOptions;
+}
+
+export const createPipelinesService = (db: DbConnection, options: PipelinesServiceOptions = {}) => {
   const agentRuntimesDao = createAgentRuntimesDao(db);
   const conversationMessagesDao = createConversationMessagesDao(db);
   const dao = createPipelinesDao(db);
@@ -140,12 +151,21 @@ export const createPipelinesService = (db: DbConnection) => {
   const jobTracesDao = createJobTracesDao(db);
   const operationsDao = createOperationsDao(db);
   const settingsDao = createSettingsDao(db);
+  const capabilityCatalogRef = { current: options.capabilityCatalog };
+  const getCapabilityCatalog = () => {
+    capabilityCatalogRef.current ??= createCapabilityCatalogService(
+      db,
+      options.capabilityCatalogOptions,
+    );
+
+    return capabilityCatalogRef.current;
+  };
 
   return {
     getAll: () => dao.findMany(),
     getById: (id: string) => dao.findById(id),
     create: (...args: Parameters<typeof dao.create>) => dao.create(...args),
-    createPendingOperations: async (
+    createPendingOperations: (
       pendingOperations: Array<{
         id: string;
         name: string;
@@ -154,11 +174,19 @@ export const createPipelinesService = (db: DbConnection) => {
         acceptedObjectTypes: ObjectNodeType[];
         sourceSkillId?: string;
       }>,
-    ) => {
-      for (const op of pendingOperations) {
-        await operationsDao.create(op);
-      }
-    },
+    ) =>
+      getCapabilityCatalog()
+        .validateOperationConfigs(pendingOperations.map((operation) => operation.config))
+        .andThen(() =>
+          ResultAsync.fromPromise(
+            (async () => {
+              for (const operation of pendingOperations) {
+                await operationsDao.create(operation);
+              }
+            })(),
+            (error) => toServiceError(error, "Create pending operations"),
+          ),
+        ),
     update: (...args: Parameters<typeof dao.update>) => dao.update(...args),
     delete: async (id: string) => {
       await pipelineRunsDao.deleteByPipelineId(id);

--- a/packages/services/src/pipelinesService/createPipelinesService.unit.test.ts
+++ b/packages/services/src/pipelinesService/createPipelinesService.unit.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
+import { ok } from "neverthrow";
 
 const mockDao = {
   findMany: vi.fn().mockResolvedValue([{ id: "p1" }]),
@@ -15,6 +16,7 @@ const mockSettingsDao = {
   }),
 };
 const mockOperationsDao = {
+  create: vi.fn(),
   findMany: vi.fn().mockResolvedValue([
     {
       id: "op-known",
@@ -54,7 +56,8 @@ vi.mock("@repo/models", () => ({
   createCapabilityRiskOverridesDao: () => ({ findMany: vi.fn().mockResolvedValue([]) }),
   createConnectorsDao: () => ({ findMany: vi.fn().mockResolvedValue([]) }),
   createConversationMessagesDao: () => mockConversationMessagesDao,
-  createPipelinesDao: () => mockDao,
+  createPipelinesDao: (executor: { pipelinesDao?: typeof mockDao }) =>
+    executor?.pipelinesDao ?? mockDao,
   createDistillationsDao: () => mockDistillationsDao,
   createJobsDao: () => ({}),
   createPipelineRunsDao: () => ({
@@ -64,7 +67,8 @@ vi.mock("@repo/models", () => ({
   createJobTracesDao: () => ({}),
   createAgentRawExportsDao: () => ({}),
   createAgentSpansDao: () => ({}),
-  createOperationsDao: () => mockOperationsDao,
+  createOperationsDao: (executor: { operationsDao?: typeof mockOperationsDao }) =>
+    executor?.operationsDao ?? mockOperationsDao,
   createSettingsDao: () => mockSettingsDao,
   createSkillsDao: () => ({
     findMany: vi.fn().mockResolvedValue([]),
@@ -113,6 +117,7 @@ describe("createPipelinesService", () => {
     mockDao.delete.mockClear();
     mockSettingsDao.get.mockClear();
     mockOperationsDao.findMany.mockClear();
+    mockOperationsDao.create.mockClear();
     mockAgentRuntimesDao.findMany.mockClear();
     mockRunAgent.mockReset();
     mockExtractJsonFromText.mockReset();
@@ -172,6 +177,93 @@ describe("createPipelinesService", () => {
     const svc = createPipelinesService({} as never);
     await svc.delete("p1");
     expect(mockDao.delete).toHaveBeenCalledWith("p1");
+  });
+
+  it("rolls back the whole pending-operation batch when the second insert fails", async () => {
+    const persistedOperations: unknown[] = [];
+    const transaction = vi.fn(async (callback: (executor: unknown) => Promise<unknown>) => {
+      const stagedOperations: unknown[] = [];
+      const operationsDao = {
+        ...mockOperationsDao,
+        create: vi.fn(async (operation: { id: string }) => {
+          if (operation.id === "op-2") throw new Error("injected second insert failure");
+          stagedOperations.push(operation);
+        }),
+      };
+
+      const value = await callback({ operationsDao });
+      persistedOperations.push(...stagedOperations);
+
+      return value;
+    });
+    const service = createPipelinesService({ transaction } as never, {
+      capabilityCatalog: {
+        validateOperationInputs: vi.fn().mockResolvedValue(ok(undefined)),
+      } as never,
+    });
+
+    const result = await service.createPendingOperations([
+      {
+        id: "op-1",
+        name: "First",
+        description: "first",
+        config: {},
+        acceptedObjectTypes: ["file"],
+      },
+      {
+        id: "op-2",
+        name: "Second",
+        description: "second",
+        config: {},
+        acceptedObjectTypes: ["file"],
+      },
+    ]);
+
+    expect(result.isErr()).toBe(true);
+    expect(transaction).toHaveBeenCalledOnce();
+    expect(persistedOperations).toEqual([]);
+  });
+
+  it("rolls back pending operations when the related pipeline insert fails", async () => {
+    const persistedOperations: unknown[] = [];
+    const transaction = vi.fn(async (callback: (executor: unknown) => Promise<unknown>) => {
+      const stagedOperations: unknown[] = [];
+      const value = await callback({
+        operationsDao: {
+          ...mockOperationsDao,
+          create: vi.fn(async (operation: unknown) => stagedOperations.push(operation)),
+        },
+        pipelinesDao: {
+          ...mockDao,
+          create: vi.fn().mockRejectedValue(new Error("injected pipeline insert failure")),
+        },
+      });
+      persistedOperations.push(...stagedOperations);
+
+      return value;
+    });
+    const service = createPipelinesService({ transaction } as never, {
+      capabilityCatalog: {
+        validateOperationInputs: vi.fn().mockResolvedValue(ok(undefined)),
+      } as never,
+    });
+
+    const result = await service.createWithPendingOperations(
+      { id: "pipeline-1", name: "Pipeline" } as never,
+      [
+        {
+          id: "op-1",
+          name: "First",
+          description: "first",
+          config: {},
+          acceptedObjectTypes: ["file"],
+        },
+      ],
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(transaction).toHaveBeenCalledOnce();
+    expect(persistedOperations).toEqual([]);
   });
 
   it("proposeActions returns a parsed proposal and diagnostics", async () => {

--- a/packages/services/src/pipelinesService/createPipelinesService.unit.test.ts
+++ b/packages/services/src/pipelinesService/createPipelinesService.unit.test.ts
@@ -51,6 +51,8 @@ const mockConversationMessagesDao = {
 
 vi.mock("@repo/models", () => ({
   createAgentRuntimesDao: () => mockAgentRuntimesDao,
+  createCapabilityRiskOverridesDao: () => ({ findMany: vi.fn().mockResolvedValue([]) }),
+  createConnectorsDao: () => ({ findMany: vi.fn().mockResolvedValue([]) }),
   createConversationMessagesDao: () => mockConversationMessagesDao,
   createPipelinesDao: () => mockDao,
   createDistillationsDao: () => mockDistillationsDao,
@@ -64,6 +66,10 @@ vi.mock("@repo/models", () => ({
   createAgentSpansDao: () => ({}),
   createOperationsDao: () => mockOperationsDao,
   createSettingsDao: () => mockSettingsDao,
+  createSkillsDao: () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    seedIfEmpty: vi.fn().mockResolvedValue(undefined),
+  }),
 }));
 vi.mock("@repo/agent", () => ({
   extractJsonFromText: (raw: string) => mockExtractJsonFromText(raw),

--- a/packages/services/src/serviceFactory.ts
+++ b/packages/services/src/serviceFactory.ts
@@ -1,6 +1,7 @@
 import { db } from "@repo/db";
 import { createAgentsService } from "./agentsService";
 import { createConnectorsService } from "./connectorsService";
+import { createCapabilityCatalogService } from "./capabilityCatalogService";
 import { createConversationMessagesService } from "./conversationMessagesService";
 import { createDistillationsService } from "./distillationsService";
 import { createGithubProjectsService } from "./githubProjectsService";
@@ -20,6 +21,7 @@ const pipelineRunnerService = createPipelineRunnerService(db);
 
 export const serviceFactory = {
   createAgentsService: () => createAgentsService(db),
+  createCapabilityCatalogService: () => createCapabilityCatalogService(db),
   createConnectorsService: () => createConnectorsService(db),
   createConversationMessagesService: () => createConversationMessagesService(db),
   createDistillationsService: () => createDistillationsService(db),


### PR DESCRIPTION
## Notice

This is an internal maintainer change for COD-340.

## Summary

- Add a unified capability catalog projected from built-in tools, skills, and connected MCP tools without introducing a second catalog source-of-truth table.
- Add stable MCP identities shared by catalog projection and runtime injection, including collision-safe handling for same-name connectors and tools.
- Add risk inference plus authenticated per-capability overrides.
- Validate operation and pending-operation capability references, runtime support, config shape, and `sourceSkillId` before persistence.
- Make pending-operation batches and pipeline create/approval persistence transactional.

## Why

Pipeline authors need one queryable inventory of capabilities that are actually executable by the selected runtime. Persisted operation configuration must fail closed when it references a missing, malformed, unsupported, or ambiguous capability instead of failing later during execution.

## API and behavior

- App tRPC: `capabilityCatalog.getMany({ runtime?, kinds? })`
- App tRPC: authenticated `capabilityCatalog.setRiskTierOverride({ id, riskTier })`
- Invalid tRPC saves return `BAD_REQUEST`; invalid REST operation/pipeline saves return 422 with structured issues.
- Catalog and runtime share `buildMcpServerKey`, `buildMcpToolReference`, `resolveMcpConnectors`, and `resolveMcpConnectorTools`.
- Skill runtimes exclude Hermes; built-in and MCP runtime claims follow the actual injection paths.
- No catalog management UI or Server REST catalog-read endpoint is added in this issue.

## Validation

- [x] `packages/schemas`: 68 tests passed
- [x] `packages/services`: 473 tests passed
- [x] `apps/server`: 97 tests passed
- [x] `apps/app`: typecheck/lint passed; 636 tests passed
- [x] `apps/create`: 31 tests passed
- [x] `packages/db-schema`: 14 tests passed
- [x] All 42 changed source/config files pass formatting; `git diff --check` passes
- [ ] Root `bun run quality`: one unchanged upstream Windows/bash assertion remains in `packages/pipeline-engine/src/infrastructure/infrastructure.test.ts` (170/171 tests pass in that package)
- [ ] Root `bun run format:check`: reports 171 pre-existing upstream files; none are in this PR's changed-file set
- [ ] Root build not run; this change has no UI surface

## Notes

- Based on `upstream/develop` at `a0f7e65f` after COD-337.
- New migrations are App `0032_capability_risk_overrides.sql` and Create `0005_capability_risk_overrides.sql`.
- COD-341 should consume this PR's public catalog/validation contracts and the stable MCP reference format rather than retain a parallel mock model.
- Linear: https://linear.app/code-forge-official/issue/COD-340/featureconnectors2-%E4%BD%9C%E4%B8%BA%E6%B5%81%E6%B0%B4%E7%BA%BF%E4%BD%9C%E8%80%85%E6%88%91%E5%B8%8C%E6%9C%9B%E4%BB%8E%E7%BB%9F%E4%B8%80%E8%83%BD%E5%8A%9B%E8%B4%A7%E6%9E%B6%E9%80%89%E6%8B%A9-mcpskill-capability-catalog
