### PR TITLE
feat: add per-step capability assignment (COD-341)

### DIFF
--- a/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationWorkspace.tsx
+++ b/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationWorkspace.tsx
@@ -13,9 +13,9 @@ import { AlertCircle, CheckCircle2, ExternalLink, Loader2, Play, Plus } from "lu
 import { Badge } from "@repo/ui/badge";
 import { Button } from "@repo/ui/button";
 import { cn } from "@repo/ui/lib/utils";
-import type { PipelineAgentProposal } from "@repo/schemas";
+import type { PipelineAgentProposal, PipelineData } from "@repo/schemas";
 import { sidebarStore as sharedSidebarStore } from "@repo/views/store/sidebarStore";
-import { dataProvider } from "@/integrations/refine/dataProvider";
+import { dataProvider, ResourceName } from "@/integrations/refine/dataProvider";
 import { materializeGeneratedPipeline } from "@/lib/materializeGeneratedPipeline";
 import { getPipelineAgentErrorMessage } from "@/lib/pipelineAgentErrorMessage";
 import {
@@ -309,12 +309,48 @@ export const PipelineCreationWorkspace = ({
       return;
     }
 
-    // COD-345:首页首条消息不就地开聊,暂存 prompt 并跳转无 id 的 /canvas 三栏工作区,
-    // 对话由右侧 AgentPanel 接管(COD-346)。已有会话/附件时保持原流程,避免中断进行中的 session。
+    // 首页首条消息先创建可持久化的空 Pipeline，再把 prompt/runtime 一次性交给画布 AgentPanel。
+    // 画布编辑会话必须有 pipelineId；直接跳无 id 的 /canvas 会丢消息并触发“Pipeline 尚未保存”。
     if (isHome && !sessionIdRef.current && messages.length === 0 && attachments.length === 0) {
-      savePendingPipelinePrompt(text);
+      setErrorMessage(null);
+      setPhase("planning");
+      const now = new Date();
+      const pipelineId = `pipeline-${Date.now()}`;
+      const currentProjectId = sharedSidebarStore.getState().currentProjectId;
+      const draftPipeline: PipelineData = {
+        id: pipelineId,
+        name: t("pipelines.createNew"),
+        description: text,
+        sharedContext: "",
+        tags: [],
+        createdAt: now,
+        updatedAt: now,
+        timeoutMs: null,
+        status: "draft",
+        version: 1,
+        nodes: [],
+        edges: [],
+      };
+      const createResult = await ResultAsync.fromPromise(
+        dataProvider.create<PipelineData>({
+          resource: ResourceName.pipelines,
+          variables: {
+            ...draftPipeline,
+            ...(currentProjectId ? { projectId: currentProjectId } : {}),
+          },
+        }),
+        (error) => (error instanceof Error ? error : new Error(String(error))),
+      );
+      if (createResult.isErr()) {
+        handlePipelineAgentError(createResult.error);
+        setPhase("conversation");
+
+        return;
+      }
+
+      savePendingPipelinePrompt(text, runtimeId);
       setInputValue("");
-      void router.navigate({ to: "/canvas", search: { id: undefined } });
+      void router.navigate({ to: "/canvas", search: { id: createResult.value.data.id } });
 
       return;
     }

--- a/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationWorkspace.unit.test.tsx
+++ b/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationWorkspace.unit.test.tsx
@@ -7,6 +7,11 @@ import { pipelineAgentSessionsClient } from "@/lib/pipelineAgentSessionsClient";
 import { router } from "@/router";
 import { PipelineCreationWorkspace } from "./PipelineCreationWorkspace";
 
+const { mockCreatePipeline, mockCustomRequest } = vi.hoisted(() => ({
+  mockCreatePipeline: vi.fn(),
+  mockCustomRequest: vi.fn(),
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -21,6 +26,14 @@ vi.mock("@tanstack/react-router", () => ({
 
 vi.mock("@/router", () => ({
   router: { navigate: vi.fn() },
+}));
+
+vi.mock("@/integrations/refine/dataProvider", () => ({
+  ResourceName: { pipelines: "pipelines" },
+  dataProvider: {
+    create: (...args: unknown[]) => mockCreatePipeline(...args),
+    custom: (...args: unknown[]) => mockCustomRequest(...args),
+  },
 }));
 
 const createClient = () => ({
@@ -41,6 +54,9 @@ describe("PipelineCreationWorkspace", () => {
     globalThis.localStorage.clear();
     globalThis.sessionStorage.clear();
     vi.clearAllMocks();
+    mockCreatePipeline.mockImplementation(async ({ variables }) => ({
+      data: { ...(variables as object), id: "draft-pipeline-1" },
+    }));
   });
 
   it("restores messages, attachments, and a pending proposal from the saved session", async () => {
@@ -337,7 +353,7 @@ describe("PipelineCreationWorkspace", () => {
     expect(await screen.findByText("pipelineAgentErrors.network")).toBeInTheDocument();
   });
 
-  it("stashes the first home message and jumps to the id-less canvas workspace", async () => {
+  it("creates a draft and transfers the first message and runtime to its canvas", async () => {
     const user = userEvent.setup();
     const client = createClient();
 
@@ -347,6 +363,7 @@ describe("PipelineCreationWorkspace", () => {
         runtimeConfigured
         client={client as typeof pipelineAgentSessionsClient}
         presentation="home"
+        runtimeId="runtime-codex"
       />,
     );
     await user.type(
@@ -355,12 +372,23 @@ describe("PipelineCreationWorkspace", () => {
     );
     await user.click(screen.getByRole("button", { name: "newPipelineDialog.send" }));
 
-    expect(globalThis.sessionStorage.getItem("ordine.pendingPipelinePrompt")).toBe(
-      "Scout hackathons for me",
+    expect(mockCreatePipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource: "pipelines",
+        variables: expect.objectContaining({
+          description: "Scout hackathons for me",
+          nodes: [],
+          edges: [],
+        }),
+      }),
     );
+    expect(JSON.parse(globalThis.sessionStorage.getItem("ordine.pendingPipelinePrompt")!)).toEqual({
+      prompt: "Scout hackathons for me",
+      runtimeId: "runtime-codex",
+    });
     expect(router.navigate).toHaveBeenCalledWith({
       to: "/canvas",
-      search: { id: undefined },
+      search: { id: "draft-pipeline-1" },
     });
     expect(client.createSession).not.toHaveBeenCalled();
     expect(client.appendMessage).not.toHaveBeenCalled();

--- a/apps/app/src/integrations/trpc/routers/pipelines.ts
+++ b/apps/app/src/integrations/trpc/routers/pipelines.ts
@@ -212,6 +212,8 @@ export const pipelinesRouter = router({
             }),
           )
           .optional(),
+        runtimeId: z.string().min(1).optional(),
+        model: z.string().min(1).optional(),
       }),
     )
     .mutation(({ input }) => pipelinesService.generateStructure(input)),

--- a/apps/app/src/lib/pendingPipelinePrompt.unit.test.ts
+++ b/apps/app/src/lib/pendingPipelinePrompt.unit.test.ts
@@ -7,9 +7,12 @@ describe("pendingPipelinePrompt", () => {
   });
 
   it("takes a saved prompt exactly once", () => {
-    savePendingPipelinePrompt("build a hackathon scout");
+    savePendingPipelinePrompt("build a hackathon scout", "runtime-codex");
 
-    expect(takePendingPipelinePrompt()).toBe("build a hackathon scout");
+    expect(takePendingPipelinePrompt()).toEqual({
+      prompt: "build a hackathon scout",
+      runtimeId: "runtime-codex",
+    });
     expect(takePendingPipelinePrompt()).toBeNull();
   });
 
@@ -21,7 +24,13 @@ describe("pendingPipelinePrompt", () => {
     savePendingPipelinePrompt("first");
     savePendingPipelinePrompt("second");
 
-    expect(takePendingPipelinePrompt()).toBe("second");
+    expect(takePendingPipelinePrompt()).toEqual({ prompt: "second" });
     expect(takePendingPipelinePrompt()).toBeNull();
+  });
+
+  it("reads the legacy plain-text prompt format", () => {
+    globalThis.sessionStorage.setItem("ordine.pendingPipelinePrompt", "legacy prompt");
+
+    expect(takePendingPipelinePrompt()).toEqual({ prompt: "legacy prompt" });
   });
 });

--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -918,7 +918,8 @@
           "addEdge": "Add edge",
           "removeEdge": "Remove edge",
           "reconnectEdge": "Reconnect edge",
-          "replaceNodeData": "Replace node data"
+          "replaceNodeData": "Replace node data",
+          "updateOperation": "Update operation executor"
         }
       },
       "checkpoint": {
@@ -2001,7 +2002,8 @@
         "reconnectEdge": "Reconnect edge",
         "removeEdge": "Remove edge",
         "removeNode": "Remove node",
-        "replaceNodeData": "Update node"
+        "replaceNodeData": "Update node",
+        "updateOperation": "Update operation executor"
       },
       "applied": {
         "hint": "Applied — the nodes are on the canvas, yours to edit. Click any node to reference it here, or hit Run."

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -912,7 +912,8 @@
           "addEdge": "添加连线",
           "removeEdge": "删除连线",
           "reconnectEdge": "重连连线",
-          "replaceNodeData": "替换节点数据"
+          "replaceNodeData": "替换节点数据",
+          "updateOperation": "更新 Operation 执行器"
         }
       },
       "checkpoint": {
@@ -1990,7 +1991,8 @@
         "reconnectEdge": "重连连线",
         "removeEdge": "删除连线",
         "removeNode": "删除节点",
-        "replaceNodeData": "更新节点"
+        "replaceNodeData": "更新节点",
+        "updateOperation": "更新 Operation 执行器"
       },
       "applied": {
         "hint": "已应用 — 节点已在画布上，随时可编辑。点选任意节点即可在这里引用它，或直接点 Run。"

--- a/apps/create/migrations/0006_add_pipeline_agent_session_tables.sql
+++ b/apps/create/migrations/0006_add_pipeline_agent_session_tables.sql
@@ -1,0 +1,64 @@
+CREATE TABLE "pipeline_agent_sessions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"entrypoint" text NOT NULL,
+	"mode" text NOT NULL,
+	"status" text NOT NULL,
+	"pipeline_id" text,
+	"snapshot" jsonb,
+	"latest_proposal_id" text,
+	"approved_proposal_id" text,
+	"created_pipeline_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "pipeline_agent_sessions_pipeline_id_pipelines_id_fk" FOREIGN KEY ("pipeline_id") REFERENCES "public"."pipelines"("id") ON DELETE set null ON UPDATE no action,
+	CONSTRAINT "pipeline_agent_sessions_created_pipeline_id_pipelines_id_fk" FOREIGN KEY ("created_pipeline_id") REFERENCES "public"."pipelines"("id") ON DELETE set null ON UPDATE no action
+);
+--> statement-breakpoint
+CREATE TABLE "pipeline_agent_messages" (
+	"id" text PRIMARY KEY NOT NULL,
+	"session_id" text NOT NULL,
+	"role" text NOT NULL,
+	"kind" text NOT NULL,
+	"content" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "pipeline_agent_messages_session_id_pipeline_agent_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."pipeline_agent_sessions"("id") ON DELETE cascade ON UPDATE no action
+);
+--> statement-breakpoint
+CREATE TABLE "pipeline_agent_attachments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"session_id" text NOT NULL,
+	"filename" text NOT NULL,
+	"mime_type" text NOT NULL,
+	"size_bytes" integer NOT NULL,
+	"source_type" text NOT NULL,
+	"storage_key" text NOT NULL,
+	"parse_status" text NOT NULL,
+	"parse_error" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "pipeline_agent_attachments_session_id_pipeline_agent_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."pipeline_agent_sessions"("id") ON DELETE cascade ON UPDATE no action
+);
+--> statement-breakpoint
+CREATE TABLE "pipeline_agent_context_artifacts" (
+	"id" text PRIMARY KEY NOT NULL,
+	"session_id" text NOT NULL,
+	"attachment_id" text,
+	"kind" text NOT NULL,
+	"content" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "pipeline_agent_context_artifacts_session_id_pipeline_agent_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."pipeline_agent_sessions"("id") ON DELETE cascade ON UPDATE no action,
+	CONSTRAINT "pipeline_agent_context_artifacts_attachment_id_pipeline_agent_attachments_id_fk" FOREIGN KEY ("attachment_id") REFERENCES "public"."pipeline_agent_attachments"("id") ON DELETE set null ON UPDATE no action
+);
+--> statement-breakpoint
+CREATE TABLE "pipeline_agent_proposals" (
+	"id" text PRIMARY KEY NOT NULL,
+	"session_id" text NOT NULL,
+	"mode" text NOT NULL,
+	"status" text NOT NULL,
+	"proposal" jsonb NOT NULL,
+	"approved_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "pipeline_agent_proposals_session_id_pipeline_agent_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."pipeline_agent_sessions"("id") ON DELETE cascade ON UPDATE no action
+);

--- a/apps/create/tests/migrations.test.ts
+++ b/apps/create/tests/migrations.test.ts
@@ -59,7 +59,7 @@ describe("runMigrations", () => {
     const result = await runMigrations(db, migrationsDir);
 
     expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toBe(5);
+    expect(result._unsafeUnwrap()).toBe(6);
     const migrations = await db.query<{ name: string }>(
       `SELECT name FROM _ordine_migrations ORDER BY name`,
     );
@@ -70,6 +70,7 @@ describe("runMigrations", () => {
       "0003_harvest_capabilities.sql",
       "0004_add_agent_default_model.sql",
       "0005_capability_risk_overrides.sql",
+      "0006_add_pipeline_agent_session_tables.sql",
     ]);
     const projects = await db.query<{ table_name: string }>(
       `SELECT table_name FROM information_schema.tables WHERE table_name = 'projects'`,
@@ -86,7 +87,7 @@ describe("runMigrations", () => {
     const result = await runMigrations(db, migrationsDir);
 
     expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toBe(5);
+    expect(result._unsafeUnwrap()).toBe(6);
 
     const migrations = await db.query<{ name: string }>(
       `SELECT name FROM _ordine_migrations ORDER BY name`,
@@ -98,6 +99,7 @@ describe("runMigrations", () => {
       "0003_harvest_capabilities.sql",
       "0004_add_agent_default_model.sql",
       "0005_capability_risk_overrides.sql",
+      "0006_add_pipeline_agent_session_tables.sql",
     ]);
 
     const columns = await db.query<{ column_name: string; table_name: string }>(

--- a/apps/server/src/routes/pipelines.ts
+++ b/apps/server/src/routes/pipelines.ts
@@ -25,6 +25,36 @@ const proposeActionsBodySchema = z.object({
   runtimeId: z.string().optional(),
 });
 
+const generateStructureBodySchema = z
+  .object({
+    name: z.string(),
+    description: z.string(),
+    matchedOperations: z
+      .array(
+        z
+          .object({
+            operationId: z.string().min(1),
+            operationName: z.string().min(1),
+            reason: z.string(),
+          })
+          .strict(),
+      )
+      .optional(),
+    unmatchedSteps: z
+      .array(
+        z
+          .object({
+            step: z.string().min(1),
+            reason: z.string(),
+          })
+          .strict(),
+      )
+      .optional(),
+    runtimeId: z.string().min(1).optional(),
+    model: z.string().min(1).optional(),
+  })
+  .strict();
+
 pipelinesRoutes.get("/", async (c) => {
   const pipelines = await pipelinesService.getAll();
 
@@ -169,17 +199,22 @@ pipelinesRoutes.post("/:id/run", async (c) => {
 });
 
 pipelinesRoutes.post("/generate-structure", async (c) => {
-  const body = (await c.req.json()) as {
-    name: string;
-    description: string;
-    matchedOperations?: Array<{ operationId: string; operationName: string; reason: string }>;
-    unmatchedSteps?: Array<{ step: string; reason: string }>;
-  };
+  const bodyResult = await ResultAsync.fromPromise(
+    c.req.json() as Promise<unknown>,
+    () => undefined,
+  );
+  const parsed = generateStructureBodySchema.safeParse(bodyResult.unwrapOr(undefined));
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request body", issues: parsed.error.issues }, 400);
+  }
+
   const result = await pipelinesService.generateStructure({
-    name: body.name ?? "",
-    description: body.description ?? "",
-    matchedOperations: body.matchedOperations,
-    unmatchedSteps: body.unmatchedSteps,
+    name: parsed.data.name,
+    description: parsed.data.description,
+    matchedOperations: parsed.data.matchedOperations,
+    unmatchedSteps: parsed.data.unmatchedSteps,
+    runtimeId: parsed.data.runtimeId,
+    model: parsed.data.model,
   });
 
   if ("error" in result) {

--- a/apps/server/tests/routes/pipelines.test.ts
+++ b/apps/server/tests/routes/pipelines.test.ts
@@ -3,6 +3,7 @@ import { err } from "neverthrow";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  generateStructure: vi.fn(),
   getById: vi.fn(),
   proposeActions: vi.fn(),
   startRun: vi.fn(),
@@ -15,6 +16,7 @@ vi.mock("../../src/services.js", () => ({
     create: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
+    generateStructure: mocks.generateStructure,
     proposeActions: mocks.proposeActions,
   },
   pipelineRunnerService: {
@@ -33,9 +35,57 @@ const makeApp = () => {
 
 describe("pipelinesRoutes", () => {
   beforeEach(() => {
+    mocks.generateStructure.mockReset();
     mocks.proposeActions.mockReset();
     mocks.startRun.mockReset();
     mocks.getById.mockReset();
+  });
+
+  it("returns 400 when generate-structure receives invalid JSON", async () => {
+    const response = await makeApp().request("/pipelines/generate-structure", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not-json",
+    });
+
+    expect(response.status).toBe(400);
+    expect(mocks.generateStructure).not.toHaveBeenCalled();
+  });
+
+  it("rejects blank runtime and model selections for generate-structure", async () => {
+    const response = await makeApp().request("/pipelines/generate-structure", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Review",
+        description: "Review code",
+        runtimeId: " ",
+        model: "",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(mocks.generateStructure).not.toHaveBeenCalled();
+  });
+
+  it("forwards validated runtime and model selections to generate-structure", async () => {
+    mocks.generateStructure.mockResolvedValue({ nodes: [], edges: [] });
+    const body = {
+      name: "Review",
+      description: "Review code",
+      unmatchedSteps: [{ step: "Review code", reason: "No matching operation" }],
+      runtimeId: "runtime-codex",
+      model: "gpt-review",
+    };
+
+    const response = await makeApp().request("/pipelines/generate-structure", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.generateStructure).toHaveBeenCalledWith(body);
   });
 
   it("returns 400 when propose-actions receives invalid JSON", async () => {

--- a/docs/spikes/COD-341-per-step-capability-assignment.md
+++ b/docs/spikes/COD-341-per-step-capability-assignment.md
@@ -1,0 +1,87 @@
+# COD-341：按 Step 分配执行器与能力
+
+## 结论
+
+COD-341 可以在现有 Pipeline Agent 流程内以 fail-closed 方式完成。生产实现把“为新 Operation 选择执行器”拆成独立的结构化输出阶段，并在生成图之前完成全批次校验：
+
+- 只接受本轮 `new/unmatched` Operation，且每个 Operation 必须恰好有一条 assignment；
+- `script`、prompt agent、skill agent 使用严格且互斥的 executor 结构；
+- Agent 的扁平 `agent + model` 必须来自 COD-337 的本地 runtime model catalog；
+- `skillId`、`allowedTools` 只接受 COD-340 能力目录的 `reference`，并校验 kind、runtime 支持和风险；
+- 首次无效时只允许一次完整 repair；repair 仍无效时返回空 assignment，不保存部分结果；
+- edit 流程通过 `updateOperation` 原地修改当前画布引用的共享 Operation，不复制 Operation。
+
+最终集成基线为 `upstream/develop@665a4dc8`，直接消费 COD-340 squash merge 后的生产契约。MCP reference 由 `buildMcpServerKey(connectorId)` 和 `buildMcpToolReference(serverKey, toolName)` 生成，未使用旧的显示名派生格式。
+
+## 生产流程
+
+### 新增或未匹配 Step
+
+1. `generateStructure` 仅为 `unmatchedSteps` 创建临时 Operation id。
+2. 编排器从会话选择的 `runtimeId + model` 中取有效组合；选择失效时依次回退到设置中的有效默认、runtime catalog 默认和首个可用模型。
+3. assignment agent 为每个 id 选择 script、prompt agent 或 skill agent，并给出单行 `assignmentReason`。
+4. `parseCapabilityAssignments` 对整个批次做结构、数量、目录、runtime 和风险校验。
+5. 第一次失败时发送完整上下文、原输出和诊断做一次 repair；第二次失败返回 `assignments: []`。
+6. 成功结果再经过 COD-340 `validateOperationConfigs` 校验，随后才进入 `pendingOperations`。已匹配 Operation 不参与分配，也不被改写。
+
+Operation 只持久化扁平 `agent` 和 `model`，不会持久化 runtime config id。图节点也不会被统一写入编排器 runtime。
+
+### 编辑已有 Operation
+
+`PipelineActionSchema` 新增严格的 `updateOperation` action。提案生成时必须同时满足：
+
+- `operationId` 是当前画布实际引用的已有 Operation；
+- executor 的 agent/model/capability 全部在目录内；
+- 不可逆能力在 `assignmentReason` 中明确说明必要性；
+- schema 或语义失败只 repair 一次。
+
+审批时再次按 session snapshot 校验 Operation 范围，保留原 inputs/outputs，仅替换 executor，并复用 COD-340 的目录校验。Operation 更新、pending Operation 创建、proposal 状态和 session 状态处于同一审批事务。
+
+### 执行优先级
+
+运行时按以下优先级决定 agent/model：
+
+1. 节点关联的 Agent entity 默认 runtime/model；
+2. 节点显式 `agentRuntime`（为避免跨 runtime 误用，此时不沿用 executor model）；
+3. Operation executor 的扁平 `agent + model`；
+4. runner 既有默认值。
+
+因此 COD-341 保存的 per-operation model 会在没有更高优先级覆盖时真实传入 prompt/skill runner。
+MCP credential source 同样按当前 Operation 的实际 agent 选择；当节点覆盖为另一种 agent 时，不会继承默认 runtime 的 SSH 连接或默认模型。Operation 详情页和画布属性编辑器在保存其他字段时会保留已有的 `agent/model/allowedTools/assignmentReason`。
+
+## 代表性 Fixture 与解析率
+
+这些结果来自确定性 JSON fixture，不调用真实 LLM。
+
+| 类型   | Fixture                                                          | 预期       | 结果 |
+| ------ | ---------------------------------------------------------------- | ---------- | ---- |
+| 有效 1 | 同一批次包含 deterministic bash script 和需要判断的 prompt agent | 接受       | 通过 |
+| 有效 2 | skill agent 使用目录 `reference` 作为 `skillId`                  | 接受       | 通过 |
+| 有效 3 | 使用稳定 MCP reference，并明确说明不可逆发送的必要性             | 接受       | 通过 |
+| 无效 1 | 缺失、重复、额外 Operation，同时包含目录外 model/tool            | 整批拒绝   | 通过 |
+| 无效 2 | 使用不可逆能力但理由未明确说明不可逆性                           | 整批拒绝   | 通过 |
+| 无效 3 | 首次失败且唯一一次 repair 仍无效                                 | 空结果中止 | 通过 |
+
+- 有效 fixture 接受率：`3/3 = 100%`；
+- 无效 fixture 预期拒绝率：`3/3 = 100%`；
+- 预期行为符合率：`6/6 = 100%`。
+
+这不是模型生成成功率。未自动调用真实模型，避免使用开发者凭据或产生外部调用成本；真实模型的一次成功率与 repair 成功率仍需在受控环境另行采样。
+
+## 关键测试覆盖
+
+- `capabilityAssignment.unit.test.ts`：script/agent/skill、稳定 MCP reference、目录外引用、不可逆理由、原子失败和一次 repair；
+- `resolveAssignmentRuntime.unit.test.ts`：runtime config 去重、会话选择、有效默认回退和无模型目录失败；
+- `generateStructure.unit.test.ts`：mixed executor、pending-only、二次目录校验、已匹配 Operation 不变；
+- `proposeActions.unit.test.ts`：`updateOperation` 成功、目录外值 repair 后拒绝、画布外 Operation 拒绝；
+- `createPipelineAgentSessionsService.unit.test.ts`：审批事务内更新共享 Operation及越权目标拒绝；
+- `OperationNode.test.ts`：executor model 生效及 Agent/node override 优先级；
+- schema、graph action、REST 输入和 proposal view 均有对应测试。
+
+最终基线上的合并验收结果：agent-engine `16/16`、schemas `2/2`、pipeline-engine `44/44`、services `115/115`、views `3/3`、server routes `9/9`，共 `189/189`。agent-engine、schemas、pipeline-engine、services、views、app、server 类型检查均通过；相关 lint exit 0（仅保留仓库既有 warning）。
+
+## 已知边界
+
+- COD-337 当前只在 local connection 上提供模型目录；没有模型目录的 SSH runtime 不会成为 assignment 编排器或 per-step agent/model 候选。
+- “最小权限”通过目录 membership、runtime 支持、最多 8 个工具、重复引用拒绝和 prompt 约束落实；是否存在更小但同样可完成任务的能力集合仍属于模型语义质量问题。
+- 真实 LLM 质量、延迟和成本不在本地 fixture 的结论范围内。

--- a/packages/agent-engine/src/agentEngine.unit.test.ts
+++ b/packages/agent-engine/src/agentEngine.unit.test.ts
@@ -186,9 +186,10 @@ describe("agentEngine", () => {
   });
 
   it("loads only the selected connector tools inside a supported adapter", async () => {
+    const stableMcpReference = "mcp__connector_676974687562__read_issue";
     const injection = {
-      mcpServers: { github: { command: "github-mcp" } },
-      toolNames: ["mcp__github__read_issue"],
+      mcpServers: { connector_676974687562: { command: "github-mcp" } },
+      toolNames: [stableMcpReference],
     };
     const getMcpConnectorInjection = vi.fn().mockResolvedValue(injection);
 
@@ -198,11 +199,11 @@ describe("agentEngine", () => {
       systemPrompt: "Analyze this",
       userPrompt: "Hello",
       cwd: "/tmp/test",
-      allowedTools: ["Read", "mcp__github__read_issue"],
+      allowedTools: ["Read", stableMcpReference],
       getMcpConnectorInjection,
     });
 
-    expect(getMcpConnectorInjection).toHaveBeenCalledWith(["mcp__github__read_issue"]);
+    expect(getMcpConnectorInjection).toHaveBeenCalledWith([stableMcpReference], "codex");
     expect(runCodex).toHaveBeenCalledWith(
       expect.objectContaining({ connectorInjection: injection }),
     );

--- a/packages/agent-engine/src/drivers.ts
+++ b/packages/agent-engine/src/drivers.ts
@@ -55,7 +55,7 @@ const loadConnectorInjection = async (
   const selectedTools = selectedConnectorToolNames(opts);
   if (!opts.getMcpConnectorInjection || selectedTools.length === 0) return undefined;
 
-  return (await opts.getMcpConnectorInjection(selectedTools)) ?? undefined;
+  return (await opts.getMcpConnectorInjection(selectedTools, opts.agent)) ?? undefined;
 };
 
 const hasRequestedConnectorInjection = (opts: AgentRunOptions): boolean =>

--- a/packages/agent-engine/src/types.ts
+++ b/packages/agent-engine/src/types.ts
@@ -41,6 +41,7 @@ export interface DriverResult {
 
 export type McpConnectorInjectionProvider = (
   selectedToolNames: readonly string[],
+  agent?: AgentRuntime,
 ) => Promise<McpConnectorInjection | null>;
 
 export interface AgentRunOptions {

--- a/packages/pipeline-engine/src/actions/applyPipelineActions.test.ts
+++ b/packages/pipeline-engine/src/actions/applyPipelineActions.test.ts
@@ -52,6 +52,60 @@ describe("validatePipelineActions", () => {
 });
 
 describe("applyPipelineActions", () => {
+  it("validates updateOperation against the current graph without changing it", () => {
+    const operationNode = {
+      id: "operation-node",
+      type: "operation" as const,
+      position: { x: 0, y: 0 },
+      data: {
+        nodeType: "operation" as const,
+        label: "Review",
+        operationId: "op-review",
+        operationName: "Review",
+        status: "idle" as const,
+      },
+    };
+    const snapshot = makeSnapshot([operationNode]);
+    const result = applyPipelineActions(snapshot, [
+      {
+        type: "updateOperation",
+        operationId: "op-review",
+        executor: {
+          type: "agent",
+          agentMode: "prompt",
+          agent: "codex",
+          model: "gpt-review",
+          prompt: "Review the input.",
+          allowedTools: [],
+          assignmentReason: "Semantic review requires an agent.",
+        },
+      },
+    ]);
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toEqual(snapshot);
+  });
+
+  it("rejects updateOperation for an operation outside the current graph", () => {
+    const result = applyPipelineActions(makeSnapshot(), [
+      {
+        type: "updateOperation",
+        operationId: "op-missing",
+        executor: {
+          type: "script",
+          language: "bash",
+          command: "bun run lint",
+          assignmentReason: "Linting is a deterministic local command.",
+        },
+      },
+    ]);
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toEqual([
+      expect.objectContaining({ code: "OPERATION_NOT_FOUND", actionIndex: 0 }),
+    ]);
+  });
+
   it("applies sequential addNode then addEdge actions", () => {
     const folderNode = makeNode("folder-1", "folder");
     const actionNode = makeNode("action-1", "operation", {

--- a/packages/pipeline-engine/src/actions/applyPipelineActions.ts
+++ b/packages/pipeline-engine/src/actions/applyPipelineActions.ts
@@ -297,6 +297,26 @@ const applyAction = (
 
       return [];
     }
+
+    case "updateOperation": {
+      // The action updates the shared Operation entity during proposal approval;
+      // its graph representation is only the stable operationId reference.
+      const operationNode = draft.nodes.find(
+        (node) =>
+          node.data.nodeType === "operation" && node.data.operationId === action.operationId,
+      );
+      if (!operationNode) {
+        return [
+          makeDiagnostic(
+            "OPERATION_NOT_FOUND",
+            `Operation "${action.operationId}" is not used by the current pipeline.`,
+            actionIndex,
+          ),
+        ];
+      }
+
+      return [];
+    }
   }
 };
 

--- a/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.test.ts
+++ b/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.test.ts
@@ -490,6 +490,48 @@ describe("executeOperationNode — agent override", () => {
     expect(deps.runPrompt).toHaveBeenCalledWith(expect.objectContaining({ agent: "codex" }));
   });
 
+  it("uses the model persisted on the operation executor", async () => {
+    const deps = makeDeps();
+    const op = makeOperation({
+      type: "agent",
+      agentMode: "prompt",
+      prompt: "Analyze",
+      agent: "codex",
+      model: "gpt-operation",
+    });
+    const ops = new Map([["op-id", op]]);
+    const node = makeNode({ operationId: "op-id" });
+    const ctx = makeCtx(deps, ops);
+
+    const result = await executeOperationNode(node, makeInput(), ctx);
+
+    expect(result.outcome).toBe("completed");
+    expect(deps.runPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "codex", model: "gpt-operation" }),
+    );
+  });
+
+  it("does not reuse an executor model when a node overrides only the runtime", async () => {
+    const deps = makeDeps();
+    const op = makeOperation({
+      type: "agent",
+      agentMode: "prompt",
+      prompt: "Analyze",
+      agent: "codex",
+      model: "gpt-operation",
+    });
+    const ops = new Map([["op-id", op]]);
+    const node = makeNode({ operationId: "op-id", agentRuntime: "mastra" });
+    const ctx = makeCtx(deps, ops);
+
+    const result = await executeOperationNode(node, makeInput(), ctx);
+
+    expect(result.outcome).toBe("completed");
+    const call = (deps.runPrompt as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(call.agent).toBe("mastra");
+    expect(call).not.toHaveProperty("model");
+  });
+
   it("resolves agentId to agent runtime for prompt mode", async () => {
     const deps = makeDeps();
     const op = makeOperation({

--- a/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.ts
+++ b/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.ts
@@ -87,6 +87,7 @@ export const executeOperationNode = async (
         return {
           agent: agent.defaultRuntime as OperationExecutorConfig["agent"],
           model: agent.defaultModel ?? undefined,
+          overridesExecutor: true,
         };
       }
       await trace(
@@ -95,9 +96,12 @@ export const executeOperationNode = async (
       );
     }
 
+    const agent = data.agentRuntime as OperationExecutorConfig["agent"] | undefined;
+
     return {
-      agent: data.agentRuntime as OperationExecutorConfig["agent"] | undefined,
+      agent,
       model: undefined,
+      overridesExecutor: Boolean(agent),
     };
   })();
   const agentOverride = agentSelection.agent;
@@ -127,6 +131,8 @@ export const executeOperationNode = async (
 
   const effectiveAgentMode =
     executor.agentMode ?? (executor.type === "agent" ? "prompt" : undefined);
+  const effectiveModel =
+    agentSelection.model ?? (agentSelection.overridesExecutor ? undefined : executor.model);
 
   // lastContent tracks the most recently emitted LLM_CONTENT so the final emit can dedupe:
   // the last streamed frame's accumulated text often equals the final full text, and
@@ -189,7 +195,7 @@ export const executeOperationNode = async (
         instruction: prompt,
       }),
       agent: agentOverride ?? executor.agent,
-      ...(agentSelection.model ? { model: agentSelection.model } : {}),
+      ...(effectiveModel ? { model: effectiveModel } : {}),
       onChunk: handleChunk,
       onProgress,
       allowedTools: executor.allowedTools,
@@ -246,7 +252,7 @@ export const executeOperationNode = async (
         instruction: skillDescription,
       }),
       agent,
-      ...(agentSelection.model ? { model: agentSelection.model } : {}),
+      ...(effectiveModel ? { model: effectiveModel } : {}),
       allowedTools: executor.allowedTools,
       onChunk: handleChunk,
       onProgress,

--- a/packages/schemas/src/operation/OperationExecutorConfigSchema.ts
+++ b/packages/schemas/src/operation/OperationExecutorConfigSchema.ts
@@ -4,15 +4,59 @@ import { AgentModeSchema } from "../agent/AgentModeSchema";
 import { AgentRuntimeSchema } from "../agent-runtime/AgentRuntimeSchema";
 import { ScriptLanguageSchema } from "../common/ScriptLanguageSchema";
 
+export const OperationAssignmentReasonSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(240)
+  .refine((reason) => !/[\r\n]/u.test(reason), "assignmentReason must be one line");
+
 export const OperationExecutorConfigSchema = z.object({
   type: OperationExecutorTypeSchema,
   agentMode: AgentModeSchema.optional(),
   agent: AgentRuntimeSchema.optional(),
+  model: z.string().trim().min(1).optional(),
   skillId: z.string().optional(),
   systemPrompt: z.string().optional(),
   prompt: z.string().optional(),
   command: z.string().optional(),
   language: ScriptLanguageSchema.optional(),
   allowedTools: z.array(z.string()).optional(),
+  assignmentReason: OperationAssignmentReasonSchema.optional(),
 });
 export type OperationExecutorConfig = z.infer<typeof OperationExecutorConfigSchema>;
+
+const AssignedAgentExecutorFields = {
+  type: z.literal("agent"),
+  agent: AgentRuntimeSchema,
+  model: z.string().trim().min(1),
+  allowedTools: z.array(z.string().trim().min(1)).max(8),
+  assignmentReason: OperationAssignmentReasonSchema,
+};
+
+/** Strict replacement shape emitted by per-step assignment and updateOperation. */
+export const AssignedOperationExecutorConfigSchema = z.union([
+  z
+    .object({
+      type: z.literal("script"),
+      language: ScriptLanguageSchema,
+      command: z.string().trim().min(1).max(8000),
+      assignmentReason: OperationAssignmentReasonSchema,
+    })
+    .strict(),
+  z
+    .object({
+      ...AssignedAgentExecutorFields,
+      agentMode: z.literal("prompt"),
+      prompt: z.string().trim().min(1).max(8000),
+    })
+    .strict(),
+  z
+    .object({
+      ...AssignedAgentExecutorFields,
+      agentMode: z.literal("skill"),
+      skillId: z.string().trim().min(1),
+    })
+    .strict(),
+]);
+export type AssignedOperationExecutorConfig = z.infer<typeof AssignedOperationExecutorConfigSchema>;

--- a/packages/schemas/src/pipeline/PipelineActionDiagnosticSchema.ts
+++ b/packages/schemas/src/pipeline/PipelineActionDiagnosticSchema.ts
@@ -9,14 +9,11 @@ export const PIPELINE_ACTION_DIAGNOSTIC_CODES = {
   INVALID_CONNECTION: "INVALID_CONNECTION",
   INVALID_NODE_DATA: "INVALID_NODE_DATA",
   NODE_NOT_FOUND: "NODE_NOT_FOUND",
+  OPERATION_NOT_FOUND: "OPERATION_NOT_FOUND",
 } as const;
 
-export const PipelineActionDiagnosticCodeSchema = z.enum(
-  PIPELINE_ACTION_DIAGNOSTIC_CODES,
-);
-export type PipelineActionDiagnosticCode = z.infer<
-  typeof PipelineActionDiagnosticCodeSchema
->;
+export const PipelineActionDiagnosticCodeSchema = z.enum(PIPELINE_ACTION_DIAGNOSTIC_CODES);
+export type PipelineActionDiagnosticCode = z.infer<typeof PipelineActionDiagnosticCodeSchema>;
 
 export const PipelineActionDiagnosticSeveritySchema = z.enum(["error", "warning"]);
 export type PipelineActionDiagnosticSeverity = z.infer<

--- a/packages/schemas/src/pipeline/PipelineActionSchema.ts
+++ b/packages/schemas/src/pipeline/PipelineActionSchema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { AssignedOperationExecutorConfigSchema } from "../operation/OperationExecutorConfigSchema";
 import { PipelineNodeDataSchema } from "./node-data/PipelineNodeDataSchema";
 import { PipelineGraphNodeSchema, PipelineGraphEdgeSchema } from "./PipelineGraphSnapshotSchema";
 
@@ -37,6 +38,15 @@ export const ReplaceNodeDataPipelineActionSchema = z.object({
   data: PipelineNodeDataSchema,
 });
 
+/** Replace the executor on the shared Operation entity without cloning it. */
+export const UpdateOperationPipelineActionSchema = z
+  .object({
+    type: z.literal("updateOperation"),
+    operationId: z.string().min(1),
+    executor: AssignedOperationExecutorConfigSchema,
+  })
+  .strict();
+
 export const PipelineActionSchema = z.discriminatedUnion("type", [
   AddNodePipelineActionSchema,
   RemoveNodePipelineActionSchema,
@@ -44,5 +54,6 @@ export const PipelineActionSchema = z.discriminatedUnion("type", [
   RemoveEdgePipelineActionSchema,
   ReconnectEdgePipelineActionSchema,
   ReplaceNodeDataPipelineActionSchema,
+  UpdateOperationPipelineActionSchema,
 ]);
 export type PipelineAction = z.infer<typeof PipelineActionSchema>;

--- a/packages/schemas/src/pipeline/PipelineActionSchema.unit.test.ts
+++ b/packages/schemas/src/pipeline/PipelineActionSchema.unit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { PipelineActionSchema } from "./PipelineActionSchema";
+
+describe("PipelineActionSchema", () => {
+  it("accepts a complete updateOperation executor", () => {
+    const result = PipelineActionSchema.safeParse({
+      type: "updateOperation",
+      operationId: "op-review",
+      executor: {
+        type: "agent",
+        agentMode: "prompt",
+        agent: "codex",
+        model: "gpt-5.4-mini",
+        prompt: "Review the supplied change.",
+        allowedTools: ["Read"],
+        assignmentReason: "Read-only repository access is sufficient for review.",
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects multiline reasons and unknown executor fields", () => {
+    expect(
+      PipelineActionSchema.safeParse({
+        type: "updateOperation",
+        operationId: "op-review",
+        executor: {
+          type: "agent",
+          assignmentReason: "First line\nsecond line",
+        },
+      }).success,
+    ).toBe(false);
+
+    expect(
+      PipelineActionSchema.safeParse({
+        type: "updateOperation",
+        operationId: "op-review",
+        executor: { type: "script", command: "bun run lint", unexpected: true },
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
@@ -829,21 +829,47 @@ export const createPipelineAgentSessionsService = (db: DbConnection) => {
           throw new Error(`Pipeline agent proposal ${proposalId} is not ready for approval`);
         }
 
-        if (proposal.proposal.mode === "edit" && proposal.proposal.pendingOperations?.length > 0) {
-          const createPendingResult = await transactionalPipelinesService.createPendingOperations(
-            proposal.proposal.pendingOperations.map((operation) => ({
-              ...operation,
-              acceptedObjectTypes: operation.acceptedObjectTypes as ObjectNodeType[],
-            })),
+        if (proposal.proposal.mode === "edit") {
+          if (proposal.proposal.pendingOperations?.length > 0) {
+            const createPendingResult = await transactionalPipelinesService.createPendingOperations(
+              proposal.proposal.pendingOperations.map((operation) => ({
+                ...operation,
+                acceptedObjectTypes: operation.acceptedObjectTypes as ObjectNodeType[],
+              })),
+            );
+            if (createPendingResult.isErr()) throw createPendingResult.error;
+          }
+
+          const operationUpdates = (proposal.proposal.actions ?? []).flatMap((action) =>
+            action.type === "updateOperation"
+              ? [{ operationId: action.operationId, executor: action.executor }]
+              : [],
           );
-          if (createPendingResult.isErr()) throw createPendingResult.error;
+          if (operationUpdates.length > 0) {
+            const editableOperationIds = new Set(
+              (session.snapshot?.nodes ?? []).flatMap((node) =>
+                node.data.nodeType === "operation" ? [node.data.operationId] : [],
+              ),
+            );
+            const invalidUpdate = operationUpdates.find(
+              (update) => !editableOperationIds.has(update.operationId),
+            );
+            if (invalidUpdate) {
+              throw new Error(
+                `Operation ${invalidUpdate.operationId} is not used by edit session ${sessionId}`,
+              );
+            }
+
+            const updateResult =
+              await transactionalPipelinesService.updateOperationExecutors(operationUpdates);
+            if (updateResult.isErr()) throw updateResult.error;
+          }
         }
 
         await transactionalProposalsDao.update(proposalId, {
           status: "approved",
           approvedAt: new Date(),
         });
-
         await transactionalSessionsDao.update(sessionId, {
           status: "approved",
           approvedProposalId: proposalId,
@@ -1261,6 +1287,7 @@ export const createPipelineAgentSessionsService = (db: DbConnection) => {
               description: pipelineDescription,
               matchedOperations: analysis.matchedOperations,
               unmatchedSteps: analysis.unmatchedSteps,
+              runtimeId: input?.runtimeId,
               runtimeType: effectiveRuntime,
             }),
             activity.controller.signal,

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
@@ -62,6 +62,7 @@ const mockPipelinesService = {
   delete: vi.fn(),
   generateStructure: vi.fn(),
   proposeActions: vi.fn(),
+  updateOperationExecutors: vi.fn(),
 };
 
 const mockRunAgent = vi.fn();
@@ -226,6 +227,7 @@ describe("createPipelineAgentSessionsService", () => {
       edges: [],
     });
     mockPipelinesService.createPendingOperations.mockResolvedValue(ok(undefined));
+    mockPipelinesService.updateOperationExecutors.mockResolvedValue(ok(undefined));
     mockPipelinesService.delete.mockResolvedValue(undefined);
     mockPipelinesService.create.mockImplementation(async (data) => ({
       id: data.id ?? "pipeline-1",
@@ -475,6 +477,7 @@ describe("createPipelineAgentSessionsService", () => {
   it("rolls back approval state and pending operations when the final session update fails", async () => {
     const committed = {
       operations: [] as string[],
+      updatedOperations: [] as string[],
       proposalStatus: "proposal_ready",
       sessionStatus: "proposal_ready",
     };
@@ -482,6 +485,23 @@ describe("createPipelineAgentSessionsService", () => {
       id: "session-1",
       mode: "edit",
       status: "proposal_ready",
+      snapshot: {
+        nodes: [
+          {
+            id: "existing-node",
+            type: "operation",
+            position: { x: 0, y: 0 },
+            data: {
+              nodeType: "operation",
+              label: "Existing",
+              operationId: "op-existing",
+              operationName: "Existing",
+              status: "idle",
+            },
+          },
+        ],
+        edges: [],
+      },
     };
     const proposal = {
       id: "proposal-edit-1",
@@ -491,6 +511,18 @@ describe("createPipelineAgentSessionsService", () => {
       proposal: {
         mode: "edit",
         readiness: "ready_for_generation",
+        actions: [
+          {
+            type: "updateOperation",
+            operationId: "op-existing",
+            executor: {
+              type: "script",
+              language: "bash",
+              command: "echo updated",
+              assignmentReason: "This deterministic command needs no Agent capability.",
+            },
+          },
+        ],
         pendingOperations: [
           {
             id: "op-new",
@@ -505,6 +537,7 @@ describe("createPipelineAgentSessionsService", () => {
     mockDb.transaction.mockImplementationOnce(async (callback) => {
       const staged = {
         operations: [...committed.operations],
+        updatedOperations: [...committed.updatedOperations],
         proposalStatus: committed.proposalStatus,
         sessionStatus: committed.sessionStatus,
       };
@@ -513,6 +546,11 @@ describe("createPipelineAgentSessionsService", () => {
           ...mockPipelinesService,
           createPendingOperations: vi.fn(async (operations: Array<{ id: string }>) => {
             staged.operations.push(...operations.map((operation) => operation.id));
+
+            return ok(undefined);
+          }),
+          updateOperationExecutors: vi.fn(async (updates: Array<{ operationId: string }>) => {
+            staged.updatedOperations.push(...updates.map((update) => update.operationId));
 
             return ok(undefined);
           }),
@@ -541,6 +579,7 @@ describe("createPipelineAgentSessionsService", () => {
     );
     expect(committed).toEqual({
       operations: [],
+      updatedOperations: [],
       proposalStatus: "proposal_ready",
       sessionStatus: "proposal_ready",
     });
@@ -552,6 +591,135 @@ describe("createPipelineAgentSessionsService", () => {
     await service.approveProposal("session-1", "proposal-1");
 
     expect(mockPipelinesService.createPendingOperations).not.toHaveBeenCalled();
+  });
+
+  it("updates a shared Operation executor while approving an edit proposal", async () => {
+    mockSessionsDao.findById.mockResolvedValueOnce({
+      id: "session-1",
+      entrypoint: "canvas-agent-panel",
+      mode: "edit",
+      status: "proposal_ready",
+      pipelineId: "pipe-1",
+      snapshot: {
+        nodes: [
+          {
+            id: "review-node",
+            type: "operation",
+            position: { x: 0, y: 0 },
+            data: {
+              nodeType: "operation",
+              label: "Review Code",
+              operationId: "review-code",
+              operationName: "Review Code",
+              status: "idle",
+            },
+          },
+        ],
+        edges: [],
+      },
+      latestProposalId: "proposal-edit-1",
+      approvedProposalId: null,
+      createdPipelineId: null,
+      createdAt: new Date("2026-06-03T12:00:00.000Z"),
+      updatedAt: new Date("2026-06-03T12:00:00.000Z"),
+    });
+    const executor = {
+      type: "agent" as const,
+      agentMode: "prompt" as const,
+      agent: "codex" as const,
+      model: "gpt-review",
+      prompt: "Review the supplied diff.",
+      allowedTools: ["Read"],
+      assignmentReason: "Read-only access is sufficient for semantic review.",
+    };
+    mockProposalsDao.findById.mockResolvedValueOnce({
+      id: "proposal-edit-1",
+      sessionId: "session-1",
+      mode: "edit",
+      status: "proposal_ready",
+      proposal: {
+        mode: "edit",
+        summary: "Change the review executor",
+        targetGraphIntent: "Use the selected review model",
+        majorChanges: [],
+        assumptions: [],
+        openQuestions: [],
+        actions: [{ type: "updateOperation", operationId: "review-code", executor }],
+        diagnosticsPreview: [],
+        readiness: "ready_for_generation",
+        pendingOperations: [],
+      },
+      createdAt: new Date("2026-06-03T12:00:02.000Z"),
+      updatedAt: new Date("2026-06-03T12:00:02.000Z"),
+      approvedAt: null,
+    });
+
+    await createPipelineAgentSessionsService({} as never).approveProposal(
+      "session-1",
+      "proposal-edit-1",
+    );
+
+    expect(mockPipelinesService.updateOperationExecutors).toHaveBeenCalledWith([
+      { operationId: "review-code", executor },
+    ]);
+    expect(mockDb.transaction).toHaveBeenCalledOnce();
+  });
+
+  it("rejects approval when updateOperation targets an Operation outside the edit snapshot", async () => {
+    mockSessionsDao.findById.mockResolvedValueOnce({
+      id: "session-1",
+      entrypoint: "canvas-agent-panel",
+      mode: "edit",
+      status: "proposal_ready",
+      pipelineId: "pipe-1",
+      snapshot: { nodes: [], edges: [] },
+      latestProposalId: "proposal-edit-1",
+      approvedProposalId: null,
+      createdPipelineId: null,
+      createdAt: new Date("2026-06-03T12:00:00.000Z"),
+      updatedAt: new Date("2026-06-03T12:00:00.000Z"),
+    });
+    mockProposalsDao.findById.mockResolvedValueOnce({
+      id: "proposal-edit-1",
+      sessionId: "session-1",
+      mode: "edit",
+      status: "proposal_ready",
+      proposal: {
+        mode: "edit",
+        summary: "Change an unrelated executor",
+        targetGraphIntent: "Change an unrelated executor",
+        majorChanges: [],
+        assumptions: [],
+        openQuestions: [],
+        actions: [
+          {
+            type: "updateOperation",
+            operationId: "not-on-this-canvas",
+            executor: {
+              type: "script",
+              language: "bash",
+              command: "echo no",
+              assignmentReason: "This is a deterministic command.",
+            },
+          },
+        ],
+        diagnosticsPreview: [],
+        readiness: "ready_for_generation",
+        pendingOperations: [],
+      },
+      createdAt: new Date("2026-06-03T12:00:02.000Z"),
+      updatedAt: new Date("2026-06-03T12:00:02.000Z"),
+      approvedAt: null,
+    });
+
+    await expect(
+      createPipelineAgentSessionsService({} as never).approveProposal(
+        "session-1",
+        "proposal-edit-1",
+      ),
+    ).rejects.toThrow("not used by edit session");
+    expect(mockPipelinesService.updateOperationExecutors).not.toHaveBeenCalled();
+    expect(mockProposalsDao.update).not.toHaveBeenCalled();
   });
 
   it("rejects approval when a proposal still needs user input", async () => {

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
@@ -139,7 +139,10 @@ export const createPipelineRunnerService = (
     });
 
   const buildMcpConnectorInjectionProvider = (preferredSource: AgentRuntime) => {
-    return async (selectedToolNames: readonly string[]) => {
+    return async (
+      selectedToolNames: readonly string[],
+      operationAgent: AgentRuntime = preferredSource,
+    ) => {
       const connectors = await connectorsDao.findMany();
       const hydratedConnectors = connectors.map((connector) => {
         if (connector.method !== "mcp" || connector.status !== "connected") return connector;
@@ -148,7 +151,7 @@ export const createPipelineRunnerService = (
             ? {}
             : { encryptionSecret: options.encryptionSecret }),
           ...(options.env ? { env: options.env } : {}),
-          preferredSource,
+          preferredSource: operationAgent,
         });
         if (hydrated.isErr()) throw hydrated.error;
 

--- a/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.ts
+++ b/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.ts
@@ -24,26 +24,32 @@ export const pipelineRunnerEngineDeps = {
     ssh?: SshConnection;
     getMcpConnectorInjection?: McpConnectorInjectionProvider;
   }): PipelineEngineDeps => ({
-    runPrompt: (o) =>
-      promptExecutor.run({
+    runPrompt: (o) => {
+      const agent = o.agent ?? defaultAgent;
+
+      return promptExecutor.run({
         ...o,
-        agent: o.agent ?? defaultAgent,
+        agent,
         jobId,
         apiKey,
-        model: o.model ?? model,
-        ssh,
+        model: o.model ?? (agent === defaultAgent ? model : undefined),
+        ...(agent === defaultAgent && ssh ? { ssh } : {}),
         getMcpConnectorInjection,
-      }),
-    runSkill: (o) =>
-      skillExecutor.run({
+      });
+    },
+    runSkill: (o) => {
+      const agent = o.agent ?? defaultAgent;
+
+      return skillExecutor.run({
         ...o,
-        agent: o.agent ?? defaultAgent,
+        agent,
         jobId,
         apiKey,
-        model: o.model ?? model,
-        ssh,
+        model: o.model ?? (agent === defaultAgent ? model : undefined),
+        ...(agent === defaultAgent && ssh ? { ssh } : {}),
         getMcpConnectorInjection,
-      }),
+      });
+    },
     structuredJsonToMarkdown: (content) => structuredOutput.toMarkdown({ content }),
     evaluateLoopCondition,
   }),

--- a/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.unit.test.ts
@@ -74,6 +74,8 @@ describe("pipelineRunnerEngineDeps", () => {
       evaluateLoopCondition,
       jobId: "job-1",
       defaultAgent: "claude-code",
+      model: "claude-default",
+      ssh: { mode: "ssh", host: "example.com", user: "runner" },
     });
 
     deps.runPrompt({
@@ -85,6 +87,8 @@ describe("pipelineRunnerEngineDeps", () => {
     expect(promptExecutor.run).toHaveBeenCalledWith(
       expect.objectContaining({
         agent: "claude-code",
+        model: "claude-default",
+        ssh: { mode: "ssh", host: "example.com", user: "runner" },
       }),
     );
   });
@@ -94,6 +98,8 @@ describe("pipelineRunnerEngineDeps", () => {
       evaluateLoopCondition,
       jobId: "job-1",
       defaultAgent: "claude-code",
+      model: "claude-default",
+      ssh: { mode: "ssh", host: "example.com", user: "runner" },
     });
 
     deps.runPrompt({
@@ -108,6 +114,12 @@ describe("pipelineRunnerEngineDeps", () => {
         agent: "codex",
       }),
     );
+    const call = vi.mocked(promptExecutor.run).mock.calls[0]?.[0] as {
+      model?: unknown;
+      ssh?: unknown;
+    };
+    expect(call.model).toBeUndefined();
+    expect(call.ssh).toBeUndefined();
   });
 
   it("applies defaultAgent to runSkill when agent is not specified", () => {

--- a/packages/services/src/pipelinesService/capabilityAssignment/buildCapabilityAssignmentPrompt.ts
+++ b/packages/services/src/pipelinesService/capabilityAssignment/buildCapabilityAssignmentPrompt.ts
@@ -1,0 +1,94 @@
+import type { CapabilityAssignmentContext } from "./schemas";
+
+export const CAPABILITY_ASSIGNMENT_SYSTEM_PROMPT = [
+  "You assign one executor to every new or unmatched Pipeline operation.",
+  "Return one JSON object only. Do not use Markdown or add commentary.",
+  "Return exactly one assignment for each supplied operationId and no others.",
+  "Prefer a script for deterministic local work such as moving files, converting formats, or calling a known API.",
+  "Use an agent only when the step needs model judgment, a skill, or catalog tools.",
+  "For agents, select agent/model only from AGENT_TARGETS.",
+  "Use capability reference values, not catalog row ids.",
+  "skillId must reference kind=skill. allowedTools may reference only builtin-tool or mcp-tool.",
+  "Grant the smallest capability set needed by the step.",
+  "assignmentReason is required inside executor, must be one line, and must explain the choice.",
+  "If any selected capability is irreversible, assignmentReason must explicitly say why the irreversible action is necessary.",
+].join("\n");
+
+const projectPromptContext = (context: CapabilityAssignmentContext) => ({
+  steps: context.steps,
+  agentTargets: context.agentTargets,
+  capabilityCatalog: context.capabilityCatalog.map((entry) => ({
+    reference: entry.reference,
+    displayName: entry.displayName,
+    description: entry.description,
+    kind: entry.kind,
+    supportedRuntimes: entry.supportedRuntimes,
+    riskTier: entry.riskTier,
+  })),
+});
+
+const OUTPUT_EXAMPLES = {
+  script: {
+    operationId: "op_example_script",
+    executor: {
+      type: "script",
+      language: "bash",
+      command: "bun run lint",
+      assignmentReason: "This deterministic local command needs no model or external capability.",
+    },
+  },
+  promptAgent: {
+    operationId: "op_example_review",
+    executor: {
+      type: "agent",
+      agentMode: "prompt",
+      agent: "claude-code",
+      model: "example-model-id",
+      prompt: "Review the supplied change and report actionable findings.",
+      allowedTools: ["Read"],
+      assignmentReason: "Read-only repository access is sufficient for semantic review.",
+    },
+  },
+  skillAgent: {
+    operationId: "op_example_skill",
+    executor: {
+      type: "agent",
+      agentMode: "skill",
+      agent: "claude-code",
+      model: "example-model-id",
+      skillId: "example-skill-reference",
+      allowedTools: [],
+      assignmentReason: "The selected skill covers the transformation without extra tools.",
+    },
+  },
+};
+
+export const buildCapabilityAssignmentPrompt = (context: CapabilityAssignmentContext): string =>
+  [
+    "=== ASSIGNMENT CONTEXT ===",
+    JSON.stringify(projectPromptContext(context), null, 2),
+    "",
+    "=== OUTPUT EXAMPLES (shape only; do not copy ids or unavailable values) ===",
+    JSON.stringify(OUTPUT_EXAMPLES, null, 2),
+    "",
+    'Return {"assignments":[...]} now.',
+  ].join("\n");
+
+export const buildCapabilityAssignmentRepairPrompt = (
+  context: CapabilityAssignmentContext,
+  invalidOutput: unknown,
+  diagnostics: string[],
+): string =>
+  [
+    "Repair the previous capability assignment once.",
+    "Return the complete JSON object only. Fix every diagnostic and preserve valid intent.",
+    "",
+    "=== ASSIGNMENT CONTEXT ===",
+    JSON.stringify(projectPromptContext(context), null, 2),
+    "",
+    "=== PREVIOUS INVALID OUTPUT ===",
+    JSON.stringify(invalidOutput, null, 2),
+    "",
+    "=== VALIDATION DIAGNOSTICS ===",
+    ...diagnostics.map((diagnostic) => `- ${diagnostic}`),
+  ].join("\n");

--- a/packages/services/src/pipelinesService/capabilityAssignment/capabilityAssignment.unit.test.ts
+++ b/packages/services/src/pipelinesService/capabilityAssignment/capabilityAssignment.unit.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildMcpServerKey, buildMcpToolReference } from "../../connectorsService";
+import { parseCapabilityAssignments } from "./parseCapabilityAssignments";
+import { planCapabilityAssignments } from "./planCapabilityAssignments";
+import type { CapabilityAssignmentContext } from "./schemas";
+
+const mailToolReference = buildMcpToolReference(buildMcpServerKey("mail"), "send");
+
+const context = {
+  steps: [
+    { operationId: "op-lint", name: "Lint", description: "Lint source files" },
+    { operationId: "op-review", name: "Review", description: "Review the resulting diff" },
+  ],
+  agentTargets: [{ agent: "claude-code", models: ["claude-review"] }],
+  capabilityCatalog: [
+    {
+      id: "builtin:Read",
+      reference: "Read",
+      displayName: "Read",
+      description: "Read files",
+      source: "builtin",
+      supportedRuntimes: ["claude-code"],
+      riskTier: "readonly",
+      inferredRiskTier: "readonly",
+      riskTierSource: "rule",
+      kind: "builtin-tool",
+    },
+    {
+      id: "mcp:mail:send",
+      reference: mailToolReference,
+      displayName: "Send mail",
+      description: "Send an email",
+      source: "manual",
+      supportedRuntimes: ["claude-code"],
+      riskTier: "irreversible",
+      inferredRiskTier: "irreversible",
+      riskTierSource: "rule",
+      kind: "mcp-tool",
+      connectorId: "mail",
+    },
+    {
+      id: "skill:release-notes",
+      reference: "release-notes",
+      displayName: "Release notes",
+      description: "Create release notes from a supplied change set",
+      source: "scanned",
+      supportedRuntimes: ["claude-code"],
+      riskTier: "readonly",
+      inferredRiskTier: "readonly",
+      riskTierSource: "rule",
+      kind: "skill",
+      skillId: "release-notes",
+    },
+  ],
+} satisfies CapabilityAssignmentContext;
+
+const validOutput = {
+  assignments: [
+    {
+      operationId: "op-lint",
+      executor: {
+        type: "script",
+        language: "bash",
+        command: "bun run lint",
+        assignmentReason: "Linting is a deterministic local command.",
+      },
+    },
+    {
+      operationId: "op-review",
+      executor: {
+        type: "agent",
+        agentMode: "prompt",
+        agent: "claude-code",
+        model: "claude-review",
+        prompt: "Review the supplied diff.",
+        allowedTools: ["Read"],
+        assignmentReason: "Semantic review needs model judgment and read-only access.",
+      },
+    },
+  ],
+};
+
+describe("capability assignment", () => {
+  it("accepts a mixed script and agent plan", () => {
+    const result = parseCapabilityAssignments(validOutput, context);
+
+    expect(result.ok).toBe(true);
+    expect(result.assignments).toHaveLength(2);
+    expect(result.assignments.map((assignment) => assignment.executor.type)).toEqual([
+      "script",
+      "agent",
+    ]);
+  });
+
+  it("accepts a skill-mode agent using the catalog reference as skillId", () => {
+    const result = parseCapabilityAssignments(
+      {
+        assignments: [
+          validOutput.assignments[0],
+          {
+            operationId: "op-review",
+            executor: {
+              type: "agent",
+              agentMode: "skill",
+              agent: "claude-code",
+              model: "claude-review",
+              skillId: "release-notes",
+              allowedTools: [],
+              assignmentReason: "The catalog skill provides the complete release-note workflow.",
+            },
+          },
+        ],
+      },
+      context,
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects missing, duplicate, off-catalog, and extra assignments atomically", () => {
+    const result = parseCapabilityAssignments(
+      {
+        assignments: [
+          {
+            operationId: "op-review",
+            executor: {
+              type: "agent",
+              agentMode: "prompt",
+              agent: "claude-code",
+              model: "invented-model",
+              prompt: "Review it.",
+              allowedTools: ["invented-tool"],
+              assignmentReason: "Review needs an agent.",
+            },
+          },
+          {
+            operationId: "op-review",
+            executor: {
+              type: "script",
+              language: "bash",
+              command: "echo duplicate",
+              assignmentReason: "Duplicate fixture.",
+            },
+          },
+          {
+            operationId: "op-existing",
+            executor: {
+              type: "script",
+              language: "bash",
+              command: "echo no",
+              assignmentReason: "Existing operations are out of scope.",
+            },
+          },
+        ],
+      },
+      context,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.assignments).toEqual([]);
+    expect(result.diagnostics.join("\n")).toContain("missing assignment");
+    expect(result.diagnostics.join("\n")).toContain("duplicate operation assignment");
+    expect(result.diagnostics.join("\n")).toContain("off-catalog agent/model pair");
+    expect(result.diagnostics.join("\n")).toContain("off-catalog capability reference");
+    expect(result.diagnostics.join("\n")).toContain("not new or unmatched");
+  });
+
+  it("requires an explicit explanation for irreversible capabilities", () => {
+    const result = parseCapabilityAssignments(
+      {
+        assignments: [
+          validOutput.assignments[0],
+          {
+            operationId: "op-review",
+            executor: {
+              type: "agent",
+              agentMode: "prompt",
+              agent: "claude-code",
+              model: "claude-review",
+              prompt: "Send the review.",
+              allowedTools: [mailToolReference],
+              assignmentReason: "Email the review to the team.",
+            },
+          },
+        ],
+      },
+      context,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics).toContain(
+      "assignments.op-review.executor.assignmentReason: an irreversible capability must be explicitly justified.",
+    );
+  });
+
+  it("accepts the stable MCP reference when irreversible use is explicitly justified", () => {
+    const result = parseCapabilityAssignments(
+      {
+        assignments: [
+          validOutput.assignments[0],
+          {
+            operationId: "op-review",
+            executor: {
+              type: "agent",
+              agentMode: "prompt",
+              agent: "claude-code",
+              model: "claude-review",
+              prompt: "Send the completed review.",
+              allowedTools: [mailToolReference],
+              assignmentReason:
+                "The irreversible email send is necessary to deliver the approved review.",
+            },
+          },
+        ],
+      },
+      context,
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("repairs once, then exposes only the complete repaired plan", async () => {
+    const runAgent = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: { assignments: [validOutput.assignments[0]] } })
+      .mockResolvedValueOnce({ ok: true, json: validOutput });
+
+    const result = await planCapabilityAssignments({ context, runAgent });
+
+    expect(result).toMatchObject({ ok: true, attempts: 2 });
+    expect(result.assignments).toHaveLength(2);
+    expect(runAgent).toHaveBeenCalledTimes(2);
+    expect(runAgent.mock.calls[1]![0]).toContain("missing assignment for new operation");
+    expect(runAgent.mock.calls[1]![0]).toContain("ASSIGNMENT CONTEXT");
+  });
+
+  it("returns no assignments when the only repair is still invalid", async () => {
+    const invalid = { assignments: [validOutput.assignments[0]] };
+    const runAgent = vi.fn().mockResolvedValue({ ok: true, json: invalid });
+
+    const result = await planCapabilityAssignments({ context, runAgent });
+
+    expect(result.ok).toBe(false);
+    expect(result.assignments).toEqual([]);
+    expect(result.attempts).toBe(2);
+    expect(runAgent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/services/src/pipelinesService/capabilityAssignment/index.ts
+++ b/packages/services/src/pipelinesService/capabilityAssignment/index.ts
@@ -1,0 +1,5 @@
+export * from "./buildCapabilityAssignmentPrompt";
+export * from "./parseCapabilityAssignments";
+export * from "./planCapabilityAssignments";
+export * from "./resolveAssignmentRuntime";
+export * from "./schemas";

--- a/packages/services/src/pipelinesService/capabilityAssignment/parseCapabilityAssignments.ts
+++ b/packages/services/src/pipelinesService/capabilityAssignment/parseCapabilityAssignments.ts
@@ -1,0 +1,158 @@
+import type { AssignedOperationExecutorConfig } from "@repo/schemas";
+import type { ZodError } from "zod/v4";
+import {
+  CapabilityAssignmentOutputSchema,
+  type CapabilityAssignmentContext,
+  type CapabilityAssignmentParseResult,
+  type PerStepCapabilityAssignment,
+} from "./schemas";
+
+const formatZodIssues = (error: ZodError): string[] =>
+  error.issues.map((issue) => `output.${issue.path.join(".") || "(root)"}: ${issue.message}`);
+
+const fail = (diagnostics: string[]): CapabilityAssignmentParseResult => ({
+  ok: false,
+  assignments: [],
+  diagnostics,
+});
+
+const selectedCapabilities = (
+  executor: AssignedOperationExecutorConfig,
+): Array<{ path: string; reference: string; expectedKind: "skill" | "tool" }> => {
+  if (executor.type === "script") return [];
+
+  const tools = executor.allowedTools.map((reference, index) => ({
+    path: `allowedTools[${index}]`,
+    reference,
+    expectedKind: "tool" as const,
+  }));
+
+  return executor.agentMode === "skill"
+    ? [
+        {
+          path: "skillId",
+          reference: executor.skillId,
+          expectedKind: "skill" as const,
+        },
+        ...tools,
+      ]
+    : tools;
+};
+
+const IRREVERSIBLE_EXPLANATION_PATTERN =
+  /irreversible|cannot be undone|permanent|不可逆|不可撤销|无法撤销/u;
+
+export const validateAssignedOperationExecutor = (input: {
+  executor: AssignedOperationExecutorConfig;
+  context: Pick<CapabilityAssignmentContext, "agentTargets" | "capabilityCatalog">;
+  pathPrefix: string;
+}): string[] => {
+  const { context, executor, pathPrefix: prefix } = input;
+  const diagnostics: string[] = [];
+  if (executor.type === "script") return diagnostics;
+
+  const target = context.agentTargets.find((candidate) => candidate.agent === executor.agent);
+  if (!target || !target.models.includes(executor.model)) {
+    diagnostics.push(
+      `${prefix}.model: off-catalog agent/model pair "${executor.agent}/${executor.model}".`,
+    );
+  }
+
+  const capabilities = selectedCapabilities(executor);
+  const references = capabilities.map((capability) => capability.reference);
+  const duplicate = references.find((reference, index) => references.indexOf(reference) !== index);
+  if (duplicate) {
+    diagnostics.push(`${prefix}: duplicate capability reference "${duplicate}".`);
+  }
+
+  for (const capability of capabilities) {
+    const entry = context.capabilityCatalog.find(
+      (candidate) => candidate.reference === capability.reference,
+    );
+    const path = `${prefix}.${capability.path}`;
+    if (!entry) {
+      diagnostics.push(`${path}: off-catalog capability reference "${capability.reference}".`);
+      continue;
+    }
+
+    const kindMatches =
+      capability.expectedKind === "skill"
+        ? entry.kind === "skill"
+        : entry.kind === "builtin-tool" || entry.kind === "mcp-tool";
+    if (!kindMatches) {
+      diagnostics.push(
+        `${path}: capability "${capability.reference}" has kind "${entry.kind}", expected ${capability.expectedKind}.`,
+      );
+    }
+    if (!entry.supportedRuntimes.includes(executor.agent)) {
+      diagnostics.push(
+        `${path}: capability "${capability.reference}" does not support runtime "${executor.agent}".`,
+      );
+    }
+  }
+
+  const usesIrreversibleCapability = capabilities.some((capability) =>
+    context.capabilityCatalog.some(
+      (entry) => entry.reference === capability.reference && entry.riskTier === "irreversible",
+    ),
+  );
+
+  if (
+    usesIrreversibleCapability &&
+    !IRREVERSIBLE_EXPLANATION_PATTERN.test(executor.assignmentReason.toLowerCase())
+  ) {
+    diagnostics.push(
+      `${prefix}.assignmentReason: an irreversible capability must be explicitly justified.`,
+    );
+  }
+
+  return diagnostics;
+};
+
+const validateAssignment = (
+  assignment: PerStepCapabilityAssignment,
+  context: CapabilityAssignmentContext,
+): string[] => {
+  if (!context.steps.some((step) => step.operationId === assignment.operationId)) {
+    return [`assignments.${assignment.operationId}: operation is not new or unmatched.`];
+  }
+
+  return validateAssignedOperationExecutor({
+    executor: assignment.executor,
+    context,
+    pathPrefix: `assignments.${assignment.operationId}.executor`,
+  });
+};
+
+export const parseCapabilityAssignments = (
+  value: unknown,
+  context: CapabilityAssignmentContext,
+): CapabilityAssignmentParseResult => {
+  if (context.steps.length === 0) {
+    return fail(["No new or unmatched operations were supplied for assignment."]);
+  }
+
+  const output = CapabilityAssignmentOutputSchema.safeParse(value);
+  if (!output.success) return fail(formatZodIssues(output.error));
+
+  const expectedIds = new Set(context.steps.map((step) => step.operationId));
+  const seenIds = new Set<string>();
+  const diagnostics: string[] = [];
+  for (const assignment of output.data.assignments) {
+    if (seenIds.has(assignment.operationId)) {
+      diagnostics.push(`assignments.${assignment.operationId}: duplicate operation assignment.`);
+    }
+    seenIds.add(assignment.operationId);
+    diagnostics.push(...validateAssignment(assignment, context));
+  }
+
+  for (const operationId of expectedIds) {
+    if (!seenIds.has(operationId)) {
+      diagnostics.push(`assignments.${operationId}: missing assignment for new operation.`);
+    }
+  }
+
+  return diagnostics.length > 0
+    ? fail(diagnostics)
+    : { ok: true, assignments: output.data.assignments, diagnostics: [] };
+};

--- a/packages/services/src/pipelinesService/capabilityAssignment/planCapabilityAssignments.ts
+++ b/packages/services/src/pipelinesService/capabilityAssignment/planCapabilityAssignments.ts
@@ -1,0 +1,61 @@
+import {
+  buildCapabilityAssignmentPrompt,
+  buildCapabilityAssignmentRepairPrompt,
+} from "./buildCapabilityAssignmentPrompt";
+import { parseCapabilityAssignments } from "./parseCapabilityAssignments";
+import type { CapabilityAssignmentContext, PerStepCapabilityAssignment } from "./schemas";
+
+export type CapabilityAssignmentAgentResult =
+  | { ok: true; json: unknown }
+  | { ok: false; error: string };
+
+export type CapabilityAssignmentPlanResult =
+  | { ok: true; assignments: PerStepCapabilityAssignment[]; attempts: 1 | 2 }
+  | { ok: false; assignments: []; attempts: 1 | 2; diagnostics: string[] };
+
+export const planCapabilityAssignments = async (input: {
+  context: CapabilityAssignmentContext;
+  runAgent: (userPrompt: string) => Promise<CapabilityAssignmentAgentResult>;
+}): Promise<CapabilityAssignmentPlanResult> => {
+  const firstAgentResult = await input.runAgent(buildCapabilityAssignmentPrompt(input.context));
+  if (!firstAgentResult.ok) {
+    return {
+      ok: false,
+      assignments: [],
+      attempts: 1,
+      diagnostics: [firstAgentResult.error],
+    };
+  }
+
+  const firstParse = parseCapabilityAssignments(firstAgentResult.json, input.context);
+  if (firstParse.ok) {
+    return { ok: true, assignments: firstParse.assignments, attempts: 1 };
+  }
+
+  const repairedAgentResult = await input.runAgent(
+    buildCapabilityAssignmentRepairPrompt(
+      input.context,
+      firstAgentResult.json,
+      firstParse.diagnostics,
+    ),
+  );
+  if (!repairedAgentResult.ok) {
+    return {
+      ok: false,
+      assignments: [],
+      attempts: 2,
+      diagnostics: [...firstParse.diagnostics, repairedAgentResult.error],
+    };
+  }
+
+  const repairedParse = parseCapabilityAssignments(repairedAgentResult.json, input.context);
+
+  return repairedParse.ok
+    ? { ok: true, assignments: repairedParse.assignments, attempts: 2 }
+    : {
+        ok: false,
+        assignments: [],
+        attempts: 2,
+        diagnostics: repairedParse.diagnostics,
+      };
+};

--- a/packages/services/src/pipelinesService/capabilityAssignment/resolveAssignmentRuntime.ts
+++ b/packages/services/src/pipelinesService/capabilityAssignment/resolveAssignmentRuntime.ts
@@ -1,0 +1,80 @@
+import type {
+  AgentRuntime,
+  AgentRuntimeConnection,
+  RuntimeModel,
+  SshConnection,
+} from "@repo/schemas";
+import type { CapabilityAssignmentAgentTarget } from "./schemas";
+
+export type AssignmentRuntimeRecord = {
+  id: string;
+  type: AgentRuntime;
+  connection: AgentRuntimeConnection;
+};
+
+const runtimeModels = (runtime: AssignmentRuntimeRecord): RuntimeModel[] =>
+  runtime.connection.mode === "local" ? (runtime.connection.models ?? []) : [];
+
+export const deriveCapabilityAssignmentAgentTargets = (
+  runtimes: AssignmentRuntimeRecord[],
+): CapabilityAssignmentAgentTarget[] => {
+  const modelsByAgent = new Map<AgentRuntime, Set<string>>();
+  for (const runtime of runtimes) {
+    const models = modelsByAgent.get(runtime.type) ?? new Set<string>();
+    runtimeModels(runtime).forEach((model) => models.add(model.id));
+    if (models.size > 0) modelsByAgent.set(runtime.type, models);
+  }
+
+  return [...modelsByAgent.entries()]
+    .map(([agent, models]) => ({ agent, models: [...models].sort() }))
+    .sort((left, right) => left.agent.localeCompare(right.agent));
+};
+
+export type ResolvedAssignmentOrchestrator = {
+  runtime: AssignmentRuntimeRecord;
+  model: string;
+  source: "session" | "default";
+  ssh?: SshConnection;
+};
+
+export const resolveAssignmentOrchestrator = (input: {
+  runtimes: AssignmentRuntimeRecord[];
+  requestedRuntimeId?: string;
+  requestedRuntimeType?: AgentRuntime;
+  requestedModel?: string;
+  defaultRuntime?: AgentRuntime | null;
+  defaultModel?: string | null;
+}): ResolvedAssignmentOrchestrator | null => {
+  const usableRuntimes = input.runtimes.filter((runtime) => runtimeModels(runtime).length > 0);
+  const requestedById = input.requestedRuntimeId
+    ? usableRuntimes.find((runtime) => runtime.id === input.requestedRuntimeId)
+    : undefined;
+  const requestedByType = input.requestedRuntimeType
+    ? usableRuntimes.find((runtime) => runtime.type === input.requestedRuntimeType)
+    : undefined;
+  const defaultRuntime = input.defaultRuntime
+    ? usableRuntimes.find((runtime) => runtime.type === input.defaultRuntime)
+    : undefined;
+  const runtime = requestedById ?? requestedByType ?? defaultRuntime ?? usableRuntimes[0];
+  if (!runtime) return null;
+
+  const models = runtimeModels(runtime);
+  const selectedFromSession = Boolean(requestedById || requestedByType);
+  const model =
+    (selectedFromSession && input.requestedModel
+      ? models.find((candidate) => candidate.id === input.requestedModel)
+      : undefined) ??
+    (input.defaultModel
+      ? models.find((candidate) => candidate.id === input.defaultModel)
+      : undefined) ??
+    models.find((candidate) => candidate.isDefault) ??
+    models[0];
+  if (!model) return null;
+
+  return {
+    runtime,
+    model: model.id,
+    source: selectedFromSession ? "session" : "default",
+    ...(runtime.connection.mode === "ssh" ? { ssh: runtime.connection } : {}),
+  };
+};

--- a/packages/services/src/pipelinesService/capabilityAssignment/resolveAssignmentRuntime.unit.test.ts
+++ b/packages/services/src/pipelinesService/capabilityAssignment/resolveAssignmentRuntime.unit.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveCapabilityAssignmentAgentTargets,
+  resolveAssignmentOrchestrator,
+  type AssignmentRuntimeRecord,
+} from "./resolveAssignmentRuntime";
+
+const runtimes = [
+  {
+    id: "codex-primary",
+    type: "codex",
+    connection: {
+      mode: "local",
+      models: [
+        { id: "gpt-fast", displayName: "Fast" },
+        { id: "gpt-default", displayName: "Default", isDefault: true },
+      ],
+    },
+  },
+  {
+    id: "codex-secondary",
+    type: "codex",
+    connection: {
+      mode: "local",
+      models: [
+        { id: "gpt-fast", displayName: "Fast duplicate" },
+        { id: "gpt-deep", displayName: "Deep" },
+      ],
+    },
+  },
+  {
+    id: "claude-empty",
+    type: "claude-code",
+    connection: { mode: "local" },
+  },
+] satisfies AssignmentRuntimeRecord[];
+
+describe("assignment runtime resolution", () => {
+  it("deduplicates configured runtime ids into persisted agent/model targets", () => {
+    expect(deriveCapabilityAssignmentAgentTargets(runtimes)).toEqual([
+      { agent: "codex", models: ["gpt-deep", "gpt-default", "gpt-fast"] },
+    ]);
+  });
+
+  it("uses the selected runtime and requested model when both are catalog-valid", () => {
+    const result = resolveAssignmentOrchestrator({
+      runtimes,
+      requestedRuntimeId: "codex-secondary",
+      requestedModel: "gpt-deep",
+      defaultRuntime: "codex",
+      defaultModel: "gpt-fast",
+    });
+
+    expect(result).toMatchObject({
+      runtime: { id: "codex-secondary" },
+      model: "gpt-deep",
+      source: "session",
+    });
+  });
+
+  it("falls back to a valid default target when the session selection is invalid", () => {
+    const result = resolveAssignmentOrchestrator({
+      runtimes,
+      requestedRuntimeId: "missing-runtime",
+      requestedModel: "invented-model",
+      defaultRuntime: "codex",
+      defaultModel: "gpt-fast",
+    });
+
+    expect(result).toMatchObject({
+      runtime: { id: "codex-primary" },
+      model: "gpt-fast",
+      source: "default",
+    });
+  });
+
+  it("uses the runtime catalog default when the configured default model is unavailable", () => {
+    const result = resolveAssignmentOrchestrator({
+      runtimes,
+      defaultRuntime: "codex",
+      defaultModel: "invented-model",
+    });
+
+    expect(result).toMatchObject({
+      runtime: { id: "codex-primary" },
+      model: "gpt-default",
+      source: "default",
+    });
+  });
+
+  it("returns null when no runtime has a COD-337 model catalog", () => {
+    expect(
+      resolveAssignmentOrchestrator({
+        runtimes: [runtimes[2]!],
+        defaultRuntime: "claude-code",
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/services/src/pipelinesService/capabilityAssignment/schemas.ts
+++ b/packages/services/src/pipelinesService/capabilityAssignment/schemas.ts
@@ -1,0 +1,43 @@
+import {
+  AssignedOperationExecutorConfigSchema,
+  type AgentRuntime,
+  type CapabilityCatalogEntry,
+} from "@repo/schemas";
+import { z } from "zod/v4";
+
+const ReferenceSchema = z.string().trim().min(1);
+
+export const PerStepCapabilityAssignmentSchema = z
+  .object({
+    operationId: ReferenceSchema,
+    executor: AssignedOperationExecutorConfigSchema,
+  })
+  .strict();
+export type PerStepCapabilityAssignment = z.infer<typeof PerStepCapabilityAssignmentSchema>;
+
+export const CapabilityAssignmentOutputSchema = z
+  .object({
+    assignments: z.array(PerStepCapabilityAssignmentSchema).min(1).max(50),
+  })
+  .strict();
+
+export type CapabilityAssignmentStep = {
+  operationId: string;
+  name: string;
+  description: string;
+};
+
+export type CapabilityAssignmentAgentTarget = {
+  agent: AgentRuntime;
+  models: string[];
+};
+
+export type CapabilityAssignmentContext = {
+  steps: CapabilityAssignmentStep[];
+  agentTargets: CapabilityAssignmentAgentTarget[];
+  capabilityCatalog: CapabilityCatalogEntry[];
+};
+
+export type CapabilityAssignmentParseResult =
+  | { ok: true; assignments: PerStepCapabilityAssignment[]; diagnostics: [] }
+  | { ok: false; assignments: []; diagnostics: string[] };

--- a/packages/services/src/pipelinesService/createPipelinesService.ts
+++ b/packages/services/src/pipelinesService/createPipelinesService.ts
@@ -16,10 +16,12 @@ import {
   createSettingsDao,
   type DbExecutor,
 } from "@repo/models";
-import { ResultAsync } from "neverthrow";
+import { errAsync, ResultAsync } from "neverthrow";
 import { logger } from "@repo/logger";
 import {
   PipelineSchema,
+  StrictOperationConfigSchema,
+  type AssignedOperationExecutorConfig,
   type AgentRuntime,
   type ObjectNodeType,
   type PipelineData,
@@ -31,8 +33,16 @@ import {
   createCapabilityCatalogService,
   type CapabilityCatalogServiceOptions,
 } from "../capabilityCatalogService";
-import { toServiceError } from "../serviceErrors";
+import { ConflictError, NotFoundError, ServiceError, toServiceError } from "../serviceErrors";
 import { MAX_SNAPSHOT_CHARS, truncate } from "./promptText";
+import {
+  CAPABILITY_ASSIGNMENT_SYSTEM_PROMPT,
+  deriveCapabilityAssignmentAgentTargets,
+  planCapabilityAssignments,
+  resolveAssignmentOrchestrator,
+  type AssignmentRuntimeRecord,
+  type PerStepCapabilityAssignment,
+} from "./capabilityAssignment";
 import { proposeActions, type ProposeActionsOptions } from "./proposeActions";
 import {
   ANALYZE_AGENT_ID,
@@ -75,6 +85,20 @@ const expandTildeInNodes = (nodes: PipelineData["nodes"]): PipelineData["nodes"]
 const SKILL_REFERENCES = [nodeTypesRef, pipelineAnatomyRef].filter(Boolean).join("\n\n---\n\n");
 const MAX_STRUCTURE_DIAGNOSTIC_ISSUES = 8;
 const MAX_STRUCTURE_SCHEMA_RETRIES = 1;
+const CAPABILITY_ASSIGNMENT_AGENT_ID = "pipeline-capability-assignment";
+
+const buildAssignedOperationConfig = (assignment: PerStepCapabilityAssignment) => ({
+  executor: assignment.executor,
+  inputs: [],
+  outputs: [
+    {
+      name: "result",
+      contentType: "markdown" as const,
+      description: "Generated result",
+      templateIds: [],
+    },
+  ],
+});
 
 const sanitizeGeneratedGraph = (value: unknown): unknown => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -202,6 +226,58 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
     create: (...args: Parameters<typeof dao.create>) => dao.create(...args),
     createPendingOperations,
     createWithPendingOperations,
+    updateOperationExecutors: (
+      updates: Array<{
+        operationId: string;
+        executor: AssignedOperationExecutorConfig;
+      }>,
+    ) => {
+      const seen = new Set<string>();
+      const duplicate = updates.find(({ operationId }) => {
+        if (seen.has(operationId)) return true;
+        seen.add(operationId);
+
+        return false;
+      });
+      if (duplicate) {
+        return errAsync(
+          new ConflictError(`Duplicate updateOperation for ${duplicate.operationId}`),
+        );
+      }
+
+      return ResultAsync.fromPromise(
+        Promise.all(
+          updates.map(async (update) => {
+            const operation = await operationsDao.findById(update.operationId);
+            if (!operation) throw new NotFoundError("Operation", update.operationId);
+
+            const parsedConfig = StrictOperationConfigSchema.safeParse(operation.config);
+            if (!parsedConfig.success) {
+              throw new ServiceError(`Operation:${update.operationId} has invalid stored config`);
+            }
+
+            return {
+              operationId: update.operationId,
+              config: { ...parsedConfig.data, executor: update.executor },
+            };
+          }),
+        ),
+        (error) => toServiceError(error, "Prepare operation executor updates"),
+      ).andThen((prepared) =>
+        getCapabilityCatalog(db)
+          .validateOperationConfigs(prepared.map(({ config }) => config))
+          .andThen(() =>
+            ResultAsync.fromPromise(
+              (async () => {
+                for (const { operationId, config } of prepared) {
+                  await operationsDao.update(operationId, { config });
+                }
+              })(),
+              (error) => toServiceError(error, "Update operation executors"),
+            ),
+          ),
+      );
+    },
     update: (...args: Parameters<typeof dao.update>) => dao.update(...args),
     delete: async (id: string) => {
       await pipelineRunsDao.deleteByPipelineId(id);
@@ -217,6 +293,7 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
           jobTracesDao,
           operationsDao,
           settingsDao,
+          capabilityCatalog: getCapabilityCatalog(db),
         },
         opts,
       ),
@@ -465,7 +542,9 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
       description: string;
       matchedOperations?: Array<{ operationId: string; operationName: string; reason: string }>;
       unmatchedSteps?: Array<{ step: string; reason: string }>;
+      runtimeId?: string;
       runtimeType?: AgentRuntime;
+      model?: string;
     }): Promise<
       | {
           nodes: PipelineData["nodes"];
@@ -495,37 +574,94 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
         acceptedObjectTypes: ObjectNodeType[];
       }> = [];
       const newOperations: Array<{ id: string; name: string; description: string }> = [];
+      const assignmentState = {
+        orchestrator: null as ReturnType<typeof resolveAssignmentOrchestrator>,
+      };
 
       if (opts.unmatchedSteps && opts.unmatchedSteps.length > 0) {
-        for (const step of opts.unmatchedSteps) {
+        const draftedOperations = opts.unmatchedSteps.map((step) => {
           const opId = `op_auto_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
           const operationDescription = `Execute this Pipeline step: ${step.step}`;
-          const systemPrompt = [
-            `You are an automation agent executing the task: "${step.step}".`,
-            "",
-            "You will receive input data from the previous pipeline step.",
-            "Analyze the input thoroughly and execute the task described above.",
-            "Output your results in well-structured markdown format.",
-            "Be specific, actionable, and data-driven in your output.",
-          ]
-            .filter(Boolean)
-            .join("\n");
-          const config = {
-            executor: {
-              type: "agent",
-              agentMode: "prompt",
-              prompt: systemPrompt,
-            },
-            inputs: [],
-            outputs: [
-              {
-                name: "result",
-                contentType: "markdown",
-                description: "Generated result",
-                templateIds: [],
-              },
-            ],
-          };
+
+          return { opId, operationDescription, step };
+        });
+        const [runtimeRecords, capabilityCatalogResult] = await Promise.all([
+          agentRuntimesDao.findMany(),
+          getCapabilityCatalog(db).getMany(),
+        ]);
+        if (capabilityCatalogResult.isErr()) {
+          logger.error(
+            { error: capabilityCatalogResult.error },
+            "generateStructure: failed to load capability catalog",
+          );
+
+          return { error: "Capability catalog is unavailable" };
+        }
+
+        const assignmentRuntimes = runtimeRecords as AssignmentRuntimeRecord[];
+        const assignmentOrchestrator = resolveAssignmentOrchestrator({
+          runtimes: assignmentRuntimes,
+          requestedRuntimeId: opts.runtimeId,
+          requestedRuntimeType: opts.runtimeType,
+          requestedModel: opts.model,
+          defaultRuntime: settings.defaultAgentRuntime,
+          defaultModel: settings.defaultModel,
+        });
+        assignmentState.orchestrator = assignmentOrchestrator;
+        const agentTargets = deriveCapabilityAssignmentAgentTargets(assignmentRuntimes);
+        if (!assignmentOrchestrator || agentTargets.length === 0) {
+          return { error: "No configured runtime has a usable model catalog" };
+        }
+
+        const assignmentContext = {
+          steps: draftedOperations.map(({ opId, operationDescription, step }) => ({
+            operationId: opId,
+            name: step.step,
+            description: operationDescription,
+          })),
+          agentTargets,
+          capabilityCatalog: capabilityCatalogResult.value,
+        };
+        const assignmentPlan = await planCapabilityAssignments({
+          context: assignmentContext,
+          runAgent: async (userPrompt) => {
+            const result = await runStructuredAgent({
+              agent: assignmentOrchestrator!.runtime.type,
+              systemPrompt: CAPABILITY_ASSIGNMENT_SYSTEM_PROMPT,
+              userPrompt,
+              agentId: CAPABILITY_ASSIGNMENT_AGENT_ID,
+              logPrefix: "assignOperationCapabilities",
+              apiKey: settings.defaultApiKey,
+              model: assignmentOrchestrator!.model,
+              ...(assignmentOrchestrator!.ssh ? { ssh: assignmentOrchestrator!.ssh } : {}),
+            });
+
+            return result.ok
+              ? { ok: true as const, json: result.json }
+              : {
+                  ok: false as const,
+                  error:
+                    result.code === "AGENT_FAILED"
+                      ? "Capability assignment agent failed"
+                      : "Capability assignment agent returned invalid JSON",
+                };
+          },
+        });
+        if (!assignmentPlan.ok) {
+          logger.error(
+            { diagnostics: assignmentPlan.diagnostics },
+            "generateStructure: capability assignment failed after one repair",
+          );
+
+          return { error: "Agent returned invalid capability assignments" };
+        }
+
+        const assignmentByOperationId = new Map(
+          assignmentPlan.assignments.map((assignment) => [assignment.operationId, assignment]),
+        );
+        for (const { opId, operationDescription, step } of draftedOperations) {
+          const assignment = assignmentByOperationId.get(opId)!;
+          const config = buildAssignedOperationConfig(assignment);
           pendingOperations.push({
             id: opId,
             name: step.step,
@@ -538,6 +674,18 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
             { opId, name: step.step },
             "generateStructure: prepared pending operation for unmatched step",
           );
+        }
+
+        const capabilityValidation = await getCapabilityCatalog(db).validateOperationConfigs(
+          pendingOperations.map((operation) => operation.config),
+        );
+        if (capabilityValidation.isErr()) {
+          logger.error(
+            { error: capabilityValidation.error },
+            "generateStructure: assigned operation failed catalog revalidation",
+          );
+
+          return { error: "Generated operation capability validation failed" };
         }
       }
 
@@ -661,13 +809,17 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
         { ok: true; data: Pick<PipelineData, "edges" | "nodes"> } | { ok: false; error: string }
       > => {
         const structured = await runStructuredAgent({
-          agent: opts.runtimeType ?? settings.defaultAgentRuntime,
+          agent:
+            assignmentState.orchestrator?.runtime.type ??
+            opts.runtimeType ??
+            settings.defaultAgentRuntime,
           systemPrompt,
           userPrompt: prompt,
           agentId: GENERATE_AGENT_ID,
           logPrefix: "generateStructure",
           apiKey: settings.defaultApiKey,
-          model: settings.defaultModel,
+          model: assignmentState.orchestrator?.model ?? settings.defaultModel,
+          ...(assignmentState.orchestrator?.ssh ? { ssh: assignmentState.orchestrator.ssh } : {}),
         });
 
         if (!structured.ok) {
@@ -732,22 +884,8 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
         return { error: generationResult.error };
       }
 
-      const generatedNodes = generationResult.data.nodes.map((node) => {
-        if (node.data.nodeType !== "operation" || !opts.runtimeType) {
-          return node;
-        }
-
-        return {
-          ...node,
-          data: {
-            ...node.data,
-            agentRuntime: opts.runtimeType,
-          },
-        };
-      });
-
       return {
-        nodes: expandTildeInNodes(generatedNodes),
+        nodes: expandTildeInNodes(generationResult.data.nodes),
         edges: generationResult.data.edges,
         ...(pendingOperations.length > 0 ? { pendingOperations } : {}),
       };

--- a/packages/services/src/pipelinesService/createPipelinesService.unit.test.ts
+++ b/packages/services/src/pipelinesService/createPipelinesService.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
-import { ok } from "neverthrow";
+import { errAsync, ok, okAsync } from "neverthrow";
 
 const mockDao = {
   findMany: vi.fn().mockResolvedValue([{ id: "p1" }]),
@@ -25,6 +25,8 @@ const mockOperationsDao = {
       acceptedObjectTypes: ["folder"],
     },
   ]),
+  findById: vi.fn(),
+  update: vi.fn(),
 };
 const mockAgentRuntimesDao = {
   findMany: vi.fn().mockResolvedValue([
@@ -49,6 +51,11 @@ const mockDistillationsDao = {
 };
 const mockConversationMessagesDao = {
   findManyByPipelineId: vi.fn().mockResolvedValue([]),
+};
+const mockCapabilityCatalog = {
+  getMany: vi.fn(() => okAsync([])),
+  validateOperationConfig: vi.fn(() => okAsync(undefined)),
+  validateOperationConfigs: vi.fn(() => okAsync(undefined)),
 };
 
 vi.mock("@repo/models", () => ({
@@ -80,6 +87,9 @@ vi.mock("@repo/agent", () => ({
 }));
 vi.mock("../pipelineRunnerService/agentRunner/agentRunner", () => ({
   runAgent: (opts: unknown) => mockRunAgent(opts),
+}));
+vi.mock("../capabilityCatalogService", () => ({
+  createCapabilityCatalogService: () => mockCapabilityCatalog,
 }));
 
 import { createPipelinesService } from "./createPipelinesService";
@@ -118,6 +128,8 @@ describe("createPipelinesService", () => {
     mockSettingsDao.get.mockClear();
     mockOperationsDao.findMany.mockClear();
     mockOperationsDao.create.mockClear();
+    mockOperationsDao.findById.mockReset();
+    mockOperationsDao.update.mockReset();
     mockAgentRuntimesDao.findMany.mockClear();
     mockRunAgent.mockReset();
     mockExtractJsonFromText.mockReset();
@@ -125,6 +137,9 @@ describe("createPipelinesService", () => {
     mockDistillationsDao.findById.mockReset();
     mockConversationMessagesDao.findManyByPipelineId.mockClear();
     mockConversationMessagesDao.findManyByPipelineId.mockResolvedValue([]);
+    mockCapabilityCatalog.getMany.mockClear();
+    mockCapabilityCatalog.validateOperationConfig.mockClear();
+    mockCapabilityCatalog.validateOperationConfigs.mockClear();
   };
 
   beforeEach(() => {
@@ -264,6 +279,83 @@ describe("createPipelinesService", () => {
     expect(result.isErr()).toBe(true);
     expect(transaction).toHaveBeenCalledOnce();
     expect(persistedOperations).toEqual([]);
+  });
+
+  it("updates a shared Operation executor while preserving ports", async () => {
+    mockOperationsDao.findById.mockResolvedValueOnce({
+      id: "op-known",
+      config: {
+        executor: { type: "agent", prompt: "Old prompt" },
+        inputs: [{ name: "source", kind: "file", required: true }],
+        outputs: [
+          {
+            name: "result",
+            contentType: "markdown",
+            description: "Review result",
+            templateIds: [],
+          },
+        ],
+      },
+    });
+    mockOperationsDao.update.mockResolvedValueOnce({ id: "op-known" });
+    const capabilityCatalog = {
+      validateOperationConfigs: vi.fn(() => okAsync(undefined)),
+    };
+    const executor = {
+      type: "agent" as const,
+      agentMode: "prompt" as const,
+      agent: "codex" as const,
+      model: "gpt-review",
+      prompt: "Review the supplied diff.",
+      allowedTools: ["Read"],
+      assignmentReason: "Read-only repository access is sufficient for review.",
+    };
+    const svc = createPipelinesService({} as never, {
+      capabilityCatalog: capabilityCatalog as never,
+    });
+
+    const result = await svc.updateOperationExecutors([{ operationId: "op-known", executor }]);
+
+    expect(result.isOk()).toBe(true);
+    expect(capabilityCatalog.validateOperationConfigs).toHaveBeenCalledOnce();
+    expect(mockOperationsDao.update).toHaveBeenCalledWith("op-known", {
+      config: expect.objectContaining({
+        executor,
+        inputs: [expect.objectContaining({ name: "source" })],
+        outputs: [expect.objectContaining({ name: "result" })],
+      }),
+    });
+  });
+
+  it("rejects an off-catalog executor before updating the shared Operation", async () => {
+    mockOperationsDao.findById.mockResolvedValueOnce({
+      id: "op-known",
+      config: { executor: { type: "agent", prompt: "Old prompt" }, inputs: [], outputs: [] },
+    });
+    const capabilityCatalog = {
+      validateOperationConfigs: vi.fn(() => errAsync(new Error("off-catalog capability"))),
+    };
+    const svc = createPipelinesService({} as never, {
+      capabilityCatalog: capabilityCatalog as never,
+    });
+
+    const result = await svc.updateOperationExecutors([
+      {
+        operationId: "op-known",
+        executor: {
+          type: "agent",
+          agentMode: "prompt",
+          agent: "codex",
+          model: "gpt-review",
+          prompt: "Review the supplied diff.",
+          allowedTools: ["invented-tool"],
+          assignmentReason: "Review needs repository access.",
+        },
+      },
+    ]);
+
+    expect(result.isErr()).toBe(true);
+    expect(mockOperationsDao.update).not.toHaveBeenCalled();
   });
 
   it("proposeActions returns a parsed proposal and diagnostics", async () => {
@@ -473,6 +565,7 @@ describe("createPipelinesService", () => {
       error: { code: "RUNTIME_NOT_FOUND", detail: "missing-runtime" },
     });
     expect(mockRunAgent).not.toHaveBeenCalled();
+    expect(mockCapabilityCatalog.getMany).not.toHaveBeenCalled();
   });
 
   it("proposeActions retries the agent three times, then reports AGENT_FAILED", async () => {

--- a/packages/services/src/pipelinesService/generateStructure.unit.test.ts
+++ b/packages/services/src/pipelinesService/generateStructure.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { okAsync } from "neverthrow";
 
 const mockRunAgent = vi.fn();
 const mockDao = {
@@ -490,9 +491,60 @@ describe("generateStructure", () => {
       ],
     };
 
-    mockRunAgent.mockResolvedValue(JSON.stringify(generatedPipeline));
+    mockAgentRuntimesDao.findMany.mockResolvedValueOnce([
+      {
+        id: "runtime-hermes",
+        type: "hermes",
+        connection: {
+          mode: "local",
+          models: [{ id: "hermes-model", displayName: "Hermes", isDefault: true }],
+        },
+      },
+    ]);
+    mockRunAgent.mockImplementation(async (input: { agentId: string; userPrompt: string }) => {
+      if (input.agentId !== "pipeline-capability-assignment") {
+        return JSON.stringify(generatedPipeline);
+      }
 
-    const svc = createPipelinesService({} as never);
+      const operationIds = [...input.userPrompt.matchAll(/"operationId": "(op_auto_[^"]+)"/gu)].map(
+        (match) => match[1]!,
+      );
+
+      return JSON.stringify({
+        assignments: [
+          {
+            operationId: operationIds[0],
+            executor: {
+              type: "script",
+              language: "bash",
+              command: "curl -fsSL https://example.invalid/data",
+              assignmentReason: "Calling a fixed API is deterministic and needs no model.",
+            },
+          },
+          {
+            operationId: operationIds[1],
+            executor: {
+              type: "agent",
+              agentMode: "prompt",
+              agent: "hermes",
+              model: "hermes-model",
+              prompt: "Summarize the supplied data into structured markdown.",
+              allowedTools: [],
+              assignmentReason: "Summarization needs model judgment but no external capability.",
+            },
+          },
+        ],
+      });
+    });
+
+    const capabilityCatalog = {
+      getMany: vi.fn(() => okAsync([])),
+      validateOperationConfigs: vi.fn(() => okAsync(undefined)),
+    };
+
+    const svc = createPipelinesService({} as never, {
+      capabilityCatalog: capabilityCatalog as never,
+    });
     const result = await svc.generateStructure({
       name: "Polymarket Pipeline",
       description: "Collect Polymarket trends",
@@ -517,17 +569,35 @@ describe("generateStructure", () => {
         "Execute this Pipeline step: Fetch Polymarket data",
       );
       expect(result.pendingOperations![0]!.description).not.toContain("No data fetching");
-      expect(
-        (result.pendingOperations![0]!.config.executor as { prompt: string }).prompt,
-      ).not.toContain("No data fetching operation available");
+      expect(result.pendingOperations![0]!.config.executor).toMatchObject({
+        type: "script",
+        command: "curl -fsSL https://example.invalid/data",
+      });
+      expect(result.pendingOperations![1]!.config.executor).toMatchObject({
+        type: "agent",
+        agent: "hermes",
+        model: "hermes-model",
+        allowedTools: [],
+      });
       const operationNodeRuntimes = result.nodes.flatMap((node) =>
         node.data.nodeType === "operation" ? [node.data.agentRuntime] : [],
       );
       expect(operationNodeRuntimes).toHaveLength(2);
-      expect(operationNodeRuntimes.every((runtime) => runtime === "hermes")).toBe(true);
+      expect(operationNodeRuntimes.every((runtime) => runtime === undefined)).toBe(true);
     }
 
-    const agentCall = mockRunAgent.mock.calls[0]![0] as { userPrompt: string };
+    expect(mockRunAgent).toHaveBeenCalledTimes(2);
+    expect(capabilityCatalog.validateOperationConfigs).toHaveBeenCalledOnce();
+    const assignmentCall = mockRunAgent.mock.calls[0]![0] as {
+      agentId: string;
+      model: string;
+      systemPrompt: string;
+      userPrompt: string;
+    };
+    expect(assignmentCall.agentId).toBe("pipeline-capability-assignment");
+    expect(assignmentCall.model).toBe("hermes-model");
+    expect(assignmentCall.systemPrompt).toContain("calling a known API");
+    const agentCall = mockRunAgent.mock.calls[1]![0] as { userPrompt: string };
     expect(agentCall.userPrompt).toContain("NEWLY CREATED OPERATIONS (MUST USE)");
     expect(agentCall.userPrompt).toContain("Fetch Polymarket data");
     expect(agentCall.userPrompt).toContain("Summarize into markdown");

--- a/packages/services/src/pipelinesService/proposeActions/__snapshots__/buildProposePrompt.snapshot.unit.test.ts.snap
+++ b/packages/services/src/pipelinesService/proposeActions/__snapshots__/buildProposePrompt.snapshot.unit.test.ts.snap
@@ -24,6 +24,13 @@ Your job is to propose a sequence of graph edit actions that modify a pipeline g
 6. replaceNodeData — replaces the data payload of a node (must keep the same nodeType):
    { "type": "replaceNodeData", "nodeId": "<nodeId>", "data": { "nodeType": "<sameNodeType>", ... } }
 
+7. updateOperation — replaces the executor on a shared Operation entity used by this pipeline:
+   { "type": "updateOperation", "operationId": "<existing operationId>", "executor": { "type": "script|agent", ... } }
+   Script executor: { "type": "script", "language": "bash|python|javascript", "command": "...", "assignmentReason": "one line" }
+   Prompt agent: { "type": "agent", "agentMode": "prompt", "agent": "...", "model": "...", "prompt": "...", "allowedTools": [], "assignmentReason": "one line" }
+   Skill agent: { "type": "agent", "agentMode": "skill", "agent": "...", "model": "...", "skillId": "...", "allowedTools": [], "assignmentReason": "one line" }
+   Use exactly one complete executor shape. Choose agent/model/skillId/allowedTools only from the provided catalogs.
+
 === NODE TYPES & REQUIRED DATA FIELDS ===
 Every node's data payload MUST contain 'label' plus the required fields for its nodeType.
 Proposals violate schema validation (and get DISCARDED) if any required field is missing.
@@ -65,6 +72,8 @@ Return ONLY a JSON object matching this exact schema:
 - When adding a node, the node 'type' MUST match the 'nodeType' inside its data payload.
 - When adding edges, both source and target nodes must already exist in the graph (or be added in a previous operation).
 - When replacing node data, the 'nodeType' inside 'data' MUST match the node's existing type.
+- updateOperation changes the shared Operation entity in place; use it only for an existing operation referenced by the current graph, never to clone an Operation.
+- For updateOperation, choose the smallest capability set. If any selected capability is irreversible, explain why it is necessary in assignmentReason.
 - When adding or replacing operation nodes, prefer operationId values from the provided available operations list.
 - If NO existing operation matches a required step, define a new one in 'newOperations' (unique id starting with op_new_, clear name, and a thorough 'prompt' describing exactly what the step must do with its input). Reference that id from addNode operation nodes.
 - Do NOT refuse a request merely because no matching operation exists — define newOperations instead. Only refuse when the request itself is unsafe or impossible.

--- a/packages/services/src/pipelinesService/proposeActions/buildProposePrompt.ts
+++ b/packages/services/src/pipelinesService/proposeActions/buildProposePrompt.ts
@@ -1,6 +1,8 @@
 import type {
+  AgentRuntime,
   AgentContextPayload,
   ArtifactAnalysis,
+  CapabilityCatalogEntry,
   PipelineGraphSnapshot,
   ProposeAttachment,
 } from "@repo/schemas";
@@ -8,6 +10,36 @@ import { MAX_SNAPSHOT_CHARS, truncate } from "../promptText";
 import { buildHistoryBlock, type ProposeHistoryMessage } from "./conversationHistory";
 
 const MAX_SELECTION_CHARS = 6000;
+
+const buildCapabilityBlocks = (
+  agentTargets: Array<{ agent: AgentRuntime; models: string[] }>,
+  capabilityCatalog: CapabilityCatalogEntry[],
+): string[] => {
+  if (agentTargets.length === 0 && capabilityCatalog.length === 0) return [];
+
+  return [
+    "=== ASSIGNABLE AGENT / MODEL TARGETS ===",
+    JSON.stringify(agentTargets, null, 2),
+    "",
+    "=== CAPABILITY CATALOG (use reference values in updateOperation) ===",
+    truncate(
+      JSON.stringify(
+        capabilityCatalog.map((entry) => ({
+          reference: entry.reference,
+          displayName: entry.displayName,
+          description: entry.description,
+          kind: entry.kind,
+          supportedRuntimes: entry.supportedRuntimes,
+          riskTier: entry.riskTier,
+        })),
+        null,
+        2,
+      ),
+      MAX_SNAPSHOT_CHARS,
+    ),
+    "",
+  ];
+};
 
 export const PROPOSE_AGENT_ID = "pipeline-propose-actions";
 
@@ -34,6 +66,13 @@ export const PROPOSE_SYSTEM_PROMPT = [
   "",
   "6. replaceNodeData — replaces the data payload of a node (must keep the same nodeType):",
   '   { "type": "replaceNodeData", "nodeId": "<nodeId>", "data": { "nodeType": "<sameNodeType>", ... } }',
+  "",
+  "7. updateOperation — replaces the executor on a shared Operation entity used by this pipeline:",
+  '   { "type": "updateOperation", "operationId": "<existing operationId>", "executor": { "type": "script|agent", ... } }',
+  '   Script executor: { "type": "script", "language": "bash|python|javascript", "command": "...", "assignmentReason": "one line" }',
+  '   Prompt agent: { "type": "agent", "agentMode": "prompt", "agent": "...", "model": "...", "prompt": "...", "allowedTools": [], "assignmentReason": "one line" }',
+  '   Skill agent: { "type": "agent", "agentMode": "skill", "agent": "...", "model": "...", "skillId": "...", "allowedTools": [], "assignmentReason": "one line" }',
+  "   Use exactly one complete executor shape. Choose agent/model/skillId/allowedTools only from the provided catalogs.",
   "",
   "=== NODE TYPES & REQUIRED DATA FIELDS ===",
   "Every node's data payload MUST contain 'label' plus the required fields for its nodeType.",
@@ -76,6 +115,8 @@ export const PROPOSE_SYSTEM_PROMPT = [
   "- When adding a node, the node 'type' MUST match the 'nodeType' inside its data payload.",
   "- When adding edges, both source and target nodes must already exist in the graph (or be added in a previous operation).",
   "- When replacing node data, the 'nodeType' inside 'data' MUST match the node's existing type.",
+  "- updateOperation changes the shared Operation entity in place; use it only for an existing operation referenced by the current graph, never to clone an Operation.",
+  "- For updateOperation, choose the smallest capability set. If any selected capability is irreversible, explain why it is necessary in assignmentReason.",
   "- When adding or replacing operation nodes, prefer operationId values from the provided available operations list.",
   "- If NO existing operation matches a required step, define a new one in 'newOperations' (unique id starting with op_new_, clear name, and a thorough 'prompt' describing exactly what the step must do with its input). Reference that id from addNode operation nodes.",
   "- Do NOT refuse a request merely because no matching operation exists — define newOperations instead. Only refuse when the request itself is unsafe or impossible.",
@@ -94,6 +135,7 @@ export type ProposeOperationCatalogItem = {
   name: string;
   description: string | null;
   acceptedObjectTypes: unknown;
+  executor?: unknown;
 };
 
 /**
@@ -131,6 +173,7 @@ const buildActiveRunBlock = (activeRun?: ProposeActiveRun): string[] => {
 };
 
 export type BuildProposeUserPromptInput = {
+  agentTargets?: Array<{ agent: AgentRuntime; models: string[] }>;
   /**
    * Run-time context, filled by the server only when the message carries a
    * runState and the job exists.
@@ -142,6 +185,7 @@ export type BuildProposeUserPromptInput = {
    */
   artifactAnalysis?: ArtifactAnalysis;
   attachments: ProposeAttachment[];
+  capabilityCatalog?: CapabilityCatalogEntry[];
   /**
    * Frontend buildAgentContext output. Items not provided are neither
    * injected nor claimed.
@@ -334,8 +378,10 @@ const buildArtifactsBlock = (attachments: ProposeAttachment[]): string[] => {
 
 export const buildProposeUserPrompt = ({
   activeRun,
+  agentTargets = [],
   artifactAnalysis,
   attachments,
+  capabilityCatalog = [],
   context,
   diagnostics = [],
   failedProposal,
@@ -360,6 +406,7 @@ export const buildProposeUserPrompt = ({
     `=== AVAILABLE OPERATIONS (${operationCatalog.length}) ===`,
     truncate(JSON.stringify(operationCatalog, null, 2), MAX_SNAPSHOT_CHARS),
     "",
+    ...buildCapabilityBlocks(agentTargets, capabilityCatalog),
     ...buildHistoryBlock(history),
     ...buildSelectionBlock(referencedNodeIds, snapshot),
     ...buildAnnotationsBlock(context),

--- a/packages/services/src/pipelinesService/proposeActions/normalizeProposalPayload.ts
+++ b/packages/services/src/pipelinesService/proposeActions/normalizeProposalPayload.ts
@@ -24,6 +24,7 @@ const ACTION_TYPE_ALIASES = {
   remove_edge: "removeEdge",
   reconnect_edge: "reconnectEdge",
   replace_node_data: "replaceNodeData",
+  update_operation: "updateOperation",
 } as const;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/packages/services/src/pipelinesService/proposeActions/proposeActions.ts
+++ b/packages/services/src/pipelinesService/proposeActions/proposeActions.ts
@@ -13,11 +13,18 @@ import {
   PipelineActionProposalSchema,
   type AgentContextPayload,
   type ArtifactAnalysis,
+  type CapabilityCatalogEntry,
   type ProposeAttachment,
   type PipelineGraphSnapshot,
   type ProposeActionsResponse,
 } from "@repo/schemas";
 import { normalizeSettingsRecord } from "../../settingsService/normalizeSettingsRecord";
+import type { createCapabilityCatalogService } from "../../capabilityCatalogService";
+import {
+  deriveCapabilityAssignmentAgentTargets,
+  validateAssignedOperationExecutor,
+  type AssignmentRuntimeRecord,
+} from "../capabilityAssignment";
 import { analyzeArtifacts } from "./analyzeArtifacts";
 import { buildProposeUserPrompt } from "./buildProposePrompt";
 import { setProposeProgress } from "./progressStore";
@@ -38,6 +45,10 @@ export type ProposeActionsDeps = {
   jobTracesDao: ReturnType<typeof createJobTracesDao>;
   operationsDao: ReturnType<typeof createOperationsDao>;
   settingsDao: ReturnType<typeof createSettingsDao>;
+  capabilityCatalog: Pick<
+    ReturnType<typeof createCapabilityCatalogService>,
+    "getMany" | "validateOperationConfigs"
+  >;
 };
 
 export type ProposeActionsOptions = {
@@ -106,6 +117,21 @@ export const proposeActions = async (
     };
   }
 
+  const capabilityCatalogResult = await deps.capabilityCatalog.getMany();
+  if (capabilityCatalogResult.isErr()) {
+    logger.error(
+      { error: capabilityCatalogResult.error },
+      "proposeActions: failed to load capability catalog",
+    );
+  }
+  const capabilityCatalogAvailable = capabilityCatalogResult.isOk();
+  const capabilityCatalog: CapabilityCatalogEntry[] = capabilityCatalogResult.isOk()
+    ? capabilityCatalogResult.value
+    : [];
+  const agentTargets = deriveCapabilityAssignmentAgentTargets(
+    configuredRuntimes as AssignmentRuntimeRecord[],
+  );
+
   const defaultRuntime =
     configuredRuntimes.find((runtime) => runtime.type === settings.defaultAgentRuntime) ?? null;
   const effectiveRuntime = selectedRuntime ?? defaultRuntime;
@@ -115,7 +141,16 @@ export const proposeActions = async (
     name: operation.name,
     description: operation.description,
     acceptedObjectTypes: operation.acceptedObjectTypes,
+    executor:
+      operation.config && typeof operation.config === "object" && "executor" in operation.config
+        ? operation.config.executor
+        : undefined,
   }));
+  const editableOperationIds = new Set(
+    snapshot.nodes.flatMap((node) =>
+      node.data.nodeType === "operation" ? [node.data.operationId] : [],
+    ),
+  );
   const operationById = new Map(
     operationCatalog.map((operation) => [operation.id, { name: operation.name }]),
   );
@@ -153,8 +188,10 @@ export const proposeActions = async (
       : undefined);
   const userPromptText = buildProposeUserPrompt({
     activeRun,
+    agentTargets,
     artifactAnalysis,
     attachments: opts.attachments ?? [],
+    capabilityCatalog,
     context: opts.context,
     diagnostics: opts.diagnostics ?? [],
     failedProposal: opts.failedProposal,
@@ -288,6 +325,64 @@ export const proposeActions = async (
     ...parsed.data,
     actions: normalizeProposalActionCatalogNames(parsed.data.actions, operationById),
   };
+  const updateOperationActions = proposal.actions.filter(
+    (action) => action.type === "updateOperation",
+  );
+  const updateOperationDiagnostics = updateOperationActions.flatMap((action) => {
+    if (!capabilityCatalogAvailable) {
+      return [
+        `updateOperation.${action.operationId}: capability catalog is unavailable; executor changes fail closed.`,
+      ];
+    }
+
+    if (!editableOperationIds.has(action.operationId)) {
+      return [
+        `updateOperation.${action.operationId}: only an existing Operation used by the current pipeline may be updated in place.`,
+      ];
+    }
+
+    return validateAssignedOperationExecutor({
+      executor: action.executor,
+      context: { agentTargets, capabilityCatalog },
+      pathPrefix: `updateOperation.${action.operationId}.executor`,
+    });
+  });
+  if (updateOperationActions.length > 0 && capabilityCatalogAvailable) {
+    const catalogValidation = await deps.capabilityCatalog.validateOperationConfigs(
+      updateOperationActions.map((action) => ({
+        executor: action.executor,
+        inputs: [],
+        outputs: [],
+      })),
+    );
+    if (catalogValidation.isErr()) {
+      updateOperationDiagnostics.push(catalogValidation.error.message);
+    }
+  }
+
+  if (updateOperationDiagnostics.length > 0) {
+    if ((opts.semanticRetry ?? 0) < MAX_SEMANTIC_RETRIES) {
+      return proposeActions(deps, {
+        ...opts,
+        diagnostics: [...(opts.diagnostics ?? []), ...updateOperationDiagnostics],
+        failedProposal: proposal,
+        precomputedAnalysis: artifactAnalysis,
+        semanticRetry: (opts.semanticRetry ?? 0) + 1,
+      });
+    }
+
+    return {
+      proposal: null,
+      diagnostics: updateOperationDiagnostics.map((message) => ({
+        actionIndex: null,
+        code: "INVALID_NODE_DATA" as const,
+        message,
+        severity: "error" as const,
+      })),
+      error: { code: "BAD_AGENT_OUTPUT", detail: "updateOperation failed validation" },
+      ...(agentOutput.reply ? { reply: agentOutput.reply } : {}),
+    };
+  }
   const validationResult = validatePipelineActions(snapshot, proposal.actions);
   const graphDiagnostics = validationResult.isErr() ? validationResult.error : [];
   const operationDiagnostics = validateProposalActionCatalog(proposal.actions, operationById);

--- a/packages/services/src/pipelinesService/proposeActions/proposeActions.unit.test.ts
+++ b/packages/services/src/pipelinesService/proposeActions/proposeActions.unit.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { logger } from "@repo/logger";
+import type { CapabilityCatalogEntry } from "@repo/schemas";
+import { errAsync, okAsync } from "neverthrow";
 
 const mockSettingsDao = {
   get: vi.fn().mockResolvedValue({
@@ -31,6 +33,10 @@ const mockJobTracesDao = {
   findByJobId: vi.fn(),
 };
 const mockRunProposeAgent = vi.fn();
+const mockCapabilityCatalog = {
+  getMany: vi.fn(() => okAsync([] as CapabilityCatalogEntry[])),
+  validateOperationConfigs: vi.fn(() => okAsync(undefined)),
+};
 
 vi.mock("@repo/models", () => ({
   createAgentRuntimesDao: () => mockAgentRuntimesDao,
@@ -85,8 +91,298 @@ describe("proposeActions", () => {
     mockJobTracesDao.findByJobId.mockReset();
     mockOperationsDao.findMany.mockReset();
     mockOperationsDao.findMany.mockResolvedValue([]);
+    mockAgentRuntimesDao.findMany.mockReset();
+    mockAgentRuntimesDao.findMany.mockResolvedValue([
+      {
+        id: "runtime-codex",
+        name: "Codex Local",
+        type: "codex",
+        connection: { mode: "local" },
+      },
+    ]);
+    mockCapabilityCatalog.getMany.mockReset();
+    mockCapabilityCatalog.getMany.mockReturnValue(okAsync([]));
+    mockCapabilityCatalog.validateOperationConfigs.mockReset();
+    mockCapabilityCatalog.validateOperationConfigs.mockReturnValue(okAsync(undefined));
     vi.mocked(logger.warn).mockClear();
     vi.mocked(logger.error).mockClear();
+  });
+
+  it("accepts a catalog-valid updateOperation for an operation in the graph", async () => {
+    mockAgentRuntimesDao.findMany.mockResolvedValueOnce([
+      {
+        id: "runtime-claude",
+        name: "Claude Local",
+        type: "claude-code",
+        connection: {
+          mode: "local",
+          models: [{ id: "claude-review", displayName: "Review" }],
+        },
+      },
+    ]);
+    mockOperationsDao.findMany.mockResolvedValueOnce([
+      {
+        id: "op-review",
+        name: "Review",
+        description: "Review changes",
+        acceptedObjectTypes: ["folder"],
+        config: { executor: { type: "agent", prompt: "Old prompt" } },
+      },
+    ]);
+    mockCapabilityCatalog.getMany.mockReturnValueOnce(
+      okAsync([
+        {
+          id: "builtin:Read",
+          reference: "Read",
+          displayName: "Read",
+          description: "Read files",
+          source: "builtin",
+          supportedRuntimes: ["claude-code"],
+          riskTier: "readonly",
+          inferredRiskTier: "readonly",
+          riskTierSource: "rule",
+          kind: "builtin-tool",
+        },
+      ]),
+    );
+    const executor = {
+      type: "agent",
+      agentMode: "prompt",
+      agent: "claude-code",
+      model: "claude-review",
+      prompt: "Review the supplied diff.",
+      allowedTools: ["Read"],
+      assignmentReason: "Semantic review needs read-only repository access.",
+    };
+    mockRunProposeAgent.mockResolvedValueOnce({
+      ok: true,
+      json: {
+        reply: "Updated the review executor.",
+        proposal: {
+          summary: "Update review executor",
+          actions: [{ type: "updateOperation", operationId: "op-review", executor }],
+        },
+      },
+    });
+    const operationSnapshot = {
+      nodes: [
+        {
+          id: "review-node",
+          type: "operation",
+          position: { x: 0, y: 0 },
+          data: {
+            nodeType: "operation",
+            label: "Review",
+            operationId: "op-review",
+            operationName: "Review",
+            status: "idle",
+          },
+        },
+      ],
+      edges: [],
+    } as never;
+
+    const result = await proposeActions(
+      {
+        agentRuntimesDao: mockAgentRuntimesDao as never,
+        conversationMessagesDao: mockConversationMessagesDao as never,
+        jobsDao: mockJobsDao as never,
+        jobTracesDao: mockJobTracesDao as never,
+        operationsDao: mockOperationsDao as never,
+        settingsDao: mockSettingsDao as never,
+        capabilityCatalog: mockCapabilityCatalog,
+      },
+      { snapshot: operationSnapshot, message: "Use the review model" },
+    );
+
+    expect(result.proposal?.actions).toEqual([
+      { type: "updateOperation", operationId: "op-review", executor },
+    ]);
+    expect(result.error).toBeUndefined();
+    expect(mockCapabilityCatalog.validateOperationConfigs).toHaveBeenCalledOnce();
+  });
+
+  it("keeps graph-only proposals available when the capability catalog cannot load", async () => {
+    mockCapabilityCatalog.getMany.mockReturnValueOnce(
+      errAsync(new Error("catalog unavailable")) as never,
+    );
+    mockRunProposeAgent.mockResolvedValueOnce({
+      ok: true,
+      json: {
+        reply: "Removed the stale node.",
+        proposal: {
+          summary: "Remove stale node",
+          actions: [{ type: "removeNode", nodeId: "folder-1" }],
+        },
+      },
+    });
+
+    const result = await proposeActions(
+      {
+        agentRuntimesDao: mockAgentRuntimesDao as never,
+        conversationMessagesDao: mockConversationMessagesDao as never,
+        jobsDao: mockJobsDao as never,
+        jobTracesDao: mockJobTracesDao as never,
+        operationsDao: mockOperationsDao as never,
+        settingsDao: mockSettingsDao as never,
+        capabilityCatalog: mockCapabilityCatalog,
+      },
+      { snapshot, message: "Remove the stale node" },
+    );
+
+    expect(result.proposal?.actions).toEqual([{ type: "removeNode", nodeId: "folder-1" }]);
+    expect(result.error).toBeUndefined();
+    expect(mockCapabilityCatalog.validateOperationConfigs).not.toHaveBeenCalled();
+  });
+
+  it("repairs an invalid updateOperation once, then rejects it without a proposal", async () => {
+    mockAgentRuntimesDao.findMany.mockResolvedValue([
+      {
+        id: "runtime-codex",
+        name: "Codex Local",
+        type: "codex",
+        connection: {
+          mode: "local",
+          models: [{ id: "gpt-review", displayName: "Review" }],
+        },
+      },
+    ]);
+    mockOperationsDao.findMany.mockResolvedValue([
+      {
+        id: "op-review",
+        name: "Review",
+        description: "Review changes",
+        acceptedObjectTypes: ["folder"],
+        config: { executor: { type: "agent", prompt: "Old prompt" } },
+      },
+    ]);
+    mockCapabilityCatalog.getMany.mockReturnValue(okAsync([]));
+    const invalidOutput = {
+      reply: "Updated.",
+      proposal: {
+        summary: "Update review executor",
+        actions: [
+          {
+            type: "updateOperation",
+            operationId: "op-review",
+            executor: {
+              type: "agent",
+              agentMode: "prompt",
+              agent: "codex",
+              model: "invented-model",
+              prompt: "Review it.",
+              allowedTools: ["invented-tool"],
+              assignmentReason: "Review needs a model.",
+            },
+          },
+        ],
+      },
+    };
+    mockRunProposeAgent.mockResolvedValue({ ok: true, json: invalidOutput });
+    const operationSnapshot = {
+      nodes: [
+        {
+          id: "review-node",
+          type: "operation",
+          position: { x: 0, y: 0 },
+          data: {
+            nodeType: "operation",
+            label: "Review",
+            operationId: "op-review",
+            operationName: "Review",
+            status: "idle",
+          },
+        },
+      ],
+      edges: [],
+    } as never;
+
+    const result = await proposeActions(
+      {
+        agentRuntimesDao: mockAgentRuntimesDao as never,
+        conversationMessagesDao: mockConversationMessagesDao as never,
+        jobsDao: mockJobsDao as never,
+        jobTracesDao: mockJobTracesDao as never,
+        operationsDao: mockOperationsDao as never,
+        settingsDao: mockSettingsDao as never,
+        capabilityCatalog: mockCapabilityCatalog,
+      },
+      { snapshot: operationSnapshot, message: "Change it" },
+    );
+
+    expect(mockRunProposeAgent).toHaveBeenCalledTimes(2);
+    expect(result.proposal).toBeNull();
+    expect(result.error).toEqual({
+      code: "BAD_AGENT_OUTPUT",
+      detail: "updateOperation failed validation",
+    });
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
+      "off-catalog agent/model pair",
+    );
+  });
+
+  it("rejects updateOperation for an existing Operation outside the current graph", async () => {
+    mockAgentRuntimesDao.findMany.mockResolvedValue([
+      {
+        id: "runtime-codex",
+        name: "Codex Local",
+        type: "codex",
+        connection: {
+          mode: "local",
+          models: [{ id: "gpt-review", displayName: "Review" }],
+        },
+      },
+    ]);
+    mockOperationsDao.findMany.mockResolvedValue([
+      {
+        id: "op-review",
+        name: "Review",
+        description: "Review changes",
+        acceptedObjectTypes: ["folder"],
+        config: { executor: { type: "agent", prompt: "Old prompt" } },
+      },
+    ]);
+    const invalidOutput = {
+      reply: "Updated.",
+      proposal: {
+        summary: "Update an unrelated executor",
+        actions: [
+          {
+            type: "updateOperation",
+            operationId: "op-review",
+            executor: {
+              type: "agent",
+              agentMode: "prompt",
+              agent: "codex",
+              model: "gpt-review",
+              prompt: "Review it.",
+              allowedTools: [],
+              assignmentReason: "Semantic review needs model judgment.",
+            },
+          },
+        ],
+      },
+    };
+    mockRunProposeAgent.mockResolvedValue({ ok: true, json: invalidOutput });
+
+    const result = await proposeActions(
+      {
+        agentRuntimesDao: mockAgentRuntimesDao as never,
+        conversationMessagesDao: mockConversationMessagesDao as never,
+        jobsDao: mockJobsDao as never,
+        jobTracesDao: mockJobTracesDao as never,
+        operationsDao: mockOperationsDao as never,
+        settingsDao: mockSettingsDao as never,
+        capabilityCatalog: mockCapabilityCatalog,
+      },
+      { snapshot, message: "Change the unrelated operation" },
+    );
+
+    expect(mockRunProposeAgent).toHaveBeenCalledTimes(2);
+    expect(result.proposal).toBeNull();
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
+      "used by the current pipeline",
+    );
   });
 
   it("returns a generic client detail and logs the full detail on AGENT_FAILED", async () => {
@@ -104,6 +400,7 @@ describe("proposeActions", () => {
         jobTracesDao: mockJobTracesDao as never,
         operationsDao: mockOperationsDao as never,
         settingsDao: mockSettingsDao as never,
+        capabilityCatalog: mockCapabilityCatalog,
       },
       { snapshot, message: "do something" },
     );
@@ -144,6 +441,7 @@ describe("proposeActions", () => {
         jobTracesDao: mockJobTracesDao as never,
         operationsDao: mockOperationsDao as never,
         settingsDao: mockSettingsDao as never,
+        capabilityCatalog: mockCapabilityCatalog,
       },
       {
         snapshot,
@@ -179,6 +477,7 @@ describe("proposeActions", () => {
         jobTracesDao: mockJobTracesDao as never,
         operationsDao: mockOperationsDao as never,
         settingsDao: mockSettingsDao as never,
+        capabilityCatalog: mockCapabilityCatalog,
       },
       {
         snapshot,

--- a/packages/services/src/pipelinesService/proposeActions/validateProposalCatalog.ts
+++ b/packages/services/src/pipelinesService/proposeActions/validateProposalCatalog.ts
@@ -59,5 +59,15 @@ export const validateProposalActionCatalog = (
       return validateOperationNodeCatalog(action.nodeId, action.data, operationById, actionIndex);
     }
 
+    if (action.type === "updateOperation" && !operationById.has(action.operationId)) {
+      return [
+        makeProposalDiagnostic(
+          "OPERATION_NOT_FOUND",
+          `updateOperation references unknown operationId "${action.operationId}".`,
+          actionIndex,
+        ),
+      ];
+    }
+
     return [];
   });

--- a/packages/services/src/pipelinesService/proposeActions/validateRejectedOperationReferences.ts
+++ b/packages/services/src/pipelinesService/proposeActions/validateRejectedOperationReferences.ts
@@ -24,7 +24,9 @@ export const validateRejectedOperationReferences = (
         ? action.node.data.operationId
         : action.type === "replaceNodeData" && action.data.nodeType === "operation"
           ? action.data.operationId
-          : undefined;
+          : action.type === "updateOperation"
+            ? action.operationId
+            : undefined;
 
     if (operationId && rejectedSet.has(operationId)) {
       diagnostics.push({

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -25,6 +25,7 @@ import { useAgentBarStore } from "./_store";
 import { Assistant, MessageTurn, ProposalCard } from "./messages";
 import type { MessageTurnSubmitInput } from "./messages/MessageTurn";
 import { Composer, type ComposerSubmitInput } from "./Composer";
+import { takePendingPipelinePrompt } from "./pendingPipelinePrompt";
 import { buildProposalItems } from "./proposalView";
 import { useAgentConversation } from "./useAgentConversation";
 
@@ -73,6 +74,7 @@ export const AgentPanel = () => {
   } = useAgentConversation({ pipelineId });
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const attachmentGraphSignatureRef = useRef<string | null>(null);
+  const pendingPromptConsumedRef = useRef(false);
   const sendInFlightRef = useRef(false);
   const isSending = isPreparingSend || isConversationSending;
   const isUploadBlocked = isHistoryLoading || isPreparingUpload || isSending;
@@ -320,6 +322,52 @@ export const AgentPanel = () => {
       t,
     ],
   );
+
+  useEffect(() => {
+    if (
+      pendingPromptConsumedRef.current ||
+      !pipelineId ||
+      isHistoryLoading ||
+      isLoadingRuntimes ||
+      runtimeOptions.length === 0 ||
+      isSending ||
+      agentPanel.isLoading ||
+      sendInFlightRef.current
+    ) {
+      return;
+    }
+
+    pendingPromptConsumedRef.current = true;
+    const pending = takePendingPipelinePrompt();
+    if (!pending) {
+      return;
+    }
+
+    const effectiveRuntimeId =
+      runtimeOptions.find((runtime) => runtime.id === pending.runtimeId)?.id ?? selectedRuntimeId;
+    if (!effectiveRuntimeId) {
+      setComposerDraft(pending.prompt);
+
+      return;
+    }
+
+    setSelectedRuntimeId(effectiveRuntimeId);
+    sendInFlightRef.current = true;
+    setIsPreparingSend(true);
+    void submitMessage({ content: pending.prompt, runtimeId: effectiveRuntimeId }).finally(() => {
+      sendInFlightRef.current = false;
+      setIsPreparingSend(false);
+    });
+  }, [
+    agentPanel.isLoading,
+    isHistoryLoading,
+    isLoadingRuntimes,
+    isSending,
+    pipelineId,
+    runtimeOptions,
+    selectedRuntimeId,
+    submitMessage,
+  ]);
 
   const handleComposerAttach = useCallback(
     async (files: File[]): Promise<ProposeAttachment[]> => {

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -175,6 +175,7 @@ const wrapperWithMutableStore = () => {
 
 describe("AgentPanel", () => {
   beforeEach(() => {
+    globalThis.sessionStorage.clear();
     vi.clearAllMocks();
     Object.defineProperty(globalThis.HTMLElement.prototype, "scrollIntoView", {
       configurable: true,
@@ -246,6 +247,48 @@ describe("AgentPanel", () => {
       "bg-transparent",
     );
     expect(screen.getByTestId("agent-assistant")).toHaveClass("text-[12px]");
+  });
+
+  it("auto-sends the home prompt with the runtime selected on the home page", async () => {
+    globalThis.sessionStorage.setItem(
+      "ordine.pendingPipelinePrompt",
+      JSON.stringify({ prompt: "Build an exam pipeline", runtimeId: "runtime-codex" }),
+    );
+    mockGetOne.mockResolvedValue({ data: { defaultAgentRuntime: "pi-agent" } });
+    mockGetList.mockResolvedValue({
+      data: [
+        {
+          id: "runtime-pi",
+          name: "local-pi-agent",
+          type: "pi-agent",
+          connection: { mode: "local" },
+        },
+        {
+          id: "runtime-codex",
+          name: "Codex Local",
+          type: "codex",
+          connection: { mode: "local" },
+        },
+      ],
+      total: 2,
+    });
+    mockPlanSessionStream.mockImplementation(async (_sessionId, { onEvent }) => {
+      onEvent({ type: "question", question: "Which exam sections?" });
+    });
+
+    render(<AgentPanel />, { wrapper: wrapperWithState() });
+
+    await waitFor(() =>
+      expect(mockPlanSessionStream).toHaveBeenCalledWith(
+        "session-1",
+        expect.objectContaining({ runtimeId: "runtime-codex" }),
+      ),
+    );
+    expect(mockAppendMessage).toHaveBeenCalledWith(
+      "session-1",
+      expect.objectContaining({ content: "Build an exam pipeline", role: "user" }),
+    );
+    expect(globalThis.sessionStorage.getItem("ordine.pendingPipelinePrompt")).toBeNull();
   });
 
   it("uses a neutral status when no runtime is selected", async () => {

--- a/packages/views/src/pages/CanvasPage/AgentPanel/pendingPipelinePrompt.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/pendingPipelinePrompt.ts
@@ -5,22 +5,6 @@ export interface PendingPipelinePrompt {
   runtimeId?: string;
 }
 
-/**
- * 首页首条消息跳转画布前，把 prompt/runtime 暂存到 sessionStorage；
- * AgentPanel 在已保存的 Pipeline 画布挂载后取出并自动首发。
- * 一次性语义:take 即删。key 与 packages/views 侧消费方保持同名,勿单边改。
- */
-export const savePendingPipelinePrompt = (prompt: string, runtimeId?: string) => {
-  if (globalThis.sessionStorage === undefined) {
-    return;
-  }
-
-  globalThis.sessionStorage.setItem(
-    PENDING_PIPELINE_PROMPT_KEY,
-    JSON.stringify({ prompt, ...(runtimeId ? { runtimeId } : {}) } satisfies PendingPipelinePrompt),
-  );
-};
-
 export const takePendingPipelinePrompt = (): PendingPipelinePrompt | null => {
   if (globalThis.sessionStorage === undefined) {
     return null;
@@ -28,7 +12,6 @@ export const takePendingPipelinePrompt = (): PendingPipelinePrompt | null => {
 
   const stored = globalThis.sessionStorage.getItem(PENDING_PIPELINE_PROMPT_KEY);
   globalThis.sessionStorage.removeItem(PENDING_PIPELINE_PROMPT_KEY);
-
   if (!stored) {
     return null;
   }
@@ -44,7 +27,6 @@ export const takePendingPipelinePrompt = (): PendingPipelinePrompt | null => {
       };
     }
   } catch {
-    // Backward compatibility for prompts saved by COD-345 before the runtime was included.
     return { prompt: stored };
   }
 

--- a/packages/views/src/pages/CanvasPage/AgentPanel/proposalView.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/proposalView.ts
@@ -17,6 +17,7 @@ const ACTION_TITLE_KEYS: Record<PipelineAction["type"], string> = {
   removeEdge: "canvas.agentPanel.proposalDetails.actionTitles.removeEdge",
   reconnectEdge: "canvas.agentPanel.proposalDetails.actionTitles.reconnectEdge",
   replaceNodeData: "canvas.agentPanel.proposalDetails.actionTitles.replaceNodeData",
+  updateOperation: "canvas.agentPanel.proposalDetails.actionTitles.updateOperation",
 };
 
 const actionDetail = (action: PipelineAction): string => {
@@ -38,6 +39,9 @@ const actionDetail = (action: PipelineAction): string => {
     }
     case "replaceNodeData": {
       return action.nodeId;
+    }
+    case "updateOperation": {
+      return action.operationId;
     }
     default: {
       return "";

--- a/packages/views/src/pages/CanvasPage/AgentPanel/proposalView.unit.test.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/proposalView.unit.test.ts
@@ -38,4 +38,25 @@ describe("proposalView", () => {
       },
     ]);
   });
+
+  it("renders an updateOperation action", () => {
+    const updateProposal = {
+      summary: "change executor",
+      actions: [
+        {
+          type: "updateOperation",
+          operationId: "op-1",
+          executor: { type: "script", command: "bun run lint" },
+        },
+      ],
+    } as PipelineActionProposal;
+
+    expect(buildProposalItems(updateProposal, [], t)).toEqual([
+      {
+        badges: [],
+        detail: "op-1",
+        title: "canvas.agentPanel.proposalDetails.actionTitles.updateOperation",
+      },
+    ]);
+  });
 });

--- a/packages/views/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasOperationPropertiesForm.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasOperationPropertiesForm.tsx
@@ -25,6 +25,7 @@ import type {
   ObjectType,
   Operation,
   OperationConfigInput,
+  OperationExecutorConfig,
   OperationExecutorType,
   Skill,
 } from "@repo/schemas";
@@ -100,11 +101,27 @@ const buildConfig = (
   promptText: string,
   scriptCommand: string,
   scriptLanguage: "bash" | "python" | "javascript",
+  existingExecutor?: OperationExecutorConfig,
 ): OperationConfigInput => {
+  const assignedAgentFields =
+    existingExecutor?.type === "agent"
+      ? {
+          ...(existingExecutor.agent ? { agent: existingExecutor.agent } : {}),
+          ...(existingExecutor.model ? { model: existingExecutor.model } : {}),
+          ...(existingExecutor.allowedTools !== undefined
+            ? { allowedTools: existingExecutor.allowedTools }
+            : {}),
+          ...(existingExecutor.assignmentReason
+            ? { assignmentReason: existingExecutor.assignmentReason }
+            : {}),
+        }
+      : {};
+
   if (executorType === "agent") {
     if (agentMode === "skill") {
       return {
         executor: {
+          ...assignedAgentFields,
           type: "agent",
           agentMode: "skill",
           skillId,
@@ -114,6 +131,7 @@ const buildConfig = (
 
     return {
       executor: {
+        ...assignedAgentFields,
         type: "agent",
         agentMode: "prompt",
         prompt: promptText,
@@ -290,6 +308,7 @@ export const CanvasOperationPropertiesForm = ({
       promptText,
       scriptCommand,
       scriptLanguage,
+      operation.config.executor,
     );
     const result = await ResultAsync.fromPromise(
       updateOpMutate({

--- a/packages/views/src/pages/OperationEditPage/OperationEditPageContent/OperationEditForm.tsx
+++ b/packages/views/src/pages/OperationEditPage/OperationEditPageContent/OperationEditForm.tsx
@@ -47,6 +47,7 @@ import {
   type OperationExecutorType,
   type AgentMode,
   type OperationConfigInput,
+  type OperationExecutorConfig,
 } from "@repo/schemas";
 import { useStore } from "zustand";
 import { useOperationEditPageStore } from "../_store";
@@ -96,11 +97,29 @@ const editFormSchema = z.object({
 
 type EditFormValues = z.infer<typeof editFormSchema>;
 
-const buildConfig = (values: EditFormValues): OperationConfigInput => {
+const buildConfig = (
+  values: EditFormValues,
+  existingExecutor?: OperationExecutorConfig,
+): OperationConfigInput => {
+  const assignedAgentFields =
+    existingExecutor?.type === "agent"
+      ? {
+          ...(existingExecutor.agent ? { agent: existingExecutor.agent } : {}),
+          ...(existingExecutor.model ? { model: existingExecutor.model } : {}),
+          ...(existingExecutor.allowedTools !== undefined
+            ? { allowedTools: existingExecutor.allowedTools }
+            : {}),
+          ...(existingExecutor.assignmentReason
+            ? { assignmentReason: existingExecutor.assignmentReason }
+            : {}),
+        }
+      : {};
+
   if (values.executorType === "agent") {
     if (values.agentMode === "skill") {
       return {
         executor: {
+          ...assignedAgentFields,
           type: "agent",
           agentMode: "skill",
           skillId: values.skillId,
@@ -110,6 +129,7 @@ const buildConfig = (values: EditFormValues): OperationConfigInput => {
 
     return {
       executor: {
+        ...assignedAgentFields,
         type: "agent",
         agentMode: "prompt",
         prompt: values.promptText,
@@ -334,7 +354,7 @@ export const OperationEditForm = ({ operation, skills }: OperationEditFormProps)
         description: values.description || null,
         config: {
           ...operation.config,
-          ...buildConfig(values),
+          ...buildConfig(values, operation.config.executor),
           outputs: values.outputs.map((output) => ({
             ...output,
             description: output.description || undefined,


### PR DESCRIPTION
## Summary

Implements COD-341 per-step capability assignment for pipeline generation and edit flows.

- Assigns strict script, prompt-agent, and skill-agent executors per unmatched step.
- Validates runtime/model selection and capability-catalog references.
- Uses stable unique MCP references from COD-340.
- Performs one repair attempt and fails closed for invalid batches.
- Adds transactional `updateOperation` approval handling for shared Operations.
- Applies per-operation model, agent, and MCP credential selection during execution.
- Preserves assignment metadata through REST and UI edits.
- Documents the production path and deterministic acceptance fixtures in the COD-341 spike report.

## Validation

- Typecheck: agent-engine, schemas, pipeline-engine, services, views, app, server
- Lint: relevant changed packages
- Targeted tests: 189/189
- `git diff --check`: passed

The branch is based on `upstream/develop@665a4dc8`, including the COD-340 squash merge.