### PR TITLE
feat: 打通空画布 Agent 生成流水线

### DIFF
--- a/apps/app/src/routes/canvas.tsx
+++ b/apps/app/src/routes/canvas.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
+import { ResultAsync } from "neverthrow";
 import { useTranslation } from "react-i18next";
 import { useOne } from "@refinedev/core";
 import { AlertTriangle, RefreshCw, SearchX } from "lucide-react";
@@ -13,6 +14,9 @@ import { AppLayout } from "@/components/AppLayout";
 import { ResourceName } from "@/integrations/refine/dataProvider";
 import { useSession } from "@/integrations/better-auth-client";
 import { requireAuthenticatedSession } from "./-requireAuthenticatedSession";
+import { materializeGeneratedPipeline } from "@/lib/materializeGeneratedPipeline";
+import { toastStore } from "@/store/toastStore";
+import { sidebarStore as sharedSidebarStore } from "@repo/views/store/sidebarStore";
 
 const CanvasRouteComponent = () => {
   const { t } = useTranslation();
@@ -26,6 +30,30 @@ const CanvasRouteComponent = () => {
   });
   const pipeline = id ? (pipelineResult ?? null) : null;
   const handlePipelineRetry = () => void pipelineQuery?.refetch();
+  const handleGeneratedPipeline = useCallback(
+    async (generatedPipelineId: string) => {
+      const result = await ResultAsync.fromPromise(
+        materializeGeneratedPipeline(
+          generatedPipelineId,
+          sharedSidebarStore.getState().currentProjectId,
+        ),
+        (error) => (error instanceof Error ? error : new Error(String(error))),
+      );
+      await result.match(
+        async (pipelineId) => {
+          await navigate({ to: "/canvas", search: { id: pipelineId } });
+        },
+        (error) => {
+          toastStore.getState().addToast({
+            type: "error",
+            title: t("canvas.agentPanel.errorTitle"),
+            description: error.message,
+          });
+        },
+      );
+    },
+    [navigate, t],
+  );
 
   useEffect(() => {
     if (!isPending && !session) {
@@ -48,7 +76,7 @@ const CanvasRouteComponent = () => {
   if (!id) {
     return (
       <AppLayout canvasMode>
-        <CanvasPage embedded />
+        <CanvasPage embedded onGeneratedPipeline={handleGeneratedPipeline} />
       </AppLayout>
     );
   }

--- a/apps/desktop-app/src/routes/canvas.tsx
+++ b/apps/desktop-app/src/routes/canvas.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Suspense, lazy } from "react";
 
 // Canvas is heavy (@xyflow/react); lazy-load it so it stays out of the initial bundle.
@@ -15,6 +15,9 @@ export const Route = createFileRoute("/canvas")({
 
 function RouteComponent() {
   const { id } = Route.useSearch();
+  const navigate = useNavigate();
+  const handleGeneratedPipeline = (pipelineId: string) =>
+    navigate({ to: "/canvas", search: { id: pipelineId } });
 
   return (
     <Suspense
@@ -24,7 +27,7 @@ function RouteComponent() {
         </div>
       }
     >
-      <CanvasPage id={id} />
+      <CanvasPage id={id} onGeneratedPipeline={handleGeneratedPipeline} />
     </Suspense>
   );
 }

--- a/packages/views/src/lib/pendingPipelinePrompt.ts
+++ b/packages/views/src/lib/pendingPipelinePrompt.ts
@@ -1,0 +1,27 @@
+/**
+ * COD-345/COD-346 跨包契约:apps/app 首页在用户首发时把 prompt 暂存到 sessionStorage
+ * 并跳转无 id 的 /canvas,这里由 AgentPanel 消费。key 必须与 apps/app 侧
+ * (apps/app/src/lib/pendingPipelinePrompt.ts)保持一致,任何一侧改动都需要同步另一侧。
+ */
+const PENDING_PIPELINE_PROMPT_KEY = "ordine.pendingPipelinePrompt";
+
+/** 只读预览,不消费。用于判断是否需要走自动首发流程。 */
+export const peekPendingPipelinePrompt = (): string | null => {
+  if (globalThis.sessionStorage === undefined) {
+    return null;
+  }
+
+  return globalThis.sessionStorage.getItem(PENDING_PIPELINE_PROMPT_KEY);
+};
+
+/** 取出并删除(一次性),保证 StrictMode 双执行/刷新场景不会重复首发。 */
+export const takePendingPipelinePrompt = (): string | null => {
+  if (globalThis.sessionStorage === undefined) {
+    return null;
+  }
+
+  const prompt = globalThis.sessionStorage.getItem(PENDING_PIPELINE_PROMPT_KEY);
+  globalThis.sessionStorage.removeItem(PENDING_PIPELINE_PROMPT_KEY);
+
+  return prompt;
+};

--- a/packages/views/src/lib/pipelineAgentSessionsClient.ts
+++ b/packages/views/src/lib/pipelineAgentSessionsClient.ts
@@ -332,11 +332,20 @@ export const createPipelineAgentSessionsClient = (platform: PipelineAgentSession
       }
     },
 
-    async generatePipelineFromApprovedProposal(sessionId: string): Promise<{ pipelineId: string }> {
+    async generatePipelineFromApprovedProposal(
+      sessionId: string,
+      input?: { runtimeId?: string },
+    ): Promise<{ pipelineId: string }> {
       const response = await platform.request(
         `${pipelineAgentSessionsBaseUrl}/${sessionId}/generate`,
         {
           method: "POST",
+          ...(input?.runtimeId
+            ? {
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ runtimeId: input.runtimeId }),
+              }
+            : {}),
         },
       );
 

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -26,6 +26,7 @@ import { Assistant, MessageTurn, ProposalCard } from "./messages";
 import type { MessageTurnSubmitInput } from "./messages/MessageTurn";
 import { Composer, type ComposerSubmitInput } from "./Composer";
 import { buildProposalItems } from "./proposalView";
+import { takePendingPipelinePrompt } from "../../../lib/pendingPipelinePrompt";
 import { useAgentConversation } from "./useAgentConversation";
 
 interface RuntimeState {
@@ -33,10 +34,14 @@ interface RuntimeState {
   suggestedRuntimeId: string | null;
 }
 
+interface AgentPanelProps {
+  onGeneratedPipeline?: (pipelineId: string) => Promise<void> | void;
+}
+
 const formatRuntimeLabel = (runtime: AgentRuntimeConfig): string =>
   runtime.name === runtime.type ? runtime.name : `${runtime.name} (${runtime.type})`;
 
-export const AgentPanel = () => {
+export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
   const { t } = useTranslation();
   const platform = usePlatform();
   const pipelineAgentSessionsClient = useMemo(
@@ -51,6 +56,9 @@ export const AgentPanel = () => {
   const nodes = useStore(store, (state) => state.nodes);
   const edges = useStore(store, (state) => state.edges);
   const [composerDraft, setComposerDraft] = useState<string | null>(null);
+  const [pendingPipelinePrompt, setPendingPipelinePrompt] = useState<string | null>(() =>
+    pipelineId ? null : takePendingPipelinePrompt(),
+  );
   const [isPreparingSend, setIsPreparingSend] = useState(false);
   const [isPreparingUpload, setIsPreparingUpload] = useState(false);
   const [isLoadingRuntimes, setIsLoadingRuntimes] = useState(true);
@@ -58,6 +66,7 @@ export const AgentPanel = () => {
   const [runtimeOptions, setRuntimeOptions] = useState<AgentRuntimeConfig[]>([]);
   const [selectedRuntimeId, setSelectedRuntimeId] = useState<string | null>(null);
   const addMessage = useAgentBarStore((state) => state.addMessage);
+  const generateProposal = useAgentBarStore((state) => state.generateProposal);
   const {
     applyProposal,
     agentContext,
@@ -70,7 +79,7 @@ export const AgentPanel = () => {
     streamingAssistantText,
     streamingProgress,
     submitMessage,
-  } = useAgentConversation({ pipelineId });
+  } = useAgentConversation({ onGeneratedPipeline, pipelineId });
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const attachmentGraphSignatureRef = useRef<string | null>(null);
   const sendInFlightRef = useRef(false);
@@ -252,16 +261,6 @@ export const AgentPanel = () => {
       sendInFlightRef.current = true;
       setIsPreparingSend(true);
       try {
-        if (!pipelineId) {
-          toastStore.getState().addToast({
-            type: "error",
-            title: t("canvas.runFailed"),
-            description: t("canvas.noPipelineId"),
-          });
-
-          return false;
-        }
-
         const runtimeSetupResult = await fetchRuntimeState();
         if (runtimeSetupResult.isErr()) {
           addMessage({
@@ -320,6 +319,24 @@ export const AgentPanel = () => {
       t,
     ],
   );
+
+  useEffect(() => {
+    if (!pendingPipelinePrompt || pipelineId || !selectedRuntimeId || isLoadingRuntimes) {
+      return;
+    }
+
+    setPendingPipelinePrompt(null);
+    void handleComposerSubmit({
+      content: pendingPipelinePrompt,
+      metadata: { attachments: [], referencedNodeIds: [] },
+    });
+  }, [
+    handleComposerSubmit,
+    isLoadingRuntimes,
+    pendingPipelinePrompt,
+    pipelineId,
+    selectedRuntimeId,
+  ]);
 
   const handleComposerAttach = useCallback(
     async (files: File[]): Promise<ProposeAttachment[]> => {
@@ -414,24 +431,52 @@ export const AgentPanel = () => {
 
   const hasBlockingDiagnostics =
     agentPanel.diagnostics?.some((diagnostic) => diagnostic.severity === "error") ?? false;
+  const generateProposalNeedsAnswer =
+    generateProposal !== null && generateProposal.readiness !== "ready_for_generation";
 
   const activeProposal = agentPanel.pendingProposal;
   const activeDiagnostics = agentPanel.diagnostics;
 
   const handleApply = useCallback(() => {
-    if (!activeProposal || hasBlockingDiagnostics) {
+    if (
+      (!activeProposal && !generateProposal) ||
+      hasBlockingDiagnostics ||
+      generateProposalNeedsAnswer
+    ) {
       return;
     }
-    void applyProposal();
-  }, [activeProposal, applyProposal, hasBlockingDiagnostics]);
+    void applyProposal(selectedRuntimeId);
+  }, [
+    activeProposal,
+    applyProposal,
+    generateProposal,
+    generateProposalNeedsAnswer,
+    hasBlockingDiagnostics,
+    selectedRuntimeId,
+  ]);
 
   const handleDiscard = useCallback(() => {
     void discardProposal();
   }, [discardProposal]);
 
   const proposal = activeProposal;
-  const hasProposal = proposal !== null;
-  const proposalItems = useMemo(() => buildProposalItems(proposal, [], t), [proposal, t]);
+  const hasProposal = proposal !== null || generateProposal !== null;
+  const proposalItems = useMemo(() => {
+    if (proposal) {
+      return buildProposalItems(proposal, [], t);
+    }
+
+    if (!generateProposal) {
+      return [];
+    }
+
+    return [
+      ...generateProposal.inputs.map((detail) => ({ detail, title: "Input" })),
+      ...generateProposal.outputs.map((detail) => ({ detail, title: "Output" })),
+      ...generateProposal.majorOperations.map((detail) => ({ detail, title: "Operation" })),
+      ...generateProposal.executionFlow.map((detail) => ({ detail, title: "Flow" })),
+    ];
+  }, [generateProposal, proposal, t]);
   const handleAskFix = useCallback(() => {
     if (selectedRuntimeId) {
       handleMessageSubmit({
@@ -591,7 +636,11 @@ export const AgentPanel = () => {
                 </span>
                 <ProposalCard
                   disabled={
-                    isSending || isPreparingUpload || isHistoryLoading || agentPanel.isLoading
+                    isSending ||
+                    isPreparingUpload ||
+                    isHistoryLoading ||
+                    agentPanel.isLoading ||
+                    generateProposalNeedsAnswer
                   }
                   items={proposalItems}
                   onApply={handleApply}
@@ -599,7 +648,7 @@ export const AgentPanel = () => {
                   onReject={handleDiscard}
                   onRevise={handleRevise}
                   subtitle={t("canvas.agentPanel.proposal.review")}
-                  title={proposal.summary}
+                  title={proposal?.summary ?? generateProposal?.purpose ?? ""}
                 />
               </div>
             </div>

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -791,7 +791,7 @@ describe("AgentPanel", () => {
     expect(screen.getByText("canvas.agentPanel.applied")).toBeInTheDocument();
   });
 
-  it("does not send when pipelineId is missing", async () => {
+  it("starts a generate session when pipelineId is missing", async () => {
     render(<AgentPanel />, { wrapper: wrapperWithoutPipeline });
     await waitFor(() => {
       expect(mockGetList).toHaveBeenCalled();
@@ -801,7 +801,13 @@ describe("AgentPanel", () => {
     await userEvent.type(input, "test");
     await userEvent.keyboard("{Enter}");
 
-    expect(mockCreateSession).not.toHaveBeenCalled();
-    expect(input).toHaveValue("test");
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith({
+        entrypoint: "canvas-agent-panel",
+        mode: "generate",
+        snapshot: { edges: [], nodes: [] },
+      });
+    });
+    expect(input).toHaveValue("");
   });
 });

--- a/packages/views/src/pages/CanvasPage/AgentPanel/_store/agentBarStore.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/_store/agentBarStore.ts
@@ -1,7 +1,7 @@
 import { createContext, createElement, useContext, useRef, type ReactNode } from "react";
 import { useStore } from "zustand";
 import { createStore, type StoreApi } from "zustand/vanilla";
-import type { ConversationMessageMetadata } from "@repo/schemas";
+import type { ConversationMessageMetadata, PipelineGenerationPlan } from "@repo/schemas";
 
 export type AgentConversationState = "idle" | "thinking" | "streaming" | "done";
 
@@ -16,6 +16,8 @@ export type AgentBarMessage = {
 
 export type AgentBarState = {
   conversationState: AgentConversationState;
+  /** COD-346:空画布 generate 会话产生的建图方案(与画布 edit 提案互斥)。 */
+  generateProposal: PipelineGenerationPlan | null;
   messages: AgentBarMessage[];
   pipelineId: string | null;
   proposalId: string | null;
@@ -31,6 +33,7 @@ export type AgentBarState = {
   resetSession: () => void;
   resolveMessage: (id: string) => void;
   setConversationState: (state: AgentConversationState) => void;
+  setGenerateProposal: (proposal: PipelineGenerationPlan | null) => void;
   setMessages: (messages: AgentBarMessage[]) => void;
   setProposalId: (proposalId: string | null) => void;
   setSession: (sessionId: string, graphSignature: string) => void;
@@ -39,6 +42,7 @@ export type AgentBarState = {
 };
 
 const initialSessionState = {
+  generateProposal: null,
   proposalId: null,
   sessionGraphSignature: null,
   sessionId: null,
@@ -111,10 +115,11 @@ export const createAgentBarStore = (pipelineId: string | null = null): AgentBarS
         ),
       })),
     setConversationState: (conversationState) => set({ conversationState }),
+    setGenerateProposal: (generateProposal) => set({ generateProposal }),
     setMessages: (messages) => set({ messages }),
     setProposalId: (proposalId) => set({ proposalId }),
     setSession: (sessionId, sessionGraphSignature) =>
-      set({ sessionId, sessionGraphSignature, proposalId: null }),
+      set({ sessionId, sessionGraphSignature, generateProposal: null, proposalId: null }),
     setStreamingAssistantText: (streamingAssistantText) => set({ streamingAssistantText }),
     setStreamingProgress: (streamingProgress) => set({ streamingProgress }),
   }));

--- a/packages/views/src/pages/CanvasPage/AgentPanel/generateSessionStorage.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/generateSessionStorage.ts
@@ -1,0 +1,30 @@
+/**
+ * COD-346:空画布 generate 会话的 sessionStorage 暂存。
+ * 无 pipelineId 时会话消息只存在于服务端 session 里(不写入 conversationMessages),
+ * 刷新后凭这里暂存的 sessionId 恢复对话;会话绑定到新建 pipeline 后即清除。
+ */
+const GENERATE_SESSION_ID_KEY = "ordine.canvasAgentGenerateSessionId";
+
+export const saveGenerateSessionId = (sessionId: string) => {
+  if (globalThis.sessionStorage === undefined) {
+    return;
+  }
+
+  globalThis.sessionStorage.setItem(GENERATE_SESSION_ID_KEY, sessionId);
+};
+
+export const loadGenerateSessionId = (): string | null => {
+  if (globalThis.sessionStorage === undefined) {
+    return null;
+  }
+
+  return globalThis.sessionStorage.getItem(GENERATE_SESSION_ID_KEY);
+};
+
+export const clearGenerateSessionId = () => {
+  if (globalThis.sessionStorage === undefined) {
+    return;
+  }
+
+  globalThis.sessionStorage.removeItem(GENERATE_SESSION_ID_KEY);
+};

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
@@ -11,7 +11,15 @@ import {
 import { usePlatform } from "../../../platform";
 import { useAgentBarStore, useAgentBarStoreApi } from "./_store";
 import { HISTORY_WINDOW_LIMIT, useAgentContext } from "./context";
-import { useAgentConversationPersistence } from "./useAgentConversationPersistence";
+import {
+  clearGenerateSessionId,
+  loadGenerateSessionId,
+  saveGenerateSessionId,
+} from "./generateSessionStorage";
+import {
+  useAgentConversationPersistence,
+  type SendAgentMessageInput,
+} from "./useAgentConversationPersistence";
 
 export type AgentConversationSubmitInput = {
   content: string;
@@ -19,7 +27,13 @@ export type AgentConversationSubmitInput = {
   runtimeId: string;
 };
 
-export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null }) => {
+export const useAgentConversation = ({
+  onGeneratedPipeline,
+  pipelineId,
+}: {
+  onGeneratedPipeline?: (pipelineId: string) => Promise<void> | void;
+  pipelineId: string | null;
+}) => {
   const { t } = useTranslation();
   const platform = usePlatform();
   const client = useMemo(() => createPipelineAgentSessionsClient(platform), [platform]);
@@ -61,6 +75,54 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
       return existing;
     }
 
+    if (!pipelineId) {
+      const persistedSessionId = loadGenerateSessionId();
+      if (persistedSessionId) {
+        const persistedSession = await ResultAsync.fromPromise(
+          client.getSessionById(persistedSessionId),
+          (error) => (error instanceof Error ? error : new Error(String(error))),
+        );
+        if (
+          persistedSession.isOk() &&
+          persistedSession.value.mode === "generate" &&
+          !persistedSession.value.createdPipelineId &&
+          persistedSession.value.status !== "failed" &&
+          persistedSession.value.status !== "completed"
+        ) {
+          const restoredMessages = (persistedSession.value.messages ?? []).flatMap((message) =>
+            message.role === "system"
+              ? []
+              : [
+                  {
+                    content: message.content,
+                    id: message.id,
+                    role: message.role,
+                  },
+                ],
+          );
+          agentBarStore.getState().setMessages(restoredMessages);
+          agentBarStore.getState().setSession(persistedSessionId, graphSignature);
+
+          const latestProposal =
+            (persistedSession.value.proposals ?? []).find(
+              (proposal) => proposal.id === persistedSession.value.latestProposalId,
+            ) ?? persistedSession.value.proposals?.at(-1);
+          if (
+            latestProposal?.mode === "generate" &&
+            latestProposal.proposal.mode === "generate" &&
+            latestProposal.status === "proposal_ready"
+          ) {
+            agentBarStore.getState().setProposalId(latestProposal.id);
+            agentBarStore.getState().setGenerateProposal(latestProposal.proposal);
+          }
+
+          return persistedSessionId;
+        }
+
+        clearGenerateSessionId();
+      }
+    }
+
     while (sessionCreationRef.current) {
       const pending = sessionCreationRef.current;
       if (pending.graphSignature === graphSignature) {
@@ -87,11 +149,16 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
       }
 
       const session = await client.createSession({
+        // COD-346:无 pipelineId 的空画布走 generate 会话(不绑定 pipeline),
+        // 方案同意后由后端创建 pipeline 并回填 createdPipelineId。
         entrypoint: "canvas-agent-panel",
-        mode: "edit",
+        mode: pipelineId ? "edit" : "generate",
         ...(pipelineId ? { pipelineId } : {}),
         snapshot: { edges, nodes },
       });
+      if (!pipelineId) {
+        saveGenerateSessionId(session.id);
+      }
 
       const history = agentBarStore.getState().messages.slice(-HISTORY_WINDOW_LIMIT);
       for (const message of history) {
@@ -115,6 +182,32 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
     return creationPromise;
   }, [agentBarStore, client, edges, nodes, pipelineId]);
 
+  // COD-346:有 pipelineId 时消息同时落 conversationMessages(可跨刷新恢复);
+  // 空画布 generate 会话没有 pipeline 可挂靠,只写本地 store,服务端由 session 持久化。
+  const persistMessage = useCallback(
+    async ({
+      content,
+      metadata,
+      phase,
+      role = "user",
+    }: SendAgentMessageInput): Promise<boolean> => {
+      if (pipelineId) {
+        return Boolean(await sendMessage({ content, metadata, phase, role }));
+      }
+
+      agentBarStore.getState().addMessage({
+        content,
+        id: `${role}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        metadata,
+        phase,
+        role,
+      });
+
+      return true;
+    },
+    [agentBarStore, pipelineId, sendMessage],
+  );
+
   const finishWithAssistantMessage = useCallback(
     async (content: string) => {
       const state = agentBarStore.getState();
@@ -122,9 +215,9 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
       state.setStreamingProgress(null);
       state.setConversationState("done");
 
-      return Boolean(await sendMessage({ content, phase: "done", role: "assistant" }));
+      return persistMessage({ content, phase: "done", role: "assistant" });
     },
-    [agentBarStore, sendMessage],
+    [agentBarStore, persistMessage],
   );
 
   const handlePlanEvent = useCallback(
@@ -166,6 +259,12 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
         return finishWithAssistantMessage(event.proposal.summary);
       }
 
+      if (event.type === "proposal_ready" && event.proposal.mode === "generate") {
+        state.setProposalId(event.proposalId);
+        state.setGenerateProposal(event.proposal);
+        return finishWithAssistantMessage(event.proposal.purpose);
+      }
+
       if (event.type === "error") {
         return finishWithAssistantMessage(event.message);
       }
@@ -184,7 +283,6 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
     async ({ content, metadata, runtimeId }: AgentConversationSubmitInput) => {
       const trimmedContent = content.trim();
       if (
-        !pipelineId ||
         isLoading ||
         trimmedContent.length === 0 ||
         conversationState === "thinking" ||
@@ -193,8 +291,11 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
         return false;
       }
 
+      // COD-346:无 pipelineId 时是空画布 generate 会话
+      const mode = pipelineId ? "edit" : "generate";
       clearPendingProposal();
       const state = agentBarStore.getState();
+      state.setGenerateProposal(null);
       state.setConversationState("thinking");
       state.setStreamingAssistantText("");
       state.setStreamingProgress(null);
@@ -207,13 +308,13 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
             kind: "text",
             role: "system",
           });
-          const persistedMessage = await sendMessage({
+          const persisted = await persistMessage({
             content: trimmedContent,
             metadata,
             phase: "thinking",
             role: "user",
           });
-          if (!persistedMessage) {
+          if (!persisted) {
             throw new Error(t("canvas.agentPanel.error"));
           }
           await client.appendMessage(sessionId, {
@@ -232,7 +333,7 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
               if (
                 event.type === "question" ||
                 event.type === "error" ||
-                (event.type === "proposal_ready" && event.proposal.mode === "edit")
+                event.type === "proposal_ready"
               ) {
                 streamedTerminalEvent.current = true;
               }
@@ -247,24 +348,24 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
           });
 
           if (streamedTerminalEvent.current) {
-            const persisted = await Promise.all(terminalPersistences);
-            if (persisted.some((value) => !value)) {
+            const persistedTerminal = await Promise.all(terminalPersistences);
+            if (persistedTerminal.some((value) => !value)) {
               throw new Error(t("canvas.agentPanel.error"));
             }
 
             return !streamFailed;
           }
 
-          const latestProposal = await client.getLatestReadyProposal(sessionId, "edit", {
+          const latestProposal = await client.getLatestReadyProposal(sessionId, mode, {
             excludeProposalId: previousProposalId,
           });
-          if (latestProposal && latestProposal.proposal.mode === "edit") {
-            const persisted = await handlePlanEvent({
+          if (latestProposal && latestProposal.proposal.mode === mode) {
+            const persistedProposal = await handlePlanEvent({
               proposal: latestProposal.proposal,
               proposalId: latestProposal.proposalId,
               type: "proposal_ready",
             });
-            if (!persisted) {
+            if (!persistedProposal) {
               throw new Error(t("canvas.agentPanel.error"));
             }
 
@@ -273,11 +374,11 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
 
           const latestQuestion = await client.getLatestAssistantQuestion(sessionId);
           if (latestQuestion) {
-            const persisted = await handlePlanEvent({
+            const persistedQuestion = await handlePlanEvent({
               question: latestQuestion.question,
               type: "question",
             });
-            if (!persisted) {
+            if (!persistedQuestion) {
               throw new Error(t("canvas.agentPanel.error"));
             }
           }
@@ -322,51 +423,98 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
       handlePlanEvent,
       isLoading,
       pipelineId,
-      sendMessage,
+      persistMessage,
       t,
     ],
   );
 
-  const applyProposal = useCallback(async () => {
-    const proposal = agentPanel.pendingProposal;
-    const hasBlockingDiagnostics =
-      agentPanel.diagnostics?.some((diagnostic) => diagnostic.severity === "error") ?? false;
-    if (!proposal || hasBlockingDiagnostics) {
-      return false;
-    }
+  const applyProposal = useCallback(
+    async (runtimeId?: string | null) => {
+      const proposal = agentPanel.pendingProposal;
+      const state = agentBarStore.getState();
+      const { generateProposal, proposalId, sessionId } = state;
+      const hasBlockingDiagnostics =
+        agentPanel.diagnostics?.some((diagnostic) => diagnostic.severity === "error") ?? false;
+      if ((!proposal && !generateProposal) || hasBlockingDiagnostics) {
+        return false;
+      }
 
-    const { proposalId, sessionId } = agentBarStore.getState();
-    const approval = await ResultAsync.fromPromise(
-      sessionId && proposalId ? client.approveProposal(sessionId, proposalId) : Promise.resolve(),
-      (error) => (error instanceof Error ? error : new Error(String(error))),
-    );
-    if (approval.isErr()) {
-      await finishWithAssistantMessage(approval.error.message);
+      if (generateProposal) {
+        if (!sessionId || !proposalId) {
+          return false;
+        }
+        state.setConversationState("thinking");
+        const generation = await ResultAsync.fromPromise(
+          (async () => {
+            await client.approveProposal(sessionId, proposalId);
 
-      return false;
-    }
+            const generated = await ResultAsync.fromPromise(
+              client.generatePipelineFromApprovedProposal(sessionId, {
+                runtimeId: runtimeId ?? undefined,
+              }),
+              (error) => (error instanceof Error ? error : new Error(String(error))),
+            );
+            if (generated.isOk()) {
+              return generated.value;
+            }
 
-    if (!applyAgentProposal(proposal)) {
-      return false;
-    }
+            const status = (generated.error as Error & { status?: number }).status;
+            if (typeof status === "number") {
+              throw generated.error;
+            }
 
-    await sendMessage({
-      content: t("canvas.agentPanel.applied"),
-      phase: "done",
-      role: "assistant",
-    });
-    agentBarStore.getState().resetSession();
+            return client.waitForCreatedPipeline(sessionId);
+          })(),
+          (error) => (error instanceof Error ? error : new Error(String(error))),
+        );
+        if (generation.isErr()) {
+          await finishWithAssistantMessage(generation.error.message);
 
-    return true;
-  }, [
-    agentBarStore,
-    agentPanel,
-    applyAgentProposal,
-    client,
-    finishWithAssistantMessage,
-    sendMessage,
-    t,
-  ]);
+          return false;
+        }
+
+        clearGenerateSessionId();
+        state.setGenerateProposal(null);
+        state.setConversationState("done");
+        await onGeneratedPipeline?.(generation.value.pipelineId);
+
+        return true;
+      }
+
+      const approval = await ResultAsync.fromPromise(
+        sessionId && proposalId ? client.approveProposal(sessionId, proposalId) : Promise.resolve(),
+        (error) => (error instanceof Error ? error : new Error(String(error))),
+      );
+      if (approval.isErr()) {
+        await finishWithAssistantMessage(approval.error.message);
+
+        return false;
+      }
+
+      if (!proposal || !applyAgentProposal(proposal)) {
+        return false;
+      }
+
+      await persistMessage({
+        content: t("canvas.agentPanel.applied"),
+        phase: "done",
+        role: "assistant",
+      });
+      agentBarStore.getState().resetSession();
+
+      return true;
+    },
+    [
+      agentBarStore,
+      agentPanel,
+      applyAgentProposal,
+      client,
+      finishWithAssistantMessage,
+      onGeneratedPipeline,
+      persistMessage,
+      t,
+    ],
+  );
 
   const discardProposal = useCallback(async () => {
     const { proposalId, sessionId } = agentBarStore.getState();
@@ -381,15 +529,16 @@ export const useAgentConversation = ({ pipelineId }: { pipelineId: string | null
     }
 
     clearPendingProposal();
+    agentBarStore.getState().setGenerateProposal(null);
     agentBarStore.getState().setProposalId(null);
-    await sendMessage({
+    await persistMessage({
       content: t("canvas.agentPanel.discarded"),
       phase: "done",
       role: "assistant",
     });
 
     return true;
-  }, [agentBarStore, clearPendingProposal, client, finishWithAssistantMessage, sendMessage, t]);
+  }, [agentBarStore, clearPendingProposal, client, finishWithAssistantMessage, persistMessage, t]);
 
   return {
     agentContext,

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
@@ -30,7 +30,11 @@ import { getScreenViewportCenter, getViewportRectCenter } from "../utils/nodePos
 
 const AGENT_PANEL_COLLAPSE_AT = 248;
 
-export const CanvasInner = () => {
+export const CanvasInner = ({
+  onGeneratedPipeline,
+}: {
+  onGeneratedPipeline?: (pipelineId: string) => Promise<void> | void;
+}) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const flowViewportRef = useRef<HTMLDivElement>(null);
@@ -210,7 +214,7 @@ export const CanvasInner = () => {
             data-testid="canvas-agent-panel-shell"
             style={{ width: `${agentPanelWidth}px`, maxWidth: "calc(100% - 1px)" }}
           >
-            <AgentPanel />
+            <AgentPanel onGeneratedPipeline={onGeneratedPipeline} />
           </div>
         </div>
       ) : (

--- a/packages/views/src/pages/CanvasPage/CanvasPage.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasPage.tsx
@@ -10,9 +10,10 @@ interface CanvasPageProps {
   // Pipeline id to load, read from the route's search params by each app.
   id?: string;
   embedded?: boolean;
+  onGeneratedPipeline?: (pipelineId: string) => Promise<void> | void;
 }
 
-export const CanvasPage = ({ embedded = false, id }: CanvasPageProps) => {
+export const CanvasPage = ({ embedded = false, id, onGeneratedPipeline }: CanvasPageProps) => {
   const { result: pipelineResult, query: pipelineQuery } = useOne<PipelineData>({
     resource: ResourceName.pipelines,
     id: id ?? "",
@@ -31,7 +32,7 @@ export const CanvasPage = ({ embedded = false, id }: CanvasPageProps) => {
   return (
     <CanvasLayout embedded={embedded}>
       <CanvasPageStoreProvider pipeline={pipeline}>
-        <CanvasPageContent />
+        <CanvasPageContent onGeneratedPipeline={onGeneratedPipeline} />
       </CanvasPageStoreProvider>
     </CanvasLayout>
   );

--- a/packages/views/src/pages/CanvasPage/CanvasPageContent/CanvasPageContent.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasPageContent/CanvasPageContent.tsx
@@ -3,11 +3,15 @@ import "@xyflow/react/dist/style.css";
 import "../canvas.css";
 import { CanvasInner } from "../CanvasInner";
 
-export const CanvasPageContent = () => {
+export const CanvasPageContent = ({
+  onGeneratedPipeline,
+}: {
+  onGeneratedPipeline?: (pipelineId: string) => Promise<void> | void;
+}) => {
   return (
     <div className="h-full w-full overflow-hidden">
       <ReactFlowProvider>
-        <CanvasInner />
+        <CanvasInner onGeneratedPipeline={onGeneratedPipeline} />
       </ReactFlowProvider>
     </div>
   );


### PR DESCRIPTION
## 变更说明

- 同步最新 develop（包含 COD-340/341）并解决 AgentPanel 冲突
- 首页新流程可把 prompt/runtime 交给已创建的草稿 Pipeline Canvas
- 直接打开无 ID Canvas 时仍支持 generate session
- generate session 支持服务端消息持久化与当前标签页刷新恢复
- 展示 generate proposal，用户批准后 materialize Pipeline 并跳转到对应 Canvas
- 桌面端 Canvas 路由同步支持生成结果跳转
- 保留已有 Pipeline 的 edit session 流程

## 验证

- 合并后根目录 check-types：21/21 通过
- AgentPanel focused tests：23/23 通过
- 首页 pending prompt tests：13/13 通过
- `git diff --check`、改动文件格式检查：通过

## 当前阻塞

- 本地 Claude runtime 长时间未返回 proposal，真实模型 proposal/approve 全链路仍未标记为通过。
- PR 的 Vercel checks 当前因 Code Forge Vercel 授权失败。
- 全量 lint 仍受 develop 中既有的 `apps/app/src/lib/pendingPipelinePrompt.ts` try-catch 规则阻塞，未在本次冲突解决中扩大修复范围。