### PR TITLE
fix: 隔离 runtime MCP 配置

### DIFF
--- a/packages/agent-engine/src/agentEngine.unit.test.ts
+++ b/packages/agent-engine/src/agentEngine.unit.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { runClaude, runCodex, runHermes, runMastra, type ClaudeStreamEvent } from "@repo/agent";
+import {
+  runClaude,
+  runCodex,
+  runHermes,
+  runKimiCode,
+  runMastra,
+  type ClaudeStreamEvent,
+} from "@repo/agent";
 
 const fakeClaudeEvents: ClaudeStreamEvent[] = [
   {
@@ -36,6 +43,14 @@ vi.mock("@repo/agent", () => ({
     await opts.onProgress?.("progress");
 
     return { text: "fake mastra output", events: [] };
+  }),
+  runKimiCode: vi.fn(async (opts: { onProgress?: (s: string) => Promise<void> }) => {
+    await opts.onProgress?.("progress");
+
+    return {
+      isErr: () => false,
+      value: "fake kimi output",
+    };
   }),
   runOpenclaw: vi.fn(async (opts: { onProgress?: (s: string) => Promise<void> }) => {
     await opts.onProgress?.("progress");
@@ -205,6 +220,31 @@ describe("agentEngine", () => {
 
     expect(getMcpConnectorInjection).toHaveBeenCalledWith([stableMcpReference], "codex");
     expect(runCodex).toHaveBeenCalledWith(
+      expect.objectContaining({ connectorInjection: injection }),
+    );
+  });
+
+  it("loads only the selected connector for Kimi", async () => {
+    const stableMcpReference = "mcp__connector_676974687562__read_issue";
+    const injection = {
+      mcpServers: { connector_676974687562: { command: "github-mcp" } },
+      toolNames: [stableMcpReference],
+    };
+    const getMcpConnectorInjection = vi.fn().mockResolvedValue(injection);
+
+    const result = await agentEngine.run({
+      agent: "kimi-code",
+      mode: "direct",
+      systemPrompt: "Analyze this",
+      userPrompt: "Hello",
+      cwd: "/tmp/test",
+      allowedTools: ["Read", stableMcpReference],
+      getMcpConnectorInjection,
+    });
+
+    expect(result.text).toBe("fake kimi output");
+    expect(getMcpConnectorInjection).toHaveBeenCalledWith([stableMcpReference], "kimi-code");
+    expect(runKimiCode).toHaveBeenCalledWith(
       expect.objectContaining({ connectorInjection: injection }),
     );
   });

--- a/packages/agent-engine/src/drivers.ts
+++ b/packages/agent-engine/src/drivers.ts
@@ -276,10 +276,12 @@ const runOpencodeDirect = async (opts: AgentRunOptions): Promise<DriverResult> =
 };
 
 const runKimiCodeDirect = async (opts: AgentRunOptions): Promise<DriverResult> => {
-  await reportConnectorInjectionSkipped(
-    opts,
-    "runtime adapter does not yet support run-level MCP injection",
-  );
+  const connectorInjection = await loadConnectorInjection(opts);
+  if (connectorInjection) {
+    await opts.onProgress?.(
+      `[Connector Injection] kimi-code injected: ${describeConnectorInjection(connectorInjection)}`,
+    );
+  }
 
   const result = await runKimiCode({
     systemPrompt: opts.systemPrompt,
@@ -287,6 +289,7 @@ const runKimiCodeDirect = async (opts: AgentRunOptions): Promise<DriverResult> =
     cwd: opts.cwd,
     model: opts.model,
     onProgress: toAsyncProgress(opts.onProgress),
+    connectorInjection,
   });
 
   if (result.isErr()) {

--- a/packages/agent/src/claude/runClaude.ts
+++ b/packages/agent/src/claude/runClaude.ts
@@ -13,6 +13,7 @@ const CLAUDE_BIN =
   process.env.CLAUDE_BIN ?? (process.platform === "win32" ? "claude.cmd" : "claude");
 const MAX_SYSTEM_PROMPT_CHARS = 10_000;
 const UNSAFE_SYSTEM_PROMPT_CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+const EMPTY_MCP_CONFIG = JSON.stringify({ mcpServers: {} });
 
 const sanitizeSystemPrompt = (value: string) =>
   value.replace(UNSAFE_SYSTEM_PROMPT_CONTROL_CHARS, "").slice(0, MAX_SYSTEM_PROMPT_CHARS);
@@ -119,7 +120,9 @@ export const runClaude = async ({
     sanitizedSystemPrompt,
     "--allowedTools",
     effectiveAllowedTools,
-    ...(mcpConfigPath ? ["--mcp-config", mcpConfigPath] : []),
+    "--mcp-config",
+    mcpConfigPath ?? EMPTY_MCP_CONFIG,
+    "--strict-mcp-config",
     "--dangerously-skip-permissions",
     "--no-session-persistence",
     "--max-budget-usd",

--- a/packages/agent/src/claude/runClaude.unit.test.ts
+++ b/packages/agent/src/claude/runClaude.unit.test.ts
@@ -1,0 +1,72 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { Readable, Writable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.fn<() => ChildProcess>();
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...(args as [])),
+}));
+
+vi.mock("@repo/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const createMockProcess = () => {
+  // eslint-disable-next-line unicorn/prefer-event-target -- ChildProcess extends EventEmitter
+  const process = new EventEmitter() as ChildProcess & {
+    stdin: Writable;
+    stdout: Readable;
+    stderr: Readable;
+  };
+  process.stdin = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+  process.stdout = new Readable({ read() {} });
+  process.stderr = new Readable({ read() {} });
+  process.kill = vi.fn();
+
+  return process;
+};
+
+import { runClaude } from "./runClaude";
+
+describe("runClaude MCP isolation", () => {
+  const testState = { process: createMockProcess() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testState.process = createMockProcess();
+    spawnMock.mockReturnValue(testState.process);
+  });
+
+  it("uses a strict empty MCP config when the job declares no MCP", async () => {
+    const promise = runClaude({ systemPrompt: "system", userPrompt: "user", cwd: "/tmp" });
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledOnce());
+    const args = (spawnMock.mock.calls[0] as unknown as [string, string[]])[1];
+    const configFlagIndex = args.indexOf("--mcp-config");
+    expect(args).toContain("--strict-mcp-config");
+    expect(configFlagIndex).toBeGreaterThan(-1);
+    expect(JSON.parse(args[configFlagIndex + 1]!)).toEqual({ mcpServers: {} });
+
+    testState.process.stdout.push(
+      `${JSON.stringify({
+        type: "result",
+        subtype: "success",
+        duration_ms: 1,
+        total_cost_usd: 0,
+        num_turns: 1,
+        result: "done",
+      })}\n`,
+    );
+    testState.process.stdout.push(null);
+    testState.process.stderr.push(null);
+    testState.process.emit("close", 0);
+
+    await expect(promise).resolves.toMatchObject({ text: "done" });
+  });
+});

--- a/packages/agent/src/codex/runCodex.ts
+++ b/packages/agent/src/codex/runCodex.ts
@@ -62,9 +62,9 @@ const setChildEnvValue = (env: Record<string, string>, name: string, value: stri
 
 const buildCodexMcpConfig = (
   injection?: McpConnectorInjection,
-): { configToml: string | null; env: Record<string, string> } => {
+): { configToml: string; env: Record<string, string> } => {
   if (!hasMcpConnectorInjection(injection)) {
-    return { configToml: null, env: {} };
+    return { configToml: "", env: {} };
   }
 
   const env: Record<string, string> = {};
@@ -162,9 +162,7 @@ export const runCodex = async ({
     `ordine-codex-last-message-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`,
   );
   const codexMcpConfig = buildCodexMcpConfig(connectorInjection);
-  const isolatedCodexHome = codexMcpConfig.configToml
-    ? await createIsolatedCodexHome(codexMcpConfig.configToml)
-    : undefined;
+  const isolatedCodexHome = await createIsolatedCodexHome(codexMcpConfig.configToml);
 
   const args = [
     "exec",
@@ -194,7 +192,7 @@ export const runCodex = async ({
         env: {
           ...process.env,
           ...codexMcpConfig.env,
-          ...(isolatedCodexHome ? { CODEX_HOME: isolatedCodexHome } : {}),
+          CODEX_HOME: isolatedCodexHome,
         },
       });
 
@@ -276,6 +274,6 @@ export const runCodex = async ({
 
   return execution().finally(async () => {
     await cleanupPath(outputFile, "output file");
-    if (isolatedCodexHome) await cleanupPath(isolatedCodexHome, "isolated home");
+    await cleanupPath(isolatedCodexHome, "isolated home");
   });
 };

--- a/packages/agent/src/codex/runCodex.unit.test.ts
+++ b/packages/agent/src/codex/runCodex.unit.test.ts
@@ -109,6 +109,29 @@ describe("runCodex", () => {
     expect(spawnOpts.cwd).toBe("/tmp/test");
   });
 
+  it("uses an isolated empty config when the job declares no MCP", async () => {
+    const promise = runCodex({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+    });
+
+    await waitForSpawn();
+    const spawnOpts = (
+      spawnMock.mock.calls[0] as unknown as [string, string[], { env: Record<string, string> }]
+    )[2];
+    const codexHome = codexHomeFromEnv(spawnOpts.env);
+    expect(await readFile(join(codexHome, "config.toml"), "utf8")).toBe("");
+
+    testState.mockProc.stdout.push("ok");
+    testState.mockProc.stdout.push(null);
+    testState.mockProc.stderr.push(null);
+    testState.mockProc.emit("close", 0);
+
+    await promise;
+    expect(existsSync(codexHome)).toBe(false);
+  });
+
   it("returns stdout text on success", async () => {
     const promise = runCodex({
       systemPrompt: "sys",

--- a/packages/agent/src/kimi-code/runKimiCode.ts
+++ b/packages/agent/src/kimi-code/runKimiCode.ts
@@ -1,5 +1,9 @@
+import { rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { logger } from "@repo/logger";
-import { ResultAsync } from "neverthrow";
+import { err, ResultAsync } from "neverthrow";
+import type { McpConnectorInjection, McpServerEntry } from "../mcp";
 import { runCliToCompletion } from "../spawn";
 
 export interface RunKimiCodeOptions {
@@ -9,9 +13,90 @@ export interface RunKimiCodeOptions {
   model?: string;
   timeoutMs?: number;
   onProgress?: (line: string) => Promise<void> | void;
+  connectorInjection?: McpConnectorInjection;
 }
 
 const KIMI_BIN = "kimi";
+const EMPTY_MCP_CONFIG = { mcpServers: {} } as const;
+const MCP_RETRY_GUIDANCE =
+  "check the authorized MCP server command and network, then retry; remove the MCP tool from this job if it is not required";
+
+const toError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+const writeKimiMcpConfig = async (injection?: McpConnectorInjection): Promise<string> => {
+  const configPath = join(tmpdir(), `ordine-kimi-mcp-${crypto.randomUUID()}.json`);
+  const config = injection ? { mcpServers: injection.mcpServers } : EMPTY_MCP_CONFIG;
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+
+  return configPath;
+};
+
+const cleanupKimiMcpConfig = async (configPath: string): Promise<void> => {
+  const cleanupError = await rm(configPath, { force: true }).then(
+    () => null,
+    (error) => error,
+  );
+  if (cleanupError) {
+    logger.debug({ err: String(cleanupError) }, "runKimiCode: failed to remove MCP config");
+  }
+};
+
+const summarizeTraceValue = (value: string, maxChars = 160): string =>
+  value.replaceAll(/\s+/g, " ").trim().slice(0, maxChars);
+
+const summarizeMcpCommand = (entry: McpServerEntry): string =>
+  "command" in entry
+    ? `${summarizeTraceValue(entry.command)} (args=${entry.args?.length ?? 0})`
+    : "HTTP endpoint";
+
+const summarizeMcpFailureReason = (reason: string): string => summarizeTraceValue(reason, 300);
+
+const extractMcpFailureReason = (message: string): string => {
+  const reason =
+    message.match(/McpError\((['"])(.*?)\1\)/s)?.[2] ??
+    message.match(/RuntimeError\((['"])(.*?)\1\)/s)?.[2] ??
+    message.match(/Failed to connect MCP servers:\s*(.+?)(?:\nSee logs:|$)/s)?.[1] ??
+    "MCP connection failed";
+
+  return summarizeMcpFailureReason(reason);
+};
+
+const extractExitReason = (message: string): string =>
+  message.match(/exited with (code [^:]+|signal [^:]+):/)?.[1] ?? "unknown";
+
+const buildKimiMcpStartupError = async ({
+  error,
+  injection,
+  onProgress,
+}: {
+  error: Error;
+  injection?: McpConnectorInjection;
+  onProgress?: RunKimiCodeOptions["onProgress"];
+}): Promise<Error> => {
+  if (!error.message.includes("Failed to connect MCP server")) return error;
+
+  const configuredServers = Object.entries(injection?.mcpServers ?? {});
+  const namedFailures = configuredServers.filter(([serverName]) =>
+    error.message.includes(serverName),
+  );
+  const failedServers = namedFailures.length > 0 ? namedFailures : configuredServers;
+  const reason = extractMcpFailureReason(error.message);
+  const exit = extractExitReason(error.message);
+
+  for (const [serverName, entry] of failedServers) {
+    await onProgress?.(
+      `[MCP Failure] server=${serverName}; command=${summarizeMcpCommand(entry)}; exit=${exit}; reason=${reason}; retry=${MCP_RETRY_GUIDANCE}`,
+    );
+  }
+
+  const serverSummary = failedServers.map(([serverName]) => serverName).join(", ") || "unknown";
+
+  return new Error(
+    `Kimi MCP startup failed: server=${serverSummary}; exit=${exit}; reason=${reason}; retry=${MCP_RETRY_GUIDANCE}`,
+    { cause: error },
+  );
+};
 
 const buildPrompt = (systemPrompt: string, userPrompt: string): string => {
   if (!systemPrompt) {
@@ -28,36 +113,55 @@ export const runKimiCode = ({
   model,
   timeoutMs = 10 * 60 * 1000,
   onProgress,
+  connectorInjection,
 }: RunKimiCodeOptions): ResultAsync<string, Error> => {
-  // --quiet = --print + text output + final message only (non-interactive,
-  // auto-approves tool calls for this invocation).
-  const args = [
-    "--quiet",
-    "--work-dir",
-    cwd,
-    "--prompt",
-    buildPrompt(systemPrompt, userPrompt),
-  ];
-
-  if (model) {
-    args.push("--model", model);
-  }
-
-  logger.info({ cwd, model }, "runKimiCode: starting");
-  const startProgress = ResultAsync.fromSafePromise(
-    Promise.resolve(onProgress?.(`[Kimi] Starting kimi --quiet (cwd=${cwd})...`)),
-  );
-
-  return startProgress.andThen(() =>
-    ResultAsync.fromSafePromise(
-      runCliToCompletion({
-        command: KIMI_BIN,
-        args,
+  return ResultAsync.fromPromise(writeKimiMcpConfig(connectorInjection), toError).andThen(
+    (mcpConfigPath) => {
+      // --quiet = --print + text output + final message only (non-interactive,
+      // auto-approves tool calls for this invocation). An explicit config file,
+      // including an empty one, suppresses Kimi's ~/.kimi/mcp.json fallback.
+      const args = [
+        "--quiet",
+        "--mcp-config-file",
+        mcpConfigPath,
+        "--work-dir",
         cwd,
-        timeoutMs,
-        label: "Kimi",
-        onProgress,
-      }),
-    ).andThen((result) => result),
+        "--prompt",
+        buildPrompt(systemPrompt, userPrompt),
+      ];
+
+      if (model) {
+        args.push("--model", model);
+      }
+
+      logger.info({ cwd, model }, "runKimiCode: starting");
+      const execution = Promise.resolve(
+        onProgress?.(`[Kimi] Starting kimi --quiet (cwd=${cwd})...`),
+      )
+        .then(() =>
+          runCliToCompletion({
+            command: KIMI_BIN,
+            args,
+            cwd,
+            timeoutMs,
+            label: "Kimi",
+            onProgress,
+          }),
+        )
+        .then(async (result) =>
+          result.isErr()
+            ? err(
+                await buildKimiMcpStartupError({
+                  error: result.error,
+                  injection: connectorInjection,
+                  onProgress,
+                }),
+              )
+            : result,
+        )
+        .finally(() => cleanupKimiMcpConfig(mcpConfigPath));
+
+      return ResultAsync.fromPromise(execution, toError).andThen((result) => result);
+    },
   );
 };

--- a/packages/agent/src/kimi-code/runKimiCode.unit.test.ts
+++ b/packages/agent/src/kimi-code/runKimiCode.unit.test.ts
@@ -1,0 +1,138 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { err, ok } from "neverthrow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runCliToCompletionMock = vi.fn();
+
+vi.mock("../spawn", () => ({
+  runCliToCompletion: (...args: unknown[]) => runCliToCompletionMock(...args),
+}));
+
+vi.mock("@repo/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { runKimiCode } from "./runKimiCode";
+
+describe("runKimiCode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes an empty job-scoped MCP config when no connector is selected", async () => {
+    const captured = { configPath: "", config: "" };
+    runCliToCompletionMock.mockImplementationOnce(async ({ args }: { args: string[] }) => {
+      const configFlagIndex = args.indexOf("--mcp-config-file");
+      captured.configPath = args[configFlagIndex + 1] ?? "";
+      captured.config = await readFile(captured.configPath, "utf8");
+
+      return ok("done");
+    });
+
+    const result = await runKimiCode({
+      systemPrompt: "system",
+      userPrompt: "user",
+      cwd: "/tmp",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(JSON.parse(captured.config)).toEqual({ mcpServers: {} });
+    expect(existsSync(captured.configPath)).toBe(false);
+  });
+
+  it("passes only the connector authorized for this job and removes its config", async () => {
+    const captured = { configPath: "", config: "" };
+    runCliToCompletionMock.mockImplementationOnce(async ({ args }: { args: string[] }) => {
+      const configFlagIndex = args.indexOf("--mcp-config-file");
+      captured.configPath = args[configFlagIndex + 1] ?? "";
+      captured.config = await readFile(captured.configPath, "utf8");
+
+      return ok("done");
+    });
+
+    const result = await runKimiCode({
+      systemPrompt: "system",
+      userPrompt: "user",
+      cwd: "/tmp",
+      connectorInjection: {
+        mcpServers: {
+          github: { command: "github-mcp", args: ["serve"] },
+        },
+        toolNames: ["mcp__github__read_issue"],
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(JSON.parse(captured.config)).toEqual({
+      mcpServers: {
+        github: { command: "github-mcp", args: ["serve"] },
+      },
+    });
+    expect(captured.config).not.toContain("blender");
+    expect(existsSync(captured.configPath)).toBe(false);
+  });
+
+  it("reports the failed server, command, exit reason, and retry guidance", async () => {
+    const captured = { configPath: "" };
+    runCliToCompletionMock.mockImplementationOnce(async ({ args }: { args: string[] }) => {
+      const configFlagIndex = args.indexOf("--mcp-config-file");
+      captured.configPath = args[configFlagIndex + 1] ?? "";
+
+      return err(
+        new Error(
+          "kimi exited with code 1: Failed to connect MCP servers: {'blender': McpError('Connection closed')}",
+        ),
+      );
+    });
+    const onProgress = vi.fn();
+
+    const result = await runKimiCode({
+      systemPrompt: "system",
+      userPrompt: "user",
+      cwd: "/tmp",
+      connectorInjection: {
+        mcpServers: {
+          blender: { command: "uvx", args: ["blender-mcp"] },
+        },
+        toolNames: ["mcp__blender__get_scene_info"],
+      },
+      onProgress,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error.message).toContain("Kimi MCP startup failed");
+    expect(onProgress).toHaveBeenCalledWith(expect.stringContaining("server=blender"));
+    expect(onProgress).toHaveBeenCalledWith(expect.stringContaining("command=uvx"));
+    expect(onProgress).toHaveBeenCalledWith(expect.stringContaining("exit=code 1"));
+    expect(onProgress).toHaveBeenCalledWith(expect.stringContaining("reason=Connection closed"));
+    expect(onProgress).toHaveBeenCalledWith(expect.stringContaining("retry="));
+    expect(existsSync(captured.configPath)).toBe(false);
+  });
+
+  it("preserves a concrete process-start reason in the MCP failure trace", async () => {
+    runCliToCompletionMock.mockResolvedValueOnce(
+      err(
+        new Error(
+          "kimi exited with code 1: Failed to connect MCP servers: {'broken': RuntimeError(\"Client failed to connect: [Errno 2] No such file or directory: 'missing-mcp'\")}",
+        ),
+      ),
+    );
+    const onProgress = vi.fn();
+
+    await runKimiCode({
+      systemPrompt: "system",
+      userPrompt: "user",
+      cwd: "/tmp",
+      connectorInjection: {
+        mcpServers: { broken: { command: "missing-mcp" } },
+        toolNames: ["mcp__broken__read"],
+      },
+      onProgress,
+    });
+
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.stringContaining("reason=Client failed to connect: [Errno 2] No such file"),
+    );
+  });
+});

--- a/packages/agent/src/mcp/mcpFakeServer.mjs
+++ b/packages/agent/src/mcp/mcpFakeServer.mjs
@@ -21,8 +21,13 @@ const safeJsonParse = Result.fromThrowable(
 
 const send = (msg) => process.stdout.write(`${JSON.stringify(msg)}\n`);
 
-const READ_FILE = { name: "read_file", description: "Read a file" };
-const WRITE_FILE = { name: "write_file" };
+const EMPTY_INPUT_SCHEMA = { type: "object", properties: {} };
+const READ_FILE = {
+  name: "read_file",
+  description: "Read a file",
+  inputSchema: EMPTY_INPUT_SCHEMA,
+};
+const WRITE_FILE = { name: "write_file", inputSchema: EMPTY_INPUT_SCHEMA };
 
 const toolsListResult = (id, cursor) => {
   if (MODE === "malformed") return { jsonrpc: "2.0", id, result: {} };


### PR DESCRIPTION
## Summary

- isolate Kimi, Codex, and Claude MCP configuration per job
- pass an explicit empty MCP config when no connector is authorized
- add Kimi connector injection, temporary-config cleanup, and structured MCP startup diagnostics
- cover empty config, single-server injection, and failed-server paths

## Verification

- `@repo/agent`: 100 passed, 3 skipped
- `@repo/agent-engine`: 22 passed
- pipeline runner targeted tests: 17 passed
- real Codex no-MCP run returned `CODEX_EMPTY_MCP_OK`
- real Kimi confirmed no global Blender startup; single authorized MCP connected; broken MCP reported server/command/exit reason/retry guidance

## Known baseline blockers

- full workspace quality remains blocked by the existing `apps/app/src/lib/pendingPipelinePrompt.ts` try-catch lint error
- full format check has existing develop baseline differences

Fixes COD-348