### PR TITLE
fix: preserve per-step runtime and model in loop evaluation (COD-347)

### DIFF
--- a/packages/agent-engine/src/agentEngine.unit.test.ts
+++ b/packages/agent-engine/src/agentEngine.unit.test.ts
@@ -181,6 +181,7 @@ describe("agentEngine", () => {
       systemPrompt: "Analyze this",
       userPrompt: "Hello",
       cwd: "/tmp/test",
+      model: "gpt-step",
       connectorInjection: {
         mcpServers: { linear: { type: "http", url: "https://mcp.linear.app/mcp" } },
         toolNames: ["mcp__linear"],
@@ -192,6 +193,7 @@ describe("agentEngine", () => {
     expect(result.usage).toBeNull();
     expect(runCodex).toHaveBeenCalledWith(
       expect.objectContaining({
+        model: "gpt-step",
         connectorInjection: {
           mcpServers: { linear: { type: "http", url: "https://mcp.linear.app/mcp" } },
           toolNames: ["mcp__linear"],

--- a/packages/agent-engine/src/drivers.ts
+++ b/packages/agent-engine/src/drivers.ts
@@ -167,6 +167,7 @@ const runCodexDirect = async (opts: AgentRunOptions): Promise<DriverResult> => {
     systemPrompt: opts.systemPrompt,
     userPrompt: opts.userPrompt,
     cwd: opts.cwd,
+    model: opts.model,
     onProgress: toAsyncProgress(opts.onProgress),
     connectorInjection,
   });

--- a/packages/pipeline-engine/src/deps.ts
+++ b/packages/pipeline-engine/src/deps.ts
@@ -1,9 +1,9 @@
 import type { ResultAsync } from "neverthrow";
-import type { RunPromptOptions, RunSkillOptions } from "./schemas";
+import type { LoopEvaluationOptions, RunPromptOptions, RunSkillOptions } from "./schemas";
 
 export interface PipelineEngineDeps {
   runPrompt: (opts: RunPromptOptions) => ResultAsync<string, Error>;
   runSkill: (opts: RunSkillOptions) => ResultAsync<string, Error>;
   structuredJsonToMarkdown: (content: string) => string;
-  evaluateLoopCondition: (conditionPrompt: string, operationOutput: string) => Promise<boolean>;
+  evaluateLoopCondition: (opts: LoopEvaluationOptions) => Promise<boolean>;
 }

--- a/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.test.ts
+++ b/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.test.ts
@@ -334,7 +334,13 @@ describe("processOperationNode", () => {
     const deps = makeDeps({
       evaluateLoopCondition: vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true),
     });
-    const op = makeOperation({ type: "agent", agentMode: "prompt", prompt: "Iterate" });
+    const op = makeOperation({
+      type: "agent",
+      agentMode: "prompt",
+      prompt: "Iterate",
+      agent: "codex",
+      model: "gpt-step",
+    });
     const ops = new Map([["op-id", op]]);
     const node = makeNode({
       operationId: "op-id",
@@ -349,10 +355,46 @@ describe("processOperationNode", () => {
     expect(result.outcome).toBe("completed");
     expect(deps.runPrompt).toHaveBeenCalledTimes(2);
     expect(deps.evaluateLoopCondition).toHaveBeenCalledTimes(2);
+    expect(deps.evaluateLoopCondition).toHaveBeenCalledWith({
+      conditionPrompt: "Is it done?",
+      operationOutput: "prompt-output",
+      agent: "codex",
+      model: "gpt-step",
+    });
     expect(trace).toHaveBeenCalledWith(
       "job-1",
       expect.stringContaining("Condition PASSED on iteration 2"),
     );
+  });
+
+  it("returns a failed node result when loop evaluation rejects", async () => {
+    const deps = makeDeps({
+      evaluateLoopCondition: vi.fn().mockRejectedValue(new Error("runtime unavailable")),
+    });
+    const op = makeOperation({
+      type: "agent",
+      agentMode: "prompt",
+      prompt: "Iterate",
+      agent: "codex",
+      model: "gpt-step",
+    });
+    const node = makeNode({
+      operationId: "op-id",
+      loopEnabled: true,
+      loopConditionPrompt: "Is it done?",
+    });
+    const ctx = makeCtx(deps, new Map([["op-id", op]]), { node });
+
+    const result = await processOperationNode(node, makeInput(), ctx);
+
+    expect(result.outcome).toBe("failed");
+    if (result.outcome === "failed") {
+      expect(result.error.message).toContain("Loop condition evaluation failed");
+      expect(result.error.message).toContain("runtime unavailable");
+    }
+    expect(ctx.nodeOutputs.has("op-1")).toBe(false);
+    expect(trace).toHaveBeenCalledWith("job-1", "@@NODE_FAIL::op-1");
+    expect(trace).not.toHaveBeenCalledWith("job-1", "@@NODE_DONE::op-1");
   });
 
   it("stops at maxLoopCount when condition never passes", async () => {

--- a/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.ts
+++ b/packages/pipeline-engine/src/nodes/OperationNode/OperationNode.ts
@@ -8,6 +8,7 @@ import {
 } from "@repo/schemas";
 import type { NodeCtx, OperationRuntimeContext } from "../../schemas";
 import { trace } from "@repo/obs";
+import { ResultAsync } from "neverthrow";
 import { ScriptExecutionError } from "../../errors";
 import { runScript, safeParseConfig } from "../../infrastructure";
 import type { OperationNodeContext, OperationExecResult, NodeResult } from "../types";
@@ -131,8 +132,13 @@ export const executeOperationNode = async (
 
   const effectiveAgentMode =
     executor.agentMode ?? (executor.type === "agent" ? "prompt" : undefined);
+  const effectiveAgent = agentOverride ?? executor.agent;
   const effectiveModel =
     agentSelection.model ?? (agentSelection.overridesExecutor ? undefined : executor.model);
+  const route = {
+    ...(effectiveAgent ? { agent: effectiveAgent } : {}),
+    ...(effectiveModel ? { model: effectiveModel } : {}),
+  };
 
   // lastContent tracks the most recently emitted LLM_CONTENT so the final emit can dedupe:
   // the last streamed frame's accumulated text often equals the final full text, and
@@ -194,7 +200,7 @@ export const executeOperationNode = async (
         operationDescription: operation.description ?? "",
         instruction: prompt,
       }),
-      agent: agentOverride ?? executor.agent,
+      agent: effectiveAgent,
       ...(effectiveModel ? { model: effectiveModel } : {}),
       onChunk: handleChunk,
       onProgress,
@@ -228,7 +234,7 @@ export const executeOperationNode = async (
     const skillDescription = skill
       ? `${skill.label}: ${skill.description}`
       : `Skill "${skillId}" (no description available)`;
-    const agent = agentOverride ?? executor.agent;
+    const agent = effectiveAgent;
 
     if (agent === "hermes") {
       const message = `Hermes is not available for skill operation "${operation.name}" because skills require local tool permissions`;
@@ -270,7 +276,7 @@ export const executeOperationNode = async (
     await trace(jobId, `Skill output (${opResult.value.length} chars)`);
   }
 
-  return { outcome: "completed", content: opResult.value };
+  return { outcome: "completed", content: opResult.value, route };
 };
 
 export const processOperationNode = async (
@@ -316,7 +322,25 @@ export const processOperationNode = async (
       exec.succeeded = true;
       loopState.currentInput = { inputPath: input.inputPath, content: resultState.content };
 
-      const passed = await deps.evaluateLoopCondition(conditionPrompt, resultState.content);
+      const evaluation = await ResultAsync.fromPromise(
+        deps.evaluateLoopCondition({
+          conditionPrompt,
+          operationOutput: resultState.content,
+          ...loopResult.route,
+        }),
+        (cause) =>
+          new ScriptExecutionError(
+            `Loop condition evaluation failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+            cause,
+          ),
+      );
+      if (evaluation.isErr()) {
+        await trace(jobId, `ERROR: ${evaluation.error.message}`);
+        await trace(jobId, encodeNodeFail(node.id));
+
+        return { outcome: "failed", error: evaluation.error };
+      }
+      const passed = evaluation.value;
       if (passed) {
         await trace(jobId, `[Loop] Condition PASSED on iteration ${attempt}`);
         break;

--- a/packages/pipeline-engine/src/nodes/types.ts
+++ b/packages/pipeline-engine/src/nodes/types.ts
@@ -1,4 +1,5 @@
 import type { PipelineRunError } from "../errors";
+import type { LoopEvaluationOptions } from "../schemas";
 export type {
   AgentInfo,
   NodeContext,
@@ -20,6 +21,10 @@ export type NodeResult =
   | { outcome: "failed"; error: PipelineRunError };
 
 export type OperationExecResult =
-  | { outcome: "completed"; content: string }
+  | {
+      outcome: "completed";
+      content: string;
+      route: Pick<LoopEvaluationOptions, "agent" | "model">;
+    }
   | { outcome: "soft-failed" }
   | { outcome: "failed"; error: PipelineRunError };

--- a/packages/pipeline-engine/src/schemas/LoopEvaluationOptionsSchema.ts
+++ b/packages/pipeline-engine/src/schemas/LoopEvaluationOptionsSchema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod/v4";
+
+import { AgentRuntimeSchema } from "@repo/schemas";
+
+export const LoopEvaluationOptionsSchema = z.object({
+  conditionPrompt: z.string(),
+  operationOutput: z.string(),
+  agent: AgentRuntimeSchema.optional(),
+  model: z.string().optional(),
+});
+export type LoopEvaluationOptions = z.infer<typeof LoopEvaluationOptionsSchema>;

--- a/packages/pipeline-engine/src/schemas/index.ts
+++ b/packages/pipeline-engine/src/schemas/index.ts
@@ -1,4 +1,5 @@
 export * from "./AgentInfoSchema";
+export * from "./LoopEvaluationOptionsSchema";
 export * from "./NodeCtxSchema";
 export * from "./NodeContextSchema";
 export * from "./OperationInfoSchema";

--- a/packages/pipeline-engine/src/tests/scenarios/failure.scenario.test.ts
+++ b/packages/pipeline-engine/src/tests/scenarios/failure.scenario.test.ts
@@ -114,6 +114,83 @@ describe("pipeline scenario: failure flow", () => {
       "flaky-op:done",
     ]);
   });
+
+  it("retries a rejected loop evaluator on the same step route and skips downstream nodes", async () => {
+    const evaluateLoopCondition = vi.fn().mockRejectedValue(new Error("runtime unavailable"));
+    const deps = makeTestDeps({ evaluateLoopCondition });
+    const operations = new Map<string, OperationInfo>([
+      [
+        "loop-op",
+        {
+          id: "loop-op",
+          name: "Loop Operation",
+          config: {
+            executor: {
+              type: "agent",
+              agentMode: "prompt",
+              prompt: "Validate",
+              agent: "codex",
+              model: "gpt-step",
+            },
+          },
+        },
+      ],
+      [
+        "downstream-op",
+        {
+          id: "downstream-op",
+          name: "Downstream Operation",
+          config: {
+            executor: { type: "agent", agentMode: "prompt", prompt: "Summarize" },
+          },
+        },
+      ],
+    ]);
+    const statusEvents: string[] = [];
+
+    const result = await executeScenario({
+      deps,
+      operations,
+      nodes: [
+        makeNode("loop-op", "operation", {
+          operationId: "loop-op",
+          loopEnabled: true,
+          loopConditionPrompt: "Is it valid?",
+        }),
+        makeNode("downstream-op", "operation", { operationId: "downstream-op" }),
+      ],
+      edges: [makeEdge("loop-op", "downstream-op")],
+      onNodeStatusChange: ({ nodeId, status }) => {
+        statusEvents.push(`${nodeId}:${status}`);
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(deps.runPrompt).toHaveBeenCalledTimes(2);
+    expect(evaluateLoopCondition).toHaveBeenCalledTimes(2);
+    expect(evaluateLoopCondition).toHaveBeenNthCalledWith(1, {
+      conditionPrompt: "Is it valid?",
+      operationOutput: "prompt-output",
+      agent: "codex",
+      model: "gpt-step",
+    });
+    expect(evaluateLoopCondition).toHaveBeenNthCalledWith(2, {
+      conditionPrompt: "Is it valid?",
+      operationOutput: "prompt-output",
+      agent: "codex",
+      model: "gpt-step",
+    });
+    expect(statusEvents).toEqual([
+      "loop-op:queued",
+      "downstream-op:queued",
+      "loop-op:running",
+      "loop-op:failed",
+      "loop-op:retrying",
+      "loop-op:running",
+      "loop-op:failed",
+      "downstream-op:skipped",
+    ]);
+  });
 });
 
 describe("pipeline scenario: fail-closed run control", () => {

--- a/packages/services/src/operationRunnerService/createOperationRunnerService.ts
+++ b/packages/services/src/operationRunnerService/createOperationRunnerService.ts
@@ -44,8 +44,6 @@ export const createOperationRunnerService = (db: DbConnection) => {
   initObs(jobTracesDao);
   initSpanRecorder({ agentRawExportsDao, agentSpansDao });
 
-  const loopEvaluatorFactory = loopEvaluator.create();
-
   const buildDepsForJob = ({
     jobId,
     apiKey,
@@ -58,15 +56,18 @@ export const createOperationRunnerService = (db: DbConnection) => {
     model?: string;
     defaultAgent?: AgentRuntime;
     ssh?: SshConnection;
-  }) =>
-    pipelineRunnerEngineDeps.build({
-      evaluateLoopCondition: loopEvaluatorFactory({ jobId }),
+  }) => {
+    const evaluateLoopCondition = loopEvaluator.create({ apiKey })({ jobId });
+
+    return pipelineRunnerEngineDeps.build({
+      evaluateLoopCondition,
       jobId,
       apiKey,
       model,
       defaultAgent,
       ssh,
     });
+  };
 
   return {
     startRun: async (opts: {

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
@@ -83,8 +83,6 @@ export const createPipelineRunnerService = (
   initObs(jobTracesDao);
   initSpanRecorder({ agentRawExportsDao, agentSpansDao });
 
-  const loopEvaluatorFactory = loopEvaluator.create();
-
   /** Run-control actions only apply to live jobs in an eligible status. */
   const guardJobStatus = async (
     action: string,
@@ -127,9 +125,11 @@ export const createPipelineRunnerService = (
     defaultAgent?: AgentRuntime;
     ssh?: SshConnection;
     getMcpConnectorInjection?: McpConnectorInjectionProvider;
-  }) =>
-    pipelineRunnerEngineDeps.build({
-      evaluateLoopCondition: loopEvaluatorFactory({ jobId }),
+  }) => {
+    const evaluateLoopCondition = loopEvaluator.create({ apiKey })({ jobId });
+
+    return pipelineRunnerEngineDeps.build({
+      evaluateLoopCondition,
       jobId,
       apiKey,
       model,
@@ -137,6 +137,7 @@ export const createPipelineRunnerService = (
       ssh,
       getMcpConnectorInjection,
     });
+  };
 
   const buildMcpConnectorInjectionProvider = (preferredSource: AgentRuntime) => {
     return async (

--- a/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.ts
+++ b/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.ts
@@ -1,7 +1,7 @@
 import { promptExecutor } from "../promptExecutor";
 import { skillExecutor } from "../skillExecutor";
 import { structuredOutput } from "../structuredOutput";
-import type { PipelineEngineDeps } from "@repo/pipeline-engine";
+import type { LoopEvaluationOptions, PipelineEngineDeps } from "@repo/pipeline-engine";
 import type { AgentRuntime, SshConnection } from "@repo/schemas";
 import type { McpConnectorInjectionProvider } from "../agentRunner/agentRunner";
 import type { LoopEvaluatorFn } from "../loopEvaluator";
@@ -23,34 +23,36 @@ export const pipelineRunnerEngineDeps = {
     defaultAgent?: AgentRuntime;
     ssh?: SshConnection;
     getMcpConnectorInjection?: McpConnectorInjectionProvider;
-  }): PipelineEngineDeps => ({
-    runPrompt: (o) => {
-      const agent = o.agent ?? defaultAgent;
+  }): PipelineEngineDeps => {
+    const resolveRoute = (route: Pick<LoopEvaluationOptions, "agent" | "model">) => {
+      const agent = route.agent ?? defaultAgent;
 
-      return promptExecutor.run({
-        ...o,
+      return {
         agent,
-        jobId,
-        apiKey,
-        model: o.model ?? (agent === defaultAgent ? model : undefined),
+        model: route.model ?? (agent === defaultAgent ? model : undefined),
         ...(agent === defaultAgent && ssh ? { ssh } : {}),
-        getMcpConnectorInjection,
-      });
-    },
-    runSkill: (o) => {
-      const agent = o.agent ?? defaultAgent;
+      };
+    };
 
-      return skillExecutor.run({
-        ...o,
-        agent,
-        jobId,
-        apiKey,
-        model: o.model ?? (agent === defaultAgent ? model : undefined),
-        ...(agent === defaultAgent && ssh ? { ssh } : {}),
-        getMcpConnectorInjection,
-      });
-    },
-    structuredJsonToMarkdown: (content) => structuredOutput.toMarkdown({ content }),
-    evaluateLoopCondition,
-  }),
+    return {
+      runPrompt: (o) =>
+        promptExecutor.run({
+          ...o,
+          ...resolveRoute(o),
+          jobId,
+          apiKey,
+          getMcpConnectorInjection,
+        }),
+      runSkill: (o) =>
+        skillExecutor.run({
+          ...o,
+          ...resolveRoute(o),
+          jobId,
+          apiKey,
+          getMcpConnectorInjection,
+        }),
+      structuredJsonToMarkdown: (content) => structuredOutput.toMarkdown({ content }),
+      evaluateLoopCondition: (o) => evaluateLoopCondition({ ...o, ...resolveRoute(o) }),
+    };
+  },
 };

--- a/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/engineDeps/engineDeps.unit.test.ts
@@ -122,6 +122,52 @@ describe("pipelineRunnerEngineDeps", () => {
     expect(call.ssh).toBeUndefined();
   });
 
+  it("resolves the same default runtime and model for loop evaluation", async () => {
+    const deps = pipelineRunnerEngineDeps.build({
+      evaluateLoopCondition,
+      jobId: "job-1",
+      defaultAgent: "codex",
+      model: "gpt-default",
+      ssh: { mode: "ssh", host: "example.com", user: "runner" },
+    });
+
+    await deps.evaluateLoopCondition({
+      conditionPrompt: "is it complete?",
+      operationOutput: "candidate",
+    });
+
+    expect(evaluateLoopCondition).toHaveBeenCalledWith({
+      conditionPrompt: "is it complete?",
+      operationOutput: "candidate",
+      agent: "codex",
+      model: "gpt-default",
+      ssh: { mode: "ssh", host: "example.com", user: "runner" },
+    });
+  });
+
+  it("preserves an explicit step route for loop evaluation", async () => {
+    const deps = pipelineRunnerEngineDeps.build({
+      evaluateLoopCondition,
+      defaultAgent: "claude-code",
+      model: "claude-default",
+      ssh: { mode: "ssh", host: "example.com", user: "runner" },
+    });
+
+    await deps.evaluateLoopCondition({
+      conditionPrompt: "is it complete?",
+      operationOutput: "candidate",
+      agent: "codex",
+      model: "gpt-step",
+    });
+
+    expect(evaluateLoopCondition).toHaveBeenCalledWith({
+      conditionPrompt: "is it complete?",
+      operationOutput: "candidate",
+      agent: "codex",
+      model: "gpt-step",
+    });
+  });
+
   it("applies defaultAgent to runSkill when agent is not specified", () => {
     const deps = pipelineRunnerEngineDeps.build({
       evaluateLoopCondition,

--- a/packages/services/src/pipelineRunnerService/loopEvaluator/loopEvaluator.ts
+++ b/packages/services/src/pipelineRunnerService/loopEvaluator/loopEvaluator.ts
@@ -1,21 +1,41 @@
 import { agentEngine } from "@repo/agent-engine";
 import { trace } from "@repo/obs";
 import { logger } from "@repo/logger";
-import type { AgentRuntime } from "@repo/schemas";
+import type { LoopEvaluationOptions } from "@repo/pipeline-engine";
+import type { SshConnection } from "@repo/schemas";
 
-export type LoopEvaluatorFn = (
-  conditionPrompt: string,
-  operationOutput: string,
-) => Promise<boolean>;
+type LoopEvaluatorOptions = LoopEvaluationOptions & { ssh?: SshConnection };
+
+export type LoopEvaluatorFn = (opts: LoopEvaluatorOptions) => Promise<boolean>;
+
+export class LoopEvaluatorRuntimeNotFoundError extends Error {
+  constructor() {
+    super("Loop evaluator runtime was not resolved");
+    this.name = "LoopEvaluatorRuntimeNotFoundError";
+  }
+}
 
 const SYSTEM_PROMPT = `You are a strict evaluator. Given acceptance criteria and operation output, determine if the output meets the criteria.
 Respond with EXACTLY one word: "PASS" if the criteria are met, or "FAIL" if not. Do not explain.`;
 
 export const loopEvaluator = {
-  create: ({ agent = "mastra" }: { agent?: AgentRuntime } = {}) => {
+  create: ({ apiKey }: { apiKey?: string } = {}) => {
     return ({ jobId }: { jobId: string }): LoopEvaluatorFn => {
-      return async (conditionPrompt: string, operationOutput: string): Promise<boolean> => {
+      return async ({
+        conditionPrompt,
+        operationOutput,
+        agent,
+        model,
+        ssh,
+      }: LoopEvaluatorOptions): Promise<boolean> => {
+        if (!agent) throw new LoopEvaluatorRuntimeNotFoundError();
+
         const userPrompt = `## Acceptance Criteria\n${conditionPrompt}\n\n## Operation Output\n${operationOutput}`;
+
+        await trace(
+          jobId,
+          `[Loop] Evaluating condition with runtime "${agent}"${model ? ` and model "${model}"` : ""}`,
+        );
 
         const result = await agentEngine.run({
           agent,
@@ -24,10 +44,13 @@ export const loopEvaluator = {
           userPrompt,
           cwd: process.cwd(),
           allowedTools: [],
+          apiKey,
+          model,
+          ssh,
         });
 
         const verdict = result.text.trim().toUpperCase();
-        logger.info({ jobId, verdict }, "loopEvaluator: evaluation complete");
+        logger.info({ jobId, verdict, agent, model }, "loopEvaluator: evaluation complete");
         await trace(jobId, `[Loop] Condition evaluation result: ${verdict}`);
 
         return verdict.startsWith("PASS");

--- a/packages/services/src/pipelineRunnerService/loopEvaluator/loopEvaluator.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/loopEvaluator/loopEvaluator.unit.test.ts
@@ -16,40 +16,67 @@ vi.mock("@repo/agent-engine", () => ({
 import { loopEvaluator } from ".";
 
 describe("loopEvaluator", () => {
-  const factory = loopEvaluator.create();
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("returns true when agent responds with PASS", async () => {
     mockRun.mockResolvedValue({ text: "PASS", usage: null });
+    const factory = loopEvaluator.create({ apiKey: "job-api-key" });
     const evaluator = factory({ jobId: "job-1" });
-    const result = await evaluator("check quality", "some output");
+    const result = await evaluator({
+      conditionPrompt: "check quality",
+      operationOutput: "some output",
+      agent: "codex",
+      model: "gpt-step",
+    });
 
     expect(result).toBe(true);
     expect(mockRun).toHaveBeenCalledWith(
       expect.objectContaining({
-        agent: "mastra",
+        agent: "codex",
+        model: "gpt-step",
+        apiKey: "job-api-key",
         mode: "direct",
         allowedTools: [],
       }),
     );
+    expect(mockRun).not.toHaveBeenCalledWith(expect.objectContaining({ agent: "mastra" }));
   });
 
   it("returns false when agent responds with FAIL", async () => {
     mockRun.mockResolvedValue({ text: "FAIL", usage: null });
+    const factory = loopEvaluator.create();
     const evaluator = factory({ jobId: "job-2" });
-    const result = await evaluator("check quality", "bad output");
+    const result = await evaluator({
+      conditionPrompt: "check quality",
+      operationOutput: "bad output",
+      agent: "claude-code",
+    });
 
     expect(result).toBe(false);
   });
 
   it("handles PASS with extra whitespace", async () => {
     mockRun.mockResolvedValue({ text: "  PASS  \n", usage: null });
+    const factory = loopEvaluator.create();
     const evaluator = factory({ jobId: "job-3" });
-    const result = await evaluator("criteria", "output");
+    const result = await evaluator({
+      conditionPrompt: "criteria",
+      operationOutput: "output",
+      agent: "codex",
+    });
 
     expect(result).toBe(true);
+  });
+
+  it("fails clearly when no runtime route was resolved", async () => {
+    const factory = loopEvaluator.create();
+    const evaluator = factory({ jobId: "job-4" });
+
+    await expect(
+      evaluator({ conditionPrompt: "criteria", operationOutput: "output" }),
+    ).rejects.toThrow("Loop evaluator runtime was not resolved");
+    expect(mockRun).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- preserve each Operation Step's resolved runtime/model when invoking its Loop Evaluator
- resolve job-default and explicit Step routes through the same dependency path, including model, API key, and SSH transport
- convert evaluator provider failures into structured node failures so self-heal retries run on the same route and downstream nodes are skipped deterministically
- forward the selected model from `agent-engine` into the Codex CLI adapter

## Reproduction fixed

With Codex selected for a loop-enabled Operation and `KIMI_API_KEY` unset, the operation body ran on Codex but the Loop Evaluator silently defaulted to Mastra/Kimi. The resulting provider error escaped the node-result boundary, leaving inconsistent node state and stopping downstream rank/output nodes.

The evaluator now receives the same per-Step route as the operation body. Different Steps may still use different runtimes; this PR does not introduce a pipeline-wide runtime lock or automatic cross-runtime failover.

## Verification

- `bun run quality` — passed across all 26 workspace packages
- `packages/pipeline-engine: bun run quality` — 177 tests passed
- `packages/services: bun run quality` — 495 passed, 1 skipped
- `packages/agent-engine: bun run quality` — 22 tests passed
- focused regression suites — 69 tests passed
- formatting check for all 15 changed files — passed
- `git diff --check` — passed

The repository-wide `bun run format:check` remains blocked by 167 pre-existing, unrelated files on `develop`; no unrelated formatting changes are included here.

## Test boundaries

- Unit and mock pipeline scenario coverage: completed
- Real browser/UI coverage: not applicable; no UI changes
- Real backend plus real Codex pipeline run: pending before this Draft is marked ready

Fixes COD-347
