### PR TITLE
feat: Pipeline Agent 规划流式预览、方案追问与 Canvas 运行状态恢复

### DIFF
--- a/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationComposer.tsx
+++ b/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationComposer.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { Button } from "@repo/ui/button";
 import { cn } from "@repo/ui/lib/utils";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui/select";
 import { Textarea } from "@repo/ui/textarea";
 
 export type PipelineCreationPhase =
@@ -21,6 +22,11 @@ export type PipelineCreationPhase =
   | "proposal_ready"
   | "generating"
   | "success";
+
+export interface PipelineCreationRuntimeOption {
+  id: string;
+  name: string;
+}
 
 interface PipelineCreationComposerProps {
   fileInputRef: RefObject<HTMLInputElement | null>;
@@ -33,7 +39,10 @@ interface PipelineCreationComposerProps {
   phase: PipelineCreationPhase;
   proposalVisible: boolean;
   runtimeConfigured?: boolean;
+  runtimeId?: string;
   runtimeLabel?: string;
+  runtimeOptions?: PipelineCreationRuntimeOption[];
+  onRuntimeChange?: (runtimeId: string | null) => void;
   onApprove: () => void;
   onCancel: () => void;
   onClose?: () => void;
@@ -58,7 +67,10 @@ export const PipelineCreationComposer = ({
   phase,
   proposalVisible,
   runtimeConfigured,
+  runtimeId,
   runtimeLabel,
+  runtimeOptions,
+  onRuntimeChange,
   onApprove: handleApprove,
   onCancel: handleCancel,
   onClose: handleClose,
@@ -150,7 +162,26 @@ export const PipelineCreationComposer = ({
             {!isHome && <span>{t("newPipelineDialog.upload")}</span>}
           </Button>
 
-          {isHome && (
+          {isHome && runtimeConfigured === true && runtimeId && runtimeOptions?.length ? (
+            <Select value={runtimeId} onValueChange={onRuntimeChange}>
+              <SelectTrigger
+                aria-label={t("home.selectLocalAgent")}
+                className="h-8 min-w-0 max-w-40 border-0 px-2 text-xs text-muted-foreground shadow-none hover:bg-surface-2 hover:text-foreground"
+                size="sm"
+              >
+                <SelectValue className="truncate">
+                  {runtimeOptions.find((option) => option.id === runtimeId)?.name ?? ""}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent align="start">
+                {runtimeOptions.map((option) => (
+                  <SelectItem key={option.id} value={option.id}>
+                    {option.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : isHome ? (
             <Link
               className="inline-flex min-w-0 items-center gap-2 rounded-lg px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-surface-2 hover:text-foreground"
               to="/local-agents"
@@ -163,7 +194,7 @@ export const PipelineCreationComposer = ({
               />
               <span className="truncate">{runtimeLabel ?? t("home.connectLocalAgent")}</span>
             </Link>
-          )}
+          ) : null}
 
           <span className="ml-auto hidden text-[11px] text-muted-foreground sm:inline">
             {t("home.sendHint")}

--- a/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationWorkspace.tsx
+++ b/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationWorkspace.tsx
@@ -31,7 +31,10 @@ import {
 } from "./usePipelineCreationSessionRecovery";
 import { type PipelineCreationAttachment } from "./PipelineCreationAttachments";
 import { PipelineCreationMessages, type PipelineCreationMessage } from "./PipelineCreationMessages";
-import { PipelineCreationComposer } from "./PipelineCreationComposer";
+import {
+  PipelineCreationComposer,
+  type PipelineCreationRuntimeOption,
+} from "./PipelineCreationComposer";
 
 type WorkspacePresentation = "dialog" | "home";
 
@@ -43,6 +46,8 @@ export interface PipelineCreationWorkspaceProps {
   runtimeConfigured?: boolean;
   runtimeId?: string;
   runtimeLabel?: string;
+  runtimeOptions?: PipelineCreationRuntimeOption[];
+  onRuntimeChange?: (runtimeId: string | null) => void;
   onClose?: () => void;
 }
 
@@ -54,6 +59,8 @@ export const PipelineCreationWorkspace = ({
   runtimeConfigured,
   runtimeId,
   runtimeLabel,
+  runtimeOptions,
+  onRuntimeChange,
   onClose: handleClose,
 }: PipelineCreationWorkspaceProps) => {
   const { t } = useTranslation();
@@ -256,9 +263,7 @@ export const PipelineCreationWorkspace = ({
     }
 
     if (event.type === "assistant_chunk") {
-      setStreamingAssistantText((current) =>
-        current.length === 0 ? event.text : `${current}\n${event.text}`,
-      );
+      setStreamingAssistantText((current) => `${current}${event.text}`);
 
       return;
     }
@@ -814,7 +819,10 @@ export const PipelineCreationWorkspace = ({
         phase={phase}
         proposalVisible={proposal !== null}
         runtimeConfigured={runtimeConfigured}
+        runtimeId={runtimeId}
         runtimeLabel={runtimeLabel}
+        runtimeOptions={runtimeOptions}
+        onRuntimeChange={onRuntimeChange}
         onApprove={handleApprove}
         onCancel={handleCancel}
         onClose={handleClose}

--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -907,6 +907,8 @@
       },
       "proposalDetails": {
         "review": "Review the proposed operations",
+        "needsAnswer": "Needs more information before applying",
+        "openQuestion": "Open question",
         "askFix": "Fix diagnostics",
         "fixDiagnostics": "Please fix the blocking diagnostics in the proposal.",
         "revisePrompt": "Please revise this proposal.",

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -901,6 +901,8 @@
       },
       "proposalDetails": {
         "review": "查看拟议操作",
+        "needsAnswer": "应用前还需要补充信息",
+        "openQuestion": "待确认问题",
         "askFix": "修复诊断问题",
         "fixDiagnostics": "请先修复方案中的阻塞诊断问题。",
         "revisePrompt": "请修改这个方案。",

--- a/apps/app/src/pages/HomePage/HomePage.tsx
+++ b/apps/app/src/pages/HomePage/HomePage.tsx
@@ -6,7 +6,6 @@ import { useStore } from "zustand";
 import type { AgentRuntimeConfig } from "@repo/schemas";
 import { Link } from "@tanstack/react-router";
 import { Button } from "@repo/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui/select";
 import { PipelineCreationWorkspace } from "@/components/PipelineCreationWorkspace";
 import { useSidebarStore } from "@/store/sidebarStore";
 
@@ -45,31 +44,15 @@ export const HomePage = () => {
           <p className="truncate text-[11px] text-muted-foreground">{t("home.subtitle")}</p>
         </div>
         {runtime ? (
-          <div className="flex items-center gap-1">
-            <Select value={runtime.id} onValueChange={handleRuntimeValueChange}>
-              <SelectTrigger
-                aria-label={t("home.selectLocalAgent")}
-                className="h-8 max-w-48 border-0 px-2 text-xs text-muted-foreground shadow-none hover:bg-surface-2 hover:text-foreground"
-                size="sm"
-              >
-                <SelectValue>{runtime.name}</SelectValue>
-              </SelectTrigger>
-              <SelectContent align="end">
-                {localRuntimes.map((candidate) => (
-                  <SelectItem key={candidate.id} value={candidate.id}>
-                    {candidate.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Link
-              aria-label={t("home.manageLocalAgents")}
-              className="inline-flex size-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-2 hover:text-foreground"
-              to="/local-agents"
-            >
-              <ChevronRight className="size-3.5" />
-            </Link>
-          </div>
+          <Link
+            aria-label={t("home.manageLocalAgents")}
+            className="flex min-w-0 max-w-[min(45vw,16rem)] items-center gap-2 rounded-lg px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-surface-2 hover:text-foreground"
+            to="/local-agents"
+          >
+            <span className="size-1.5 shrink-0 rounded-full bg-info" />
+            <span className="truncate">{runtimeLabel}</span>
+            <ChevronRight className="size-3.5 shrink-0" />
+          </Link>
         ) : (
           <Link
             className="inline-flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-surface-2 hover:text-foreground"
@@ -115,6 +98,8 @@ export const HomePage = () => {
             runtimeConfigured={query.isLoading ? undefined : Boolean(runtime)}
             runtimeId={runtime?.id}
             runtimeLabel={runtimeLabel}
+            runtimeOptions={localRuntimes.map(({ id, name }) => ({ id, name }))}
+            onRuntimeChange={handleRuntimeValueChange}
           />
         </div>
       </main>

--- a/apps/app/src/pages/HomePage/HomePage.unit.test.tsx
+++ b/apps/app/src/pages/HomePage/HomePage.unit.test.tsx
@@ -44,11 +44,15 @@ vi.mock("@/components/PipelineCreationWorkspace", () => ({
     runtimeConfigured,
     runtimeId,
     runtimeLabel,
+    runtimeOptions,
+    onRuntimeChange,
   }: {
     presentation: string;
-    runtimeConfigured: boolean;
+    runtimeConfigured?: boolean;
     runtimeId?: string;
     runtimeLabel?: string;
+    runtimeOptions?: Array<{ id: string; name: string }>;
+    onRuntimeChange?: (runtimeId: string) => void;
   }) => (
     <div
       data-connected={runtimeConfigured}
@@ -56,7 +60,21 @@ vi.mock("@/components/PipelineCreationWorkspace", () => ({
       data-runtime={runtimeLabel}
       data-runtime-id={runtimeId}
       data-testid="pipeline-creation-workspace"
-    />
+    >
+      {runtimeOptions?.length && runtimeId ? (
+        <select
+          aria-label="home.selectLocalAgent"
+          value={runtimeId}
+          onChange={(event) => onRuntimeChange?.(event.target.value)}
+        >
+          {runtimeOptions.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.name}
+            </option>
+          ))}
+        </select>
+      ) : null}
+    </div>
   ),
 }));
 
@@ -105,6 +123,10 @@ describe("HomePage", () => {
     renderHomePage();
 
     expect(screen.getByText("home.heading")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "home.manageLocalAgents" })).toHaveAttribute(
+      "href",
+      "/local-agents",
+    );
     expect(screen.getByRole("combobox", { name: "home.selectLocalAgent" })).toHaveTextContent(
       "Codex",
     );
@@ -145,8 +167,10 @@ describe("HomePage", () => {
 
     renderHomePage();
     const user = userEvent.setup();
-    await user.click(screen.getByRole("combobox", { name: "home.selectLocalAgent" }));
-    await user.click(await screen.findByRole("option", { name: "Hermes" }));
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "home.selectLocalAgent" }),
+      "local-hermes",
+    );
 
     expect(screen.getByTestId("pipeline-creation-workspace")).toHaveAttribute(
       "data-runtime-id",

--- a/apps/desktop-app/src/locales/en.json
+++ b/apps/desktop-app/src/locales/en.json
@@ -604,7 +604,12 @@
       "runtimeLoading": "Loading runtimes...",
       "inputPlaceholder": "Type your request...",
       "runtimeNotConfigured": "AI runtime is not configured yet.",
-      "goToRuntimeSettings": "Go to configuration"
+      "goToRuntimeSettings": "Go to configuration",
+      "proposalDetails": {
+        "review": "Review the proposed operations",
+        "needsAnswer": "Needs more information before applying",
+        "openQuestion": "Open question"
+      }
     },
     "emptyState": {
       "title": "Start with a node",

--- a/apps/desktop-app/src/locales/zh.json
+++ b/apps/desktop-app/src/locales/zh.json
@@ -598,7 +598,12 @@
       "runtimeLoading": "正在加载运行时...",
       "inputPlaceholder": "输入你的需求...",
       "runtimeNotConfigured": "暂未配置运行时 AI。",
-      "goToRuntimeSettings": "前往配置"
+      "goToRuntimeSettings": "前往配置",
+      "proposalDetails": {
+        "review": "查看拟议操作",
+        "needsAnswer": "应用前还需要补充信息",
+        "openQuestion": "待确认问题"
+      }
     },
     "emptyState": {
       "title": "从一个节点开始",

--- a/apps/server/src/routes/pipelineAgentSessions.ts
+++ b/apps/server/src/routes/pipelineAgentSessions.ts
@@ -245,6 +245,9 @@ pipelineAgentSessionsRoutes.post("/:id/plan", async (c) => {
           onProgress: (message) => {
             send("progress", { message });
           },
+          onTextDelta: (text) => {
+            send("assistant_chunk", { text });
+          },
         }),
         (error) => (error instanceof Error ? error : new Error(String(error))),
       );

--- a/apps/server/tests/routes/pipelineAgentSessions.test.ts
+++ b/apps/server/tests/routes/pipelineAgentSessions.test.ts
@@ -301,6 +301,7 @@ describe("pipelineAgentSessionsRoutes", () => {
   it("streams planning events for a session", async () => {
     mocks.planSession.mockImplementation(async (_sessionId, input) => {
       await input.onProgress?.("planner: started");
+      await input.onTextDelta?.("safe preview");
       return {
         type: "question",
         question: "What output format do you want?",
@@ -319,7 +320,8 @@ describe("pipelineAgentSessionsRoutes", () => {
     const body = await response.text();
     expect(body).toContain("event: phase");
     expect(body).toContain("event: progress");
-    expect(body).not.toContain("event: assistant_chunk");
+    expect(body).toContain("event: assistant_chunk");
+    expect(body).toContain('"text":"safe preview"');
     expect(body).toContain("event: question");
     expect(body).toContain("What output format do you want?");
     expect(mocks.planSession).toHaveBeenCalledWith(

--- a/packages/agent-engine/src/agentEngine.unit.test.ts
+++ b/packages/agent-engine/src/agentEngine.unit.test.ts
@@ -26,11 +26,17 @@ vi.mock("@repo/agent", () => ({
 
     return { text: "fake claude output", events: fakeClaudeEvents };
   }),
-  runCodex: vi.fn(async (opts: { onProgress?: (s: string) => Promise<void> }) => {
+  runCodex: vi.fn(
+    async (opts: {
+      onProgress?: (s: string) => Promise<void>;
+      onTextDelta?: (s: string) => Promise<void>;
+    }) => {
     await opts.onProgress?.("progress");
+    await opts.onTextDelta?.("partial codex output");
 
     return "fake codex output";
-  }),
+    },
+  ),
   runHermes: vi.fn(async (opts: { onProgress?: (s: string) => Promise<void> }) => {
     await opts.onProgress?.("progress");
 
@@ -198,6 +204,21 @@ describe("agentEngine", () => {
         },
       }),
     );
+  });
+
+  it("forwards Codex text deltas to the caller", async () => {
+    const onTextDelta = vi.fn();
+
+    await agentEngine.run({
+      agent: "codex",
+      mode: "direct",
+      systemPrompt: "Analyze this",
+      userPrompt: "Hello",
+      cwd: "/tmp/test",
+      onTextDelta,
+    });
+
+    expect(onTextDelta).toHaveBeenCalledWith("partial codex output");
   });
 
   it("loads only the selected connector tools inside a supported adapter", async () => {

--- a/packages/agent-engine/src/drivers.ts
+++ b/packages/agent-engine/src/drivers.ts
@@ -32,6 +32,18 @@ const toAsyncProgress = (
   };
 };
 
+const toAsyncTextDelta = (
+  onTextDelta?: AgentRunOptions["onTextDelta"],
+): ((text: string) => Promise<void>) | undefined => {
+  if (!onTextDelta) {
+    return undefined;
+  }
+
+  return async (text: string) => {
+    await onTextDelta(text);
+  };
+};
+
 type PreparedClaudeMcpInjection = {
   configPath: string;
   toolNames: readonly string[];
@@ -134,6 +146,7 @@ const runLocalClaudeDirect = async (opts: AgentRunOptions): Promise<DriverResult
       cwd: opts.cwd,
       ...(effectiveTools ? { allowedTools: effectiveTools } : {}),
       onProgress: toAsyncProgress(opts.onProgress),
+      onTextDelta: toAsyncTextDelta(opts.onTextDelta),
       extraEnv,
       ssh: opts.ssh,
       mcpConfigPath: preparedMcp?.configPath,
@@ -167,7 +180,9 @@ const runCodexDirect = async (opts: AgentRunOptions): Promise<DriverResult> => {
     systemPrompt: opts.systemPrompt,
     userPrompt: opts.userPrompt,
     cwd: opts.cwd,
+    ...(opts.model ? { model: opts.model } : {}),
     onProgress: toAsyncProgress(opts.onProgress),
+    onTextDelta: toAsyncTextDelta(opts.onTextDelta),
     connectorInjection,
   });
 

--- a/packages/agent-engine/src/types.ts
+++ b/packages/agent-engine/src/types.ts
@@ -53,6 +53,7 @@ export interface AgentRunOptions {
   attachments?: AgentInputAttachment[];
   allowedTools?: readonly string[];
   onProgress?: (msg: string) => Promise<void> | void;
+  onTextDelta?: (text: string) => Promise<void> | void;
   jobId?: string;
   agentId?: string;
   apiKey?: string;

--- a/packages/agent/src/claude/runClaude.ts
+++ b/packages/agent/src/claude/runClaude.ts
@@ -1,5 +1,8 @@
 import { spawn } from "node:child_process";
-import { Result } from "neverthrow";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Result, ResultAsync } from "neverthrow";
 import { logger } from "@repo/logger";
 import { spawnCommand } from "../spawn/spawnCommand";
 import { ClaudeStreamEventSchema, type ClaudeStreamEvent } from "./schemas/ClaudeStreamEventSchema";
@@ -58,6 +61,41 @@ const safeJsonParse = Result.fromThrowable(
   () => "invalid JSON",
 );
 
+const createTemporarySystemPromptFile = async (prompt: string) => {
+  const directory = await mkdtemp(join(tmpdir(), "oc-"));
+  const filePath = join(directory, "p.txt");
+
+  const writeResult = await ResultAsync.fromPromise(
+    writeFile(filePath, prompt, { encoding: "utf8", mode: 0o600 }),
+    (error) => error,
+  );
+  if (writeResult.isErr()) {
+    await rm(directory, { recursive: true, force: true });
+    throw writeResult.error;
+  }
+
+  return {
+    filePath,
+    cleanup: () => rm(directory, { recursive: true, force: true }),
+  };
+};
+
+const extractTextDelta = (event: ClaudeStreamEvent): string | undefined => {
+  if (event.type !== "stream_event") return undefined;
+
+  const streamEvent = event.event;
+  if (
+    streamEvent?.type !== "content_block_delta" ||
+    streamEvent.delta?.type !== "text_delta" ||
+    typeof streamEvent.delta.text !== "string" ||
+    streamEvent.delta.text.length === 0
+  ) {
+    return undefined;
+  }
+
+  return streamEvent.delta.text;
+};
+
 /**
  * Extract the final text result from stream-json events.
  * Looks at the last `assistant` message's text content blocks.
@@ -96,6 +134,7 @@ export const runClaude = async ({
   timeoutMs = 20 * 60 * 1000,
   maxBudgetUsd = 5,
   onProgress,
+  onTextDelta,
   extraEnv,
   ssh,
   mcpConfigPath,
@@ -111,13 +150,22 @@ export const runClaude = async ({
   // Connector tool names (mcp__server__tool) are merged with the built-in allowedTools.
   const effectiveAllowedTools = [...allowedTools, ...(mcpToolNames ?? [])].join(",");
 
+  const isSsh = !!ssh;
+  const label = isSsh ? `[Claude SSH ${ssh.user}@${ssh.host}]` : "[Claude]";
+  const systemPromptFile =
+    !isSsh && process.platform === "win32"
+      ? await createTemporarySystemPromptFile(sanitizedSystemPrompt)
+      : null;
+
   const claudeArgs = [
     "-p",
     "--verbose",
     "--output-format",
     "stream-json",
-    "--system-prompt",
-    sanitizedSystemPrompt,
+    "--include-partial-messages",
+    ...(systemPromptFile
+      ? ["--system-prompt-file", systemPromptFile.filePath]
+      : ["--system-prompt", sanitizedSystemPrompt]),
     "--allowedTools",
     effectiveAllowedTools,
     "--mcp-config",
@@ -128,9 +176,6 @@ export const runClaude = async ({
     "--max-budget-usd",
     String(maxBudgetUsd),
   ];
-
-  const isSsh = !!ssh;
-  const label = isSsh ? `[Claude SSH ${ssh.user}@${ssh.host}]` : "[Claude]";
 
   logger.info({ cwd, ssh: isSsh ? `${ssh?.user}@${ssh?.host}` : "local" }, "runClaude: starting");
   await onProgress?.(`${label} Starting claude -p (cwd=${cwd})...`);
@@ -171,22 +216,29 @@ export const runClaude = async ({
       return;
     }
 
+    const processStreamLine = (line: string) => {
+      if (!line.trim()) return;
+
+      const parsed = safeJsonParse(line.trim());
+      if (!parsed.isOk()) return;
+
+      const validated = ClaudeStreamEventSchema.safeParse(parsed.value);
+      if (!validated.success) {
+        logger.warn({ line }, "runClaude: unrecognised stream event shape, skipping");
+
+        return;
+      }
+
+      events.push(validated.data);
+      const textDelta = extractTextDelta(validated.data);
+      if (textDelta) void onTextDelta?.(textDelta);
+    };
+
     stdout.on("data", (chunk: Buffer) => {
       streamState.lineBuf += chunk.toString("utf8");
       const lines = streamState.lineBuf.split("\n");
       streamState.lineBuf = lines.pop() ?? "";
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        const parsed = safeJsonParse(line);
-        if (parsed.isOk()) {
-          const validated = ClaudeStreamEventSchema.safeParse(parsed.value);
-          if (validated.success) {
-            events.push(validated.data);
-          } else {
-            logger.warn({ line }, "runClaude: unrecognised stream event shape, skipping");
-          }
-        }
-      }
+      for (const line of lines) processStreamLine(line);
     });
 
     stderr.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
@@ -211,12 +263,7 @@ export const runClaude = async ({
       const stderr = Buffer.concat(stderrChunks).toString("utf8");
 
       // Flush remaining line buffer
-      if (streamState.lineBuf.trim()) {
-        const parsed = safeJsonParse(streamState.lineBuf.trim());
-        if (parsed.isOk()) {
-          events.push(parsed.value as ClaudeStreamEvent);
-        }
-      }
+      processStreamLine(streamState.lineBuf);
 
       // stream-json may exit with non-zero on budget exceeded but still has valid events
       if (code !== 0 && events.length === 0) {
@@ -238,5 +285,7 @@ export const runClaude = async ({
       void onProgress?.(`${label} Complete (${resultText.length} chars, ${events.length} events)`);
       resolve({ text: resultText, events });
     });
+  }).finally(async () => {
+    await systemPromptFile?.cleanup();
   });
 };

--- a/packages/agent/src/claude/runClaude.unit.test.ts
+++ b/packages/agent/src/claude/runClaude.unit.test.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { existsSync, readFileSync } from "node:fs";
 import { Readable, Writable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -68,5 +69,70 @@ describe("runClaude MCP isolation", () => {
     testState.process.emit("close", 0);
 
     await expect(promise).resolves.toMatchObject({ text: "done" });
+  });
+});
+
+describe("runClaude partial text deltas", () => {
+  const testState = { process: createMockProcess() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testState.process = createMockProcess();
+    spawnMock.mockReturnValue(testState.process);
+  });
+
+  it("forwards only text_delta content and enables partial messages", async () => {
+    const textDeltas: string[] = [];
+    const promise = runClaude({
+      systemPrompt: "Plan safely",
+      userPrompt: "Plan this",
+      cwd: "/tmp/project",
+      onTextDelta: (text) => {
+        textDeltas.push(text);
+      },
+    });
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledOnce());
+    const args = (spawnMock.mock.calls[0] as unknown as [string, string[]])[1];
+    const systemPromptFlag =
+      process.platform === "win32" ? "--system-prompt-file" : "--system-prompt";
+    const systemPromptFlagIndex = args.indexOf(systemPromptFlag);
+
+    expect(systemPromptFlagIndex).toBeGreaterThanOrEqual(0);
+    if (process.platform === "win32") {
+      const promptFilePath = args[systemPromptFlagIndex + 1]!;
+      expect(promptFilePath).toBeTruthy();
+      expect(args).not.toContain("Plan safely");
+      expect(readFileSync(promptFilePath, "utf8")).toBe("Plan safely");
+    } else {
+      expect(args).toContain("Plan safely");
+    }
+
+    testState.process.stdout.push(
+      '{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"SECRET"}}}\n',
+    );
+    testState.process.stdout.push(
+      '{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"SECRET"}}}\n',
+    );
+    testState.process.stdout.push(
+      '{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"safe"}}}\n',
+    );
+    testState.process.stdout.push(
+      '{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":" preview"}}}\n',
+    );
+    testState.process.stdout.push('{"type":"result","result":"final"}');
+    testState.process.stdout.push(null);
+    testState.process.stderr.push(null);
+    testState.process.emit("close", 0);
+
+    const result = await promise;
+
+    expect(args).toContain("--include-partial-messages");
+    expect(textDeltas).toEqual(["safe", " preview"]);
+    expect(textDeltas.join("")).not.toContain("SECRET");
+    expect(result.text).toBe("final");
+    if (process.platform === "win32") {
+      expect(existsSync(args[systemPromptFlagIndex + 1]!)).toBe(false);
+    }
   });
 });

--- a/packages/agent/src/claude/schemas/ClaudeStreamEventSchema.ts
+++ b/packages/agent/src/claude/schemas/ClaudeStreamEventSchema.ts
@@ -2,10 +2,31 @@ import { z } from "zod/v4";
 import { ClaudeMessageSchema } from "./ClaudeMessageSchema";
 import { ClaudeModelUsageSchema } from "./ClaudeModelUsageSchema";
 
+const ClaudeStreamDeltaSchema = z.object({
+  type: z.string(),
+  text: z.string().optional(),
+});
+
+const ClaudeStreamInnerDeltaSchema = z
+  .object({
+    type: z.string().optional(),
+    text: z.string().optional(),
+  })
+  .passthrough();
+
+const ClaudeStreamInnerEventSchema = z
+  .object({
+    type: z.string(),
+    delta: ClaudeStreamInnerDeltaSchema.optional(),
+  })
+  .passthrough();
+
 export const ClaudeStreamEventSchema = z.object({
   type: z.string(),
   subtype: z.string().optional(),
   message: ClaudeMessageSchema.optional(),
+  delta: ClaudeStreamDeltaSchema.optional(),
+  event: ClaudeStreamInnerEventSchema.optional(),
   duration_ms: z.number().optional(),
   total_cost_usd: z.number().optional(),
   modelUsage: z.record(z.string(), ClaudeModelUsageSchema).optional(),

--- a/packages/agent/src/claude/schemas/RunClaudeOptionsSchema.ts
+++ b/packages/agent/src/claude/schemas/RunClaudeOptionsSchema.ts
@@ -20,6 +20,7 @@ export const RunClaudeOptionsSchema = z.object({
   timeoutMs: z.number().optional(),
   maxBudgetUsd: z.number().optional(),
   onProgress: z.custom<(line: string) => Promise<void>>().optional(),
+  onTextDelta: z.custom<(text: string) => Promise<void> | void>().optional(),
   extraEnv: z.record(z.string(), z.string()).optional(),
   ssh: SshConnectionOptionsSchema.optional(),
   // Connector injection: mcpConfigPath points at a generated MCP config file

--- a/packages/agent/src/codex/runCodex.ts
+++ b/packages/agent/src/codex/runCodex.ts
@@ -3,6 +3,7 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { hasMcpConnectorInjection, type McpConnectorInjection } from "../mcp";
 import { logger } from "@repo/logger";
+import { Result } from "neverthrow";
 import { spawnCommand } from "../spawn/spawnCommand";
 
 export interface RunCodexOptions {
@@ -13,8 +14,22 @@ export interface RunCodexOptions {
   model?: string;
   timeoutMs?: number;
   onProgress?: (line: string) => Promise<void>;
+  onTextDelta?: (text: string) => Promise<void> | void;
   connectorInjection?: McpConnectorInjection;
 }
+
+type CodexJsonEvent = {
+  type?: unknown;
+  item?: {
+    type?: unknown;
+    text?: unknown;
+  };
+};
+
+const parseCodexJsonEvent = Result.fromThrowable(
+  (line: string) => JSON.parse(line) as CodexJsonEvent,
+  () => null,
+);
 
 const CODEX_BIN = process.platform === "win32" ? "codex.cmd" : "codex";
 
@@ -150,6 +165,7 @@ export const runCodex = async ({
   model,
   timeoutMs = 10 * 60 * 1000,
   onProgress,
+  onTextDelta,
   connectorInjection,
 }: RunCodexOptions): Promise<string> => {
   const MAX_INPUT_CHARS = 50_000;
@@ -170,6 +186,7 @@ export const runCodex = async ({
     sandbox,
     "--ephemeral",
     "--skip-git-repo-check",
+    "--json",
     "-C",
     cwd,
     "--output-last-message",
@@ -199,8 +216,51 @@ export const runCodex = async ({
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
       const completion = { settled: false };
+      const streamState = {
+        lineBuffer: "",
+        parsedEventCount: 0,
+        emittedAgentMessage: false,
+        lastAgentMessage: "",
+        delivery: Promise.resolve(),
+      };
 
-      child.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+      const processStreamLine = (line: string) => {
+        if (!line.trim()) return;
+
+        const parsed = parseCodexJsonEvent(line.trim());
+        if (parsed.isErr()) return;
+        streamState.parsedEventCount += 1;
+
+        const event = parsed.value;
+        if (
+          event.type !== "item.completed" ||
+          event.item?.type !== "agent_message" ||
+          typeof event.item.text !== "string" ||
+          event.item.text.length === 0
+        ) {
+          return;
+        }
+
+        const textDelta = streamState.emittedAgentMessage
+          ? `\n\n${event.item.text}`
+          : event.item.text;
+        streamState.emittedAgentMessage = true;
+        streamState.lastAgentMessage = event.item.text;
+        streamState.delivery = streamState.delivery
+          .then(() => onTextDelta?.(textDelta))
+          .then(() => undefined)
+          .catch((error) => {
+            logger.warn({ err: String(error) }, "runCodex: text delta callback failed");
+          });
+      };
+
+      child.stdout.on("data", (chunk: Buffer) => {
+        stdoutChunks.push(chunk);
+        streamState.lineBuffer += chunk.toString("utf8");
+        const lines = streamState.lineBuffer.split("\n");
+        streamState.lineBuffer = lines.pop() ?? "";
+        for (const line of lines) processStreamLine(line);
+      });
       child.stderr.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
 
       const prompt = `<system>${systemPrompt}</system>\n\n${truncatedPrompt}`;
@@ -230,9 +290,13 @@ export const runCodex = async ({
         const stdout = Buffer.concat(stdoutChunks).toString("utf8");
         const stderr = Buffer.concat(stderrChunks).toString("utf8");
         void (async () => {
+          processStreamLine(streamState.lineBuffer);
+          await streamState.delivery;
           const output = await readFile(outputFile, "utf8").then(
             (fileOutput) => fileOutput,
-            () => stdout,
+            () =>
+              streamState.lastAgentMessage ||
+              (streamState.parsedEventCount === 0 ? stdout : ""),
           );
 
           if (code !== 0 && output.trim().length === 0) {

--- a/packages/agent/src/codex/runCodex.ts
+++ b/packages/agent/src/codex/runCodex.ts
@@ -295,8 +295,7 @@ export const runCodex = async ({
           const output = await readFile(outputFile, "utf8").then(
             (fileOutput) => fileOutput,
             () =>
-              streamState.lastAgentMessage ||
-              (streamState.parsedEventCount === 0 ? stdout : ""),
+              streamState.lastAgentMessage || (streamState.parsedEventCount === 0 ? stdout : ""),
           );
 
           if (code !== 0 && output.trim().length === 0) {

--- a/packages/agent/src/codex/runCodex.unit.test.ts
+++ b/packages/agent/src/codex/runCodex.unit.test.ts
@@ -106,6 +106,7 @@ describe("runCodex", () => {
     expect(args).toContain("exec");
     expect(args).toContain("--sandbox");
     expect(args).toContain("read-only");
+    expect(args).toContain("--json");
     expect(spawnOpts.cwd).toBe("/tmp/test");
   });
 
@@ -130,6 +131,35 @@ describe("runCodex", () => {
 
     await promise;
     expect(existsSync(codexHome)).toBe(false);
+  });
+
+  it("streams completed Codex agent messages before process completion", async () => {
+    const onTextDelta = vi.fn();
+    const promise = runCodex({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      cwd: "/tmp",
+      onTextDelta,
+    });
+
+    await waitForSpawn();
+    testState.mockProc.stdout.push(
+      '{"type":"item.completed","item":{"type":"agent_message","text":"Inspecting input"}}\n',
+    );
+    testState.mockProc.stdout.push(
+      '{"type":"item.completed","item":{"type":"agent_message","text":"Final answer"}}\n',
+    );
+
+    await vi.waitFor(() => {
+      expect(onTextDelta).toHaveBeenNthCalledWith(1, "Inspecting input");
+      expect(onTextDelta).toHaveBeenNthCalledWith(2, "\n\nFinal answer");
+    });
+
+    testState.mockProc.stdout.push(null);
+    testState.mockProc.stderr.push(null);
+    testState.mockProc.emit("close", 0);
+
+    await expect(promise).resolves.toBe("Final answer");
   });
 
   it("returns stdout text on success", async () => {

--- a/packages/schemas/src/pipeline/PipelineActionProposalSchema.ts
+++ b/packages/schemas/src/pipeline/PipelineActionProposalSchema.ts
@@ -1,8 +1,11 @@
 import { z } from "zod/v4";
+import { PipelineAgentPlanReadinessSchema } from "../pipeline-agent/PipelineGenerationPlanSchema";
 import { PipelineActionSchema } from "./PipelineActionSchema";
 
 export const PipelineActionProposalSchema = z.object({
   summary: z.string().min(1),
   actions: z.array(PipelineActionSchema).min(1),
+  openQuestions: z.array(z.string()).optional(),
+  readiness: PipelineAgentPlanReadinessSchema.optional(),
 });
 export type PipelineActionProposal = z.infer<typeof PipelineActionProposalSchema>;

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
@@ -41,6 +41,7 @@ import {
 import { getNextCronRunAt } from "@repo/utils";
 import { runAgent } from "../pipelineRunnerService/agentRunner/agentRunner";
 import { createPipelinesService } from "../pipelinesService/createPipelinesService";
+import { createPlanningPreviewStreamer } from "./streamPlanningPreview";
 
 const RelaxedCanvasEditPlanningResultSchema = z.discriminatedUnion("type", [
   z.object({
@@ -166,6 +167,27 @@ export const createPipelineAgentSessionsService = (db: DbConnection) => {
     if (activeActivities.get(sessionId)?.controller === activity.controller) {
       activeActivities.delete(sessionId);
     }
+  };
+  const savePlanningQuestion = async (
+    sessionId: string,
+    question: string,
+    activity: PipelineAgentActivity,
+  ) => {
+    await db.transaction(async (tx) => {
+      assertActivityActive(sessionId, activity);
+      const transactionalMessagesDao = createPipelineAgentMessagesDao(tx);
+      const transactionalSessionsDao = createPipelineAgentSessionsDao(tx);
+      await transactionalMessagesDao.create({
+        id: crypto.randomUUID(),
+        sessionId,
+        role: "assistant",
+        kind: "question",
+        content: question,
+      });
+      assertActivityActive(sessionId, activity);
+      await transactionalSessionsDao.update(sessionId, { status: "awaiting_user" });
+      assertActivityActive(sessionId, activity);
+    });
   };
   const resolveEffectiveRuntime = (input: {
     requestedRuntimeId?: string;
@@ -968,6 +990,7 @@ export const createPipelineAgentSessionsService = (db: DbConnection) => {
       sessionId: string,
       input?: {
         onProgress?: (message: string) => Promise<void> | void;
+        onTextDelta?: (text: string) => Promise<void> | void;
         runtimeId?: string;
         signal?: AbortSignal;
       },
@@ -1005,6 +1028,12 @@ export const createPipelineAgentSessionsService = (db: DbConnection) => {
             throw createRuntimeNotFoundError(input?.runtimeId);
           }
 
+          const planningPreview = createPlanningPreviewStreamer({
+            mode: session.mode,
+            onText: (text) => {
+              void input?.onTextDelta?.(text);
+            },
+          });
           const raw = await runAbortable(
             runAgent({
               agent: effectiveRuntime,
@@ -1024,10 +1053,12 @@ export const createPipelineAgentSessionsService = (db: DbConnection) => {
               apiKey: settings.defaultApiKey,
               model: settings.defaultModel,
               onProgress: input?.onProgress,
+              onTextDelta: planningPreview.push,
             }),
             activity.controller.signal,
             sessionId,
           );
+          planningPreview.push(raw);
           assertActivityActive(sessionId, activity);
 
           const parsed = (
@@ -1038,23 +1069,18 @@ export const createPipelineAgentSessionsService = (db: DbConnection) => {
           assertActivityActive(sessionId, activity);
 
           if (parsed.type === "question") {
-            await db.transaction(async (tx) => {
-              assertActivityActive(sessionId, activity);
-              const transactionalMessagesDao = createPipelineAgentMessagesDao(tx);
-              const transactionalSessionsDao = createPipelineAgentSessionsDao(tx);
-              await transactionalMessagesDao.create({
-                id: crypto.randomUUID(),
-                sessionId,
-                role: "assistant",
-                kind: "question",
-                content: parsed.question,
-              });
-              assertActivityActive(sessionId, activity);
-              await transactionalSessionsDao.update(sessionId, { status: "awaiting_user" });
-              assertActivityActive(sessionId, activity);
-            });
+            await savePlanningQuestion(sessionId, parsed.question, activity);
 
             return parsed;
+          }
+
+          if (parsed.proposal.readiness !== "ready_for_generation") {
+            const question =
+              parsed.proposal.openQuestions.map((item) => item.trim()).filter(Boolean).join("\n") ||
+              "Please provide the missing details before I continue.";
+            await savePlanningQuestion(sessionId, question, activity);
+
+            return { type: "question" as const, question };
           }
 
           if (session.mode === "edit") {

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
@@ -1076,8 +1076,10 @@ export const createPipelineAgentSessionsService = (db: DbConnection) => {
 
           if (parsed.proposal.readiness !== "ready_for_generation") {
             const question =
-              parsed.proposal.openQuestions.map((item) => item.trim()).filter(Boolean).join("\n") ||
-              "Please provide the missing details before I continue.";
+              parsed.proposal.openQuestions
+                .map((item) => item.trim())
+                .filter(Boolean)
+                .join("\n") || "Please provide the missing details before I continue.";
             await savePlanningQuestion(sessionId, question, activity);
 
             return { type: "question" as const, question };

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
@@ -1158,6 +1158,58 @@ describe("createPipelineAgentSessionsService", () => {
     );
   });
 
+  it("returns an edit question without calling proposeActions when planning needs user input", async () => {
+    mockSessionsDao.findById.mockResolvedValueOnce({
+      id: "session-edit",
+      entrypoint: "canvas-agent-panel",
+      mode: "edit",
+      status: "draft",
+      pipelineId: "pipe-1",
+      snapshot: { nodes: [], edges: [] },
+      latestProposalId: null,
+      approvedProposalId: null,
+      createdPipelineId: null,
+      createdAt: new Date("2026-06-03T12:00:00.000Z"),
+      updatedAt: new Date("2026-06-03T12:00:00.000Z"),
+    });
+    mockRunAgent.mockResolvedValueOnce(
+      JSON.stringify({
+        type: "proposal",
+        proposal: {
+          mode: "edit",
+          summary: "Update the exam pipeline",
+          targetGraphIntent: "Clarify the required exam format",
+          majorChanges: ["Update the output step"],
+          assumptions: [],
+          openQuestions: ["Which grade level should this target?", "Which output format?"],
+          readiness: "needs_user_answer",
+        },
+      }),
+    );
+
+    const result = await createPipelineAgentSessionsService({} as never).planSession(
+      "session-edit",
+      { runtimeId: "runtime-codex" },
+    );
+
+    expect(result).toEqual({
+      type: "question",
+      question: "Which grade level should this target?\nWhich output format?",
+    });
+    expect(mockPipelinesService.proposeActions).not.toHaveBeenCalled();
+    expect(mockProposalsDao.create).not.toHaveBeenCalled();
+    expect(mockMessagesDao.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-edit",
+        kind: "question",
+        content: expect.stringContaining("Which grade level should this target?"),
+      }),
+    );
+    expect(mockSessionsDao.update).toHaveBeenLastCalledWith("session-edit", {
+      status: "awaiting_user",
+    });
+  });
+
   it("stores pendingOperations returned by proposeActions in the edit proposal", async () => {
     mockSessionsDao.findById.mockResolvedValueOnce({
       id: "session-edit",

--- a/packages/services/src/pipelineAgentSessionsService/streamPlanningPreview.ts
+++ b/packages/services/src/pipelineAgentSessionsService/streamPlanningPreview.ts
@@ -1,0 +1,116 @@
+import { Result } from "neverthrow";
+
+type PlanningPreviewMode = "edit" | "generate";
+type PreviewField = "purpose" | "question" | "summary";
+
+const fieldsForMode = (mode: PlanningPreviewMode): readonly PreviewField[] =>
+  mode === "generate" ? ["question", "purpose"] : ["question", "summary"];
+
+const safeJsonStringParse = Result.fromThrowable(
+  (candidate: string) => JSON.parse(`"${candidate}"`) as string,
+  () => undefined,
+);
+
+const stripTrailingBackslashes = (value: string): string =>
+  value.endsWith("\\") ? stripTrailingBackslashes(value.slice(0, -1)) : value;
+
+const decodePartialJsonString = (raw: string): string => {
+  const candidate = stripTrailingBackslashes(raw);
+  const direct = safeJsonStringParse(candidate);
+  if (direct.isOk()) {
+    return direct.value;
+  }
+
+  const lastEscape = candidate.lastIndexOf("\\");
+  if (lastEscape < 0) {
+    return "";
+  }
+
+  const trimmed = safeJsonStringParse(candidate.slice(0, lastEscape));
+
+  return trimmed.isOk() ? trimmed.value : "";
+};
+
+const skipWhitespace = (source: string, index: number): number =>
+  /\s/.test(source[index] ?? "") ? skipWhitespace(source, index + 1) : index;
+
+const countTrailingBackslashes = (source: string, index: number): number =>
+  index >= 0 && source[index] === "\\" ? countTrailingBackslashes(source, index - 1) + 1 : 0;
+
+const findUnescapedQuoteEnd = (source: string, startIndex: number): number => {
+  const index = source.indexOf('"', startIndex);
+  if (index < 0) {
+    return source.length;
+  }
+
+  if (countTrailingBackslashes(source, index - 1) % 2 === 1) {
+    return findUnescapedQuoteEnd(source, index + 1);
+  }
+
+  return index;
+};
+
+const extractFieldPrefix = (source: string, fields: readonly PreviewField[]): string | null => {
+  const allowedFields = new Set(fields);
+  const state = { index: 0, selected: null as { start: number; valueStart: number } | null };
+
+  while (state.index < source.length && !state.selected) {
+    if (source[state.index] !== '"') {
+      state.index += 1;
+      continue;
+    }
+
+    const keyStart = state.index + 1;
+    const keyEnd = findUnescapedQuoteEnd(source, keyStart);
+    if (keyEnd >= source.length) {
+      break;
+    }
+
+    const key = decodePartialJsonString(source.slice(keyStart, keyEnd));
+    const valueStartBefore = skipWhitespace(source, keyEnd + 1);
+    if (!allowedFields.has(key as PreviewField) || source[valueStartBefore] !== ":") {
+      state.index = keyEnd + 1;
+      continue;
+    }
+
+    const valueStart = skipWhitespace(source, valueStartBefore + 1);
+    if (source[valueStart] === '"') {
+      state.selected = { start: state.index, valueStart: valueStart + 1 };
+      break;
+    }
+
+    state.index = keyEnd + 1;
+  }
+
+  if (!state.selected) {
+    return null;
+  }
+
+  const valueEnd = findUnescapedQuoteEnd(source, state.selected.valueStart);
+
+  return decodePartialJsonString(source.slice(state.selected.valueStart, valueEnd));
+};
+
+export const createPlanningPreviewStreamer = (input: {
+  mode: PlanningPreviewMode;
+  onText: (text: string) => void;
+}) => {
+  const fields = fieldsForMode(input.mode);
+  const state = { source: "", emitted: "" };
+
+  const push = (text: string) => {
+    state.source += text;
+    const preview = extractFieldPrefix(state.source, fields);
+    if (!preview || !preview.startsWith(state.emitted)) {
+      return;
+    }
+
+    const delta = preview.slice(state.emitted.length);
+    state.emitted = preview;
+    if (delta.length > 0) {
+      input.onText(delta);
+    }
+  };
+
+  return { push };
+};

--- a/packages/services/src/pipelineAgentSessionsService/streamPlanningPreview.unit.test.ts
+++ b/packages/services/src/pipelineAgentSessionsService/streamPlanningPreview.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { createPlanningPreviewStreamer } from "./streamPlanningPreview";
+
+describe("createPlanningPreviewStreamer", () => {
+  it("only emits the mode-specific safe field and never raw JSON", () => {
+    const chunks: string[] = [];
+    const preview = createPlanningPreviewStreamer({
+      mode: "generate",
+      onText: (text) => chunks.push(text),
+    });
+
+    preview.push('{"type":"proposal","proposal":{"mode":"generate","purpose":"Plan');
+    preview.push(
+      ' a review","inputs":["SECRET_TOOL_ARG"],"thinking":"fake ,\\"purpose\\":\\"SECRET_THINKING\\""}}',
+    );
+
+    expect(chunks.join("")).toBe("Plan a review");
+    expect(chunks.join("")).not.toContain("SECRET");
+    expect(chunks.join("")).not.toContain("purpose");
+  });
+
+  it("uses question and summary for edit planning", () => {
+    const chunks: string[] = [];
+    const preview = createPlanningPreviewStreamer({
+      mode: "edit",
+      onText: (text) => chunks.push(text),
+    });
+
+    preview.push('{"type":"question","question":"Which node?"}');
+
+    expect(chunks.join("")).toBe("Which node?");
+  });
+});

--- a/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.ts
+++ b/packages/services/src/pipelineRunnerService/agentRunner/agentRunner.ts
@@ -19,6 +19,7 @@ export interface AgentRunnerOptions {
   agentId: string;
   allowedTools?: readonly string[];
   onProgress?: (line: string) => Promise<void> | void;
+  onTextDelta?: (text: string) => Promise<void> | void;
   logPrefix: string;
   attachments?: AgentInputAttachment[];
   apiKey?: string;
@@ -38,6 +39,7 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
     agentId,
     allowedTools,
     onProgress,
+    onTextDelta,
     logPrefix,
     attachments,
     apiKey,
@@ -81,6 +83,7 @@ export const runAgent = async (opts: AgentRunnerOptions): Promise<string> => {
       attachments,
       allowedTools: allowedTools ?? [],
       onProgress,
+      onTextDelta,
       jobId,
       agentId,
       apiKey,

--- a/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.ts
+++ b/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.ts
@@ -134,6 +134,7 @@ const run = ({
   return ResultAsync.fromPromise(
     (async () => {
       const systemPrompt = `${buildSystemPrompt({ prompt, runtimeContext })}\n${USER_ACTION_SECTION}`;
+      const streamState = { accumulated: "" };
       const raw = await runAgent({
         agent,
         systemPrompt,
@@ -143,6 +144,12 @@ const run = ({
         agentId: PROMPT_AGENT_ID,
         allowedTools: effectiveAllowedTools,
         onProgress,
+        onTextDelta: onChunk
+          ? async (text) => {
+              streamState.accumulated += text;
+              await onChunk(streamState.accumulated);
+            }
+          : undefined,
         logPrefix: "[LLM] runPrompt",
         apiKey,
         model,

--- a/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/promptExecutor/promptExecutor.unit.test.ts
@@ -68,6 +68,22 @@ describe("promptExecutor", () => {
     );
   });
 
+  it("forwards accumulated runtime text to the pipeline chunk callback", async () => {
+    vi.mocked(agentEngine.run).mockImplementationOnce(async (options) => {
+      await options.onTextDelta?.("first");
+      await options.onTextDelta?.(" second");
+
+      return { text: "first second", usage: null };
+    });
+    const onChunk = vi.fn();
+
+    const result = await promptExecutor.run({ ...baseOpts, agent: "codex", onChunk });
+
+    expect(result.isOk()).toBe(true);
+    expect(onChunk).toHaveBeenNthCalledWith(1, "first");
+    expect(onChunk).toHaveBeenNthCalledWith(2, "first second");
+  });
+
   it("falls back to process.cwd() when no inputPath is configured", async () => {
     const result = await promptExecutor.run({ ...baseOpts, inputPath: "", agent: "codex" });
 

--- a/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.ts
+++ b/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.ts
@@ -240,6 +240,7 @@ const run = ({
   return ResultAsync.fromPromise(
     (async () => {
       await onProgress?.("runSkill: start");
+      const streamState = { accumulated: "" };
 
       const raw = await runAgent({
         agent,
@@ -250,6 +251,12 @@ const run = ({
         agentId: skillId,
         allowedTools,
         onProgress,
+        onTextDelta: onChunk
+          ? async (text) => {
+              streamState.accumulated += text;
+              await onChunk(streamState.accumulated);
+            }
+          : undefined,
         logPrefix: "runSkill",
         apiKey,
         model,

--- a/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/skillExecutor/skillExecutor.unit.test.ts
@@ -100,6 +100,27 @@ describe("skillExecutor", () => {
     }
   });
 
+  it("forwards accumulated runtime text to the pipeline chunk callback", async () => {
+    vi.mocked(agentEngine.run).mockImplementationOnce(async (options) => {
+      await options.onTextDelta?.('{"type":"check",');
+      await options.onTextDelta?.(
+        '"summary":"ok","findings":[],"stats":{"totalFiles":1,"totalFindings":0,"errors":0,"warnings":0,"infos":0,"skipped":0}}',
+      );
+
+      return {
+        text: '{"type":"check","summary":"ok","findings":[],"stats":{"totalFiles":1,"totalFindings":0,"errors":0,"warnings":0,"infos":0,"skipped":0}}',
+        usage: null,
+      };
+    });
+    const onChunk = vi.fn();
+
+    const result = await skillExecutor.run({ ...baseOpts, agent: "codex", onChunk });
+
+    expect(result.isOk()).toBe(true);
+    expect(onChunk).toHaveBeenNthCalledWith(1, '{"type":"check",');
+    expect(onChunk.mock.calls[1]?.[0]).toContain('"summary":"ok"');
+  });
+
   it("forwards jobId and agentId to agentEngine", async () => {
     vi.mocked(agentEngine.run).mockResolvedValueOnce({
       text: '{"type":"check","summary":"ok","findings":[],"stats":{"totalFiles":1,"totalFindings":0,"errors":0,"warnings":0,"infos":0,"skipped":0}}',

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -476,17 +476,20 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
 
   const hasBlockingDiagnostics =
     agentPanel.diagnostics?.some((diagnostic) => diagnostic.severity === "error") ?? false;
-  const generateProposalNeedsAnswer =
-    generateProposal !== null && generateProposal.readiness !== "ready_for_generation";
-
   const activeProposal = agentPanel.pendingProposal;
   const activeDiagnostics = agentPanel.diagnostics;
+  const proposalNeedsAnswer =
+    (activeProposal?.readiness !== undefined &&
+      activeProposal.readiness !== "ready_for_generation") ||
+    (activeProposal?.openQuestions?.some((question) => question.trim().length > 0) ?? false) ||
+    (generateProposal !== null && generateProposal.readiness !== "ready_for_generation") ||
+    (generateProposal?.openQuestions.some((question) => question.trim().length > 0) ?? false);
 
   const handleApply = useCallback(() => {
     if (
       (!activeProposal && !generateProposal) ||
       hasBlockingDiagnostics ||
-      generateProposalNeedsAnswer
+      proposalNeedsAnswer
     ) {
       return;
     }
@@ -495,8 +498,8 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
     activeProposal,
     applyProposal,
     generateProposal,
-    generateProposalNeedsAnswer,
     hasBlockingDiagnostics,
+    proposalNeedsAnswer,
     selectedRuntimeId,
   ]);
 
@@ -507,8 +510,16 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
   const proposal = activeProposal;
   const hasProposal = proposal !== null || generateProposal !== null;
   const proposalItems = useMemo(() => {
+    const openQuestionItems = (proposal?.openQuestions ?? generateProposal?.openQuestions ?? [])
+      .map((question) => question.trim())
+      .filter(Boolean)
+      .map((detail) => ({
+        detail,
+        title: t("canvas.agentPanel.proposalDetails.openQuestion"),
+      }));
+
     if (proposal) {
-      return buildProposalItems(proposal, [], t);
+      return [...buildProposalItems(proposal, [], t), ...openQuestionItems];
     }
 
     if (!generateProposal) {
@@ -520,6 +531,7 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
       ...generateProposal.outputs.map((detail) => ({ detail, title: "Output" })),
       ...generateProposal.majorOperations.map((detail) => ({ detail, title: "Operation" })),
       ...generateProposal.executionFlow.map((detail) => ({ detail, title: "Flow" })),
+      ...openQuestionItems,
     ];
   }, [generateProposal, proposal, t]);
   const handleAskFix = useCallback(() => {
@@ -684,15 +696,19 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
                     isSending ||
                     isPreparingUpload ||
                     isHistoryLoading ||
-                    agentPanel.isLoading ||
-                    generateProposalNeedsAnswer
+                    agentPanel.isLoading
                   }
+                  applyDisabled={proposalNeedsAnswer}
                   items={proposalItems}
                   onApply={handleApply}
                   onAskFix={hasBlockingDiagnostics ? handleAskFix : undefined}
                   onReject={handleDiscard}
                   onRevise={handleRevise}
-                  subtitle={t("canvas.agentPanel.proposal.review")}
+                  subtitle={t(
+                    proposalNeedsAnswer
+                      ? "canvas.agentPanel.proposalDetails.needsAnswer"
+                      : "canvas.agentPanel.proposalDetails.review",
+                  )}
                   title={proposal?.summary ?? generateProposal?.purpose ?? ""}
                 />
               </div>

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -486,11 +486,7 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
     (generateProposal?.openQuestions.some((question) => question.trim().length > 0) ?? false);
 
   const handleApply = useCallback(() => {
-    if (
-      (!activeProposal && !generateProposal) ||
-      hasBlockingDiagnostics ||
-      proposalNeedsAnswer
-    ) {
+    if ((!activeProposal && !generateProposal) || hasBlockingDiagnostics || proposalNeedsAnswer) {
       return;
     }
     void applyProposal(selectedRuntimeId);
@@ -693,10 +689,7 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
                 </span>
                 <ProposalCard
                   disabled={
-                    isSending ||
-                    isPreparingUpload ||
-                    isHistoryLoading ||
-                    agentPanel.isLoading
+                    isSending || isPreparingUpload || isHistoryLoading || agentPanel.isLoading
                   }
                   applyDisabled={proposalNeedsAnswer}
                   items={proposalItems}

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -602,6 +602,51 @@ describe("AgentPanel", () => {
     });
   });
 
+  it("keeps an edit proposal needing answers non-applicable while leaving revise and discard enabled", async () => {
+    mockPlanSessionStream.mockImplementation(async (_sessionId, { onEvent }) => {
+      onEvent({
+        type: "proposal_ready",
+        proposalId: "proposal-needs-answer",
+        proposal: {
+          mode: "edit",
+          summary: "Prepare the exam pipeline",
+          targetGraphIntent: "Clarify the exam requirements",
+          majorChanges: ["Update the output step"],
+          assumptions: [],
+          openQuestions: ["Which grade level should this target?"],
+          readiness: "needs_user_answer",
+          diagnosticsPreview: [],
+          actions: [
+            {
+              type: "removeNode",
+              nodeId: "node-1",
+            },
+          ],
+        },
+      });
+    });
+
+    render(<AgentPanel />, { wrapper: wrapperWithState() });
+    await waitFor(() => expect(mockGetList).toHaveBeenCalled());
+    await userEvent.type(
+      screen.getByPlaceholderText("workspace.agentBar.composer.placeholder"),
+      "Prepare the exam pipeline",
+    );
+    await userEvent.keyboard("{Enter}");
+
+    await waitFor(() => expect(mockPlanSessionStream).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(screen.getByTestId("agent-proposal")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Which grade level should this target\?/)).toBeInTheDocument();
+    expect(screen.getByTestId("agent-proposal-apply")).toBeDisabled();
+    expect(screen.getByTestId("agent-proposal-revise")).toBeEnabled();
+    expect(screen.getByTestId("agent-proposal-reject")).toBeEnabled();
+
+    await userEvent.click(screen.getByTestId("agent-proposal-apply"));
+    expect(mockApproveProposal).not.toHaveBeenCalled();
+  });
+
   it("renders an edit proposal from session fallback when the stream misses proposal_ready", async () => {
     mockPlanSessionStream.mockResolvedValue(undefined);
     mockGetLatestReadyProposal.mockResolvedValueOnce({

--- a/packages/views/src/pages/CanvasPage/AgentPanel/_store/agentBarStore.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/_store/agentBarStore.ts
@@ -89,10 +89,7 @@ export const createAgentBarStore = (pipelineId: string | null = null): AgentBarS
       })),
     appendStreamingAssistantText: (text) =>
       set((state) => ({
-        streamingAssistantText:
-          state.streamingAssistantText.length === 0
-            ? text
-            : `${state.streamingAssistantText}\n${text}`,
+        streamingAssistantText: `${state.streamingAssistantText}${text}`,
       })),
     clearMessages: () => set({ messages: [] }),
     removeMessage: (id) =>

--- a/packages/views/src/pages/CanvasPage/AgentPanel/_store/agentBarStore.unit.test.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/_store/agentBarStore.unit.test.ts
@@ -44,7 +44,7 @@ describe("createAgentBarStore", () => {
     store.getState().appendStreamingAssistantText("second");
     store.getState().setConversationState("streaming");
     expect(store.getState().conversationState).toBe("streaming");
-    expect(store.getState().streamingAssistantText).toBe("first\nsecond");
+    expect(store.getState().streamingAssistantText).toBe("firstsecond");
 
     store.getState().setConversationState("done");
     expect(store.getState().conversationState).toBe("done");

--- a/packages/views/src/pages/CanvasPage/AgentPanel/messages/ProposalCard.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/messages/ProposalCard.tsx
@@ -16,6 +16,7 @@ export type ProposalCardProps = {
   onAskFix?: () => void;
   onReject?: () => void;
   onRevise?: () => void;
+  applyDisabled?: boolean;
   disabled?: boolean;
   subtitle: string;
   title: string;
@@ -28,6 +29,7 @@ export const ProposalCard = ({
   onAskFix,
   onReject,
   onRevise,
+  applyDisabled = false,
   disabled = false,
   subtitle,
   title,
@@ -64,7 +66,7 @@ export const ProposalCard = ({
         <Button
           className="h-7 rounded-lg px-3 text-[11.5px]"
           data-testid="agent-proposal-apply"
-          disabled={disabled || Boolean(onAskFix)}
+          disabled={disabled || applyDisabled || Boolean(onAskFix)}
           size="sm"
           onClick={onApply}
         >

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
@@ -257,6 +257,8 @@ export const useAgentConversation = ({
       if (event.type === "proposal_ready" && event.proposal.mode === "edit") {
         const proposal: PipelineActionProposal = {
           actions: event.proposal.actions,
+          openQuestions: event.proposal.openQuestions,
+          readiness: event.proposal.readiness,
           summary: event.proposal.summary,
         };
         state.setProposalId(event.proposalId);

--- a/packages/views/src/pages/CanvasPage/CanvasPage.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasPage.tsx
@@ -5,6 +5,7 @@ import { PageLoadingState } from "../../components/PageLoadingState";
 import { ResourceName } from "../../constants";
 import { CanvasPageStoreProvider } from "./_store";
 import { CanvasPageContent } from "./CanvasPageContent";
+import { RunStateRestorer } from "./RunConsole/RunStateRestorer";
 
 interface CanvasPageProps {
   // Pipeline id to load, read from the route's search params by each app.
@@ -32,6 +33,7 @@ export const CanvasPage = ({ embedded = false, id, onGeneratedPipeline }: Canvas
   return (
     <CanvasLayout embedded={embedded}>
       <CanvasPageStoreProvider pipeline={pipeline}>
+        <RunStateRestorer />
         <CanvasPageContent onGeneratedPipeline={onGeneratedPipeline} />
       </CanvasPageStoreProvider>
     </CanvasLayout>

--- a/packages/views/src/pages/CanvasPage/OperationNode/OperationNode.tsx
+++ b/packages/views/src/pages/CanvasPage/OperationNode/OperationNode.tsx
@@ -2,7 +2,6 @@ import {
   Zap,
   CheckCircle2,
   XCircle,
-  Loader2,
   Circle,
   Brain,
   Repeat,
@@ -49,8 +48,8 @@ const statusConfig: Record<NodeRunStatus, { icon: ElementType; color: string; la
       labelKey: "nodes.operation.statusQueued",
     },
     running: {
-      icon: Loader2,
-      color: "animate-spin text-blue-500 dark:text-blue-400",
+      icon: Circle,
+      color: "fill-current text-blue-500 dark:text-blue-400",
       labelKey: "nodes.operation.statusRunning",
     },
     waitingForUser: {
@@ -140,7 +139,8 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
   } = useStore(store, useShallow(selectNodePortCounts(id)));
   const agentOpen = operationAgentDropdownNodeId === id;
 
-  const { icon: StatusIcon, color, labelKey } = statusConfig[data.status ?? "idle"];
+  const effectiveStatus = nodeRunStatus ?? data.status ?? "idle";
+  const { icon: StatusIcon, color, labelKey } = statusConfig[effectiveStatus];
   const statusLabel = t(labelKey);
 
   const operation = operations.find((op: Operation) => op.id === data.operationId);
@@ -208,14 +208,14 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
           <div
             className={cn(
               "flex min-w-fit shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border px-2 py-1 shadow-sm",
-              data.status === "done" && "border-emerald-500/20 bg-emerald-500/10",
-              data.status === "failed" && "border-red-500/20 bg-red-500/10",
-              data.status === "running" && "border-blue-500/20 bg-blue-500/10",
-              data.status === "retrying" && "border-blue-500/20 bg-blue-500/10",
-              data.status === "waitingForUser" && "border-amber-500/20 bg-amber-500/10",
-              data.status === "skipped" && "border-border bg-surface-2",
-              data.status === "cancelled" && "border-amber-500/20 bg-amber-500/10",
-              (!data.status || data.status === "idle" || data.status === "queued") &&
+              effectiveStatus === "done" && "border-emerald-500/20 bg-emerald-500/10",
+              effectiveStatus === "failed" && "border-red-500/20 bg-red-500/10",
+              effectiveStatus === "running" && "border-blue-500/20 bg-blue-500/10",
+              effectiveStatus === "retrying" && "border-blue-500/20 bg-blue-500/10",
+              effectiveStatus === "waitingForUser" && "border-amber-500/20 bg-amber-500/10",
+              effectiveStatus === "skipped" && "border-border bg-surface-2",
+              effectiveStatus === "cancelled" && "border-amber-500/20 bg-amber-500/10",
+              (effectiveStatus === "idle" || effectiveStatus === "queued") &&
                 "border-border bg-surface-2",
             )}
           >

--- a/packages/views/src/pages/CanvasPage/OperationNode/OperationNode.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/OperationNode/OperationNode.unit.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "../../../test/test-wrapper";
 import type * as RefineCore from "@refinedev/core";
 import i18n from "i18next";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OperationNodeData } from "@repo/schemas";
@@ -111,6 +111,19 @@ describe("OperationNode", () => {
     );
     expect(screen.getByRole("spinbutton", { name: "最大循环次数" })).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: "循环验收条件" })).toBeInTheDocument();
+  });
+
+  it("renders the live run status instead of the persisted idle status", () => {
+    const store = renderOperationNode();
+
+    act(() => {
+      store.getState().setNodeRunStatuses({ [nodeId]: "running" });
+    });
+
+    const runningLabel = screen.getByText("运行中");
+    expect(runningLabel).toBeInTheDocument();
+    expect(runningLabel.parentElement?.querySelector("svg")).not.toHaveClass("animate-spin");
+    expect(screen.queryByText("待运行")).not.toBeInTheDocument();
   });
 
   it("updates runtime selection without bubbling canvas interactions", async () => {

--- a/packages/views/src/pages/CanvasPage/RunConsole/RunConsole.tsx
+++ b/packages/views/src/pages/CanvasPage/RunConsole/RunConsole.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Terminal, X, ChevronUp, ChevronDown, Loader2, FileText } from "lucide-react";
 import { Button } from "@repo/ui/button";
@@ -110,6 +110,7 @@ export const RunConsole = () => {
   const markNodePassed = useStore(store, (s) => s.markNodePassed);
   const markNodeFailed = useStore(store, (s) => s.markNodeFailed);
   const applyNodeLlmContent = useStore(store, (s) => s.applyNodeLlmContent);
+  const setNodeRunStatuses = useStore(store, (s) => s.setNodeRunStatuses);
   const stopTestRun = useStore(store, (s) => s.stopTestRun);
   const isConsoleCollapsed = useStore(store, (s) => s.isConsoleCollapsed);
   const handleToggleConsoleCollapse = useStore(store, (s) => s.handleToggleConsoleCollapse);
@@ -178,6 +179,14 @@ export const RunConsole = () => {
   const job = (jobQuery.data?.data as Job | undefined) ?? null;
   const jobRef = useRef(job);
   jobRef.current = job;
+
+  useEffect(() => {
+    if (!job?.nodeStatuses) {
+      return;
+    }
+
+    setNodeRunStatuses(job.nodeStatuses);
+  }, [job, setNodeRunStatuses]);
 
   const { result: tracesResult } = useCustom<{ traces: RunTrace[] }>({
     url: "jobs/traces",

--- a/packages/views/src/pages/CanvasPage/RunConsole/RunConsole.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/RunConsole/RunConsole.unit.test.tsx
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RunConsole } from "./RunConsole";
 import { CanvasPageStoreProvider, useCanvasPageStore } from "../_store";
 import { useRef } from "react";
+import { useStore } from "zustand";
+import type { Job } from "@repo/schemas";
 
 vi.mock("@xyflow/react", () => ({
   Handle: () => null,
@@ -43,6 +45,13 @@ const wrapperWithJob = (jobId: string | null) => {
   return Wrapper;
 };
 
+const RunStatusProbe = ({ nodeId }: { nodeId: string }) => {
+  const store = useCanvasPageStore();
+  const status = useStore(store, (state) => state.nodeRunStatuses[nodeId]);
+
+  return <span data-testid="run-status-probe">{status ?? "missing"}</span>;
+};
+
 const timelineWrapper = ({ children }: { children?: React.ReactNode }) => (
   <CanvasPageStoreProvider
     pipeline={{
@@ -68,22 +77,22 @@ const timelineWrapper = ({ children }: { children?: React.ReactNode }) => (
   </CanvasPageStoreProvider>
 );
 
-const mockJobRunning = {
+const mockJobRunning: Job = {
   id: "job-1",
   title: "Pipeline run",
   type: "pipeline_run",
-  status: "running" as string,
+  status: "running",
   error: null,
   meta: { createdAt: new Date(), updatedAt: new Date() },
-  startedAt: Date.now(),
-  finishedAt: null as number | null,
+  startedAt: new Date(),
+  finishedAt: null,
   parentJobId: null,
 };
 
 const mockJobDone = {
   ...mockJobRunning,
   status: "done" as const,
-  finishedAt: Date.now(),
+  finishedAt: new Date(),
 };
 
 type MockTrace = {
@@ -91,7 +100,7 @@ type MockTrace = {
   message: string;
 };
 
-const useOneData = vi.fn(() => mockJobRunning);
+const useOneData = vi.fn<() => Job>(() => mockJobRunning);
 const useTraceData = vi.fn<() => MockTrace[]>(() => [
   { message: "[2026-04-08T16:00:00.000Z] Starting pipeline abc" },
   { message: "[2026-04-08T16:00:01.000Z] Processing node [github-project] skills" },
@@ -152,6 +161,25 @@ describe("RunConsole", () => {
   it("shows status bar with running indicator", () => {
     render(<RunConsole />, { wrapper: wrapperWithJob("job-1") });
     expect(screen.getByText(/Running/i)).toBeInTheDocument();
+  });
+
+  it("syncs authoritative job node statuses without structured trace markers", async () => {
+    useOneData.mockReturnValue({
+      ...mockJobRunning,
+      nodeStatuses: { "node-op": "running" },
+    });
+
+    render(
+      <>
+        <RunConsole />
+        <RunStatusProbe nodeId="node-op" />
+      </>,
+      { wrapper: wrapperWithJob("job-1") },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("run-status-probe")).toHaveTextContent("running");
+    });
   });
 
   it("displays log entries from traces", async () => {

--- a/packages/views/src/pages/CanvasPage/RunConsole/RunStateRestorer.tsx
+++ b/packages/views/src/pages/CanvasPage/RunConsole/RunStateRestorer.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useList } from "@refinedev/core";
+import { useStore } from "zustand";
+import type { Job } from "@repo/schemas";
+import { ResourceName } from "../../../constants";
+import { useCanvasPageStore } from "../_store";
+
+const getJobTimestamp = (job: Job): number => {
+  const value = job.meta?.createdAt ?? job.startedAt ?? job.finishedAt;
+
+  return value ? new Date(value).getTime() : 0;
+};
+
+export const findLatestPipelineJob = (jobs: Job[], pipelineId: string): Job | null =>
+  jobs.reduce<Job | null>((latest, job) => {
+    if (job.pipelineId !== pipelineId) {
+      return latest;
+    }
+
+    return !latest || getJobTimestamp(job) > getJobTimestamp(latest) ? job : latest;
+  }, null);
+
+export const RunStateRestorer = () => {
+  const store = useCanvasPageStore();
+  const pipelineId = useStore(store, (state) => state.pipelineId);
+  const restoreRunState = useStore(store, (state) => state.restoreRunState);
+  const restoredKeyRef = useRef<string | null>(null);
+  const { result } = useList<Job>({
+    resource: ResourceName.jobs,
+    queryOptions: { enabled: pipelineId !== null },
+  });
+  const latestJob = useMemo(
+    () => (pipelineId ? findLatestPipelineJob(result.data, pipelineId) : null),
+    [pipelineId, result.data],
+  );
+
+  useEffect(() => {
+    if (!pipelineId || !latestJob) {
+      return;
+    }
+
+    const restoreKey = `${pipelineId}:${latestJob.id}`;
+    if (restoredKeyRef.current === restoreKey) {
+      return;
+    }
+
+    restoredKeyRef.current = restoreKey;
+    restoreRunState(latestJob);
+  }, [latestJob, pipelineId, restoreRunState]);
+
+  return null;
+};

--- a/packages/views/src/pages/CanvasPage/RunConsole/RunStateRestorer.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/RunConsole/RunStateRestorer.unit.test.tsx
@@ -1,0 +1,118 @@
+import { render } from "../../../test/test-wrapper";
+import type * as RefineCore from "@refinedev/core";
+import { screen, waitFor } from "@testing-library/react";
+import { useStore } from "zustand";
+import { describe, expect, it, vi } from "vitest";
+import type { Job } from "@repo/schemas";
+import { CanvasPageStoreProvider, useCanvasPageStore } from "../_store";
+import { RunStateRestorer } from "./RunStateRestorer";
+
+const jobs: Job[] = [];
+
+vi.mock("@refinedev/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof RefineCore>()),
+  useList: () => ({ result: { data: jobs } }),
+}));
+
+const makeJob = (input: Partial<Job> & Pick<Job, "id" | "pipelineId" | "status">): Job => ({
+  error: null,
+  finishedAt: input.status === "done" ? new Date("2026-08-14T10:02:00.000Z") : null,
+  id: input.id,
+  meta: {
+    createdAt: input.meta?.createdAt ?? new Date("2026-08-14T10:00:00.000Z"),
+    updatedAt: input.meta?.updatedAt ?? new Date("2026-08-14T10:02:00.000Z"),
+  },
+  nodeStatuses: input.nodeStatuses ?? null,
+  parentJobId: null,
+  pipelineId: input.pipelineId,
+  startedAt: input.startedAt ?? new Date("2026-08-14T10:00:00.000Z"),
+  status: input.status,
+  title: "Pipeline run",
+  type: "pipeline_run",
+});
+
+const RunStateProbe = () => {
+  const store = useCanvasPageStore();
+  const activeJobId = useStore(store, (value) => value.activeJobId);
+  const isConsoleOpen = useStore(store, (value) => value.isConsoleOpen);
+  const statuses = useStore(store, (value) => value.nodeRunStatuses);
+
+  return (
+    <output data-testid="run-state">
+      {JSON.stringify({ activeJobId, isConsoleOpen, statuses })}
+    </output>
+  );
+};
+
+const wrapper = ({ children }: React.PropsWithChildren) => (
+  <CanvasPageStoreProvider pipeline={{ id: "pipe-1", name: "Pipeline", nodes: [], edges: [] }}>
+    {children}
+  </CanvasPageStoreProvider>
+);
+
+describe("RunStateRestorer", () => {
+  it("restores the latest completed job statuses after a refresh", async () => {
+    jobs.splice(
+      0,
+      jobs.length,
+      makeJob({
+        id: "older-run",
+        pipelineId: "pipe-1",
+        status: "done",
+        nodeStatuses: { operation: "failed" },
+      }),
+      makeJob({
+        id: "latest-run",
+        meta: {
+          createdAt: new Date("2026-08-14T11:00:00.000Z"),
+          updatedAt: new Date("2026-08-14T11:02:00.000Z"),
+        },
+        pipelineId: "pipe-1",
+        status: "done",
+        nodeStatuses: { operation: "done" },
+      }),
+      makeJob({ id: "other-pipeline", pipelineId: "pipe-2", status: "running" }),
+    );
+
+    render(
+      <>
+        <RunStateRestorer />
+        <RunStateProbe />
+      </>,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("run-state")).toHaveTextContent('"operation":"done"');
+    });
+    expect(screen.getByTestId("run-state")).toHaveTextContent('"activeJobId":null');
+    expect(screen.getByTestId("run-state")).toHaveTextContent('"isConsoleOpen":false');
+  });
+
+  it("reattaches a running job so polling continues after a refresh", async () => {
+    jobs.splice(
+      0,
+      jobs.length,
+      makeJob({
+        id: "live-run",
+        pipelineId: "pipe-1",
+        status: "running",
+        nodeStatuses: { operation: "running" },
+      }),
+    );
+
+    render(
+      <>
+        <RunStateRestorer />
+        <RunStateProbe />
+      </>,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("run-state")).toHaveTextContent('"activeJobId":"live-run"');
+    });
+    expect(screen.getByTestId("run-state")).toHaveTextContent('"isConsoleOpen":true');
+    expect(screen.getByTestId("run-state")).toHaveTextContent('"operation":"running"');
+  });
+});

--- a/packages/views/src/pages/CanvasPage/_store/uiSlice.ts
+++ b/packages/views/src/pages/CanvasPage/_store/uiSlice.ts
@@ -1,6 +1,7 @@
 import type { ChangeEvent } from "react";
 import { applyPipelineActions } from "@repo/pipeline-engine/actions";
 import type {
+  Job,
   NodeRunStatus,
   PipelineActionDiagnostic,
   PipelineActionProposal,
@@ -153,6 +154,8 @@ export interface UISlice {
   startTestRun: () => void;
   stopTestRun: () => void;
   applyNodeLlmContent: (nodeId: string, content: string) => void;
+  restoreRunState: (job: Job) => void;
+  setNodeRunStatuses: (statuses: Record<string, NodeRunStatus>) => void;
 
   // Semantic actions
   handleCloseConsole: () => void;
@@ -419,6 +422,32 @@ export const createUISlice = (
     set((state) => ({
       nodeLlmContent: { ...state.nodeLlmContent, [nodeId]: content },
     }));
+  },
+
+  restoreRunState: (job) => {
+    const live = job.status === "queued" || job.status === "running" || job.status === "paused";
+    const nodeRunStatuses = { ...job.nodeStatuses };
+    const runningNodeId =
+      Object.entries(nodeRunStatuses).find(
+        ([, status]) => status === "running" || status === "retrying",
+      )?.[0] ?? null;
+
+    set({
+      activeJobId: live ? job.id : null,
+      isConsoleOpen: live,
+      isTestRunning: live,
+      nodeRunStatuses,
+      runningNodeId,
+    });
+  },
+
+  setNodeRunStatuses: (nodeRunStatuses) => {
+    const runningNodeId =
+      Object.entries(nodeRunStatuses).find(
+        ([, status]) => status === "running" || status === "retrying",
+      )?.[0] ?? null;
+
+    set({ nodeRunStatuses: { ...nodeRunStatuses }, runningNodeId });
   },
 
   // Semantic actions


### PR DESCRIPTION
## 概述

Pipeline Agent 规划阶段体验增强：支持规划内容的流式预览与方案追问，并补齐 Canvas 运行状态恢复能力。

## 变更内容

### 1. Pipeline Agent 规划流式预览 + 方案追问
- `packages/agent`：`runClaude` / `runCodex` 透出 `onTextDelta`，流式解析 `stream-json` 增量文本
- `packages/agent-engine`：driver / executor 传递文本增量
- `packages/services`：新增 `streamPlanningPreview`（安全提取规划字段，不泄露原始 JSON）；`createPipelineAgentSessionsService` 支持方案追问（`openQuestions` / `readiness`）
- `packages/views`：`AgentPanel` 规划流展示 + `ProposalCard` 方案追问交互
- `packages/schemas`：`PipelineActionProposalSchema` 扩展追问字段
- `apps/server`：规划流经 SSE `assistant_chunk` 下发

### 2. 首页运行时选择器下沉
- `apps/app`：运行时选择器从 `HomePage` 移入 `PipelineCreationComposer`，集中创建流程状态

### 3. Canvas 运行状态恢复
- `packages/views`：新增 `RunStateRestorer`，进入 Canvas 时恢复运行中节点状态；`uiSlice` 增加 `restoreRunState`
- `RunConsole` 状态同步与 `OperationNode` 联动

## 测试

- `packages/agent`：102 passed
- `packages/agent-engine`：23 passed
- `packages/services`：498 passed
- `apps/server`：100 passed
- `packages/views`：382 passed
- `apps/app`（HomePage / PipelineCreationWorkspace）：14 passed
- lint（oxlint）与 typecheck（tsc --noEmit）全部通过

## 说明

- 无前端视觉样式截图差异（行为变更为主）
- 未包含无关的 `COD-334-agent-selector-playground-handoff.md`（独立交接文档）