### PR TITLE
feat: Alan 前端视觉与交互体验迁移（COD-355）

### DIFF
--- a/apps/app/e2e/alan-migration.visual.e2e.spec.ts
+++ b/apps/app/e2e/alan-migration.visual.e2e.spec.ts
@@ -1,0 +1,351 @@
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const visualEvidenceEnabled = process.env.COD355_VISUAL_EVIDENCE === "1";
+const alanHarnessEnabled = process.env.COD355_ALAN_HARNESS === "1";
+const evidenceRoot = path.resolve(process.cwd(), "../../pr-assets/cod-355");
+const desktopViewport = { height: 900, width: 1440 };
+const responsiveViewports = [
+  { height: 900, width: 1440 },
+  { height: 820, width: 1180 },
+  { height: 820, width: 981 },
+  { height: 820, width: 701 },
+  { height: 844, width: 390 },
+] as const;
+
+type Version = "alan" | "before" | "after";
+
+type Surface = {
+  name: string;
+  routes: Record<Version, string>;
+  normalizeSearch?: boolean;
+};
+
+const surfaces: Surface[] = [
+  {
+    name: "pipelines",
+    normalizeSearch: true,
+    routes: {
+      alan: "http://localhost:9440/pipelines",
+      before: "http://localhost:9450/pipelines",
+      after: "http://localhost:9430/pipelines",
+    },
+  },
+  {
+    name: "components",
+    normalizeSearch: true,
+    routes: {
+      alan: "http://localhost:9440/components",
+      before: "http://localhost:9450/components",
+      after: "http://localhost:9430/components",
+    },
+  },
+  {
+    name: "operations",
+    normalizeSearch: true,
+    routes: {
+      alan: "http://localhost:9440/pipelines/operations",
+      before: "http://localhost:9450/pipelines/operations",
+      after: "http://localhost:9430/pipelines/operations",
+    },
+  },
+  {
+    name: "jobs",
+    normalizeSearch: true,
+    routes: {
+      alan: "http://localhost:9440/jobs",
+      before: "http://localhost:9450/pipelines/jobs",
+      after: "http://localhost:9430/pipelines/jobs",
+    },
+  },
+  {
+    name: "settings",
+    routes: {
+      alan: "http://localhost:9440/settings",
+      before: "http://localhost:9450/settings",
+      after: "http://localhost:9430/settings",
+    },
+  },
+  {
+    name: "canvas",
+    routes: {
+      alan: "http://localhost:9440/pipelines",
+      before: "http://localhost:9450/canvas",
+      after: "http://localhost:9430/canvas",
+    },
+  },
+];
+
+const initializeStablePresentation = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("i18nextLng", "en");
+    localStorage.setItem(
+      "ordine.theme",
+      JSON.stringify({ state: { preference: "light" }, version: 0 }),
+    );
+  });
+};
+
+const hideDynamicOverlays = async (page: Page) => {
+  await page.addStyleTag({
+    content: `
+      div.fixed.top-4.right-4.z-50.flex.flex-col.gap-2 { display: none !important; }
+      * { caret-color: transparent !important; }
+    `,
+  });
+};
+
+const normalizeSurfaceState = async (page: Page, surface: Surface) => {
+  if (!surface.normalizeSearch) {
+    return;
+  }
+
+  const searchInputs = page.locator("main input");
+  const count = await searchInputs.count();
+  if (count > 0) {
+    await searchInputs.last().fill("cod355-visual-no-match");
+    await page.waitForTimeout(250);
+  }
+};
+
+const captureSurface = async ({
+  page,
+  surface,
+  version,
+  viewport,
+}: {
+  page: Page;
+  surface: Surface;
+  version: Version;
+  viewport: { height: number; width: number };
+}) => {
+  await page.setViewportSize(viewport);
+  if (surface.name === "canvas" && version === "alan") {
+    const pipelinesSurface = surfaces.find((candidate) => candidate.name === "pipelines");
+    if (!pipelinesSurface) {
+      throw new Error("Pipelines visual surface is missing");
+    }
+
+    await page.goto(pipelinesSurface.routes.alan, { waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("button", { name: "New Pipeline" })).toBeVisible();
+    await page.getByRole("button", { name: "New Pipeline" }).click();
+    await page.waitForURL(/\/workspace\/pipeline-[a-f0-9-]+\/?$/);
+    await expect(page.getByTestId("canvas-v2-root")).toBeVisible();
+  } else {
+    await page.goto(surface.routes[version], { waitUntil: "domcontentloaded" });
+  }
+  await page.locator("body").waitFor({ state: "visible" });
+  await page.waitForTimeout(1100);
+  await expect
+    .poll(
+      async () => {
+        const bodyText = await page.locator("body").textContent();
+
+        return bodyText?.trim().length ?? 0;
+      },
+      { timeout: 20_000 },
+    )
+    .toBeGreaterThan(20);
+  await hideDynamicOverlays(page);
+  await normalizeSurfaceState(page, surface);
+
+  const filename = `${surface.name}-${viewport.width}x${viewport.height}-${version}.png`;
+  const filePath = path.join(evidenceRoot, filename);
+  await page.screenshot({ animations: "disabled", path: filePath });
+
+  return filePath;
+};
+
+const captureCanvasNodeCard = async ({ page, version }: { page: Page; version: Version }) => {
+  const canvasSurface = surfaces.find((surface) => surface.name === "canvas");
+  if (!canvasSurface) {
+    throw new Error("Canvas visual surface is missing");
+  }
+
+  await page.setViewportSize(desktopViewport);
+  const entryRoute =
+    version === "alan"
+      ? surfaces.find((surface) => surface.name === "pipelines")!.routes.alan
+      : canvasSurface.routes[version];
+  await page.goto(entryRoute, { waitUntil: "domcontentloaded" });
+  await page.locator("body").waitFor({ state: "visible" });
+  await page.waitForTimeout(1200);
+  await hideDynamicOverlays(page);
+
+  const node: Locator =
+    version === "alan"
+      ? await (async () => {
+          await expect(page.getByRole("button", { name: "New Pipeline" })).toBeVisible();
+          await page.getByRole("button", { name: "New Pipeline" }).click();
+          await page.waitForURL(/\/workspace\/pipeline-[a-f0-9-]+\/?$/);
+
+          const seedButton = page.getByTestId("canvas-v2-empty-seed");
+          await expect(seedButton).toBeVisible();
+          await seedButton.click();
+
+          return page.getByTestId("canvas-v2-node-shell-root").first();
+        })()
+      : version === "before"
+        ? await (async () => {
+            await page
+              .getByRole("button", { name: /^File File/ })
+              .first()
+              .click();
+
+            return page.locator(".react-flow__node-file").first();
+          })()
+        : await (async () => {
+            await page.getByTestId("canvas-component-object-file").click();
+            await page.getByTestId("canvas-v2-settings").click();
+            await page.getByRole("button", { name: "Expanded" }).click();
+            await page.getByRole("button", { name: "Close Canvas settings" }).click();
+
+            return page.locator(".react-flow__node-file").first();
+          })();
+
+  await expect(node).toBeVisible();
+  await node.hover();
+  await page.waitForTimeout(200);
+  await hideDynamicOverlays(page);
+
+  const filePath = path.join(evidenceRoot, `canvas-nodecard-1440x900-${version}.png`);
+  await page.screenshot({ animations: "disabled", path: filePath });
+
+  return filePath;
+};
+
+const captureDifference = async ({
+  afterPath,
+  beforePath,
+  page,
+  surface,
+  viewport,
+}: {
+  afterPath: string;
+  beforePath: string;
+  page: Page;
+  surface: Surface;
+  viewport: { height: number; width: number };
+}) => {
+  const [after, before] = await Promise.all([readFile(afterPath), readFile(beforePath)]);
+  const afterUrl = `data:image/png;base64,${after.toString("base64")}`;
+  const beforeUrl = `data:image/png;base64,${before.toString("base64")}`;
+  await page.setViewportSize(viewport);
+  await page.setContent(`
+    <!doctype html>
+    <html>
+      <head>
+        <style>
+          html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; background: #000; }
+          .stack { position: relative; width: 100%; height: 100%; }
+          img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: fill; }
+          img.after { mix-blend-mode: difference; }
+        </style>
+      </head>
+      <body>
+        <div class="stack">
+          <img alt="Before" src="${beforeUrl}" />
+          <img alt="After difference" class="after" src="${afterUrl}" />
+        </div>
+      </body>
+    </html>
+  `);
+  await page.waitForFunction(() =>
+    [...document.images].every((image) => image.complete && image.naturalWidth > 0),
+  );
+  await page.screenshot({
+    animations: "disabled",
+    path: path.join(evidenceRoot, `${surface.name}-${viewport.width}x${viewport.height}-diff.png`),
+  });
+};
+
+test.describe("COD-355 visual evidence", () => {
+  test.skip(
+    !visualEvidenceEnabled || !alanHarnessEnabled,
+    "Set COD355_VISUAL_EVIDENCE=1 and COD355_ALAN_HARNESS=1; exact Alan harness is currently blocked by the fixed reference infrastructure.",
+  );
+
+  test("captures Alan, Before, After, Diff, and five Canvas viewports", async ({ page }) => {
+    test.setTimeout(180_000);
+    await mkdir(evidenceRoot, { recursive: true });
+    await initializeStablePresentation(page);
+
+    for (const surface of surfaces) {
+      const alanPath = await captureSurface({
+        page,
+        surface,
+        version: "alan",
+        viewport: desktopViewport,
+      });
+      const beforePath = await captureSurface({
+        page,
+        surface,
+        version: "before",
+        viewport: desktopViewport,
+      });
+      const afterPath = await captureSurface({
+        page,
+        surface,
+        version: "after",
+        viewport: desktopViewport,
+      });
+
+      await expect(readFile(alanPath)).resolves.toBeTruthy();
+      await captureDifference({ afterPath, beforePath, page, surface, viewport: desktopViewport });
+    }
+
+    const canvasSurface = surfaces.find((surface) => surface.name === "canvas");
+    expect(canvasSurface).toBeDefined();
+    if (!canvasSurface) {
+      return;
+    }
+
+    for (const viewport of responsiveViewports.slice(1)) {
+      await captureSurface({ page, surface: canvasSurface, version: "after", viewport });
+    }
+
+    await page.setViewportSize(desktopViewport);
+    await page.goto("http://localhost:9430/settings", { waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("heading", { level: 1, name: "Settings" })).toBeVisible();
+    await hideDynamicOverlays(page);
+    await page.getByTestId("settings-appearance-dark").click();
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    await page.screenshot({
+      animations: "disabled",
+      path: path.join(evidenceRoot, "settings-1440x900-after-dark-en.png"),
+    });
+
+    await page.getByRole("combobox").first().click();
+    await page.getByRole("option", { name: "简体中文" }).click();
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await expect(page.getByRole("heading", { level: 1, name: "设置" })).toBeVisible();
+    await page.screenshot({
+      animations: "disabled",
+      path: path.join(evidenceRoot, "settings-1440x900-after-dark-zh.png"),
+    });
+  });
+
+  test("captures direct Alan, Before, and After NodeCard states", async ({ page }) => {
+    test.setTimeout(90_000);
+    await mkdir(evidenceRoot, { recursive: true });
+    await initializeStablePresentation(page);
+
+    const alanPath = await captureCanvasNodeCard({ page, version: "alan" });
+    const beforePath = await captureCanvasNodeCard({ page, version: "before" });
+    const afterPath = await captureCanvasNodeCard({ page, version: "after" });
+    const nodeCardSurface: Surface = {
+      name: "canvas-nodecard",
+      routes: surfaces.find((surface) => surface.name === "canvas")!.routes,
+    };
+
+    await expect(readFile(alanPath)).resolves.toBeTruthy();
+    await captureDifference({
+      afterPath,
+      beforePath,
+      page,
+      surface: nodeCardSurface,
+      viewport: desktopViewport,
+    });
+  });
+});

--- a/apps/app/e2e/canvas.e2e.spec.ts
+++ b/apps/app/e2e/canvas.e2e.spec.ts
@@ -85,12 +85,27 @@ const measureInteraction = async (
   metrics.push({ durationMs: Math.round(finishedAt - startedAt), name });
 };
 
+const clickCanvasAction = async (page: Page, name: string) => {
+  await page.getByTestId("canvas-actions-menu").click();
+  await page.getByRole("menuitem", { name, exact: true }).click();
+};
+
 const dragNodeBy = async (page: Page, node: Locator, delta: { x: number; y: number }) => {
   const before = await node.boundingBox();
   expect(before).not.toBeNull();
   if (!before) return;
 
-  const start = { x: before.x + 20, y: before.y + 20 };
+  const headerIcon = node
+    .getByTestId("canvas-v2-node-card")
+    .locator('[data-slot="card-header"] > div')
+    .first();
+  const headerIconBounds = await headerIcon.boundingBox();
+  const start = headerIconBounds
+    ? {
+        x: headerIconBounds.x + headerIconBounds.width / 2,
+        y: headerIconBounds.y + headerIconBounds.height / 2,
+      }
+    : { x: before.x + 20, y: before.y + 20 };
   await page.mouse.move(start.x, start.y);
   await page.mouse.down();
   await page.mouse.move(start.x + delta.x, start.y + delta.y, { steps: 16 });
@@ -180,6 +195,22 @@ const createOperation = async (page: Page, operationId: string) => {
   expect(response.ok()).toBe(true);
 };
 
+const createAgentRuntime = async (page: Page, runtimeId: string) => {
+  const response = await page.request.post("/api/trpc/agentRuntimes.create?batch=1", {
+    data: {
+      0: {
+        json: {
+          connection: { binaryName: "node", mode: "local" },
+          id: runtimeId,
+          name: "Canvas E2E Runtime",
+          type: "hermes",
+        },
+      },
+    },
+  });
+  expect(response.ok()).toBe(true);
+};
+
 const openCanvasPage = async (page: Page, runId: string) => {
   await navigateAndWait(page, "/pipelines");
   const pipelineId = `pipeline-e2e-${runId}`;
@@ -207,19 +238,20 @@ const openCanvasPage = async (page: Page, runId: string) => {
 };
 
 test.describe("Canvas editor", () => {
-  test("keeps the desktop Canvas inside 701-1440px viewports", async ({
-    page,
-    pageErrors,
-  }, testInfo) => {
+  test("keeps the Canvas inside 390-1440px viewports", async ({ page, pageErrors }, testInfo) => {
     await openCanvasPage(page, `responsive-${Date.now()}-${testInfo.workerIndex}`);
 
-    for (const width of [1440, 1180, 981, 701]) {
+    for (const width of [1440, 1180, 981, 701, 390]) {
       await page.setViewportSize({ width, height: 820 });
       await expect(page.getByTestId("canvas-langflow-shell")).toBeVisible();
       await expect(page.getByTestId("canvas-top-chrome")).toBeVisible();
-      await expect(page.getByTestId("canvas-toolbar")).toBeVisible();
+      await expect(page.getByTestId("canvas-v2-toolbar")).toBeVisible();
       await expect(page.getByTestId("canvas-agent-panel-region")).toBeVisible();
-      await expect(page.getByRole("button", { name: "Notifications" })).toBeVisible();
+      if (width <= 768) {
+        await expect(page.getByRole("button", { name: "Toggle Sidebar" })).toBeVisible();
+      } else {
+        await expect(page.getByTestId("notification-bell")).toBeVisible();
+      }
 
       const metrics = await page.evaluate(() => {
         const agentBounds = document
@@ -228,8 +260,37 @@ test.describe("Canvas editor", () => {
         const shellBounds = document
           .querySelector<HTMLElement>('[data-testid="canvas-langflow-shell"]')
           ?.getBoundingClientRect();
+        const sidebarToggleBounds = document
+          .querySelector<HTMLElement>('[data-sidebar="trigger"]')
+          ?.getBoundingClientRect();
+        const sidebarToggleBar = document.querySelector<HTMLElement>(
+          '[data-sidebar="trigger"]',
+        )?.parentElement;
         const topChromeBounds = document
           .querySelector<HTMLElement>('[data-testid="canvas-top-chrome"]')
+          ?.getBoundingClientRect();
+        const topRightControlSelectors = [
+          '[data-testid="canvas-v2-state-legend-trigger"]',
+          '[data-testid="canvas-v2-run"]',
+          '[data-testid="canvas-v2-agent-reopen"]',
+        ];
+        const topRightControls = topRightControlSelectors.flatMap((selector) => {
+          const bounds = document.querySelector<HTMLElement>(selector)?.getBoundingClientRect();
+
+          return bounds
+            ? [
+                {
+                  bottom: bounds.bottom,
+                  left: bounds.left,
+                  right: bounds.right,
+                  selector,
+                  top: bounds.top,
+                },
+              ]
+            : [];
+        });
+        const agentShellBounds = document
+          .querySelector<HTMLElement>('[data-testid="canvas-agent-panel-shell"]')
           ?.getBoundingClientRect();
 
         return {
@@ -242,6 +303,7 @@ test.describe("Canvas editor", () => {
               }
             : null,
           documentWidth: document.documentElement.scrollWidth,
+          agentShellWidth: agentShellBounds?.width ?? null,
           shell: shellBounds
             ? {
                 bottom: shellBounds.bottom,
@@ -250,6 +312,26 @@ test.describe("Canvas editor", () => {
                 top: shellBounds.top,
               }
             : null,
+          sidebarToggle: sidebarToggleBounds
+            ? {
+                bottom: sidebarToggleBounds.bottom,
+                left: sidebarToggleBounds.left,
+                right: sidebarToggleBounds.right,
+                top: sidebarToggleBounds.top,
+              }
+            : null,
+          sidebarToggleBarZIndex: sidebarToggleBar
+            ? Number.parseInt(getComputedStyle(sidebarToggleBar).zIndex, 10)
+            : null,
+          topChromeZIndex: document.querySelector<HTMLElement>('[data-testid="canvas-top-chrome"]')
+            ? Number.parseInt(
+                getComputedStyle(
+                  document.querySelector<HTMLElement>('[data-testid="canvas-top-chrome"]')!,
+                ).zIndex,
+                10,
+              )
+            : null,
+          topRightControls,
           topChrome: topChromeBounds
             ? {
                 bottom: topChromeBounds.bottom,
@@ -268,11 +350,19 @@ test.describe("Canvas editor", () => {
       if (width <= 1180) {
         expect(metrics.agent?.top).toBeGreaterThanOrEqual((metrics.topChrome?.bottom ?? 0) - 1);
       }
+      if (width <= 768) {
+        expect(metrics.sidebarToggle).not.toBeNull();
+      }
+      if (width === 390) {
+        expect(metrics.sidebarToggleBarZIndex).toBeGreaterThan(metrics.topChromeZIndex ?? 0);
+        expect(metrics.agentShellWidth).toBeGreaterThan(width - 2);
+        for (const control of metrics.topRightControls) {
+          expect(control.left).toBeGreaterThanOrEqual(-1);
+          expect(control.right).toBeLessThanOrEqual(width + 1);
+        }
+      }
 
-      await testInfo.attach(`canvas-${width}x820`, {
-        body: await page.screenshot(),
-        contentType: "image/png",
-      });
+      process.stdout.write(`CANVAS_VIEWPORT_METRICS ${JSON.stringify({ width, ...metrics })}\n`);
     }
 
     expectNoJSErrors(pageErrors);
@@ -283,20 +373,56 @@ test.describe("Canvas editor", () => {
 
     await expect(page.getByTestId("canvas-langflow-shell")).toBeVisible();
     await expect(page.getByTestId("canvas-flow-viewport")).toBeVisible();
-    await expect(page.getByTestId("canvas-toolbar")).toBeVisible();
+    await expect(page.getByTestId("canvas-v2-toolbar")).toBeVisible();
     await expect(page.getByTestId("canvas-top-chrome")).toBeVisible();
     await expect(page.getByTestId("canvas-component-panel")).toBeVisible();
     await expect(page.getByTestId("canvas-agent-panel")).toBeVisible();
 
-    const folderButton = page.getByRole("button", {
-      name: /(?:Folder Folder|文件夹 文件夹)/,
-    });
+    await page.getByTestId("canvas-v2-state-legend-trigger").click();
+    await expect(page.getByTestId("canvas-v2-state-legend")).toBeVisible();
+    await expect(page.getByTestId("canvas-status-bar")).toBeVisible();
+    await page.getByTestId("canvas-v2-state-legend-trigger").click();
+
+    const folderButton = page.getByTestId("canvas-component-object-folder");
     await expect(folderButton).toBeVisible();
 
     await folderButton.click();
-    await expect(
-      page.getByTestId("canvas-flow-viewport").locator(".react-flow__node").first(),
-    ).toBeVisible();
+    const folderNode = page
+      .getByTestId("canvas-flow-viewport")
+      .locator(".react-flow__node")
+      .first();
+    await expect(folderNode).toBeVisible();
+    await folderNode.hover();
+    await folderNode.getByTestId("canvas-node-configure").click();
+
+    const nodeConfig = page.getByTestId("canvas-v2-node-config");
+    await expect(nodeConfig).toBeVisible();
+    await expect(nodeConfig.getByTestId("node-config-label")).toBeVisible();
+    await expect(page.getByTestId("canvas-properties-panel")).toHaveCSS("width", "440px");
+    await testInfo.attach("canvas-node-config", {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    });
+    await nodeConfig.getByTestId("node-config-done").click();
+    await expect(nodeConfig).toHaveCount(0);
+
+    await page.getByTestId("canvas-component-panel-toggle").click();
+    await page.getByTestId("canvas-flow-viewport").click({
+      button: "right",
+      position: { x: 600, y: 520 },
+    });
+    const canvasMenu = page.getByRole("menu");
+    await expect(canvasMenu).toBeVisible();
+    await expect(canvasMenu).toHaveClass(/rounded-2xl/);
+    await expect(canvasMenu.getByRole("menuitem", { name: /Folder/i }).first()).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    await clickCanvasAction(page, "Quick add node");
+    const quickAdd = page.getByRole("dialog", { name: "Quick add node" });
+    await expect(quickAdd).toBeVisible();
+    await expect(quickAdd).toHaveClass(/rounded-2xl/);
+    await quickAdd.getByRole("button", { name: "Close quick add" }).click();
+    await expect(quickAdd).toHaveCount(0);
 
     expectNoJSErrors(pageErrors);
   });
@@ -308,22 +434,11 @@ test.describe("Canvas editor", () => {
     test.setTimeout(60_000);
     const runId = `${Date.now()}-${testInfo.workerIndex}-${testInfo.repeatEachIndex}`;
     const operationId = `operation-e2e-${runId}`;
+    const runtimeId = `runtime-e2e-${runId}`;
     const interactions: InteractionMetric[] = [];
 
     await mockCanvasAgent(page);
-    await navigateAndWait(page, "/local-agents");
-    await page.getByRole("button", { name: "Re-scan" }).click();
-    const runtimeDialog = page.getByRole("dialog", { name: "Runtime scan results" });
-    await expect(runtimeDialog).toBeVisible();
-    const syncButton = runtimeDialog.getByRole("button", { name: "Sync changes" });
-    if (await syncButton.isVisible()) {
-      await syncButton.click();
-    } else {
-      await expect(runtimeDialog.getByText("No runtime changes detected.")).toBeVisible();
-      await runtimeDialog.getByRole("button", { name: "Cancel", exact: true }).click();
-    }
-    await expect(runtimeDialog).toHaveCount(0);
-    await expect(page.getByText(/\d+ of \d+ supported Local Agents are synced\./)).toBeVisible();
+    await createAgentRuntime(page, runtimeId);
     await openCanvasPage(page, runId);
     await createOperation(page, operationId);
     await page.reload();
@@ -333,44 +448,72 @@ test.describe("Canvas editor", () => {
 
     const componentPanel = page.getByTestId("canvas-component-panel");
     const flow = page.getByTestId("canvas-flow-viewport");
-    const fileEntry = componentPanel.getByRole("button", { name: /^File File/ });
+    const fileEntry = componentPanel.getByTestId("canvas-component-object-file");
     const operationEntry = componentPanel.getByTestId(`canvas-operation-${operationId}`);
     await expect(operationEntry).toBeVisible();
 
     await measureInteraction(page, interactions, "drag file from palette", async () => {
-      await fileEntry.dragTo(flow, { targetPosition: { x: 120, y: 120 } });
+      await fileEntry.dragTo(flow, { targetPosition: { x: 450, y: 220 } });
       await expect(page.locator(".react-flow__node-file")).toHaveCount(1);
     });
     await measureInteraction(page, interactions, "add operation from palette", async () => {
       await operationEntry.click();
       await expect(page.locator(".react-flow__node-operation")).toHaveCount(1);
     });
+    await page.getByTestId("canvas-component-panel-toggle").click();
 
     const fileNode = page.locator(".react-flow__node-file");
     const operationNode = page.locator(".react-flow__node-operation");
     await page.getByRole("button", { name: "Select" }).click();
-    const operationPositionBeforeMove = await operationNode.boundingBox();
+    await expect(operationNode.getByTestId("canvas-v2-node-shell-root")).toHaveAttribute(
+      "data-card-mode",
+      "compact",
+    );
+    const operationTransformBeforeMove = await operationNode.evaluate(
+      (element) => (element as HTMLElement).style.transform,
+    );
     await measureInteraction(page, interactions, "move operation node", async () => {
       await dragNodeBy(page, operationNode, { x: 120, y: 80 });
     });
-    await page.getByTitle("Undo").click();
+    await clickCanvasAction(page, "Undo");
+    await flow.click({ position: { x: 600, y: 100 } });
     await expect
-      .poll(async () => {
-        const afterUndo = await operationNode.boundingBox();
-        if (!operationPositionBeforeMove || !afterUndo) return Number.POSITIVE_INFINITY;
-
-        return Math.hypot(
-          afterUndo.x - operationPositionBeforeMove.x,
-          afterUndo.y - operationPositionBeforeMove.y,
-        );
-      })
-      .toBeLessThan(12);
-    await page.getByTitle("Redo").click();
+      .poll(() => operationNode.evaluate((element) => (element as HTMLElement).style.transform))
+      .toBe(operationTransformBeforeMove);
+    await clickCanvasAction(page, "Redo");
 
     await measureInteraction(page, interactions, "connect file to operation", async () => {
       await connectNodes(page, fileNode, operationNode);
       await expect(page.locator(".react-flow__edge")).toHaveCount(1);
     });
+
+    await page.locator(".react-flow__edge-interaction").first().dispatchEvent("click");
+    const edgeInspector = page.getByTestId("canvas-edge-inspector");
+    await expect(edgeInspector).toBeVisible();
+    await edgeInspector.getByTestId("canvas-edge-condition").fill("approved");
+    await expect(edgeInspector.getByTestId("canvas-edge-condition")).toHaveValue("approved");
+    await edgeInspector.getByTestId("canvas-edge-inspector-close").click();
+    await expect(edgeInspector).toHaveCount(0);
+
+    await Promise.all([
+      page.waitForResponse(
+        (response) => response.url().includes("pipelines.update") && response.ok(),
+      ),
+      page
+        .getByTestId("canvas-top-chrome")
+        .getByRole("button", { name: "Save", exact: true })
+        .click(),
+    ]);
+    await expect(page.getByText("Pipeline saved")).toBeVisible();
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await startRenderingSample(page);
+    await expect(page.locator(".react-flow__node-file")).toHaveCount(1);
+    await expect(page.locator(".react-flow__node-operation")).toHaveCount(1);
+    await expect(page.locator(".react-flow__edge")).toHaveCount(1);
+    await page.locator(".react-flow__edge-interaction").first().dispatchEvent("click");
+    await expect(page.getByTestId("canvas-edge-condition")).toHaveValue("approved");
+    await page.getByTestId("canvas-edge-inspector-close").click();
 
     await measureInteraction(page, interactions, "send canvas Agent message", async () => {
       await page.getByRole("textbox", { name: "Message" }).fill("Review the connected nodes");

--- a/apps/app/e2e/frontend-acceptance.e2e.spec.ts
+++ b/apps/app/e2e/frontend-acceptance.e2e.spec.ts
@@ -1,0 +1,135 @@
+import { createRequire } from "node:module";
+import { expect } from "@playwright/test";
+import { test, navigateAndWait, expectNoJSErrors } from "./fixtures";
+
+const rootRequire = createRequire(import.meta.url);
+const a11yAddonEntry = rootRequire.resolve("@storybook/addon-a11y");
+const axeScriptPath = createRequire(a11yAddonEntry).resolve("axe-core/axe.min.js");
+
+type AxeViolation = {
+  help: string;
+  id: string;
+  impact: "minor" | "moderate" | "serious" | "critical" | null;
+  nodes: Array<{ html: string; target: string[] }>;
+};
+
+test.describe("COD-355 frontend acceptance", () => {
+  test("switches the develop theme and language controls", async ({ page, pageErrors }) => {
+    await navigateAndWait(page, "/settings");
+
+    const darkTheme = page.getByTestId("settings-appearance-dark");
+    await darkTheme.click();
+    await expect(darkTheme).toHaveAttribute("aria-pressed", "true");
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.style.colorScheme))
+      .toBe("dark");
+
+    const lightTheme = page.getByTestId("settings-appearance-light");
+    await lightTheme.click();
+    await expect(lightTheme).toHaveAttribute("aria-pressed", "true");
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+
+    await page.getByRole("combobox").first().click();
+    await page.getByRole("option", { name: "English (US)" }).click();
+    await page.getByRole("button", { name: /Save changes|保存更改/ }).click();
+    await expect(page.getByRole("heading", { level: 1, name: "Settings" })).toBeVisible();
+    await expect.poll(() => page.evaluate(() => localStorage.getItem("i18nextLng"))).toMatch(/^en/);
+
+    expectNoJSErrors(pageErrors);
+  });
+
+  test("supports keyboard search, visible focus, and reduced motion", async ({
+    page,
+    pageErrors,
+  }) => {
+    await navigateAndWait(page, "/pipelines");
+    await page.keyboard.press("Control+K");
+    const searchDialog = page.getByRole("dialog");
+    await expect(searchDialog).toBeVisible();
+    await expect(searchDialog.getByRole("textbox")).toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(searchDialog).toHaveCount(0);
+
+    await page.locator("body").press("Tab");
+    const focusEvidence = await page.evaluate(() => {
+      const element = document.activeElement as HTMLElement | null;
+      const style = element ? getComputedStyle(element) : null;
+
+      return {
+        accessibleName: element?.getAttribute("aria-label") ?? element?.textContent?.trim() ?? "",
+        boxShadow: style?.boxShadow ?? "none",
+        outlineStyle: style?.outlineStyle ?? "none",
+        tagName: element?.tagName ?? "",
+      };
+    });
+    expect(focusEvidence.accessibleName.length).toBeGreaterThan(0);
+    expect(["A", "BUTTON", "INPUT"]).toContain(focusEvidence.tagName);
+    expect(focusEvidence.boxShadow !== "none" || focusEvidence.outlineStyle !== "none").toBe(true);
+
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await navigateAndWait(page, "/canvas");
+    const reducedMotion = await page.evaluate(() => {
+      const animatedSurface = document.querySelector<HTMLElement>(".fade-rise");
+      const style = animatedSurface ? getComputedStyle(animatedSurface) : null;
+      const animationDuration = style?.animationDuration ?? "0s";
+      const transitionDuration = style?.transitionDuration ?? "0s";
+
+      return {
+        animationMs: animationDuration.endsWith("ms")
+          ? Number.parseFloat(animationDuration)
+          : Number.parseFloat(animationDuration) * 1000,
+        scrollBehavior: style?.scrollBehavior ?? "auto",
+        transitionMs: transitionDuration.endsWith("ms")
+          ? Number.parseFloat(transitionDuration)
+          : Number.parseFloat(transitionDuration) * 1000,
+      };
+    });
+    expect(reducedMotion.animationMs).toBeLessThanOrEqual(0.02);
+    expect(reducedMotion.transitionMs).toBeLessThanOrEqual(0.02);
+    expect(reducedMotion.scrollBehavior).toBe("auto");
+
+    expectNoJSErrors(pageErrors);
+  });
+
+  test("has no serious or critical Axe violations on shared Pipelines and Canvas", async ({
+    page,
+    pageErrors,
+  }) => {
+    const violationsByRoute: Record<string, AxeViolation[]> = {};
+
+    for (const route of ["/pipelines", "/canvas"]) {
+      await navigateAndWait(page, route);
+      await page.addScriptTag({ path: axeScriptPath });
+      const violations = await page.evaluate(async () => {
+        const axe = (
+          globalThis as unknown as {
+            axe: {
+              run: (
+                root: Document,
+                options: Record<string, unknown>,
+              ) => Promise<{ violations: AxeViolation[] }>;
+            };
+          }
+        ).axe;
+        const result = await axe.run(document, {
+          runOnly: {
+            type: "tag",
+            values: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"],
+          },
+        });
+
+        return result.violations.filter(
+          (violation) => violation.impact === "critical" || violation.impact === "serious",
+        );
+      });
+      violationsByRoute[route] = violations;
+    }
+
+    expect(violationsByRoute, JSON.stringify(violationsByRoute, null, 2)).toEqual({
+      "/canvas": [],
+      "/pipelines": [],
+    });
+    expectNoJSErrors(pageErrors);
+  });
+});

--- a/apps/app/src/components/AppLayout.tsx
+++ b/apps/app/src/components/AppLayout.tsx
@@ -39,17 +39,15 @@ export const AppLayout = ({
                         "[&_[data-slot=sidebar-container]]:hidden [&_[data-slot=sidebar-gap]]:w-0",
                     )}
                     defaultWidth={236}
-                    maxWidth={320}
-                    minWidth={216}
+                    maxWidth={360}
+                    minWidth={200}
                     widthStorageKey="ordine.sidebar.width"
                   >
                     <AppSidebar />
                     <SidebarInset className={cn(canvasMode && "h-svh min-h-0 overflow-hidden")}>
-                      {!canvasMode && (
-                        <div className="hidden h-12 shrink-0 items-center border-b border-border px-3 min-[701px]:flex md:hidden">
-                          <SidebarTrigger />
-                        </div>
-                      )}
+                      <div className="relative z-50 flex h-12 shrink-0 items-center border-b border-border px-3 md:hidden">
+                        <SidebarTrigger />
+                      </div>
                       {children}
                     </SidebarInset>
                     <ToastContainer />

--- a/apps/app/src/components/AppSidebar.tsx
+++ b/apps/app/src/components/AppSidebar.tsx
@@ -43,7 +43,7 @@ const WebUserFooter = () => {
             </Avatar>
             <div className="flex flex-1 flex-col overflow-hidden group-data-[state=collapsed]/sidebar:hidden">
               <span className="truncate text-xs font-medium">{session?.user?.name ?? "User"}</span>
-              <span className="truncate text-[10px] text-muted-foreground">
+              <span className="truncate text-[10px] text-foreground/70">
                 {session?.user?.email ?? ""}
               </span>
             </div>

--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -91,6 +91,8 @@
     "library": "Library",
     "knowledge": "Knowledge",
     "search": "Search...",
+    "sidebarFilterPlaceholder": "Filter navigation...",
+    "searchPipelinesHint": "Search across your pipeline workspaces.",
     "newPipeline": "New Pipeline",
     "preview": "Preview",
     "plugins": "Plugins",
@@ -796,6 +798,7 @@
       "categories": {
         "input": "Input Objects",
         "operations": "Operations",
+        "compound": "Compound",
         "skills": "Skills",
         "output": "Output"
       }
@@ -839,6 +842,24 @@
       },
       "operationDefinition": "Operation definition"
     },
+    "edgeInspector": {
+      "clear": "Clear",
+      "close": "Close",
+      "condition": "Condition",
+      "dropped": "dropped",
+      "flow": "Flow",
+      "maxRetries": "Max retries",
+      "noMappings": "New connection · fields are inferred at run time.",
+      "noTransform": "No transform steps.",
+      "onFail": "On fail",
+      "qualityGate": "Quality Gate",
+      "qualityPlaceholder": "non-empty or required text",
+      "sourceField": "Source field",
+      "targetInput": "Target input",
+      "title": "Data Contract",
+      "toggleHint": "Tap a field to toggle downstream flow · {{enabled}}/{{total}} on",
+      "transform": "Transform"
+    },
     "collapseSidebar": "Collapse sidebar",
     "expandSidebar": "Expand sidebar",
     "nodeLibrary": "Node Library",
@@ -874,8 +895,14 @@
     "aiMode": "AI Mode",
     "agentPanel": {
       "toggle": "AI Assistant",
-      "title": "AI Assistant",
+      "title": "Agent",
       "welcome": "Hi! I'm your AI assistant. Tell me what you'd like to do with your pipeline and I'll suggest operations.",
+      "empty": {
+        "intro": "New canvas — tell me what to make, or drop a finished sample and I'll reverse-engineer the pipeline behind it.",
+        "suggestChangelog": "Summarize a GitHub repo into a changelog",
+        "suggestQuiz": "Turn my textbook PDFs into a Notion quiz",
+        "suggestReverse": "Upload a finished sample → reverse-engineer it"
+      },
       "thinking": "Thinking...",
       "proposal": "Proposed Operations",
       "proposalReceived": "I've received a proposal. Review it below and choose to apply or discard.",
@@ -885,7 +912,7 @@
       "applied": "Proposal applied.",
       "discarded": "Proposal discarded.",
       "diagnostics": "Diagnostics",
-      "error": "Request failed. Please try again later.",
+      "requestFailed": "Request failed. Please try again later.",
       "errorTitle": "AI Assistant Error",
       "close": "Close AI assistant",
       "resize": "Resize AI assistant",
@@ -973,8 +1000,8 @@
       "resize": "Resize operations panel"
     },
     "emptyState": {
-      "title": "Start with a node",
-      "description": "Add an input object or Operation to shape the first pipeline path.",
+      "title": "Start with a node...",
+      "description": "Start with a node, then connect inputs, operations, and outputs into a runnable pipeline.",
       "quickAdd": "Quick add node",
       "contextHint": "You can also right-click blank canvas space to create nodes."
     },

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -91,6 +91,8 @@
     "library": "库",
     "knowledge": "知识",
     "search": "搜索...",
+    "sidebarFilterPlaceholder": "筛选导航...",
+    "searchPipelinesHint": "搜索你的流水线工作区。",
     "newPipeline": "新建流水线",
     "preview": "预览",
     "plugins": "插件",
@@ -789,7 +791,8 @@
       "newCustomOperation": "新建自定义 Operation",
       "categories": {
         "input": "输入对象",
-        "operations": "Operation",
+        "operations": "工序",
+        "compound": "复合节点",
         "skills": "技能",
         "output": "输出"
       }
@@ -833,6 +836,24 @@
       },
       "operationDefinition": "Operation 定义"
     },
+    "edgeInspector": {
+      "clear": "清空",
+      "close": "关闭",
+      "condition": "条件",
+      "dropped": "不传递",
+      "flow": "流向",
+      "maxRetries": "最大重试",
+      "noMappings": "新连接 · 字段将在运行时推断。",
+      "noTransform": "暂无转换步骤。",
+      "onFail": "失败时",
+      "qualityGate": "质量门",
+      "qualityPlaceholder": "非空或必须包含的文本",
+      "sourceField": "源字段",
+      "targetInput": "目标输入",
+      "title": "数据契约",
+      "toggleHint": "点击字段切换是否向下游传递 · {{enabled}}/{{total}} 开启",
+      "transform": "转换"
+    },
     "collapseSidebar": "收起侧栏",
     "expandSidebar": "展开侧栏",
     "nodeLibrary": "节点库",
@@ -868,8 +889,14 @@
     "aiMode": "AI 模式",
     "agentPanel": {
       "toggle": "AI 助手",
-      "title": "AI 助手",
+      "title": "Agent",
       "welcome": "你好！我是你的 AI 助手。告诉我你想对 Pipeline 做什么，我会帮你生成操作建议。",
+      "empty": {
+        "intro": "新画布 — 告诉我要做什么，或拖入一个成品样本，我会逆向推导出生成它的 Pipeline。",
+        "suggestChangelog": "把 GitHub 仓库总结成 changelog",
+        "suggestQuiz": "把我的教材 PDF 变成 Notion 测验",
+        "suggestReverse": "上传成品样本 → 逆向工程"
+      },
       "thinking": "思考中...",
       "proposal": "操作建议",
       "proposalReceived": "已收到操作建议，请查看并决定是否应用。",
@@ -879,7 +906,7 @@
       "applied": "已应用操作建议。",
       "discarded": "已丢弃操作建议。",
       "diagnostics": "诊断信息",
-      "error": "请求失败，请稍后重试。",
+      "requestFailed": "请求失败，请稍后重试。",
       "errorTitle": "AI 助手错误",
       "close": "关闭 AI 助手",
       "resize": "调整 AI 助手宽度",
@@ -968,7 +995,7 @@
     },
     "emptyState": {
       "title": "从一个节点开始",
-      "description": "添加输入对象或 Operation，搭出第一条流水线。",
+      "description": "先放一个节点，再把输入、Operation 和输出连接成可运行的 Pipeline。",
       "quickAdd": "快速新建节点",
       "contextHint": "也可以在画布空白处右键创建节点。"
     },

--- a/apps/app/src/routes/canvas.tsx
+++ b/apps/app/src/routes/canvas.tsx
@@ -75,15 +75,19 @@ const CanvasRouteComponent = () => {
 
   if (!id) {
     return (
-      <AppLayout canvasMode>
-        <CanvasPage embedded onGeneratedPipeline={handleGeneratedPipeline} />
+      <AppLayout>
+        <CanvasPage
+          embedded
+          showCanvasMiniSidebar={false}
+          onGeneratedPipeline={handleGeneratedPipeline}
+        />
       </AppLayout>
     );
   }
 
   if (id && pipelineQuery?.isLoading) {
     return (
-      <AppLayout canvasMode>
+      <AppLayout>
         <PageLoadingState variant="detail" />
       </AppLayout>
     );
@@ -91,7 +95,7 @@ const CanvasRouteComponent = () => {
 
   if (pipelineQuery?.isError) {
     return (
-      <AppLayout canvasMode>
+      <AppLayout>
         <div className="grid h-full w-full place-items-center bg-background p-6">
           <PageState
             action={
@@ -112,7 +116,7 @@ const CanvasRouteComponent = () => {
 
   if (!pipeline) {
     return (
-      <AppLayout canvasMode>
+      <AppLayout>
         <div className="grid h-full w-full place-items-center bg-background p-6">
           <PageState
             action={
@@ -132,8 +136,13 @@ const CanvasRouteComponent = () => {
   }
 
   return (
-    <AppLayout canvasMode>
-      <CanvasPage embedded id={id} onGeneratedPipeline={handleGeneratedPipeline} />
+    <AppLayout>
+      <CanvasPage
+        embedded
+        id={id}
+        showCanvasMiniSidebar={false}
+        onGeneratedPipeline={handleGeneratedPipeline}
+      />
     </AppLayout>
   );
 };

--- a/apps/desktop-app/src/locales/en.json
+++ b/apps/desktop-app/src/locales/en.json
@@ -62,6 +62,8 @@
     "library": "Library",
     "knowledge": "Knowledge",
     "search": "Search...",
+    "sidebarFilterPlaceholder": "Filter navigation...",
+    "searchPipelinesHint": "Search across your pipeline workspaces.",
     "newPipeline": "New Pipeline",
     "preview": "Preview",
     "plugins": "Plugins",
@@ -549,6 +551,24 @@
         "description": "Align dragged nodes to the canvas grid."
       }
     },
+    "edgeInspector": {
+      "clear": "Clear",
+      "close": "Close",
+      "condition": "Condition",
+      "dropped": "dropped",
+      "flow": "Flow",
+      "maxRetries": "Max retries",
+      "noMappings": "New connection · fields are inferred at run time.",
+      "noTransform": "No transform steps.",
+      "onFail": "On fail",
+      "qualityGate": "Quality Gate",
+      "qualityPlaceholder": "non-empty or required text",
+      "sourceField": "Source field",
+      "targetInput": "Target input",
+      "title": "Data Contract",
+      "toggleHint": "Tap a field to toggle downstream flow · {{enabled}}/{{total}} on",
+      "transform": "Transform"
+    },
     "collapseSidebar": "Collapse sidebar",
     "expandSidebar": "Expand sidebar",
     "nodeLibrary": "Node Library",
@@ -584,8 +604,14 @@
     "aiMode": "AI Mode",
     "agentPanel": {
       "toggle": "AI Assistant",
-      "title": "AI Assistant",
+      "title": "Agent",
       "welcome": "Hi! I'm your AI assistant. Tell me what you'd like to do with your pipeline and I'll suggest operations.",
+      "empty": {
+        "intro": "New canvas — tell me what to make, or drop a finished sample and I'll reverse-engineer the pipeline behind it.",
+        "suggestChangelog": "Summarize a GitHub repo into a changelog",
+        "suggestQuiz": "Turn my textbook PDFs into a Notion quiz",
+        "suggestReverse": "Upload a finished sample → reverse-engineer it"
+      },
       "thinking": "Thinking...",
       "proposal": "Proposed Operations",
       "proposalReceived": "I've received a proposal. Review it below and choose to apply or discard.",
@@ -595,25 +621,91 @@
       "applied": "Proposal applied.",
       "discarded": "Proposal discarded.",
       "diagnostics": "Diagnostics",
-      "error": "Request failed. Please try again later.",
+      "requestFailed": "Request failed. Please try again later.",
       "errorTitle": "AI Assistant Error",
       "close": "Close AI assistant",
+      "resize": "Resize AI assistant",
+      "reopen": "Open AI assistant",
       "send": "Send request",
+      "upload": "Upload context",
+      "revise": "Revise plan",
       "runtimeLabel": "Runtime",
       "runtimePlaceholder": "Select a configured runtime",
       "runtimeLoading": "Loading runtimes...",
       "inputPlaceholder": "Type your request...",
       "runtimeNotConfigured": "AI runtime is not configured yet.",
       "goToRuntimeSettings": "Go to configuration",
+      "messageActions": {
+        "copy": "Copy message",
+        "copied": "Copied",
+        "edit": "Edit message",
+        "retry": "Retry message"
+      },
       "proposalDetails": {
         "review": "Review the proposed operations",
         "needsAnswer": "Needs more information before applying",
-        "openQuestion": "Open question"
-      }
+        "openQuestion": "Open question",
+        "askFix": "Fix diagnostics",
+        "fixDiagnostics": "Please fix the blocking diagnostics in the proposal.",
+        "revisePrompt": "Please revise this proposal.",
+        "newOperationBadge": "new op",
+        "loopBadge": "loop x{{count}}",
+        "actionTitles": {
+          "addNode": "Add node: {{nodeType}}",
+          "removeNode": "Remove node",
+          "addEdge": "Add edge",
+          "removeEdge": "Remove edge",
+          "reconnectEdge": "Reconnect edge",
+          "replaceNodeData": "Replace node data",
+          "updateOperation": "Update operation executor"
+        }
+      },
+      "checkpoint": {
+        "waiting": "Waiting for review at {{node}}",
+        "nextNode": "the next node",
+        "controls": "Run checkpoint controls",
+        "pause": "Pause",
+        "resume": "Resume",
+        "review": "Review"
+      },
+      "error": {
+        "title": "Request failed",
+        "tryPrefix": "Try:"
+      },
+      "errorActions": {
+        "openSettings": "Open runtime settings",
+        "retry": "Retry request"
+      },
+      "userAction": {
+        "title": "Action needed ({{count}})",
+        "openConfig": "Open config",
+        "askAgent": "Ask assistant"
+      },
+      "reversing": {
+        "steps": {
+          "structure": "Read structure",
+          "structureDetail": "Understand the current graph",
+          "steps": "Map steps",
+          "stepsDetail": "Identify the requested operations",
+          "matched": "Match nodes",
+          "matchedDetail": "Match operations to the graph",
+          "draft": "Draft proposal",
+          "draftDetail": "Prepare a safe change"
+        }
+      },
+      "action": {
+        "addNode": "Add node: {{type}}",
+        "removeNode": "Remove node: {{nodeId}}",
+        "addEdge": "Add edge: {{source}} → {{target}}",
+        "removeEdge": "Remove edge: {{edgeId}}",
+        "reconnectEdge": "Reconnect edge: {{edgeId}}",
+        "replaceNodeData": "Replace node data: {{nodeId}}"
+      },
+      "contextReset": "The canvas changed, so the attached context was cleared."
     },
     "emptyState": {
-      "title": "Start with a node",
-      "description": "Add an input object or Operation to shape the first pipeline path.",
+      "title": "Start with a node...",
+      "description": "Start with a node, then connect inputs, operations, and outputs into a runnable pipeline.",
       "quickAdd": "Quick add node",
       "contextHint": "You can also right-click blank canvas space to create nodes."
     },
@@ -667,6 +759,20 @@
       "saveSuccessDescription": "Pipeline \"{{name}}\" was saved",
       "createSuccessDescription": "Pipeline \"{{name}}\" was created",
       "saveFailedDescription": "Please try again later"
+    },
+    "componentPanel": {
+      "searchLabel": "Search components",
+      "searchPlaceholder": "Search components...",
+      "categoryAriaLabel": "{{label}} category",
+      "skillFallbackLabel": "Skill",
+      "newCustomOperation": "New Custom Operation",
+      "categories": {
+        "input": "Input Objects",
+        "operations": "Operations",
+        "compound": "Compound",
+        "skills": "Skills",
+        "output": "Output"
+      }
     },
     "nodeTypes": {
       "operation": {
@@ -1315,7 +1421,32 @@
     "createPipeline": "Create one",
     "objectsCount": "{{count}} objects",
     "noPipelineSelected": "\u2014 No pipeline selected",
-    "entireProject": "Entire project"
+    "entireProject": "Entire project",
+    "canvas": {
+      "edges": {
+        "defaultLabel": "data"
+      },
+      "chrome": {
+        "states": {
+          "cancelled": "Cancelled",
+          "done": "Done",
+          "failed": "Failed",
+          "idle": "Idle",
+          "queued": "Queued",
+          "retrying": "Retrying",
+          "running": "Running",
+          "skipped": "Skipped",
+          "title": "Node run states",
+          "trigger": "States",
+          "waitingForUser": "Waiting for user"
+        }
+      },
+      "nodeConfig": {
+        "close": "Close",
+        "done": "Done",
+        "editable": "Editable"
+      }
+    }
   },
   "validation": {
     "nameRequired": "Name is required",

--- a/apps/desktop-app/src/locales/zh.json
+++ b/apps/desktop-app/src/locales/zh.json
@@ -65,6 +65,8 @@
     "library": "库",
     "knowledge": "知识",
     "search": "搜索...",
+    "sidebarFilterPlaceholder": "筛选导航...",
+    "searchPipelinesHint": "搜索你的流水线工作区。",
     "newPipeline": "新建流水线",
     "preview": "预览",
     "plugins": "插件",
@@ -543,6 +545,24 @@
         "description": "拖动节点时对齐到画布网格。"
       }
     },
+    "edgeInspector": {
+      "clear": "清空",
+      "close": "关闭",
+      "condition": "条件",
+      "dropped": "不传递",
+      "flow": "流向",
+      "maxRetries": "最大重试",
+      "noMappings": "新连接 · 字段将在运行时推断。",
+      "noTransform": "暂无转换步骤。",
+      "onFail": "失败时",
+      "qualityGate": "质量门",
+      "qualityPlaceholder": "非空或必须包含的文本",
+      "sourceField": "源字段",
+      "targetInput": "目标输入",
+      "title": "数据契约",
+      "toggleHint": "点击字段切换是否向下游传递 · {{enabled}}/{{total}} 开启",
+      "transform": "转换"
+    },
     "collapseSidebar": "收起侧栏",
     "expandSidebar": "展开侧栏",
     "nodeLibrary": "节点库",
@@ -578,8 +598,14 @@
     "aiMode": "AI 模式",
     "agentPanel": {
       "toggle": "AI 助手",
-      "title": "AI 助手",
+      "title": "Agent",
       "welcome": "你好！我是你的 AI 助手。告诉我你想对 Pipeline 做什么，我会帮你生成操作建议。",
+      "empty": {
+        "intro": "新画布 — 告诉我要做什么，或拖入一个成品样本，我会逆向推导出生成它的 Pipeline。",
+        "suggestChangelog": "把 GitHub 仓库总结成 changelog",
+        "suggestQuiz": "把我的教材 PDF 变成 Notion 测验",
+        "suggestReverse": "上传成品样本 → 逆向工程"
+      },
       "thinking": "思考中...",
       "proposal": "操作建议",
       "proposalReceived": "已收到操作建议，请查看并决定是否应用。",
@@ -589,25 +615,91 @@
       "applied": "已应用操作建议。",
       "discarded": "已丢弃操作建议。",
       "diagnostics": "诊断信息",
-      "error": "请求失败，请稍后重试。",
+      "requestFailed": "请求失败，请稍后重试。",
       "errorTitle": "AI 助手错误",
       "close": "关闭 AI 助手",
+      "resize": "调整 AI 助手宽度",
+      "reopen": "打开 AI 助手",
       "send": "发送请求",
+      "upload": "上传上下文",
+      "revise": "修改方案",
       "runtimeLabel": "运行时",
       "runtimePlaceholder": "选择已配置的运行时",
       "runtimeLoading": "正在加载运行时...",
       "inputPlaceholder": "输入你的需求...",
       "runtimeNotConfigured": "暂未配置运行时 AI。",
       "goToRuntimeSettings": "前往配置",
+      "messageActions": {
+        "copy": "复制消息",
+        "copied": "已复制",
+        "edit": "编辑消息",
+        "retry": "重试消息"
+      },
       "proposalDetails": {
         "review": "查看拟议操作",
         "needsAnswer": "应用前还需要补充信息",
-        "openQuestion": "待确认问题"
-      }
+        "openQuestion": "待确认问题",
+        "askFix": "修复诊断问题",
+        "fixDiagnostics": "请先修复方案中的阻塞诊断问题。",
+        "revisePrompt": "请修改这个方案。",
+        "newOperationBadge": "新操作",
+        "loopBadge": "循环 x{{count}}",
+        "actionTitles": {
+          "addNode": "添加节点: {{nodeType}}",
+          "removeNode": "删除节点",
+          "addEdge": "添加连线",
+          "removeEdge": "删除连线",
+          "reconnectEdge": "重连连线",
+          "replaceNodeData": "替换节点数据",
+          "updateOperation": "更新 Operation 执行器"
+        }
+      },
+      "checkpoint": {
+        "waiting": "等待在 {{node}} 处审核",
+        "nextNode": "下一个节点",
+        "controls": "运行检查点控制",
+        "pause": "暂停",
+        "resume": "继续",
+        "review": "审核"
+      },
+      "error": {
+        "title": "请求失败",
+        "tryPrefix": "尝试："
+      },
+      "errorActions": {
+        "openSettings": "打开运行时配置",
+        "retry": "重试请求"
+      },
+      "userAction": {
+        "title": "需要操作 ({{count}})",
+        "openConfig": "打开配置",
+        "askAgent": "询问助手"
+      },
+      "reversing": {
+        "steps": {
+          "structure": "读取结构",
+          "structureDetail": "了解当前图结构",
+          "steps": "梳理步骤",
+          "stepsDetail": "识别请求中的操作",
+          "matched": "匹配节点",
+          "matchedDetail": "将操作匹配到当前图",
+          "draft": "生成方案",
+          "draftDetail": "准备安全变更"
+        }
+      },
+      "action": {
+        "addNode": "添加节点: {{type}}",
+        "removeNode": "删除节点: {{nodeId}}",
+        "addEdge": "添加连线: {{source}} → {{target}}",
+        "removeEdge": "删除连线: {{edgeId}}",
+        "reconnectEdge": "重连连线: {{edgeId}}",
+        "replaceNodeData": "替换节点数据: {{nodeId}}"
+      },
+      "contextReset": "画布已变更，已清除附加的上下文。"
     },
     "emptyState": {
       "title": "从一个节点开始",
-      "description": "添加输入对象或 Operation，搭出第一条流水线。",
+      "description": "先放一个节点，再把输入、Operation 和输出连接成可运行的 Pipeline。",
       "quickAdd": "快速新建节点",
       "contextHint": "也可以在画布空白处右键创建节点。"
     },
@@ -661,6 +753,20 @@
       "saveSuccessDescription": "Pipeline「{{name}}」已保存",
       "createSuccessDescription": "Pipeline「{{name}}」已创建",
       "saveFailedDescription": "请稍后重试"
+    },
+    "componentPanel": {
+      "searchLabel": "搜索组件",
+      "searchPlaceholder": "搜索组件...",
+      "categoryAriaLabel": "{{label}} 分类",
+      "skillFallbackLabel": "技能",
+      "newCustomOperation": "新建自定义 Operation",
+      "categories": {
+        "input": "输入对象",
+        "operations": "工序",
+        "compound": "复合节点",
+        "skills": "技能",
+        "output": "输出"
+      }
     },
     "nodeTypes": {
       "operation": {
@@ -1304,7 +1410,32 @@
     "createPipeline": "去创建",
     "objectsCount": "{{count}} 个对象",
     "noPipelineSelected": "— 未选 Pipeline",
-    "entireProject": "整个项目"
+    "entireProject": "整个项目",
+    "canvas": {
+      "edges": {
+        "defaultLabel": "数据"
+      },
+      "chrome": {
+        "states": {
+          "cancelled": "已取消",
+          "done": "完成",
+          "failed": "失败",
+          "idle": "空闲",
+          "queued": "排队中",
+          "retrying": "重试中",
+          "running": "运行中",
+          "skipped": "已跳过",
+          "title": "节点运行状态",
+          "trigger": "状态",
+          "waitingForUser": "等待确认"
+        }
+      },
+      "nodeConfig": {
+        "close": "关闭",
+        "done": "完成",
+        "editable": "可编辑"
+      }
+    }
   },
   "validation": {
     "nameRequired": "名称不能为空",

--- a/apps/desktop-app/src/routes/canvas.tsx
+++ b/apps/desktop-app/src/routes/canvas.tsx
@@ -27,7 +27,12 @@ function RouteComponent() {
         </div>
       }
     >
-      <CanvasPage id={id} onGeneratedPipeline={handleGeneratedPipeline} />
+      <CanvasPage
+        embedded
+        id={id}
+        showCanvasMiniSidebar={false}
+        onGeneratedPipeline={handleGeneratedPipeline}
+      />
     </Suspense>
   );
 }

--- a/docs/frontend-alan-migration.md
+++ b/docs/frontend-alan-migration.md
@@ -1,0 +1,927 @@
+# COD-355 前端体验迁移合同（Alan 基准）ADR
+
+> 状态：COD-355 实施与作用域验收已收口；Canvas/Agent/RunConsole、五视口、Web/Desktop 共享、Storybook 构建、页面 acceptance Playwright 与 fresh visual evidence 已完成。固定 Alan SHA 原始迁移目录缺少当前运行时所需的 routines 兼容列；本轮用不改 Alan 源码的临时 PGlite/migration harness 完成 9440 对照。Alan Storybook manager 可列出 stories，但 preview iframe 仍为空白/loading，见 §36；仓库级 app lint 与 Desktop 直接 tsc 仍保留任务前即可复现的历史基线失败，本文不据此宣称仓库所有历史质量门全绿
+> 关联票：COD-355 · 关联：COD-329 / COD-333 / COD-316（历史）· COD-354（活动架构）
+> 分支：`issue-355-alan-ui-migration`
+
+---
+
+## 1. 决策
+
+以 `Alan-Youngzhe/Ordine-fork` 仓库 `develop-fork` 分支的固定提交为**体验规范基准**，以当前 `upstream/develop` 为**业务/架构规范基准**，系统迁移当前 develop 前端，使其在保留全部新功能、数据能力与运行时能力的前提下，恢复 Alan 版本清晰、稳定、直觉一致的产品体验。
+
+本任务**不是**整分支覆盖，**不是**直接 cherry-pick；禁止为追求外观还原而恢复已废弃实体、旧 API 或旧状态模型。
+
+## 2. 冻结基线
+
+| 角色     | 权威来源                                     | 分支                           | 固定引用                                   | 时间                         |
+| -------- | -------------------------------------------- | ------------------------------ | ------------------------------------------ | ---------------------------- |
+| 体验基准 | https://github.com/Alan-Youngzhe/Ordine-fork | `develop-fork`（仓库默认分支） | `c3cf683f231b0021473cb6621f9d619402831bfb` | 2026-06-21                   |
+| 业务基准 | https://github.com/forge-town/ordine         | `develop`                      | `5771dce1b4ab0e60af6af2bd5da3a67f905c86cf` | 2026-08-13（任务开始时最新） |
+
+**远端校验（2026-08-14 现场确认）：**
+
+```
+GitHub HEAD (refs/heads/develop-fork):  c3cf683f231b0021473cb6621f9d619402831bfb
+本地跟踪 alan-fork/develop-fork:         c3cf683f231b0021473cb6621f9d619402831bfb
+固定参考提交:                              c3cf683f231b0021473cb6621f9d619402831bfb
+三者一致 → PASS
+```
+
+本地映射：
+
+```bash
+git remote add alan-fork https://github.com/Alan-Youngzhe/Ordine-fork.git
+git fetch alan-fork develop-fork
+# 若远端未来消失，不可变恢复引用：
+# git cat-file -p c3cf683f231b0021473cb6621f9d619402831bfb
+```
+
+**固定引用恢复说明**：固定 SHA 已通过本地对象库与远端双重记录；若远端 `develop-fork` 未来被 force-push 或删除，以本 ADR 中的 SHA 为准，通过 `git fetch alan-fork <sha>` 仍可恢复（git 允许按 SHA 直接取回对象）。
+
+## 3. 目录映射
+
+| Alan（apps/app/src）                        | 当前（共享包）                                                               | 说明                               |
+| ------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------- |
+| `pages/<X>`                                 | `packages/views/src/pages/<X>`                                               | 页面迁移到共享层，Web/Desktop 复用 |
+| `components/AppSidebar/`                    | `packages/views/src/components/AppSidebar.tsx` + `NavGroup.tsx`              | 侧栏                               |
+| `components/AppLayout.tsx`                  | `packages/views/src/components/AppLayout.tsx`                                | 全局壳层                           |
+| `components/AppSidebar/ProjectSwitcher.tsx` | `packages/views/src/components/ProjectSwitcher.tsx`                          | 项目切换器                         |
+| `components/AppSidebar/NavGroup.tsx`        | `packages/views/src/components/NavGroup.tsx`                                 | 导航分组                           |
+| `components/AppSidebar/UserFooter.tsx`      | 并入 `ProjectSwitcher.tsx`                                                   | 用户脚注                           |
+| `components/primitives/`                    | `packages/views/src/components/primitives/`                                  | 共享 primitive                     |
+| `store/themeStore/`                         | `packages/views/src/store/themeStore/`                                       | 主题 store（当前为 context 版）    |
+| `store/sidebarStore/`                       | `packages/views/src/store/sidebarStore/`                                     | 侧栏 store                         |
+| `store/toastStore/`                         | `packages/views/src/store/toastStore/`                                       | Toast store                        |
+| `store/notificationStore/`                  | `packages/views/src/store/notificationStore/`                                | 通知 store                         |
+| `store/autonomyStore/`                      | `packages/views/src/store/autonomyStore/`                                    | 自治 store（当前新增）             |
+| `pages/WorkspacePage/`                      | `packages/views/src/pages/CanvasPage/`                                       | 画布（重构后的承接）               |
+| `styles.css`                                | `apps/app/src/styles.css` + `packages/views/src/pages/CanvasPage/canvas.css` | 样式（大量动画类缺失，见 §6）      |
+| `locales/en.json / zh.json`                 | `apps/app/src/locales/` + `apps/desktop-app/src/locales/`                    | i18n（当前键量 2.7x）              |
+
+## 4. 路由对照矩阵
+
+当前路由以 `apps/app/src/routes/_layout/*.tsx` 为准；Desktop 用独立 routeTree，但页面组件引用共享 `packages/views`。Alan 仅有 `apps/app` 一份路由。
+
+| 表面（Route）       | Alan（apps/app）                                         | 当前（apps/app + views）                                           | 迁移策略                                            |
+| ------------------- | -------------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------- |
+| 首页 / 创建入口     | `_layout/index.tsx` → redirect `/pipelines`              | `_layout/index.tsx` → `HomePage`（首条消息直达三栏工作区 COD-345） | **由当前等价实现承接**（COD-345 新功能，保留）      |
+| Pipelines 列表      | `pipelines.index.tsx`                                    | `_layout/pipelines.index.tsx`                                      | **适配后复用**（布局与筛选密度已承接）              |
+| Pipeline 详情/画布  | `workspace.$pipelineId.tsx`                              | `canvas.tsx` → `CanvasPage`                                        | **适配后复用**（结构重构）                          |
+| Jobs 列表           | `jobs.index.tsx`（顶层）                                 | `_layout/pipelines.jobs.index.tsx`（归入 pipelines）               | **适配后复用**（路由层级变更，行为承接）            |
+| Job 详情            | `pipelines.jobs.$jobId.tsx`                              | `_layout/pipelines.jobs.$jobId.tsx`                                | **适配后复用**（详情层级与 develop 日志能力承接）   |
+| Components          | `_layout/components.tsx`                                 | `_layout/components.tsx`                                           | **适配后复用**（共享页面布局）                      |
+| Operations          | `_layout/pipelines.operations.*`                         | `_layout/pipelines.operations.*`（新增 new/edit 子页）             | **由当前等价实现承接**（更细粒度路由）              |
+| Objects             | 无（Alan 期无此功能）                                    | `_layout/pipelines.objects.*`                                      | **当前承接**（保留 develop 对象目录与插件对象详情） |
+| Connectors          | `_layout/connectors.tsx`                                 | `_layout/connectors.tsx`                                           | **适配后复用**（卡片/筛选密度承接）                 |
+| Agents              | `_layout/agents.index.tsx` / `agents.$agentId.index.tsx` | 同结构                                                             | **当前承接**（保留 develop Agent 表单）             |
+| Local Agents        | `_layout/local-agents.tsx`                               | `_layout/local-agents.tsx`                                         | **当前承接**（保留 develop 本机扫描/同步）          |
+| Runtimes            | 无（Alan 期无）                                          | `_layout/runtimes.*`                                               | **当前承接**（保留 develop 扫描、详情和编辑）       |
+| Skills              | `_layout/skills.tsx`                                     | `_layout/skills.tsx`                                               | **适配后复用**（筛选/卡片/导入入口承接）            |
+| Plugins             | `_layout/plugins.tsx`                                    | `_layout/plugins.tsx`                                              | **当前承接**（保留插件对象类型能力）                |
+| Usage               | `_layout/usage.tsx`                                      | `_layout/usage.tsx`                                                | **当前承接**（保留 Token/运行时统计）               |
+| Distillations       | 无独立路由（desktop 有）                                 | `_layout/distillations.*`（新增列表/详情/新建）                    | **当前承接**（保留 develop 蒸馏工作流）             |
+| Distillation Studio | 无                                                       | `_layout/distillation-studio.tsx`                                  | **当前承接**（保留 develop Studio 表单）            |
+| Settings            | `_layout/settings.tsx`                                   | `_layout/settings.tsx`                                             | **适配后复用**（分组导航与响应式承接）              |
+| Assistant           | 无                                                       | `_layout/assistant.tsx`                                            | **当前承接**（保留 develop 当前路由）               |
+| Login               | `login.tsx`                                              | `login.tsx`                                                        | **当前承接**（保留 develop AuthShell/登录能力）     |
+| Sign-up             | `sign-up.tsx`                                            | `sign-up.tsx`                                                      | **当前承接**（保留 develop AuthShell/注册能力）     |
+| 404                 | `-NotFound.tsx`                                          | `-NotFound.tsx`                                                    | **当前承接**（空白页级错误态保留）                  |
+| API routes          | `api/*`（auth/local-session/trpc）                       | `api/*`（+operations/pipelines/pipeline-agent-sessions）           | **由当前等价实现承接**                              |
+
+### Alan 有而当前无的路由
+
+| Alan 路由                   | 当前状态                             | 结论                                            |
+| --------------------------- | ------------------------------------ | ----------------------------------------------- |
+| `jobs.index.tsx`（顶层）    | 已并入 `pipelines.jobs.index.tsx`    | **适配后复用**（信息架构归位到 Pipelines 分组） |
+| `workspace.$pipelineId.tsx` | 已重构为 `canvas.tsx` + `CanvasPage` | **适配后复用**                                  |
+
+### 当前有而 Alan 无的路由（保留 develop 当前承接）
+
+`assistant`、`distillations*`、`distillation-studio`、`runtimes*`、`pipelines.objects*`、`agents.$agentId.index`。
+
+这些路由没有 Alan 页面基准，但继续使用 develop 的路由、Store、API、Schema 和运行时能力；迁移结论记录为“当前承接”，不删除、不恢复旧实体，也不把缺少 Alan 对应页误记为“不适用”。
+
+## 5. 页面/组件迁移矩阵（v2，源码与浏览器证据版）
+
+> 状态枚举：**直接复用** / **适配后复用** / **当前承接** / **不适用**。
+> 本矩阵以双方固定源码基线为起点，并由 §13–§34 的单测、Storybook、真实浏览器和 Playwright 证据持续更新；禁止以"风格参考"替代交互证据。
+
+### 5.1 全局壳层
+
+| Alan 表面                                                                         | 当前对应                                             | 结论       | 证据/说明                                                                                                                                               |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AppLayout（含侧栏宽度记忆、折叠）                                                 | `packages/views/src/components/AppLayout.tsx`        | 适配后复用 | shared 壳层恢复 COD-124 的 `SidebarProvider widthStorageKey`；Web wrapper 继续保留 develop 的宽度范围，`SidebarRail` 的折叠和记忆能力不变，证据见 §38。 |
+| AppSidebar（NavGroup 分组、徽标、搜索、折叠）                                     | `AppSidebar.tsx` + `NavGroup.tsx`                    | 适配后复用 | 以 `5cfcd232` 的已提交壳层恢复品牌行、项目切换器、搜索/新建入口和折叠对齐，同时保留 develop 新导航，证据见 §38。                                        |
+| ProjectSwitcher                                                                   | `ProjectSwitcher.tsx`                                | 适配后复用 | 恢复 COD-124 的 `FolderKanban`/项目按钮/`py-2` 壳层；项目查询、切换、创建逻辑继续使用 develop。                                                         |
+| NotificationCenter                                                                | `NotificationCenter.tsx`                             | 适配后复用 | 当前存在，结构近                                                                                                                                        |
+| SearchPipelineDialog                                                              | `SearchPipelineDialog.tsx`                           | 适配后复用 | Alan 式宽度、空态、结果分组、图标方块与状态 Tag 已承接；当前仍只搜索 develop Pipeline 资源并导航 `/canvas?id=...`，证据见 §25。                         |
+| NewPipelineDialog                                                                 | `NewPipelineDialog.tsx`                              | 当前承接   | 当前使用 develop `PipelineCreationWorkspace`，保留生成/预览/运行/创建 another 业务，不恢复 Alan 旧状态。                                                |
+| ToastContainer / toastStore                                                       | `ToastContainer.tsx` / `toastStore`                  | 当前承接   | —                                                                                                                                                       |
+| ThemeStore（dark/light/system）                                                   | `themeStore`（context 版）                           | 当前承接   | 当前默认 `system`，Alan 默认 `light`；语义等价                                                                                                          |
+| PageLoadingState                                                                  | `PageLoadingState.tsx`                               | 当前承接   | 现有 list/detail/grid stories 与页面 loading 语义继续复用。                                                                                             |
+| PageHeader                                                                        | `PageHeader.tsx`                                     | 适配后复用 | 当前共享 header 保留 Alan 的标题/返回/动作层级，并额外承接 develop eyebrow/sub/badge。                                                                  |
+| primitives（Chip/Dot/Icon/MiniChain/Mono/SearchInput/Stat/StatusPill/Tag/BarRow） | 同清单在 `packages/views/src/components/primitives/` | 直接复用   | 文件名一一对应，已落共享层                                                                                                                              |
+
+### 5.2 页面（Alan → 当前）
+
+| Alan 页面                           | 当前对应                                                                  | 结论       | 证据/说明                                                                                                                                         |
+| ----------------------------------- | ------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PipelinesPage                       | `PipelinesPage`                                                           | 适配后复用 | 筛选计数、右侧搜索、圆角空态和卡片密度已承接，证据见 §18。                                                                                        |
+| PipelineDetailPage                  | `PipelineDetailPage`                                                      | 适配后复用 | 当前 develop 详情保留 Canvas 预览、运行面板、节点列表和蒸馏入口，页面层级与 Alan 对齐；证据见 §30。                                               |
+| WorkspacePage（画布）               | `CanvasPage`                                                              | 适配后复用 | 结构大改：Alan `canvas/`（CanvasRoot/flow/nodes/chrome）→ 当前扁平 `CanvasPage/*`（30+ 子组件），节点/面板拆分更细。体验语义需逐一对照（见 §6.2） |
+| JobsPage                            | `JobsPage`                                                                | 适配后复用 | Alan 式无厚边框工具栏、右对齐筛选、圆角空态和排程选择器已承接；列表/日历/Routine/Job 控制保持 develop，证据见 §26。                               |
+| JobDetailPage                       | `JobDetailPage`                                                           | 适配后复用 | 当前 develop 详情保留 Job 状态、Agent Runs、日志、蒸馏和路由行为，页面层级与 Alan 对齐；证据见 §30。                                              |
+| ComponentsPage                      | `ComponentsPage`                                                          | 适配后复用 | Alan 式分类密度、网格和空态已承接，develop 内置项/Operation/资产/推荐能力保持，证据见 §27。                                                       |
+| OperationsPage                      | `OperationsPage`                                                          | 适配后复用 | Alan 式轻量工具栏、Grid/List 和空态已承接，develop 导入/排序/创建保持，证据见 §28。                                                               |
+| OperationCreatePage / Edit / Detail | `OperationCreatePage` / `OperationEditPage` / `OperationDetailPage`       | 适配后复用 | 表单、脚本/Agent 动态分支、数据契约和摘要区已在真实浏览器验证，证据见 §33。                                                                       |
+| ConnectorsPage                      | `ConnectorsPage`                                                          | 适配后复用 | 共享壳层、筛选 chip、MCP 卡片、测试/管理动作已验证，见 §32。                                                                                      |
+| AgentsPage / AgentDetailPage        | `AgentsPage` / `AgentDetailPage`                                          | 当前承接   | 空态、搜索、创建 Agent 表单继续使用 develop 资源和 Store，见 §37。                                                                                |
+| LocalAgentsPage                     | `LocalAgentsPage`                                                         | 当前承接   | 保留本机扫描、同步和配置运行时能力，见 §32。                                                                                                      |
+| SkillsPage                          | `SkillsPage`                                                              | 适配后复用 | 分类筛选、搜索、导入预览、卡片和 Operation 入口已验证，见 §32。                                                                                   |
+| PluginsPage                         | `PluginsPage`                                                             | 当前承接   | 插件版本与对象类型展示继续使用 develop 数据，见 §32。                                                                                             |
+| UsagePage                           | `UsagePage`                                                               | 当前承接   | Token 趋势、Pipeline/Agent 统计和空数据文案继续使用 develop 查询，见 §32。                                                                        |
+| SettingsPage                        | `SettingsPage`                                                            | 适配后复用 | Alan 式窄内容列与分组导航已承接；develop 设置 section、Store、语言/主题/键盘帮助保持。证据见 §29。                                                |
+| LoginPage / SignUpPage              | `LoginPage` / `SignUpPage`                                                | 当前承接   | develop AuthShell、OAuth/邮箱表单和本地化文案保留；本地模式会自动登录，未伪造匿名浏览器截图。                                                     |
+| （无）                              | `DashboardPage`                                                           | 当前承接   | develop 当前首页/仪表盘能力保留，不复制 Alan 旧实体                                                                                               |
+| （无）                              | `ObjectsPage` / `ObjectTypeDetailPage`                                    | 当前承接   | develop 对象类型目录与插件对象详情保留；本轮真实证据见 §37                                                                                        |
+| （无）                              | `RuntimesPage` / `RuntimeDetailPage` / `RuntimeEditPage`                  | 当前承接   | develop 本机扫描、运行时详情和编辑能力保留；本轮真实证据见 §37                                                                                    |
+| （无）                              | `DistillationsPage` / `DistillationDetailPage` / `DistillationStudioPage` | 当前承接   | develop 蒸馏草稿、结果、刷新恢复和删除能力保留；本轮真实证据见 §37                                                                                |
+
+### 5.3 Agent / Canvas 交互子表面
+
+| Alan 子表面                                                                                                                     | 当前对应                                                                                | 结论       | 证据/说明                                                                                                                                                                                                                                           |
+| ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AgentBar（`WorkspacePage/AgentBar/`）                                                                                           | AgentPanel（`CanvasPage/AgentPanel/`）                                                  | 适配后复用 | Alan header/body/footer、空态建议、Composer/ContextStrip/RefChips 与 Proposal/message 语法已承接；runtime/session/upload/streaming/diagnostics/proposal actions 继续使用 develop。                                                                  |
+| canvas/chrome（CanvasToolbar/ComponentPanel/StateLegend/TopPill/VersionMenu）                                                   | CanvasToolbar/CanvasComponentPanel/CanvasTopChrome/CanvasStatusBar/CanvasMiniSidebar 等 | 适配后复用 | `ComponentPanel.tsx`、`TopPill.tsx`、`CanvasToolbar.tsx` 的 JSX/class 已直接移植；面板开关、创建/拖拽、标题、保存、设置、运行和 Agent 动作全部继续调用 develop Store/API。                                                                          |
+| canvas/flow（CanvasFlow/SemanticEdge）                                                                                          | CanvasFlow + SemanticEdge                                                               | 适配后复用 | 所有 routed edge 已注册为稳定 `semantic` 类型；选中、proposal、运行完成/流动、condition 和 qualityGate 仅读取 develop `selectedEdgeId`、`agentPanel.pendingProposal`、`nodeRunStatuses` 与 `PipelineEdgeData`。                                     |
+| canvas/nodes（OperationNode/PromptNode/CompoundNode/FileNode/FolderNode/GithubProjectNode/OutputNode/GNodeShell/NodeCardPorts） | 同清单 + 新增 ErrorNode/CodeFileNode/OutputLocalPathNode/OutputProjectPathNode          | 适配后复用 | Alan `GNodeShell` 的 214px wrapper、原生 card、header/body/status、hover action pill 与 12px ports 已直接移植；develop 节点继续使用当前字段、focus/Agent/duplicate/remove 和 port mask/count。Compound 保留 parent/child 容器语义，仅承接中性视觉。 |
+| canvas/panels（EdgeInspector/NodeConfig 各 section）                                                                            | CanvasEdgeInspector + CanvasNodePropertiesPanel + ConnectionMenu + CanvasSettingsDrawer | 适配后复用 | Alan 420px EdgeInspector 与 440px NodeConfig modal 已承接；mapping/condition/transform/qualityGate/节点字段只调用 develop actions，未引入 Alan delete/history/persist 状态。                                                                        |
+| canvas/run（RunConsole/CheckpointDialog/useRunPolling）                                                                         | RunConsole/CheckpointCard/useCanvasWorkspacePersistence                                 | 适配后复用 | Alan 浮动 console shell/mono log 已承接；Job 轮询、trace parser、节点状态、timeline、multi-input、artifact、刷新和错误处理保持 develop。                                                                                                            |
+| canvas/ask（AskComposer）                                                                                                       | AgentPanel Composer                                                                     | 适配后复用 | Alan composer 外观接到 develop runtime/session/upload/message 协议；没有恢复 Alan workspace Store。                                                                                                                                                 |
+
+## 6. 样式资产差异（静态证据）
+
+### 6.1 全局 token
+
+双方 `styles.css` 的 `@theme inline` 与 `:root` token 集**基本一致**（radius、shadow、surface/canvas/edge 系、font 均相同）。逐 token 静态对比仅 2 个差异（`--xy-node-border`、`--xy-node-boxshadow-selected`，且已在当前 `CanvasPage/canvas.css` 内定义）。真实差异集中在**自定义 CSS 类与动画**：
+
+| 差异               | Alan             | 当前                                  |
+| ------------------ | ---------------- | ------------------------------------- |
+| styles.css 行数    | 597              | 241                                   |
+| 自定义 CSS 类/动画 | 约 50 个（见下） | 仅 canvas.css 保留约 10 个            |
+| token 集           | 完整             | 等价（`--xy-node-*` 移到 canvas.css） |
+
+Alan 有而当前缺失的样式类（静态枚举，须逐项决定承接/删除）：
+
+```
+.canvas-grid / .canvas-board-grid / .edge-path(.is-active/.is-pending)
+.status-wash-success / .status-wash-error / .status-wash-muted
+.node-running / .node-appear / .node-pulse / .canvas-node-pop
+.edge-flow / .dash-flow / .spin / .ping / .fade-rise / .page-swap
+.slide-in / .drawer-in / .bar-grow / .cfg-pop / .node-config-card
+.edge-inspector-card / .cfg-range / .io-handle / .no-bar
+.canvas-component-drag-image（含 icon/text/meta）
+@media (prefers-reduced-motion: reduce)
+```
+
+### 6.2 Canvas 专用样式
+
+当前 `packages/views/src/pages/CanvasPage/canvas.css` 已扩展到 346 行，承接 React Flow 节点基础样式、网格、连线状态、节点运行反馈、面板进入动效和 reduced-motion 降级；仍保留 develop 的 Canvas 状态与交互实现。
+
+## 7. 双版本启动与截图流程（固定）
+
+### 7.1 端口分配
+
+| 版本                   | App  | Server | 登录模式                 |
+| ---------------------- | ---- | ------ | ------------------------ |
+| Alan（固定 SHA）       | 9440 | 9443   | `ORDINE_LOCAL_MODE=true` |
+| 当前 develop（迁移前） | 9430 | 9433   | `ORDINE_LOCAL_MODE=true` |
+
+### 7.2 Alan 版本启动
+
+```bash
+# 1) 检出固定 SHA 到隔离目录（不可变引用）
+git fetch alan-fork c3cf683f231b0021473cb6621f9d619402831bfb
+git worktree add /tmp/ordine-alan c3cf683f231b0021473cb6621f9d619402831bfb
+
+# 2) 用环境变量覆盖端口启动（Alan 的 dev 脚本硬编码 9430，需 PORT 覆盖）
+#    Alan 期 vite.config 未读 PORT env，须临时改 --port（仅截图验证环境，不入库）
+cd /tmp/ordine-alan/apps/app && PORT=9440 bun run dev
+cd /tmp/ordine-alan/apps/server && PORT=9443 ORDINE_LOCAL_MODE=true bun run dev
+# 访问 http://localhost:9440
+```
+
+### 7.3 当前版本启动
+
+```bash
+cd .worktrees/cod-355-alan-migration/apps/app
+ORDINE_LOCAL_MODE=true \
+PGLITE_DATA_DIR=.runtime/pglite \
+PGLITE_MIGRATIONS_DIR=../create/migrations \
+BETTER_AUTH_SECRET=<local-only-secret-at-least-32-chars> \
+bunx vite --host 0.0.0.0 --port 9430
+# App http://localhost:9430; local-session is created by /api/local-session
+```
+
+### 7.4 截图约束
+
+- 目标视口：`1440×900`、`1180×820`、`981×820`、`701×820`、`390×844`
+- 同路由、同数据种子、同语言（默认 en）、同主题（light）、同滚动位置
+- 动态区域（时间、光标、流式文本）先 mask 再比较
+- 四联证据：Alan / Before / After / Diff（存 `pr-assets/`）
+
+## 8. 实施拆分（按可独立验收表面）
+
+| Phase | 表面                                                                                                                  | PR 建议    |
+| ----- | --------------------------------------------------------------------------------------------------------------------- | ---------- |
+| 1     | 设计基础 + 全局壳层（token 补全、AppLayout 拖拽调宽、侧栏/顶栏/搜索/通知）                                            | 1–2 个 PR  |
+| 2     | 首页→Canvas 上下文传递；Canvas 核心视觉/交互；Agent Panel/Composer/Proposal；Run Console 视觉表达                     | 3–5 个 PR  |
+| 3     | Pipelines/Components/Operations/Objects；Jobs/Usage/Distillations；Connectors/Agents/Runtimes/Skills/Plugins/Settings | 按页面组拆 |
+| 4     | Web/Desktop 共享；响应式断点；亮暗/中英；键盘/焦点/Reduced Motion                                                     | 1–2 个 PR  |
+| 5     | 删除被替换的重复实现；视觉回归/E2E/构建/Storybook；证据矩阵收口                                                       | 收尾 PR    |
+
+## 9. 验收标准（冻结）
+
+1. Alan 权威仓库、`develop-fork` 分支与固定 SHA 已写入本 ADR 与测试说明。
+2. 当前 develop 基线 SHA 已记录（§2）。
+3. Route × Component × State × Interaction 迁移矩阵覆盖率 100%；每项均有四选一结论。
+4. 所有"不适用"项有具体可验证原因。
+5. 全局壳层与核心导航达到 Alan 信息层级与交互质量。
+6. 首页选择的 Agent、Runtime、用户消息完整进入 Canvas。
+7. Canvas 编辑交互与 Alan 等价或更优。
+8. Proposal 应用有成功/失败/重试/冲突反馈。
+9. Agent 活动、流式内容、无输出、心跳、错误状态清晰可见。
+10. 刷新后运行状态与时间线可恢复，不回退为误导性"待运行"。
+11. 运行产物在节点/Run Console/统一入口可发现。
+12. Alan 之后新增功能全部可用；Web/Desktop 共享实现无平行复制。
+13. 不引入旧 API/旧实体/第二套状态机；不遗留无调用 legacy 组件。
+14. 亮暗、中英通过；五视口无遮挡/溢出/不可操作。
+15. 键盘导航、焦点环、语义标签、Reduced Motion 通过。
+16. 关键组件具备 Storybook 全状态矩阵；关键路径有 Playwright 回归。
+17. 受影响包 typecheck/lint/build/定向测试通过。
+18. PR 附 Alan/Before/After/Diff 证据与运行命令。
+19. 产品负责人确认矩阵，Alan 完成体验复核。
+
+## 10. 非目标
+
+- 不重写后端或数据模型；不直接替换整个 develop；不整体 cherry-pick Alan。
+- 不回退 Alan 之后新增功能；不将全部工作塞入一个超大 PR。
+- 不以静态截图冒充交互完成；不以"视觉接近"替代逐项迁移与证据。
+
+## 11. 风险与缓解
+
+| 风险                  | 缓解                                                   |
+| --------------------- | ------------------------------------------------------ |
+| 历史依赖过旧          | 只迁移体验语义与可维护代码，依赖按当前栈替换           |
+| 当前功能被覆盖        | 当前 API/Store/Schema 为不可回退基线，关键流必须有 E2E |
+| 范围失控              | Phase 0 冻结矩阵后按表面拆票/PR                        |
+| 重复组件增加          | 每个迁移 PR 说明替换关系，同阶段删除旧实现             |
+| "完成"无法复核        | 强制双版本同路由同数据同视口证据                       |
+| 与 Agent 活动架构冲突 | 共享 COD-354 事件与状态契约，只迁移呈现层              |
+
+## 12. 现场证据（Phase 0 静态枚举）
+
+- 双方路由差异：见 §4
+- 双方页面/组件差异：见 §5
+- 样式资产差异：见 §6
+- Alan 33 个 stories vs 当前 73 个 stories（当前覆盖更广，需按状态矩阵补全）
+- Alan 11 个 e2e spec vs 当前 22 个（当前覆盖更广）
+- i18n：Alan en.json 33,829 B vs 当前 90,117 B（当前键量 2.7x，多语言能力保留）
+
+## 13. Phase 1 首个 slice：共享侧栏宽度与折叠语义
+
+本 slice 只迁移 Alan 全局壳层中可独立验证的侧栏行为，不改变业务 API、路由、Store、Canvas 状态或 Web/Desktop 的数据契约：
+
+| Alan 语义                    | 当前实现                                                                                                 | 结论             | 代码证据                                                                                    |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------- |
+| 默认侧栏宽度 236px           | Web wrapper 继续由 `apps/app/src/components/AppLayout.tsx` 配置；shared 恢复 COD-124 默认 provider       | 适配后复用       | `apps/app/src/components/AppLayout.tsx`、`packages/views/src/components/AppLayout.tsx`、§38 |
+| 可调范围 200–360px           | Web wrapper 保留 develop 的 `minWidth={200}` / `maxWidth={360}`；shared 不再覆盖 COD-124 provider 默认值 | 当前承接         | 同上                                                                                        |
+| 拖拽到不可用宽度时折叠       | 共享 `SidebarRail` 保留拖拽/折叠能力，当前壳层使用默认阈值                                               | 当前等价实现承接 | `packages/ui/src/sidebar.tsx`、`SidebarRail.unit.test.tsx`、§38                             |
+| 键盘调整、点击切换、宽度记忆 | 既有 `SidebarRail` 与 `widthStorageKey` 保留                                                             | 当前等价实现承接 | `packages/ui/src/sidebar.tsx`、`SidebarRail.unit.test.tsx`                                  |
+
+定向证据：
+
+- `packages/views` `SidebarRail.unit.test.tsx`：5 tests passed，包含 168px Alan 折叠阈值场景；
+- `packages/ui` `check-types`：exit 0；`lint`：exit 0；
+- `packages/views` `check-types`：exit 0；
+- `apps/app` `check-types`：exit 0；
+- 受影响文件 formatter check：exit 0；`git diff --check`：exit 0；
+- 运行时使用隔离 PGlite 数据目录和 7 个迁移，`GET /` 与 `GET /api/local-session` 均返回 HTTP 200；
+- 2026-08-18 的 COD-124 壳层恢复与 Canvas 桌面浏览器证据见 §38；侧栏拖拽细节仍由 `SidebarRail.unit.test.tsx` 覆盖，未把未执行的拖拽动作宣称为浏览器完成。
+
+## 14. Phase 1 第二个 slice：Canvas 状态动效与 Reduced Motion
+
+本 slice 迁移 Alan 的 Canvas 视觉语义，并复用当前 `NodeRunStatus`，不引入第二套运行状态或事件协议：
+
+| Alan 语义                     | 当前实现                                                                                                           | 结论             | 代码证据                                         |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------- | ------------------------------------------------ |
+| Canvas 网格与画布板网格 token | 共享 `canvas.css` 提供 `.canvas-grid` / `.canvas-board-grid`                                                       | 直接复用         | `packages/views/src/pages/CanvasPage/canvas.css` |
+| 运行节点柔和脉冲              | `NodeCard` 在 `runStatus=running` 时使用 `.node-running`                                                           | 适配后复用       | `NodeCard.tsx`、`NodeCardFrame.tsx`              |
+| 完成/失败/空闲状态 wash       | Run Console 时间线与错误块映射现有状态到 `.status-wash-success/error/muted`                                        | 适配后复用       | `RunConsole.tsx`                                 |
+| 连线流动与 hover 反馈         | React Flow animated edge 使用 `.react-flow__edge.animated` 规则                                                    | 当前等价实现承接 | `canvas.css`、`CanvasFlow.tsx`                   |
+| 节点/面板/抽屉/配置进入动效   | 共享 CSS 提供 `.node-appear`、`.fade-rise`、`.panel-in`、`.drawer-in`、`.node-config-card`、`.edge-inspector-card` | 直接复用         | `canvas.css`                                     |
+| Reduced Motion                | Canvas 根节点及 descendants 统一缩短动画/过渡并关闭平滑滚动                                                        | 适配后复用       | `canvas.css`、`CanvasFlow.tsx`                   |
+
+定向证据：
+
+- CanvasFlow + NodeCard：2 个测试文件、29 tests passed；
+- `packages/views` typecheck：exit 0；Canvas 受影响文件 lint：exit 0；formatter 与 `git diff --check`：exit 0；
+- Canvas 的编辑、连接、删除、撤销/重做和交互禁用语义仍由原有 store 与 CanvasFlow 测试覆盖；本 slice 只改变呈现层 class/CSS。
+- 2026-08-17 已在 `http://localhost:9430/canvas?id=pipeline-1786937112479` 真实浏览器确认网格、浮层、节点/Agent/Run Console 运行态；五视口无横向溢出与面板互斥结果见 §23，状态矩阵见 §24。
+
+## 15. Phase 1 第三个 slice：Canvas 面板进入与运行反馈动效
+
+本 slice 将 Alan 的面板层动效接到当前已存在的挂载边界，确保动画只表达“进入/运行反馈”，不改变面板开关、消息流或运行状态：
+
+| 表面                    | 当前承接                            | 结论       | 代码证据                                                    |
+| ----------------------- | ----------------------------------- | ---------- | ----------------------------------------------------------- |
+| Canvas 顶部标题与工具栏 | `.fade-rise`                        | 适配后复用 | `CanvasTopChrome.tsx`                                       |
+| 组件库与 Inspector      | `.panel-in`                         | 适配后复用 | `CanvasComponentPanel.tsx`、`CanvasNodePropertiesPanel.tsx` |
+| Settings Drawer         | `.drawer-in`                        | 适配后复用 | `CanvasSettingsDrawer.tsx`                                  |
+| Agent Panel             | `.panel-in`；活动指示点改用 `.ping` | 适配后复用 | `AgentPanel.tsx`                                            |
+| Run Console             | `.fade-rise`                        | 适配后复用 | `RunConsole.tsx`                                            |
+
+定向证据：
+
+- CanvasTopChrome、CanvasComponentPanel、CanvasNodePropertiesPanel、CanvasSettingsDrawer、AgentPanel、RunConsole：6 个测试文件、46 tests passed；
+- `packages/views` typecheck：exit 0；受影响文件 formatter 与 `git diff --check`：exit 0；
+- AgentPanel 的全文件 lint 仍被迁移前既有 `no-try`、handler 命名、JSX prop 排序问题阻塞；本 slice 未修改这些业务/规则问题。
+- 2026-08-17 已在 9430 Canvas 和 9460 Storybook 真实浏览器确认浮层、面板进入与 Run Console 运行态；Agent Panel 拖拽专项证据见 §34。
+
+## 16. 累计验证
+
+- `packages/views` 全量 Vitest：87 个测试文件、383 tests passed；
+- `apps/app` production build：成功，client 4349 modules、SSR 3871 modules transformed；仅有既有 route-test、chunk size 和第三方 eval warnings；
+- `apps/app` Storybook production build：成功，4195 modules transformed；构建提示仅包含既有 package.json 查找、无 MDX story 和 chunk size warnings；
+- 真实浏览器双基线对照地址固定为 `http://localhost:9430` 与 `http://localhost:9440`；已取得的页面、Canvas 五视口和 Storybook 状态证据分别记录在 §17–§24，未覆盖的交互仍按矩阵保留。
+
+## 17. Phase 1 第四个 slice：Alan 全局壳层信息架构
+
+本 slice 的历史记录保留为迁移过程证据；最终壳层已按用户反馈恢复到已提交的 COD-124 结构，详见 §38。
+
+| Alan 语义                       | 当前承接                                                                            | 结论       | 代码证据                                                              |
+| ------------------------------- | ----------------------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------- |
+| 项目切换入口与 develop 项目逻辑 | `ProjectSwitcher` 恢复为 COD-124 的项目按钮壳层，筛选/创建逻辑不变                  | 适配后复用 | `packages/views/src/components/ProjectSwitcher.tsx`、`AppSidebar.tsx` |
+| 侧栏搜索入口                    | `AppSidebar` 恢复为 COD-124 的 `SidebarMenuButton`，点击继续打开 develop 搜索对话框 | 适配后复用 | `AppSidebar.tsx`、`SearchPipelineDialog.tsx`                          |
+| 搜索结果与导航筛选              | 不再由侧栏本地 inline query 过滤；由既有 SearchPipelineDialog/Store 承接            | 当前承接   | `SearchPipelineDialog.tsx`、`sidebarStore`                            |
+| Alan 原有导航                   | 保留并扩展 Operations、Objects、Distillations、Agents、Plugins 等 develop 新能力    | 当前承接   | `AppSidebar.tsx`                                                      |
+
+定向证据：
+
+- AppSidebar + ProjectSwitcher 的定向测试通过；`sidebarStore` 保持 develop 原契约；
+- `packages/views` typecheck、受影响文件 lint/format、`git diff --check` 均通过；
+- 历史预览记录保留；最终恢复证据、当前 DOM 几何和真实搜索交互见 §38。
+
+## 18. Phase 2 第一个 slice：Pipelines 列表页面密度与空态
+
+本 slice 保留当前 Pipelines 的指标、标签、项目筛选、调度和详情路由，只迁移 Alan 的页面级布局语义：
+
+| Alan 语义                             | 当前承接                                                                        | 结论       | 代码证据                   |
+| ------------------------------------- | ------------------------------------------------------------------------------- | ---------- | -------------------------- |
+| 筛选 chip 带数量并保持单行密度        | `All/Saved Skills/Drafts/Scheduled` 映射当前四种 filter，并从真实数据计算 count | 适配后复用 | `PipelinesPageContent.tsx` |
+| 搜索靠右、工具栏无额外厚边框          | `SearchInput ml-auto w-60`，标签筛选继续保留在下一行                            | 适配后复用 | `PipelinesPageContent.tsx` |
+| 空态使用圆角 surface-2 容器和二级说明 | 当前空数据/无结果均使用 Alan 风格容器，业务文案继续走 i18n                      | 适配后复用 | `PipelinesPageContent.tsx` |
+| 卡片网格密度                          | `xl:grid-cols-2`、`2xl:grid-cols-3`，保留当前 PipelineCard 指标与动作           | 适配后复用 | `PipelinesPageContent.tsx` |
+
+浏览器证据：`http://localhost:9430/pipelines` 已显示计数筛选、右侧搜索、草稿卡片和当前新功能动作；Alan 对照页面为 `http://localhost:9440/pipelines`。
+
+## 19. Phase 2 第二个 slice：Canvas Workspace 空间关系
+
+本 slice 将当前 Canvas 从“隐藏全局壳层的独立全屏模式”适配为 Alan 的 Workspace 关系：
+
+| Alan 语义                               | 当前承接                                                                                             | 结论       | 代码证据                                                                   |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------- |
+| Workspace 保留全局侧栏                  | Web/桌面 Canvas 路由使用普通 `AppLayout`，不再传 `canvasMode`；Desktop 使用 embedded Canvas          | 适配后复用 | `apps/app/src/routes/canvas.tsx`、`apps/desktop-app/src/routes/canvas.tsx` |
+| Workspace 不再额外显示 Canvas mini rail | 真实路由传 `showCanvasMiniSidebar={false}`；组件面板可见性继续由 develop 的 `isSidebarOpen` 状态决定 | 适配后复用 | `CanvasPage.tsx`、`CanvasPageContent.tsx`、`CanvasInner.tsx`、`uiSlice.ts` |
+| 顶部浮动标题 pill                       | 标题输入、组件面板入口、设置入口采用绝对定位浮层                                                     | 适配后复用 | `CanvasTopChrome.tsx`                                                      |
+| 工具栏悬浮在画布底部                    | `CanvasToolbar` 从顶栏移到主画布右下浮层                                                             | 适配后复用 | `CanvasInner.tsx`                                                          |
+| Agent Bar/Panel 右侧停靠                | 6px 独立 resize gutter + 浮动 panel region；可拉伸 Agent Panel 行为保留                              | 适配后复用 | `CanvasInner.tsx`                                                          |
+
+真实浏览器证据：`http://localhost:9430/canvas?id=pipeline-1786937112479` 已显示全局侧栏、浮动标题、底部工具栏、空画布和右侧 Agent 面板；Alan 对照通过 `http://localhost:9440/pipelines → New Pipeline → /workspace/pipeline-*` 取得有效 Workspace。
+
+## 20. Phase 2 第三个 slice：Canvas 顶部浮层与底部工具栏
+
+在 §19 的 Workspace 空间关系上继续对齐 Alan 的 Canvas chrome：
+
+- `CanvasTopChrome` 从占据整行的 border bar 改为浮动标题 pill，并保留组件面板/设置入口；
+- `CanvasToolbar` 从顶部布局流移到画布右下角浮层；
+- `CanvasInner` 根节点纳入 Canvas Reduced Motion 范围；
+- 生产路由不再显示 Alan 之外的 Canvas mini rail；组件面板默认值、开关和宽度状态继续以 develop 的 `uiSlice` 为准，顶部入口只调用现有 action。
+
+真实浏览器截图已确认当前 develop Canvas 与 Alan Workspace 共享“全局侧栏 + 干净画布 + 右侧 Agent + 浮动 chrome”空间关系。
+
+## 21. Phase 2 第四个 slice：Agent Panel 空态引导与上下文入口
+
+本 slice 只迁移 Agent Panel 的呈现和入口交互：
+
+- 空会话显示 Alan 风格的说明文案与三条建议目标；
+- 教材测验、GitHub changelog 建议直接复用现有 `handleComposerSubmit`；
+- 成品样本建议填充现有 Composer 草稿，附件上传仍走当前 `pipelineAgentSessionsClient`；
+- Context Strip、Runtime 选择、Proposal、Diagnostics 和 Composer 状态协议保持 develop 实现；
+- Web/Desktop 语言包同步补齐 `canvas.agentPanel.empty.*`，避免界面泄漏 key。
+
+证据：AgentPanel + Composer 4 files / 30 tests、messages 12 tests passed；完整 Canvas E2E 真实发送 Agent 消息并收到 mock response。真实 `9430/canvas` 与 1440/701/390 截图均显示 Alan 式 header/body/footer，同时保留 runtime 选择。
+
+## 22. Phase 2 第五个 slice：RunConsole 视觉承接
+
+本 slice 只迁移 Alan 的 RunConsole 呈现，不增加或迁移状态能力：
+
+- 保留 develop 已有的 `pipelineId`、`activeJobId`、`isConsoleOpen`、Job 轮询、trace parser、节点运行状态和产物解析；
+- 状态启动、刷新恢复、关闭 Console 和错误处理继续由 develop 原有实现负责；
+- Alan 的浮动 `inset-x-3 bottom-16` shell、compact header、mono 10.5px log 和 error wash 只改变呈现；不写入新的 session storage 或恢复 action。
+
+证据：`RunConsole.unit.test.tsx` 8 tests passed；Storybook production build 4206 modules；9460 Running/Completed/Failed 截图位于 `pr-assets/cod-355/runconsole-*-1200x500.png`，Loading/Queued 仍由同一 story matrix 覆盖。此前临时 `RunStateRestorer`/`runStateStorage` 已移除。
+
+## 23. Phase 4 第一个 slice：Canvas 窄视口层级互斥
+
+真实 Canvas 视口矩阵复验结果：
+
+| 视口     | 横向溢出 | Agent shell   | 组件面板         | 移动/TopChrome 证据                 |
+| -------- | -------- | ------------- | ---------------- | ----------------------------------- |
+| 1440×900 | 无       | 344px         | 230px 浮层       | Alan desktop pill                   |
+| 1180×820 | 无       | 344px overlay | Agent 打开时隐藏 | controls right ≤ 1168               |
+| 981×820  | 无       | 344px overlay | Agent 打开时隐藏 | controls right ≤ 969                |
+| 701×820  | 无       | 344px overlay | Agent 打开时隐藏 | mobile trigger z50 > chrome z20     |
+| 390×844  | 无       | 389px 满宽    | Agent 打开时隐藏 | icon-only States/Run，right ≤ 382px |
+
+在 1180px 及以下，Agent 打开时不再让组件面板与 Agent overlay 互相遮挡；390px 的移动 trigger、TopChrome、Agent 和 composer 均有真实截图与 bounding-box 断言。NodeConfig/EdgeInspector 同时保留 440/420px 桌面宽度并增加 viewport max-width。
+
+## 24. Phase 4 第二个 slice：Run Console 状态表达矩阵
+
+本 slice 只补齐可复现的视觉验收状态，不改变 develop 的运行状态机：
+
+| 状态      | Storybook 入口                                   | 证据                                 |
+| --------- | ------------------------------------------------ | ------------------------------------ |
+| Loading   | `/?path=/story/canvaspage-runconsole--loading`   | `控制台 / 加载中...`                 |
+| Queued    | `/?path=/story/canvaspage-runconsole--queued`    | `排队中`、空时间线                   |
+| Running   | `/?path=/story/canvaspage-runconsole--running`   | `运行中`、日志、当前步骤、节点时间线 |
+| Completed | `/?path=/story/canvaspage-runconsole--completed` | `完成`、空时间线                     |
+| Failed    | `/?path=/story/canvaspage-runconsole--failed`    | `失败`、develop Job error 文案       |
+
+实现位于 `packages/views/src/pages/CanvasPage/RunConsole/RunConsole.stories.tsx`，通过现有 `canvasStoryDataProvider` 的 `Job`、`JobStatus` 和 `jobs/traces` 数据承接；没有引入 Alan 的状态或 Store。2026-08-17 已在 `http://localhost:9460` 真实浏览器逐项打开上述 5 个入口，均渲染 `控制台`，状态文案和错误态内容符合预期。Run Console 当前没有独立的 disabled 业务控件，因此未伪造 disabled 状态；该状态由仍在 develop 中的页面控件矩阵承接。
+
+## 25. Phase 3 第一个 slice：全局搜索对话框密度
+
+本 slice 迁移 Alan 的搜索呈现，不扩展或替换 develop 的搜索业务契约：
+
+- 对话框改为 Alan 式 `sm:max-w-2xl`、紧凑搜索行、分组标题、圆角结果行、图标方块和状态 Tag；
+- 空查询显示工作区搜索引导，无结果保留当前 Pipeline 空态；
+- 查询使用 `SearchPipelineDialog` 本地 UI state，关闭/选中后清理，不向共享 Store 添加 Alan 字段；
+- 数据仍只读取 develop `ResourceName.pipelines`，选中仍调用 develop `/canvas` search 参数，未引入 Alan 旧路由或旧实体。
+
+证据：`SearchPipelineDialog.unit.test.tsx` 3 tests passed；`packages/views` typecheck、定向 oxlint/oxfmt 通过；真实浏览器 `http://localhost:9430/pipelines` 使用 `Ctrl+K` 打开对话框，输入 `新建` 后显示 `流水线 / 新建 Pipeline / draft`，点击结果导航到 `http://localhost:9430/canvas?id=pipeline-1786937112479`。
+
+## 26. Phase 3 第二个 slice：Jobs 页面工具栏与空态
+
+本 slice 只对齐 Alan 的页面层布局，保留 develop Job 运行控制、列表/日历切换、Routine 编辑器、状态筛选和详情抽屉：
+
+| Alan 语义                   | 当前承接                                                              | 结论       | 代码证据                                               |
+| --------------------------- | --------------------------------------------------------------------- | ---------- | ------------------------------------------------------ |
+| 无厚边框的紧凑工具栏        | 工具栏移除 `border-b/bg`，改为 `px-7 pb-3.5` 并右对齐筛选/搜索        | 适配后复用 | `JobsPageContent.tsx`                                  |
+| 列表/日历 Segmented Control | 保留 develop 两种视图和现有 `JobsCalendar` 数据                       | 当前承接   | `JobsPageContent.tsx`、`JobsPageContent.unit.test.tsx` |
+| 圆角 surface 空态           | 空结果使用 `rounded-2xl bg-surface-2/50`                              | 适配后复用 | `JobsPageContent.tsx`                                  |
+| 圆角排程选择器              | 保留当前 Pipeline/Routine 选择和 ScheduleEditor，调整为 `rounded-2xl` | 适配后复用 | `JobsPageContent.tsx`                                  |
+
+证据：`JobsPageContent.unit.test.tsx` 4 tests passed；真实浏览器 `http://localhost:9430/pipelines/jobs` 已验证列表 → 日历切换及“新建 Routine”打开 Pipeline 选择器，截图记录了全局壳层、日历和选择器。
+
+## 27. Phase 3 第三个 slice：Components 页面资产库密度
+
+本 slice 对齐 Alan 的组件库布局，同时完整保留 develop 之后新增的 Operation、Pipeline Asset、组件推荐和删除引用检查：
+
+- 工具栏去除厚边框，改为 Alan 式分类 chip + 右侧搜索密度；
+- 资产网格在 `xl` 使用两列、`2xl` 使用三列，保持当前内置输入对象、输出对象、Operation 和 Pipeline Skill；
+- 无匹配结果改为圆角 surface 空态；
+- `Find for me`、新建 Operation、蒸馏 Pipeline Skill、编辑/删除和 usage-count 查询均未改变。
+
+证据：`ComponentsPageContent.unit.test.tsx` 7 tests passed；真实浏览器 `http://localhost:9430/components` 已验证搜索 `文件` 只保留文件夹/文件卡片，并打开“新建组件”菜单显示 `新建操作` 与 `蒸馏 Pipeline Skill`；截图记录了筛选、卡片网格和菜单。
+
+## 28. Phase 3 第四个 slice：Operations 页面工具栏与空态
+
+本 slice 对齐 Alan 的 Operations 页面层级，保留 develop 的导入、创建、搜索、排序和 Grid/List 视图：
+
+| Alan 语义           | 当前承接                                                                | 结论       | 代码证据                    |
+| ------------------- | ----------------------------------------------------------------------- | ---------- | --------------------------- |
+| 轻量搜索/排序工具栏 | `bg-muted/30` + 紧凑输入/Select，保留当前 Store 排序字段                | 适配后复用 | `OperationsPageContent.tsx` |
+| Grid/List 内容区    | Alan 式 grid 间距与无额外厚卡片的 List 分隔线，现有两种视图 action 保持 | 适配后复用 | `OperationsPageContent.tsx` |
+| 空态                | 保留 develop 创建入口与清空搜索动作，布局对齐 Alan 空态                 | 当前承接   | `OperationsPageContent.tsx` |
+
+证据：受影响文件 typecheck、oxlint、oxfmt 通过；真实浏览器 `http://localhost:9430/pipelines/operations` 显示轻量工具栏、排序 Select、Grid/List 控件和本地化内容；隔离数据已包含 `COD355 Visual Check` 与 Canvas E2E Operation，卡片/列表态已进入截图证据。
+
+## 29. Phase 3 第五个 slice：Settings 分组导航与内容列
+
+本 slice 只迁移 Alan 的 Settings 页面层级，不替换 develop 的 Settings Store 或 section 行为：
+
+- 页面标题去除 develop 额外副标题，保留 Alan 简洁 header；
+- 内容列从 `max-w-2xl` 收窄到 Alan 的 `max-w-lg`；
+- 桌面分组导航、移动端横向导航、语言/主题/时区表单、键盘帮助对话框均继续使用 develop 实现；
+- Web/Desktop 共享 `packages/views`，没有创建平行设置页面或迁移旧配置状态。
+
+证据：`SettingsPageContent.unit.test.tsx` 5 tests passed；真实浏览器 `http://localhost:9430/settings` 刷新后确认无副标题，点击“默认项”切换 section，点击“快捷键”打开帮助对话框；截图记录了分组导航与键盘帮助状态。
+
+## 30. Phase 3 第六个 slice：Pipeline / Job 详情当前承接
+
+这两个详情页的主要 UI 结构在 develop 中已保持 Alan 的成熟层级，本轮完成真实页面钉证，不复制 Alan 的旧路由或状态：
+
+| 页面            | 真实路径                                               | 当前承接                                                                |
+| --------------- | ------------------------------------------------------ | ----------------------------------------------------------------------- |
+| Pipeline Detail | `/pipelines/pipeline-1786937112479`                    | 头部返回/Canvas/蒸馏动作、信息卡、统计、Canvas 预览、运行面板和空节点态 |
+| Job Detail      | `/pipelines/jobs/99365c14-3671-4f45-a665-6a5c2742aea9` | 完成状态 pill、状态色条、基本信息、Agent Runs 空态、3 条真实 trace 日志 |
+
+2026-08-17 真实浏览器证据：Pipeline Detail 显示 `PIPELINE 预览`、`全屏编辑 →`、`执行流水线`；Job Detail 显示 `完成`、`智能体运行`、`日志` 和 `Pipeline complete...`。两页继续使用 develop 的 `PipelineData`、`Job`、`JobTrace`、蒸馏入口和 Canvas 路由，不迁移 Alan 旧状态。
+
+## 31. Phase 4 第三个 slice：Playwright 页面回归证据
+
+在实施 worktree 使用隔离端口和 Playwright 临时 PGlite 数据执行：
+
+```powershell
+$env:PLAYWRIGHT_PORT = "9472"
+bun run test:e2e -- e2e/canvas.e2e.spec.ts e2e/pipelines.e2e.spec.ts e2e/components.e2e.spec.ts e2e/operations.e2e.spec.ts e2e/jobs.e2e.spec.ts e2e/settings.e2e.spec.ts
+```
+
+旧的 9472 运行曾为 10/11；其阻塞已在后续 Canvas 直接移植回合消除。最终在稳定 9430 一次运行：
+
+```powershell
+$env:PLAYWRIGHT_PORT = "9430"
+bun run test:e2e -- canvas.e2e.spec.ts pipelines.e2e.spec.ts components.e2e.spec.ts operations.e2e.spec.ts jobs.e2e.spec.ts settings.e2e.spec.ts frontend-acceptance.e2e.spec.ts
+```
+
+结果为 `14 passed (1.6m)`。真实覆盖：五视口、StateLegend、组件菜单、QuickAdd/右键菜单、Folder + NodeConfig、File 拖入、Operation 创建、NodeCard 移动、Undo/Redo、12px ports、SemanticEdge、EdgeInspector、保存/刷新恢复、Agent Composer、六页面回归、主题/语言、键盘焦点、reduced motion 与 Axe。最终交互最大值 1156ms，`p95FrameGapMs=17`、`maxLongTaskMs=0`；Pipelines/Canvas serious/critical Axe violations 均为 0。
+
+## 32. Phase 3 第七个 slice：Capabilities 页面当前承接
+
+2026-08-17 在 9430 实施预览逐页打开以下路由，并记录了共享壳层与关键交互：
+
+| 页面         | 浏览器证据                                                                                  | 状态边界                                                 |
+| ------------ | ------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Connectors   | `/connectors` 显示 7 个 MCP 卡片；点击 `通过 MCP` 保持筛选区和测试/管理动作                 | 继续使用 develop Connector schema、连接/测试 API         |
+| Agents       | `/agents` 显示空态和 `创建智能体`；打开创建表单可见名称、描述、默认运行时、系统提示词和标签 | 继续使用 develop Agent Store/API 与运行时枚举            |
+| Local Agents | `/local-agents` 显示本机扫描说明、7 个运行时和 `重新扫描`                                   | 扫描结果依赖本机 CLI，不固定为 Alan 数据                 |
+| Skills       | `/skills` 显示 210 个技能、来源筛选、导入预览和卡片；输入 `Yuanbao` 只保留对应卡片          | 继续使用 develop Skill schema、导入和 Operation 生成入口 |
+| Plugins      | `/plugins` 显示 GitHub Projects 插件版本和对象类型                                          | 当前 develop 插件注册能力完整保留                        |
+| Usage        | `/usage` 显示 Token 趋势、Pipeline/Agent 汇总和空数据说明                                   | 继续使用 develop 用量查询和本地 Token 语义               |
+
+这些页面未发现需要复制 Alan 旧状态机的视觉差异，故记录为“适配后复用”或“当前承接”，不新增平行 UI。截图和交互记录由本轮浏览器预览留存。
+
+## 34. Phase 4 第四个 slice：Agent Panel 拖拽与窄视口层级
+
+在 9430 Canvas `1280×720` 真实浏览器中，Agent Panel resize handle 从 `x=935` 拖到 `x=875`：
+
+- shell 宽度从 `344px` 变为 `404px`；
+- shell right 保持 `1280px`，`document.scrollWidth=1280`、`clientWidth=1280`，无横向溢出；
+- 与 Canvas 顶部浮层之间使用 `top-16` 对齐，窄视口 E2E 的几何断言不再因 `top-14` 产生 7px 间隙；
+- develop 的 `agentPanelWidth`、`setAgentPanelWidth`、折叠 action 和 Agent 内容保持不变，仅修正布局呈现。
+
+证据：`CanvasInner.unit.test.tsx` 与相关 chrome/modal 定向矩阵通过；真实拖拽结果和截图已留存。旧 Notifications/Local Agents 阻塞已由固定 runtime seed 消除，最终全量结果见 §31 的 14/14。
+
+## 33. Phase 3 第八个 slice：Operation 表单与错误页承接
+
+- `http://localhost:9430/pipelines/operations/new` 已验证 Alan 式窄卡片表单、对象类型 chip、Agent/Script 执行方式切换；切到 Script 后出现脚本命令和语言字段；
+- 在隔离 PGlite 中创建了 `COD355 Visual Check`（`op-1786941891496`），真实导航到详情页并显示运行/编辑/输出项/基本信息/元数据；点击编辑后真实打开 `/pipelines/operations/op-1786941891496/edit`，显示身份与范围、执行契约、数据契约和摘要；
+- 创建/编辑/详情继续使用 develop Operation schema、Store、创建 API 和输出模板能力，没有恢复 Alan 旧实体；
+- 认证页源码继续使用 develop `AuthShell`、邮箱/OAuth 表单和现有 auth hook。因本地模式会自动创建/恢复 `Local User` 会话，访问 `/login` 在真实浏览器会按现有 develop 行为回到 `/`，因此没有把匿名登录页截图冒充为已验收；
+- 访问未知路由 `/route-that-does-not-exist` 显示 `404 — 页面不存在`，空白页级错误态已记录。
+
+## 35. Phase 2 Canvas 直接移植回合：Alan 原 JSX/class + develop 逻辑
+
+本回合不再用“近似设计”重画 Canvas，而是以 Alan 固定提交逐文件复制呈现结构，再把 develop 的数据与 action 接回：
+
+| 表面               | Alan 源                                             | 当前落点                                     | develop 权威逻辑                                                            | 定向证据                           |
+| ------------------ | --------------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------- | ---------------------------------- |
+| Components menu    | `canvas/chrome/ComponentPanel.tsx`                  | `CanvasComponentPanel.tsx`                   | sidebar UI、operations/skills query、generic Compound、create/drag handlers | 7 tests                            |
+| NodeCard + ports   | `nodes/GNodeShell.tsx`、`support/NodeCardPorts.tsx` | `NodeCard/*` + develop 节点                  | node fields、run status、focus/Agent/duplicate/remove、port masks/counts    | 8 files / 54 tests + body 41 tests |
+| TopPill + States   | `canvas/chrome/TopPill.tsx`、`StateLegend.tsx`      | `CanvasTopChrome.tsx`、`CanvasStatusBar.tsx` | title/save/settings/run/runtime/Agent + develop summary                     | 3 files / 19 tests                 |
+| Toolbar            | `canvas/chrome/CanvasToolbar.tsx`                   | `CanvasToolbar.tsx`、`CanvasInner.tsx`       | tool/zoom/fit + develop-only undo/redo/layout/quick-add/delete menu         | 2 files / 21 tests                 |
+| Semantic edge      | `canvas/edges/SemanticEdge.tsx`                     | `SemanticEdge/*`、`CanvasFlow.tsx`           | selected edge、proposal、node statuses、PipelineEdgeData、edge click        | 2 files / 18 tests                 |
+| Edge Inspector     | `panels/EdgeInspector/EdgeInspector.tsx`            | `CanvasEdgeInspector/*`                      | selectedEdgeId、updateEdgeData、clearSelection                              | 2 tests                            |
+| Empty state        | `canvas/CanvasEmptyState.tsx`                       | `CanvasEmptyState/*`                         | current quick-add action                                                    | 2 tests                            |
+| NodeConfig         | `panels/NodeConfig/NodeConfig.tsx`                  | `CanvasNodePropertiesPanel/*`                | every develop node field/update handler                                     | Properties + Inner 27 tests        |
+| Agent/Composer     | `WorkspacePage/AgentBar/*`                          | `CanvasPage/AgentPanel/*`                    | runtime/session/upload/stream/proposal/diagnostics                          | 30 + 12 tests                      |
+| RunConsole         | `canvas/run/RunConsole.tsx`                         | `CanvasPage/RunConsole/*`                    | Job polling/traces/timeline/artifacts                                       | 8 tests                            |
+| Current-only menus | Alan component-row grammar                          | Canvas/Node/Connection/QuickAdd menus        | all develop create/connect/group/ungroup/detach actions                     | 4 files / 5 tests                  |
+
+Sol 审查中发现并修复两类“看似复制、实际仍偏差”的问题：共享 `Card` 会注入 `gap-3/py-3`，已改回 Alan 原生 `<div>`；SemanticEdge map 推断成窄类型导致 `ReactFlowInstance` typecheck 失败，已用原 `PipelineEdge[]` 宽类型承接。两处修复后的 `packages/views` typecheck 均为 exit 0。
+
+当前截图：
+
+- Alan：`pr-assets/cod-355/canvas-1440x900-alan.png`
+- 直接移植后：`pr-assets/cod-355/canvas-direct-port-1440x900.png`
+- 旧 Before/After/Diff：`pr-assets/cod-355/canvas-1440x900-{before,after,diff}.png`
+- NodeCard：`pr-assets/cod-355/canvas-nodecard-1440x900-{alan,before,after,diff}.png`
+- 五视口 After：`canvas-{1440x900,1180x820,981x820,701x820,390x844}-after.png`
+- RunConsole：`runconsole-{running,completed,failed}-1200x500.png`
+
+截图中的业务数据、中文/英文内容与 Alan 可不同；评审目标是布局、密度、组件形状、层级和交互语法。Store、API、Schema、运行状态与安全约束全部继续以 develop 为准。
+
+## 36. 最终质量矩阵与基线例外
+
+本节区分既有浏览器/截图记录与固定 Alan SHA 的 fresh visual evidence；后者在 harness 阻塞时不记为通过。
+
+| 验收项                       | 最终结果                       | 证据                                                                                                                                                                                                                                                                                                                                       |
+| ---------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `packages/views` 全量单测    | 通过                           | 91 files / 397 tests                                                                                                                                                                                                                                                                                                                       |
+| `apps/app` 全量单测          | 通过                           | 141 files / 664 tests                                                                                                                                                                                                                                                                                                                      |
+| views/app/ui typecheck       | 通过                           | 三命令 exit 0                                                                                                                                                                                                                                                                                                                              |
+| Desktop 直接 tsc             | 历史基线失败                   | 当前与 `cod-355-before-5771dce` 输出一致：platform headers、sidecar null、React 双类型、Distillation 路由；Canvas/locale 不在错误列表                                                                                                                                                                                                      |
+| app lint                     | 历史基线失败                   | 当前与 Before 均为 `pendingPipelinePrompt.ts:36` no-try + Pipeline route func-style warning                                                                                                                                                                                                                                                |
+| desktop/ui lint              | 通过                           | desktop 仅 2 条既有 func-style warning，exit 0；ui exit 0                                                                                                                                                                                                                                                                                  |
+| 新增 Canvas 文件定向 lint    | 通过                           | EdgeInspector/SemanticEdge/useNodeCardActions exit 0                                                                                                                                                                                                                                                                                       |
+| Visual evidence spec lint    | 通过                           | `apps/app/e2e/alan-migration.visual.e2e.spec.ts` 定向 oxlint exit 0；全量 app lint 仅保留 `pendingPipelinePrompt.ts:36` no-try 与 Pipeline route func-style 历史基线问题                                                                                                                                                                   |
+| changed-file format / diff   | 通过                           | 当前 worktree `git status --short --untracked-files=all` 为 97 个 changed text files（83 tracked + 14 untracked）；本文件 `oxfmt --check` 与 `git diff --check` 均 exit 0                                                                                                                                                                  |
+| Web production build         | 通过                           | `apps/app` client 4354、SSR 2209 modules                                                                                                                                                                                                                                                                                                   |
+| Desktop production build     | 通过                           | 4180 modules                                                                                                                                                                                                                                                                                                                               |
+| Root turbo build             | 历史基线失败                   | Web/Desktop/docs/cli 构建完成；`apps/create` 在 Windows 执行 Unix `cp -r` 报 `cp: illegal option -- r`，失败文件未被 COD-355 修改                                                                                                                                                                                                          |
+| Storybook production build   | 通过                           | 4206 modules；Objects/SemanticEdge/EdgeInspector/Node/Run stories 在产物中                                                                                                                                                                                                                                                                 |
+| 页面 + acceptance Playwright | 通过                           | 页面/Canvas 历史完整套件 14/14；最终 `frontend-acceptance.e2e.spec.ts` 3/3，主题/语言、键盘、reduced-motion、Pipelines/Canvas Axe serious/critical=0                                                                                                                                                                                       |
+| Visual evidence Playwright   | 通过（迁移侧）                 | `pr-assets/cod-355` 已生成最新 Alan/Before/After/Diff、NodeCard Alan/Before/After/Diff 与 Canvas 五视口截图；visual spec 最终 2 passed。Alan Canvas 通过真实 `/pipelines → New Pipeline` 取得有效 Workspace，NodeCard 通过 `New Pipeline → 添加种子节点` 取得，动态 toast 已在截图阶段隐藏；9440 使用隔离 PGlite harness，未修改 Alan 源码 |
+| Storybook 浏览器预览         | 通过（迁移侧） / Alan 参考阻塞 | 迁移 worktree 9471 的 NodeCard story iframe 实际显示 `Example Node`，Objects story iframe 实际显示对象目录，console 无错误；`bun run build-storybook` exit 0，4206 modules。固定 Alan 9470 manager 可列出 stories，但 iframe 保持空白/loading，直连 iframe 超时；该问题只记录为 Alan 参考基础设施阻塞，不改变迁移侧 Storybook 结果         |
+| 主 checkout 隔离             | 物理隔离已确认                 | 实施 worktree 为 `D:\Coding\项目ORDINE\.worktrees\cod-355-alan-migration`；主 checkout 存在重叠脏路径，最终 status 不能单独证明变更归属；本次未提交、推送、合并或删除                                                                                                                                                                      |
+
+根据执行规则 11，Desktop tsc 与 app lint 的任务前基线失败保留为证据，不扩展 COD-355 去修改 sidecar、Distillation 路由或错误处理架构。固定 Alan SHA 的 Storybook 参考 iframe 仍受基础设施限制，但迁移侧 fresh visual evidence、迁移侧 Storybook 浏览器预览与构建均已通过；因此本文仍不使用“仓库全面复用完成/所有质量门全绿”的表述，COD-355 作用域内新增或修改的前端行为、构建、页面 acceptance Playwright、视觉和可访问性验收已完成。
+
+## 37. Phase 5：develop 当前承接页面浏览器钉证
+
+本节记录 Alan 没有对应页面、但必须继续由 develop 承接的前端表面；不把它们重新解释为 Alan 迁移缺口，也不迁移 Alan 不存在的旧状态。
+
+| 表面                  | 真实路径与交互证据                                                                                                                                                                                                     | 当前结论                                                       |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Home / Dashboard      | `/` 显示 Ordine Studio、当前本地 Agent 选择、目标输入、上传上下文和创建 Pipeline/整理重复工作/沉淀流程三个入口；390×844 emulation 下 `scrollWidth=390`，无横向溢出                                                     | 当前承接；保留 develop HomePage 与 Agent/生成入口              |
+| Agents / Agent Detail | `/agents` 显示列表、搜索和创建入口；创建对话框包含运行时、模型、系统提示词、标签；`agents-workflow.e2e.spec.ts` exit 0，1 passed，覆盖创建→详情→编辑；详情页 `/agents/{id}` 在 390×844 emulation 下 `scrollWidth=390`  | 当前承接；使用 develop Agent Store/API/Schema                  |
+| Objects               | `/pipelines/objects` 显示文件、文件夹和 GitHub Projects 对象卡片；点击 GitHub Projects 进入 `/pipelines/objects/github-project`，显示“暂无对象”空态；390×844 emulation 下 `scrollWidth=390`，无横向溢出                | 当前承接；使用 develop plugin registry 与对象查询              |
+| Runtimes              | `/runtimes` 显示 19 个本机 Agent；点击“重新扫描”进入“扫描中...”禁用态；点击 Hermes“配置”进入 `/runtimes/local-hermes`，再进入 `/edit` 显示编辑表单；390×844 emulation 下 `clientWidth=380/scrollWidth=380`，无横向溢出 | 当前承接；使用 develop runtime Store、扫描 API、详情和编辑路由 |
+| Distillations         | `/distillations` 显示空态和“打开蒸馏室”；`/distillation-studio` 显示标题、来源类型、模式、来源、目标、Runtime、模型覆盖和保存/运行操作；`distillations-workflow.e2e.spec.ts` exit 0，1 passed                          | 当前承接；创建、编辑、刷新恢复、删除均由 develop 业务逻辑负责  |
+| Assistant             | `/assistant` 真实显示当前 develop 的 `Hello "/assistant"!` 占位路由；Alan 无对应页面                                                                                                                                   | 当前承接；本轮不虚构 Assistant 业务或 Alan 视觉迁移            |
+
+## 38. Phase 5 第二个 slice：恢复已提交的 COD-124 侧边栏壳层
+
+用户明确要求恢复之前已经提交过的侧边栏，而不是继续保留本轮 Alan 视觉改造后的临时壳层。本 slice 以 Git 提交 `5cfcd232`（`feat: 完成侧边栏导航与项目切换（COD-124）`）为视觉/布局源，手工恢复 shared `packages/views` 的对应结构；没有 cherry-pick 整个提交，也没有恢复其中的旧业务路由或旧状态。
+
+### 源码变更
+
+| 文件                                                | 恢复内容                                                                                                                                        | develop 保留项                                                                                                                    |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/views/src/components/AppSidebar.tsx`      | `border-r bg-sidebar`、`border-b px-2 py-2`、`h-8` 品牌行、`Workflow` Logo、`right-0.5/top-0.5` Trigger、独立 `SidebarMenuButton` 搜索/新建入口 | Components、Usage、Local Agents、Connectors、Distillations、Plugins、NotificationCenter、Settings 和 `handleSearchClick` fallback |
+| `packages/views/src/components/ProjectSwitcher.tsx` | COD-124 的 `py-2` 容器与 `h-9 w-full` 项目按钮                                                                                                  | develop 项目查询、切换、创建和 `sidebarStore` 持久化                                                                              |
+| `packages/views/src/components/AppLayout.tsx`       | 恢复 `SidebarProvider widthStorageKey`，不再由 shared 层覆盖本轮 Alan 的宽度约束                                                                | Web wrapper 的 develop 宽度配置仍在 `apps/app/src/components/AppLayout.tsx`                                                       |
+| 定向单测                                            | 更新品牌/项目按钮语义断言                                                                                                                       | 业务行为断言继续覆盖搜索、项目切换和能力导航                                                                                      |
+
+### 真实浏览器证据
+
+- 路由：`http://localhost:9430/canvas?id=pipeline-e2e-1786957641321-0-0`。
+- 视口：`1356×1032`，本地模式固定种子数据，Canvas 节点和 Agent Panel 正常显示。
+- Before：用户在同一路由提交的浏览器评论截图，侧栏使用 `O / Ordine Studio / 工作区`、Primary 新建按钮和 Alan 临时项目身份条；用户标记了 Logo、新建流水线、搜索三个位置的错位。
+- After（折叠）：DOM `data-state=collapsed`；Trigger `10,10,28×28`，项目/搜索/新建按钮分别为 `8,56,32×32`、`8,104,32×32`、`8,140,32×32`，图标中心统一在同一侧栏栅格。
+- After（展开）：DOM `data-state=expanded`；Trigger 位于 `197,10,28×28`，项目/搜索/新建按钮均从 `x=8` 开始、宽 `219px`，无重叠。
+- 交互：折叠态点击“搜索...”打开 `搜索...` 对话框；点击 Close 后回到 Canvas；点击 Toggle Sidebar 在 expanded/collapsed 两态间切换。
+- 运行时：浏览器控制台 error 数为 `0`；Canvas 节点、组件面板和 Agent Panel 在侧栏切换后仍存在。
+- 视觉截图：Playwright 已生成 `cod355-sidebar-collapsed-after.png` 与 `cod355-sidebar-expanded-after.png`（工具输出目录）；用户 Before 截图作为本 slice 的对照证据保留在本对话浏览器评论中。
+
+### 定向验证
+
+```powershell
+Push-Location packages/views
+bun run test -- AppSidebar.unit.test.tsx ProjectSwitcher.unit.test.tsx
+bun run check-types
+Pop-Location
+git diff --check -- packages/views/src/components/AppSidebar.tsx packages/views/src/components/ProjectSwitcher.tsx packages/views/src/components/AppLayout.tsx packages/views/src/components/AppSidebar.unit.test.tsx packages/views/src/components/ProjectSwitcher.unit.test.tsx
+```
+
+结果：2 个 test files / 6 tests passed；`packages/views` typecheck exit 0；`git diff --check` exit 0；本 slice 修改 5 个授权文件，未提交、推送、合并或修改主 checkout。
+
+## 39. Phase 5 第三个 slice：紧凑 NodeCard 选中态不再误展开
+
+用户在 9430 Canvas 反馈“点击这个卡片后就会展开”。根因是所有 develop 节点组件都使用 `nodeCardMode === "compact" && !selected`；节点一旦被 React Flow 选中，就绕过了全局紧凑模式。该行为与 Alan 的节点交互表达不一致，也使 Canvas 设置中的 Compact/Expanded 选择失去确定性。
+
+### 实现
+
+- `OperationNode`、`FileNode`、`FolderNode`、`GitHubProjectNode`、`OutputLocalPathNode`、`OutputProjectPathNode`、`PromptNode` 统一改为只由 `nodeCardMode` 决定 `compact`。
+- 保留 `selected` 的视觉 ring、focus、hover actions 和 develop Store/API 行为；未恢复 Alan 旧状态或改变节点数据。
+- 新增 `OperationNode.unit.test.tsx` 回归断言：`selected=true` 且 `nodeCardMode="compact"` 时，shell 的 `data-card-mode` 仍为 `compact`，Agent body 不渲染。
+
+### 真实浏览器证据
+
+- 路由：`http://localhost:9430/canvas?id=pipeline-e2e-1786957641321-0-0`，视口 `1356×1032`。
+- 修改后点击 Operation node：DOM 从 `selected=false / data-card-mode=compact` 变为 `selected=true / data-card-mode=compact`；点击后卡片正文保持隐藏，没有误展开。
+- 定向浏览器页面仍显示全局侧栏、组件菜单、Canvas 节点和 Agent Panel；本轮未改变组件菜单或运行状态。
+
+### 定向验证
+
+```powershell
+Push-Location packages/views
+bun run test -- OperationNode.unit.test.tsx NodeCard.unit.test.tsx FileNode.unit.test.tsx FolderNode.unit.test.tsx GitHubProjectNode.unit.test.tsx OutputLocalPathNode.unit.test.tsx OutputProjectPathNode.unit.test.tsx PromptNode.unit.test.tsx
+bun run check-types
+Pop-Location
+bunx oxlint packages/views/src/pages/CanvasPage/OperationNode/OperationNode.tsx packages/views/src/pages/CanvasPage/OperationNode/OperationNode.unit.test.tsx packages/views/src/pages/CanvasPage/NodeCard/NodeCard.tsx packages/views/src/pages/CanvasPage/FileNode/FileNode.tsx packages/views/src/pages/CanvasPage/FolderNode/FolderNode.tsx packages/views/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx packages/views/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx packages/views/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.tsx packages/views/src/pages/CanvasPage/PromptNode/PromptNode.tsx
+git diff --check
+```
+
+结果：8 个 test files / 55 tests passed；views typecheck、oxlint、oxfmt 和 `git diff --check` 均 exit 0。
+
+## 40. Phase 5 第四个 slice：Canvas 顶部浮层对齐 Alan TopPill
+
+本 slice 继续以 Alan `WorkspacePage/canvas/chrome/TopPill.tsx` 的布局语义为视觉基准，但不恢复 Alan 的版本状态、旧 Store 或旧运行协议。develop 的保存、设置、状态、运行、Agent Panel 和运行禁用条件继续作为唯一业务来源。
+
+### 实现
+
+- `CanvasTopChrome.tsx`：将标题、Workflow 图标、保存、设置合并为单一紧凑圆角 pill；标题保留 develop 的可编辑 input 和 `handlePipelineNameChange`。
+- 右侧保留 `CanvasStatusBar`、运行按钮和 Agent reopen；使用现有 `agentPanelWidth` 计算顶部 chrome 的右侧偏移。
+- 标题和按钮增加 `truncate`、`flex-1`、窄视口约束，避免长标题挤压状态/运行控件。
+- `CanvasTopChrome.unit.test.tsx` 增加 pill 结构、保存 action、设置/运行 action、运行中禁用和 Agent reopen 断言。
+
+### 9430 / 9440 浏览器证据
+
+- 9430：`http://localhost:9430/canvas?id=pipeline-e2e-1786957641321-0-0`，`1356×1032`；顶部 pill 位于 `x=248,y=12,width=256,height=40`，状态入口 `x=852`，运行入口 `x=928`，右侧 Agent 偏移为 `344px`。
+- 9430：`document.scrollWidth=1356`、`clientWidth=1356`，控制台 error 数为 `0`；点击“设置”打开 `Canvas 设置` 对话框，点击关闭恢复 Canvas。
+- 9430 窄视口：Luna 已验证 `390×844`，`bodyScrollWidth=390`、`clientWidth=390`，长标题截断且无横向溢出。
+- 9440 Alan 对照：同为 `1356×1032` 时显示 Alan 的 `Untitled pipeline` 标题按钮、版本/草稿胶囊和右侧 `状态/运行`；本次只复制其顶部密度和分组关系，未复制其版本状态业务。
+- 截图：Playwright 生成 `cod355-topchrome-before-9430.png`、`cod355-topchrome-alan-9440.png`；本轮 After 由 9430 当前浏览器 DOM 几何和交互记录钉证。
+
+### 定向验证
+
+```powershell
+Push-Location packages/views
+bun run test -- CanvasTopChrome.unit.test.tsx
+bun run check-types
+Pop-Location
+bunx oxlint packages/views/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.tsx packages/views/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
+bunx oxfmt --config packages/oxc-formatter-config/oxfmt.json --check packages/views/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.tsx packages/views/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
+git diff --check -- packages/views/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.tsx packages/views/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
+```
+
+结果：1 个 test file / 5 tests passed；views typecheck、oxlint、oxfmt、`git diff --check` 均 exit 0。
+
+## 41. Phase 5 第五个 slice：组件菜单分类文案与 Alan 对照
+
+真实对照确认 9430 与 Alan 的组件面板结构已基本一致，develop 额外的 Skills 与多条 Operation 是业务能力差异，不删除。为消除可见的分类差异，本 slice 只调整中文 Operations 分类文案。
+
+### 实现
+
+- `apps/app/src/locales/zh.json`：`canvas.componentPanel.categories.operations` 从 `Operation` 改为 `工序`。
+- `apps/desktop-app/src/locales/zh.json`：同步修改同一 key，保持 Web/Desktop 共享视图的本地化一致。
+- `CanvasComponentPanel.tsx`、Store、API、创建/拖拽逻辑未修改。
+
+### 9430 / 9440 浏览器证据
+
+- 9430：`http://localhost:9430/canvas?id=pipeline-e2e-1786957641321-0-0`，`1356×1032`，面板 `x=248,y=100,width=230,height=619`，分类为 `输入对象 / 工序 / 技能 / 输出`，`scrollWidth=clientWidth=1356`。
+- 9440：`http://localhost:9440/workspace/pipeline-0fa487e9-c6c8-44ab-8252-6205de938b01`，同视口，Alan 面板 `x=254,y=100,width=230,height=461`，分类文案包含 `工序`。
+- 高度差异来自 develop 保留的 Operations 数据和 Skills 分组，不是布局溢出；当前菜单仍支持分类折叠、Operation/Compound/Skill 创建与拖拽。
+
+### 定向验证
+
+```powershell
+Push-Location packages/views
+bun run test -- CanvasComponentPanel.unit.test.tsx
+bun run check-types
+Pop-Location
+bunx oxfmt --config packages/oxc-formatter-config/oxfmt.json --check apps/app/src/locales/zh.json apps/desktop-app/src/locales/zh.json
+git diff --check -- apps/app/src/locales/zh.json apps/desktop-app/src/locales/zh.json
+```
+
+结果：CanvasComponentPanel 1 个 test file / 7 tests passed；views typecheck、oxfmt、`git diff --check` 均 exit 0。Luna 定向 oxlint exit 0。
+
+## 42. Phase 5 第六个 slice：Agent Panel 浮动 shell
+
+真实对照确认 AgentPanel 内容、Composer、runtime 选择和 develop 会话行为已经承接；本 slice 只修正外层空间关系。用户在 `1194×1032` 评论中指出 9430 看起来像“一个面板覆盖在另一个面板上”。DOM 对照证明根因不是 Agent 内容，而是 resize handle 被嵌在 panel region 内：9430 原结构为 1px 有实线 separator + panel，Alan 则为独立的 6px 无实线 gutter，后接单一浮动 panel region。
+
+### 实现
+
+- `CanvasInner.tsx` 将桌面 resize handle 从 panel region 中拆出，放入前置的 `w-1.5`（6px）透明 gutter；`ResizeHandle` 继续复用 develop 的拖拽、键盘与折叠逻辑，但该处设置 `line={false}`，不再画出贴边分割线。
+- panel region 只负责 `h-full / overflow-hidden / py-1.5 / pr-1.5`；唯一可见 shell 负责 `rounded-2xl / bg-surface / shadow-float / ring-1 ring-border-strong`，没有第二层背景、边框或阴影。
+- `max-[480px]:!w-full` 与窄屏 overlay 保留；390px 下 gutter 为 1px、shell 使用剩余 389px，不改变 Composer 输入和 Agent Panel 内容。
+- `agentPanelWidth`、ResizeHandle delta、折叠阈值、Store/API、runtime/session 和运行状态未改变。
+- `CanvasInner.unit.test.tsx` 增加 wrapper/gutter/region sibling、6px desktop gutter、无实线 separator 和单一 shell 断言，原有 resize/collapse/keyboard 行为断言继续通过。
+
+### 9430 / 9440 浏览器证据
+
+- 9430，`1194×1032`：wrapper `x=838,width=356`；独立 gutter `x=838,width=6`；region `x=844,width=350`；唯一 shell `x=844,y=6,width=344,height=1020`；`separatorHasLine=false`；`scrollWidth=clientWidth=1194`。
+- 9440 Alan，同视口：独立 separator `x=828,width=6`；region `x=834,width=360`；唯一 shell `x=834,y=6,width=354,height=1020`；结构关系、6px gutter、上下/右侧 inset 一致。10px shell 宽度差异来自 develop 的 `agentPanelWidth=344` 与 Alan 默认宽度，不改 develop 状态约束。
+- 9430，`1356×1032`：gutter `x=1000,width=6`；shell `x=1006,y=6,width=344,height=1020`；9440 Alan 为 separator `x=990,width=6`、shell `x=996,y=6,width=354,height=1020`；两边均无横向溢出。
+- 9430 窄视口：`390×820` 时 wrapper `x=0,y=64,width=390`、gutter `1px`、shell `389px`，`scrollWidth=clientWidth=390`；`1180×820` 断点仍为 absolute overlay，shell `x=836,width=344`，`scrollWidth=clientWidth=1180`。
+- Composer 和消息区仍可见，未改变发送、附件、上下文引用或运行内容。
+- 截图：`pr-assets/cod-355/agent-panel-9430-1194-current.png`（Before）、`agent-panel-9430-1194-after-gutter.png`（After）、`agent-panel-9440-1194-alan.png`（Alan）、`agent-panel-9430-1194-before-after-diff.png`（Diff）、`agent-panel-9430-1356-after-gutter.png`、`agent-panel-9440-1356-alan.png`、`agent-panel-9430-390-after-gutter.png`。
+
+### 定向验证
+
+```powershell
+Push-Location packages/views
+bun run test -- CanvasInner.unit.test.tsx
+bun run check-types
+Pop-Location
+bunx oxlint packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
+bunx oxfmt --config packages/oxc-formatter-config/oxfmt.json --check packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
+git diff --check -- packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
+Push-Location apps/app
+bun run test:e2e -- e2e/canvas.e2e.spec.ts --grep "keeps the Canvas inside 390-1440px viewports"
+Pop-Location
+```
+
+结果：CanvasInner 1 个 test file / 14 tests passed；Canvas 响应式 Playwright 1 test passed，覆盖 `1440 / 1180 / 981 / 701 / 390`；views typecheck、oxlint、oxfmt、`git diff --check` 均 exit 0。1194px 刷新后标题仍为 `Canvas E2E Pipeline`、2 个节点仍在，page error 和 console error 均为 0。
+
+## 43. Phase 5 第七个 slice：Run Console 当前承接
+
+RunConsole 的 shell 已与 Alan 固定版本保持同一视觉结构，本轮未做无必要的重画：底部浮动、圆角、终端图标、日志计数、状态标签、折叠箭头和关闭入口均一致。develop 额外保留了运行轮询、结构化节点时间线、多输入等待规则、产物发现、错误信息和关闭动作。
+
+### 证据
+
+- 9430 与 Alan 的 RunConsole 源码都使用 `absolute inset-x-3 bottom-16`、`rounded-2xl`、`shadow-float`、终端标题栏和 `h-44` 日志区。
+- develop `RunConsole.tsx` 继续读取 develop `activeJobId`、Job、traces、node statuses 和 artifacts，不复制 Alan 旧 `useRunPolling` 状态。
+- 当前 9430/9440 Canvas 页面均无活动 Job，因此没有伪造运行态数据；已有 RunConsole Storybook/浏览器证据记录在 §22 和 §36。
+
+### 定向验证
+
+```powershell
+Push-Location packages/views
+bun run test -- RunConsole.unit.test.tsx
+bun run check-types
+Pop-Location
+bunx oxlint packages/views/src/pages/CanvasPage/RunConsole/RunConsole.tsx packages/views/src/pages/CanvasPage/RunConsole/RunConsole.unit.test.tsx
+bunx oxfmt --config packages/oxc-formatter-config/oxfmt.json --check packages/views/src/pages/CanvasPage/RunConsole/RunConsole.tsx packages/views/src/pages/CanvasPage/RunConsole/RunConsole.unit.test.tsx
+git diff --check -- packages/views/src/pages/CanvasPage/RunConsole/RunConsole.tsx packages/views/src/pages/CanvasPage/RunConsole/RunConsole.unit.test.tsx
+```
+
+结果：1 个 test file / 8 tests passed；views typecheck、oxlint、oxfmt、`git diff --check` 均 exit 0。本轮没有修改 RunConsole 源码。
+
+## 44. Phase 5 第八个 slice：Canvas 刷新恢复与窄视口回归
+
+本轮没有修改 persistence 或 Store；通过真实浏览器确认当前 develop 的刷新恢复能力在顶部浮层、组件菜单、Agent Panel 和节点数据迁移后仍然成立。
+
+### 9430 浏览器证据
+
+- 桌面 `1356×1032`：刷新前后标题均为 `Canvas E2E Pipeline`，节点数量均为 `2`，组件面板和 Agent shell 均存在，顶部浮层存在；`scrollWidth=clientWidth=1356`。
+- 窄视口 `390×844`：刷新后标题仍为 `Canvas E2E Pipeline`，节点数量 `2`，顶部浮层和 Agent shell 均存在；`scrollWidth=clientWidth=390`。
+- 两次刷新后的控制台 error 数均为 `0`。
+- 9440 Alan 同路由对照仍保持独立参考数据；本轮未修改 Alan 源码或状态。
+
+### 结论
+
+刷新恢复继续以 develop 的 Canvas Store、Pipeline 数据和 Agent 会话逻辑为准；Alan 只用于确认 shell 的空间关系。该项不引入第二套恢复状态，也没有回退 develop 的节点或运行字段。
+
+## 45. Phase 5 第九个 slice：主题、语言与键盘焦点回归
+
+本轮对已经修改的 Canvas shell 做低成本真实回归，不引入新的主题/语言状态。
+
+- 9430 `/settings`：点击“深色”后根节点 class 为 `dark`；点击“跟随系统”后恢复系统模式。
+- 9430 设置页键盘：Tab 可以继续移动到页面控件，关键侧栏和设置控件保留可访问名称。
+- 9430 Canvas：返回 `http://localhost:9430/canvas?id=pipeline-e2e-1786957641321-0-0` 后顶部浮层、组件菜单、Agent shell 和节点仍可见。
+- 主题回归控制台 error 数为 `0`；Alan 9440 仍作为独立固定参考，不修改其主题或状态。
+
+## 46. Phase 5 第十个 slice：侧栏恢复后的对比度回归修复
+
+本轮 acceptance Playwright 首次执行发现恢复 COD-124 侧栏后浅色主题的 `text-muted-foreground` 在 Sidebar 背景上的对比度为 `4.39:1`，影响 Search、New Pipeline、Capabilities 和 Settings，属于本轮侧栏恢复引入的问题。
+
+- `packages/views/src/components/AppSidebar.tsx` 将上述入口文字调整为 `text-foreground/70`，只提高前景对比度，不改变历史壳层布局、Store、路由或交互。
+- `AppSidebar.unit.test.tsx` 定向测试：3 tests passed。
+- `apps/app/e2e/frontend-acceptance.e2e.spec.ts` 重跑：3 tests passed；主题/语言、键盘/reduced-motion、Pipelines/Canvas serious/critical Axe violations 均通过。
+- 迁移侧 acceptance 命令最终 exit 0；该次失败不再作为历史基线保留。
+
+## 47. Phase 5 第十一个 slice：最终构建与 acceptance 结果
+
+- Storybook production build：`bun run build-storybook` exit 0，4206 modules；CanvasTopChrome、CanvasInner、AgentPanel、RunConsole、NodeCard、SemanticEdge 和 EdgeInspector stories 均进入产物。
+- Desktop production build：`apps/desktop-app` `bun run build` exit 0，4180 modules。
+- Web production build：`apps/app` client 4354 modules、SSR 2209 modules 均构建完成；root `bun run build` 最终 exit 1 是因为 `apps/create` 的 Windows 历史脚本使用 Unix `cp -r`，报 `cp: illegal option -- r`，不在本轮修改文件中。
+- Canvas frontend acceptance：`PLAYWRIGHT_PORT=9430 bun run test:e2e -- e2e/frontend-acceptance.e2e.spec.ts` 最终 `3 passed`；包含主题/语言、键盘/reduced-motion 和 Pipelines/Canvas Axe serious/critical=0。
+- 迁移 worktree 未提交、推送、合并或删除内容；主 checkout 未由本轮命令修改。
+
+## 48. Phase 5 第十二个 slice：Fresh visual evidence 修复与重建
+
+最终截图审查发现旧 visual spec 的 Alan Canvas route 使用了已失效的固定 pipeline ID，生成的 `canvas-1440x900-alan.png` 实际是 `Pipeline not found`；NodeCard Alan 图还被固定参考 jobs 查询错误 toast 遮挡。两者均属于证据脚本问题，不能作为完成证明。
+
+### 修复
+
+- `apps/app/e2e/alan-migration.visual.e2e.spec.ts`：Alan Canvas 截图改为从 `/pipelines` 真实点击 `New Pipeline`，等待有效 `/workspace/pipeline-*` 和 `canvas-v2-root` 后截图。
+- NodeCard 截图在目标 Workspace 导航和节点创建完成后重新注入动态 overlay 隐藏样式，避免参考 harness 的 toast 遮挡节点；不隐藏 Canvas 或 NodeCard 内容。
+
+### 最终结果
+
+- full visual evidence：2 tests passed，约 1.6 分钟；页面 Alan/Before/After/Diff、Canvas 五视口、主题/语言和 NodeCard 证据全部重新生成。
+- NodeCard 定向重跑：1 test passed；最新 Alan NodeCard 图显示有效 `Starter prompt` 节点、顶部 chrome、组件入口和 Agent Bar，无错误 toast。
+- 最新证据时间为 2026-08-18 14:27；`canvas-1440x900-alan.png`、`canvas-1440x900-after.png`、`canvas-1440x900-diff.png`、五视口 After 和 NodeCard 四联图均非空。
+- visual spec 的 oxlint、oxfmt 和 `git diff --check` 均 exit 0。
+
+## 49. Phase 5 第十三个 slice：NodeCard 端口与 SemanticEdge 当前承接
+
+源码和真实页面对照确认端口与连线已经是 Alan 的视觉实现，develop 只扩展了状态来源和边数据语义，本轮不重写。
+
+- 9430 当前节点端口使用 React Flow 的 0×0 handle 加 12px pseudo visual；连接端口真实 DOM 标记为 `data-connected="true"`，输入/输出 aria label 保留。
+- 9430 当前 SemanticEdge 使用 2px 状态线和居中 pill label；当前 `数据` 标签与 warning 虚线来自 develop 的 `PipelineEdgeData`，没有引入 Alan 旧 edge 状态。
+- 9430 `1356×1032` 页面 `scrollWidth=clientWidth=1356`，edge label 可见，端口 connected/idle 状态可从 DOM 复核。
+- 9440 Alan 固定源码的 `NodeCardPorts`/`SemanticEdge` class 与当前 shared 结构一致；Alan 本轮种子数据没有连线，未伪造连接态对照。
+
+定向验证：`NodeCard.unit.test.tsx` + `SemanticEdge.unit.test.tsx` 为 2 个 test files / 21 tests passed；views typecheck、oxlint、oxfmt、`git diff --check` 均 exit 0。本轮没有修改端口或连线源码。
+
+## 50. Phase 5 第十四个 slice：Agent 标题对齐
+
+Fresh Canvas 对照中，develop Agent Panel 头部仍显示 `AI Assistant / AI 助手`，Alan 固定版本显示 `Agent`。该差异只涉及前端文案，不涉及会话、runtime 或运行状态。
+
+- Web/Desktop 的 `canvas.agentPanel.title` 英文和中文值统一为 `Agent`。
+- 9430 真实浏览器头部显示 `Agent · 运行时 · runtime-e2e-*`，不再出现 `AI Assistant` 或 `AI 助手`；9440 Alan 同样显示 `Agent`。
+- AgentPanel 定向测试 1 file / 20 tests passed；views typecheck、locale oxfmt 和 `git diff --check` 均 exit 0。
+- 最终 visual evidence 已在该文案修改后重新生成，`canvas-1440x900-after.png` 可见 `Agent` 标题。
+
+## 51. Phase 5 第十五个 slice：Canvas 空画布文案对齐
+
+- Web/Desktop 空画布标题和描述同步 Alan：英文为 `Start with a node...` 与“连接 inputs、operations、outputs”，中文为“先放一个节点，再把输入、Operation 和输出连接成可运行的 Pipeline”。
+- develop 的主按钮仍保留 `Quick add node / 快速新建节点`，继续调用 `handleOpenQuickAdd` 打开现有 Quick Add palette，没有替换为 Alan 的 seed Store 或旧节点创建逻辑。
+- 9430 真实点击主按钮后出现 `搜索节点或 Operation...` Quick Add 对话框，Escape 可关闭；9440 新建 Workspace 显示 Alan `Start with a node... / Seed node` 空态。
+- 9430 `1356×1032` 真实 DOM：组件面板为 `x=213..443`，空态内容为 `x=490..938`，`overlap=false`；页面 `scrollWidth=clientWidth=1356`。
+- `CanvasEmptyState.unit.test.tsx` 3 tests passed；views typecheck、locale oxfmt、`git diff --check` 均 exit 0。

--- a/packages/ui/src/sidebar.tsx
+++ b/packages/ui/src/sidebar.tsx
@@ -359,6 +359,7 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
 function SidebarRail({
   className,
   resizable = false,
+  autoCollapseWidth = SIDEBAR_AUTO_COLLAPSE_WIDTH,
   side = "left",
   onClick,
   onKeyDown,
@@ -372,6 +373,7 @@ function SidebarRail({
   title,
   ...props
 }: React.ComponentProps<"button"> & {
+  autoCollapseWidth?: number;
   resizable?: boolean;
   side?: "left" | "right";
 }) {
@@ -454,11 +456,11 @@ function SidebarRail({
     if (
       dragState.initialOpen &&
       !dragState.autoCollapsed &&
-      dragState.liveWidth <= SIDEBAR_AUTO_COLLAPSE_WIDTH
+      dragState.liveWidth <= autoCollapseWidth
     ) {
       dragState.autoCollapsed = true;
       setOpen(false);
-    } else if (!dragState.initialOpen && dragState.liveWidth > SIDEBAR_AUTO_COLLAPSE_WIDTH) {
+    } else if (!dragState.initialOpen && dragState.liveWidth > autoCollapseWidth) {
       setOpen(true);
     }
   };

--- a/packages/views/src/components/AppLayout.tsx
+++ b/packages/views/src/components/AppLayout.tsx
@@ -17,12 +17,7 @@ export const AppLayout = ({ children }: { children: React.ReactNode }) => {
             <SidebarStoreProvider>
               <ThemeApplier />
               <ToastNotificationBridge toastStore={toastStore} />
-              <SidebarProvider
-                defaultWidth={236}
-                maxWidth={320}
-                minWidth={216}
-                widthStorageKey="ordine.sidebar.width"
-              >
+              <SidebarProvider widthStorageKey="ordine.sidebar.width">
                 <AppSidebar />
                 <SidebarInset>{children}</SidebarInset>
                 <ToastContainer />

--- a/packages/views/src/components/AppSidebar.tsx
+++ b/packages/views/src/components/AppSidebar.tsx
@@ -18,6 +18,7 @@ import {
   Search,
   Settings,
   SquarePen,
+  Workflow,
   Zap,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -127,33 +128,36 @@ export const AppSidebar = ({
   }, [currentPath, handleSidebarLocationChange]);
 
   return (
-    <Sidebar className="border-r border-sidebar-border bg-sidebar" collapsible="icon">
-      <SidebarHeader className="border-b border-sidebar-border px-3 pb-2 pt-2.5">
-        <div className="relative flex h-10 items-center">
+    <Sidebar className="border-r bg-sidebar" collapsible="icon">
+      <SidebarHeader className="border-b px-2 py-2">
+        <div className="relative flex h-8 items-center">
           <div
             aria-hidden={sidebarState === "collapsed"}
-            className="pointer-events-none flex w-full max-w-full min-w-0 items-center gap-2.5 overflow-hidden pr-9 transition-[max-width,opacity,transform] duration-200 ease-out motion-reduce:transition-none group-data-[state=collapsed]/sidebar:max-w-0 group-data-[state=collapsed]/sidebar:-translate-x-1 group-data-[state=collapsed]/sidebar:opacity-0"
+            className="pointer-events-none flex w-full max-w-full min-w-0 items-center gap-2 overflow-hidden pr-9 transition-[max-width,opacity,transform] duration-200 ease-out motion-reduce:transition-none group-data-[state=collapsed]/sidebar:max-w-0 group-data-[state=collapsed]/sidebar:-translate-x-1 group-data-[state=collapsed]/sidebar:opacity-0"
           >
-            <div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary text-[11px] font-semibold text-primary-foreground">
-              O
+            <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-primary">
+              <Workflow className="h-3.5 w-3.5 text-primary-foreground" />
             </div>
-            <div className="min-w-0 leading-tight">
-              <div className="truncate text-[13px] font-semibold tracking-[-0.01em]">
-                Ordine Studio
-              </div>
-              <div className="truncate text-[10.5px] text-muted-foreground">
-                {t("nav.workspace")}
-              </div>
-            </div>
+            <span className="truncate text-sm font-bold">ordine</span>
           </div>
-          <SidebarTrigger className="absolute right-0 top-1.5 z-10 shrink-0 rounded-md shadow-none transition-[right] duration-200 ease-out motion-reduce:transition-none active:translate-y-0! focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-inset group-data-[state=collapsed]/sidebar:right-[calc(50%_-_0.875rem)]" />
+          <SidebarTrigger className="absolute right-0.5 top-0.5 z-10 shrink-0 rounded-md shadow-none transition-[right] duration-200 ease-out motion-reduce:transition-none active:translate-y-0! focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-inset group-data-[state=collapsed]/sidebar:right-[calc(50%_-_0.875rem)]" />
         </div>
         <ProjectSwitcher />
         <SidebarMenu className="gap-1">
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              className="h-8 text-foreground/70"
+              tooltip={t("nav.search")}
+              onClick={handleSearchClick}
+            >
+              <Search />
+              <span className="truncate">{t("nav.search")}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
           {handleNewPipeline && (
             <SidebarMenuItem>
               <SidebarMenuButton
-                className="h-9 justify-center bg-primary text-primary-foreground shadow-none hover:bg-primary/90 hover:text-primary-foreground data-[active=true]:bg-primary data-[active=true]:text-primary-foreground"
+                className="h-8 text-foreground/70"
                 tooltip={t("nav.newPipeline")}
                 onClick={handleNewPipeline}
               >
@@ -162,16 +166,6 @@ export const AppSidebar = ({
               </SidebarMenuButton>
             </SidebarMenuItem>
           )}
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              className="h-8 bg-surface-3/70 text-muted-foreground hover:bg-sidebar-accent"
-              tooltip={t("nav.search")}
-              onClick={handleSearchClick}
-            >
-              <Search />
-              <span className="truncate">{t("nav.search")}</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>
 
@@ -196,7 +190,7 @@ export const AppSidebar = ({
           className="px-2! py-0!"
         >
           <SidebarGroupLabel
-            className="h-7 px-2 text-[11px] font-medium uppercase text-muted-foreground group-data-[collapsible=icon]:sr-only"
+            className="h-7 px-2 text-[11px] font-medium uppercase text-foreground/70 group-data-[collapsible=icon]:sr-only"
             render={
               <button
                 aria-expanded={capabilitiesOpen}
@@ -219,14 +213,14 @@ export const AppSidebar = ({
         </SidebarGroup>
       </SidebarContent>
 
-      <SidebarFooter className="gap-1 border-t border-sidebar-border p-2">
+      <SidebarFooter className="border-t p-2">
         <SidebarMenu>
           <SidebarMenuItem>
             <NotificationCenter />
           </SidebarMenuItem>
           <SidebarMenuItem>
             <SidebarMenuButton
-              className="h-8 text-muted-foreground"
+              className="h-8 text-foreground/70"
               isActive={currentPath === "/settings"}
               render={<Link to="/settings" />}
               tooltip={t("nav.settings")}

--- a/packages/views/src/components/AppSidebar.unit.test.tsx
+++ b/packages/views/src/components/AppSidebar.unit.test.tsx
@@ -98,14 +98,14 @@ describe("AppSidebar", () => {
       </NotificationStoreContext.Provider>,
     );
 
-    const brand = screen.getByText("Ordine Studio").parentElement?.parentElement;
+    const brand = screen.getByText("ordine").parentElement;
     const trigger = screen.getByRole("button", { name: "Toggle Sidebar" });
     fireEvent.click(trigger);
 
     expect(brand).toHaveAttribute("aria-hidden", "true");
     expect(trigger).toHaveClass(
-      "right-0",
-      "top-1.5",
+      "right-0.5",
+      "top-0.5",
       "active:translate-y-0!",
       "group-data-[state=collapsed]/sidebar:right-[calc(50%_-_0.875rem)]",
     );

--- a/packages/views/src/components/NavGroup.tsx
+++ b/packages/views/src/components/NavGroup.tsx
@@ -80,7 +80,7 @@ export const NavGroup = ({
     {separated && <SidebarSeparator className="my-1 bg-sidebar-border/60" />}
     <SidebarGroup aria-label={ariaLabel} className="px-2! py-0!">
       {label && (
-        <SidebarGroupLabel className="h-8 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground group-data-[collapsible=icon]:sr-only">
+        <SidebarGroupLabel className="h-8 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-foreground/70 group-data-[collapsible=icon]:sr-only">
           {label}
         </SidebarGroupLabel>
       )}

--- a/packages/views/src/components/NotificationCenter/NotificationCenter.tsx
+++ b/packages/views/src/components/NotificationCenter/NotificationCenter.tsx
@@ -86,7 +86,7 @@ export const NotificationCenter = ({ className, variant = "sidebar" }: Notificat
         <PopoverTrigger
           aria-label={triggerLabel}
           className={cn(
-            "relative flex items-center text-muted-foreground outline-none transition-colors hover:bg-sidebar-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+            "relative flex items-center text-foreground/70 outline-none transition-colors hover:bg-sidebar-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring",
             variant === "rail"
               ? "size-9 justify-center rounded-md"
               : "h-8 w-full gap-2 overflow-hidden rounded-md px-2 text-left text-sm group-data-[collapsible=icon]/sidebar:size-8! group-data-[collapsible=icon]/sidebar:p-2!",

--- a/packages/views/src/components/ProjectSwitcher.tsx
+++ b/packages/views/src/components/ProjectSwitcher.tsx
@@ -114,13 +114,8 @@ export const ProjectSwitcher = () => {
     <div className="py-2">
       <DropdownMenu>
         <DropdownMenuTrigger
-          aria-label={`${t("nav.projects", { defaultValue: "Projects" })}: ${currentProjectName}`}
-          render={
-            <SidebarMenuButton
-              className="h-8 w-full rounded-lg border border-sidebar-border bg-surface/65 text-[12px] shadow-none"
-              tooltip={currentProjectName}
-            />
-          }
+          aria-label={t("nav.projects", { defaultValue: "Projects" })}
+          render={<SidebarMenuButton className="h-9 w-full" tooltip={currentProjectName} />}
         >
           <FolderKanban />
           <span className="truncate text-left">{currentProjectName}</span>

--- a/packages/views/src/components/ProjectSwitcher.unit.test.tsx
+++ b/packages/views/src/components/ProjectSwitcher.unit.test.tsx
@@ -70,10 +70,11 @@ describe("ProjectSwitcher", () => {
   it("inherits the sidebar header padding so its icon aligns with navigation items", () => {
     renderSwitcher();
 
-    const trigger = screen.getByRole("button", { name: "项目: 所有项目" });
+    const trigger = screen.getByRole("button", { name: "项目" });
 
     expect(trigger.parentElement).toHaveClass("py-2");
     expect(trigger.parentElement).not.toHaveClass("px-2");
+    expect(trigger).toHaveClass("h-9", "w-full");
   });
 
   it("shows all projects by default and lets the user switch the project filter", async () => {
@@ -81,13 +82,13 @@ describe("ProjectSwitcher", () => {
 
     await waitFor(() => expect(store.getState().currentProjectId).toBeNull());
     expect(screen.getByText("所有项目")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "项目: 所有项目" }));
+    fireEvent.click(screen.getByRole("button", { name: "项目" }));
     fireEvent.click(await screen.findByText("Beta"));
 
     expect(store.getState().currentProjectId).toBe("project-2");
     expect(localStorage.getItem("ordine.sidebar.currentProjectId")).toBe("project-2");
 
-    fireEvent.click(screen.getByRole("button", { name: "项目: Beta" }));
+    fireEvent.click(screen.getByRole("button", { name: "项目" }));
     fireEvent.click(await screen.findByRole("menuitem", { name: "所有项目" }));
 
     expect(store.getState().currentProjectId).toBeNull();
@@ -98,7 +99,7 @@ describe("ProjectSwitcher", () => {
     createProject.mockResolvedValue({ data: { ...projects[0], id: "project-3", name: "Gamma" } });
     const store = renderSwitcher();
 
-    fireEvent.click(screen.getByRole("button", { name: "项目: 所有项目" }));
+    fireEvent.click(screen.getByRole("button", { name: "项目" }));
     fireEvent.click(await screen.findByText("新建项目"));
     fireEvent.change(screen.getByRole("textbox", { name: "项目名称" }), {
       target: { value: "Gamma" },

--- a/packages/views/src/components/SearchPipelineDialog.tsx
+++ b/packages/views/src/components/SearchPipelineDialog.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { Search, Layers } from "lucide-react";
+import { Search, Workflow } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useList } from "@refinedev/core";
 import { useStore } from "zustand";
@@ -11,6 +11,7 @@ import { Button } from "@repo/ui/button";
 import { ResourceName } from "../constants";
 import type { PipelineData } from "@repo/schemas";
 import { useSidebarStore } from "../store/sidebarStore";
+import { Icon, Tag } from "./primitives";
 
 export const SearchPipelineDialog = () => {
   const { t } = useTranslation();
@@ -48,56 +49,74 @@ export const SearchPipelineDialog = () => {
     void navigate({ to: "/canvas", search: { id: pipeline.id } });
   };
 
-  const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setQuery(e.target.value);
-  };
+  const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value);
 
   const handleOpenChange = (value: boolean) => {
     handleSearchDialogOpenChange(value);
     if (!value) setQuery("");
   };
 
+  const normalizedQuery = query.trim().toLowerCase();
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-md p-0 gap-0 overflow-hidden">
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-2xl">
         <DialogTitle className="sr-only">{t("nav.search")}</DialogTitle>
         <DialogDescription className="sr-only">{t("pipelines.title")}</DialogDescription>
         <div className="flex items-center border-b px-3">
           <Search className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
           <Input
-            aria-label={t("nav.search")}
             autoFocus
-            className="h-10 border-0 shadow-none focus-visible:ring-0 px-0"
+            aria-label={t("nav.search")}
+            className="h-11 border-0 px-0 shadow-none focus-visible:ring-0"
             placeholder={t("nav.search")}
             value={query}
             onChange={handleQueryChange}
           />
         </div>
-        <div className="max-h-75 overflow-y-auto p-1">
-          {filtered.length === 0 ? (
-            <div className="py-6 text-center text-sm text-muted-foreground">
-              {t("pipelines.noPipelines")}
-            </div>
-          ) : (
-            filtered.map((pipeline) => (
-              <Button
-                key={pipeline.id}
-                className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm h-auto"
-                type="button"
-                variant="ghost"
-                onClick={() => handleSelect(pipeline)}
-              >
-                <Layers className="h-4 w-4 shrink-0 text-muted-foreground" />
-                <div className="min-w-0 flex-1">
-                  <div className="truncate font-medium">{pipeline.name}</div>
-                  {pipeline.description && (
-                    <div className="truncate text-xs text-muted-foreground">
-                      {pipeline.description}
-                    </div>
-                  )}
+        <div className="max-h-[min(520px,70vh)] overflow-y-auto p-2">
+          {normalizedQuery ? (
+            filtered.length === 0 ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                {t("pipelines.noPipelines")} “{query}”
+              </div>
+            ) : (
+              <section className="py-1">
+                <div className="px-2 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                  {t("nav.pipelines")}
                 </div>
-              </Button>
-            ))
+                <div className="space-y-1">
+                  {filtered.map((pipeline) => (
+                    <Button
+                      key={pipeline.id}
+                      className="flex h-auto w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left"
+                      type="button"
+                      variant="ghost"
+                      onClick={() => handleSelect(pipeline)}
+                    >
+                      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-surface-2">
+                        <Icon className="text-foreground/75" icon={Workflow} size={14} />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-[13px] font-medium">
+                          {pipeline.name}
+                        </span>
+                        <span className="block truncate text-[11.5px] text-muted-foreground">
+                          {pipeline.description || t("pipelines.title")}
+                        </span>
+                      </span>
+                      <Tag>{pipeline.status ?? "pipeline"}</Tag>
+                    </Button>
+                  ))}
+                </div>
+              </section>
+            )
+          ) : (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              {t("nav.searchPipelinesHint", {
+                defaultValue: "Search across your pipeline workspaces.",
+              })}
+            </div>
           )}
         </div>
       </DialogContent>

--- a/packages/views/src/components/SearchPipelineDialog.unit.test.tsx
+++ b/packages/views/src/components/SearchPipelineDialog.unit.test.tsx
@@ -9,11 +9,13 @@ const pipelines = [
     id: "pipeline-1",
     name: "Release notes",
     description: "Create a changelog from merged pull requests",
+    status: "ready",
   },
   {
     id: "pipeline-2",
     name: "Issue triage",
     description: "Classify new issues",
+    status: "draft",
   },
 ];
 
@@ -75,6 +77,15 @@ describe("SearchPipelineDialog", () => {
 
     expect(screen.getByText("Issue triage")).toBeInTheDocument();
     expect(screen.queryByText("Release notes")).not.toBeInTheDocument();
+    expect(screen.getByText("draft")).toBeInTheDocument();
+  });
+
+  it("shows the Alan-style empty guidance before a query", () => {
+    searchStore.setState({ searchOpen: true });
+    render(<SearchPipelineDialog />);
+
+    expect(screen.getByText("搜索你的流水线工作区。")).toBeInTheDocument();
+    expect(screen.queryByText("Release notes")).not.toBeInTheDocument();
   });
 
   it("navigates to the selected pipeline canvas", async () => {
@@ -82,6 +93,7 @@ describe("SearchPipelineDialog", () => {
     searchStore.setState({ searchOpen: true });
     render(<SearchPipelineDialog />);
 
+    await user.type(await screen.findByRole("textbox", { name: /搜索/ }), "release");
     await user.click(screen.getByRole("button", { name: /Release notes/ }));
 
     expect(navigate).toHaveBeenCalledWith({

--- a/packages/views/src/components/SidebarRail.unit.test.tsx
+++ b/packages/views/src/components/SidebarRail.unit.test.tsx
@@ -4,11 +4,11 @@ import { Sidebar, SidebarProvider, SidebarRail } from "@repo/ui/sidebar";
 
 const STORAGE_KEY = "test.sidebar.width";
 
-const renderRail = () => {
+const renderRail = (autoCollapseWidth?: number) => {
   const result = render(
     <SidebarProvider widthStorageKey={STORAGE_KEY}>
       <Sidebar collapsible="icon">
-        <SidebarRail resizable />
+        <SidebarRail resizable autoCollapseWidth={autoCollapseWidth} />
       </Sidebar>
     </SidebarProvider>,
   );
@@ -152,5 +152,15 @@ describe("SidebarRail", () => {
     const second = renderRail();
     expect(second.wrapper.style.getPropertyValue("--sidebar-width")).toBe("384px");
     expect(localStorage.getItem(STORAGE_KEY)).toBe("384");
+  });
+
+  it("supports an Alan-style collapse threshold for the shared app shell", () => {
+    const { rail, sidebar, wrapper } = renderRail(168);
+
+    dragRail(rail, 256, 100, 9);
+
+    expect(sidebar).toHaveAttribute("data-state", "collapsed");
+    expect(wrapper.style.getPropertyValue("--sidebar-width")).toBe("256px");
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 });

--- a/packages/views/src/components/primitives/Chip.tsx
+++ b/packages/views/src/components/primitives/Chip.tsx
@@ -20,7 +20,7 @@ export const Chip = ({ active = false, children, className, count, onClick }: Ch
         <span
           className={cn(
             "rounded-full px-1.5 text-[10px] tabular-nums",
-            active ? "bg-background text-foreground" : "bg-surface-2",
+            active ? "bg-background text-foreground" : "bg-surface-2 text-foreground/70",
           )}
         >
           {count}

--- a/packages/views/src/components/primitives/Tag.tsx
+++ b/packages/views/src/components/primitives/Tag.tsx
@@ -9,7 +9,7 @@ export type TagProps = {
 export const Tag = ({ children, className }: TagProps) => (
   <span
     className={cn(
-      "rounded-md bg-surface-2 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground",
+      "rounded-md bg-surface-2 px-1.5 py-0.5 font-mono text-[11px] text-foreground/70",
       className,
     )}
   >

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -1,9 +1,8 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
-import { Bot, ChevronsRight, AlertCircle, AlertTriangle } from "lucide-react";
+import { ChevronsRight, AlertCircle, AlertTriangle } from "lucide-react";
 import { Button } from "@repo/ui/button";
-import { ScrollArea } from "@repo/ui/scroll-area";
 import {
   Select,
   SelectContent,
@@ -22,7 +21,7 @@ import { createPipelineAgentSessionsClient } from "../../../lib/pipelineAgentSes
 import { usePlatform } from "../../../platform";
 import { toastStore } from "../../../store/toastStore";
 import { useAgentBarStore } from "./_store";
-import { Assistant, MessageTurn, ProposalCard } from "./messages";
+import { Assistant, MessageTurn, ProposalCard, SuggestionList } from "./messages";
 import type { MessageTurnSubmitInput } from "./messages/MessageTurn";
 import { Composer, type ComposerSubmitInput } from "./Composer";
 import { hasPendingPipelinePrompt, takePendingPipelinePrompt } from "./pendingPipelinePrompt";
@@ -264,7 +263,7 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
         const runtimeSetupResult = await fetchRuntimeState();
         if (runtimeSetupResult.isErr()) {
           addMessage({
-            content: t("canvas.agentPanel.error"),
+            content: t("canvas.agentPanel.requestFailed"),
             id: `assistant-${Date.now()}`,
             role: "assistant",
           });
@@ -541,67 +540,49 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
   const handleRevise = useCallback(() => {
     setComposerDraft(t("canvas.agentPanel.proposalDetails.revisePrompt"));
   }, [t]);
-  const selectedRuntime = runtimeOptions.find((runtime) => runtime.id === selectedRuntimeId);
+  const handleEmptySuggestion = useCallback(
+    (content: string, submit: boolean) => {
+      if (submit) {
+        void handleComposerSubmit({
+          content,
+          metadata: { attachments: [], referencedNodeIds: [] },
+        });
+
+        return;
+      }
+
+      setComposerDraft(content);
+    },
+    [handleComposerSubmit],
+  );
   const isConversationActive = isSending || agentPanel.isLoading;
-  const headerSubtitle = isConversationActive
-    ? (streamingProgress ?? t("canvas.agentPanel.thinking"))
-    : selectedRuntime
-      ? formatRuntimeLabel(selectedRuntime)
-      : t("canvas.agentPanel.runtimePlaceholder");
 
   return (
     <aside className="flex h-full w-full flex-col bg-surface" data-testid="canvas-agent-panel">
       <header
-        className="flex h-14 shrink-0 items-center justify-between border-b border-border/70 px-3"
+        className="flex shrink-0 items-center justify-between px-3.5 pb-2 pt-3"
         data-testid="canvas-agent-panel-header"
       >
-        <div className="flex min-w-0 items-center gap-2.5">
-          <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-surface-2 text-foreground ring-1 ring-border">
-            <Bot className="size-4" />
-          </span>
-          <div className="min-w-0">
-            <div className="truncate text-[12px] font-semibold">{t("canvas.agentPanel.title")}</div>
-            <div className="flex min-w-0 items-center gap-1.5">
-              <span
-                className={cn(
-                  "size-1.5 shrink-0 rounded-full",
-                  isConversationActive
-                    ? "animate-pulse bg-foreground"
-                    : selectedRuntimeId
-                      ? "bg-success"
-                      : "bg-muted-foreground/45",
-                )}
-                data-testid="canvas-agent-panel-status-dot"
-              />
-              <span className="truncate text-[10.5px] text-muted-foreground">{headerSubtitle}</span>
-            </div>
-          </div>
-        </div>
-        <Button
-          aria-label={t("canvas.agentPanel.close")}
-          className="h-7 w-7 shrink-0"
-          data-testid="canvas-agent-panel-collapse"
-          size="icon"
-          title={t("canvas.agentPanel.close")}
-          variant="ghost"
-          onClick={handleToggleAgentPanel}
-        >
-          <ChevronsRight className="size-3.5" />
-        </Button>
-      </header>
-
-      <div
-        className="mx-3 mb-1 rounded-lg bg-surface-2 px-2.5 py-2 ring-1 ring-border-strong"
-        data-testid="canvas-agent-panel-runtime-context"
-      >
-        <div className="flex flex-col gap-1.5">
-          <span className="text-[10.5px] font-medium text-muted-foreground">
-            {t("canvas.agentPanel.runtimeLabel")}
-          </span>
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            className={cn(
+              "size-1.5 shrink-0 rounded-full",
+              isConversationActive
+                ? "animate-pulse bg-foreground"
+                : selectedRuntimeId
+                  ? "bg-success"
+                  : "bg-muted-foreground/45",
+            )}
+            data-testid="canvas-agent-panel-status-dot"
+          />
+          <span className="truncate text-[12px] font-semibold">{t("canvas.agentPanel.title")}</span>
+          <span className="truncate text-[10.5px] text-muted-foreground">·</span>
+          <span className="sr-only">{t("canvas.agentPanel.runtimeLabel")}</span>
           <Select value={selectedRuntimeId} onValueChange={handleRuntimeValueChange}>
             <SelectTrigger
               aria-label={t("canvas.agentPanel.runtimeLabel")}
-              className="h-7 w-full text-[11px]"
+              className="h-auto w-fit min-w-0 rounded-none border-0 bg-transparent p-0 text-[10.5px] font-normal text-muted-foreground shadow-none ring-0 focus-visible:border-transparent focus-visible:ring-0 [&>svg]:size-2.5"
+              data-testid="canvas-agent-panel-runtime-context"
               disabled={isLoadingRuntimes || runtimeOptions.length === 0}
             >
               <SelectValue
@@ -623,92 +604,131 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
             </SelectContent>
           </Select>
         </div>
-      </div>
+        <Button
+          aria-label={t("canvas.agentPanel.close")}
+          className="h-7 w-7 shrink-0"
+          data-testid="canvas-agent-panel-collapse"
+          size="icon"
+          title={t("canvas.agentPanel.close")}
+          variant="ghost"
+          onClick={handleToggleAgentPanel}
+        >
+          <ChevronsRight className="size-3.5" />
+        </Button>
+      </header>
 
-      <ScrollArea className="min-h-0 flex-1" data-testid="canvas-agent-panel-messages">
-        <div className="flex flex-col gap-3 p-3">
-          {messages.length === 0 && <Assistant>{t("canvas.agentPanel.welcome")}</Assistant>}
-          {messages.map((msg, index) => (
-            <MessageTurn
-              key={msg.id}
-              isLast={index === messages.length - 1}
-              isSending={isSending || isPreparingUpload || isHistoryLoading || agentPanel.isLoading}
-              message={msg}
-              runtimeId={selectedRuntimeId}
-              refs={canvasRefs}
-              visibleMessages={messages}
-              onEditDraft={setComposerDraft}
-              onOpenSettings={handleOpenRuntimeSettings}
-              onSubmit={handleMessageSubmit}
+      <div
+        className="min-h-0 flex-1 space-y-3.5 overflow-y-auto px-4 py-3"
+        data-testid="canvas-agent-panel-messages"
+      >
+        {messages.length === 0 && (
+          <div data-testid="agent-empty-state">
+            <Assistant>{t("canvas.agentPanel.empty.intro")}</Assistant>
+            <SuggestionList
+              items={[
+                {
+                  id: "quiz",
+                  label: t("canvas.agentPanel.empty.suggestQuiz"),
+                  onSelect: () =>
+                    handleEmptySuggestion(t("canvas.agentPanel.empty.suggestQuiz"), true),
+                },
+                {
+                  id: "changelog",
+                  label: t("canvas.agentPanel.empty.suggestChangelog"),
+                  onSelect: () =>
+                    handleEmptySuggestion(t("canvas.agentPanel.empty.suggestChangelog"), true),
+                },
+                {
+                  id: "reverse",
+                  label: t("canvas.agentPanel.empty.suggestReverse"),
+                  onSelect: () =>
+                    handleEmptySuggestion(t("canvas.agentPanel.empty.suggestReverse"), false),
+                  reverse: true,
+                },
+              ]}
             />
-          ))}
-          {streamingAssistantText && (
-            <Assistant className="whitespace-pre-wrap">{streamingAssistantText}</Assistant>
-          )}
+          </div>
+        )}
+        {messages.map((msg, index) => (
+          <MessageTurn
+            key={msg.id}
+            isLast={index === messages.length - 1}
+            isSending={isSending || isPreparingUpload || isHistoryLoading || agentPanel.isLoading}
+            message={msg}
+            runtimeId={selectedRuntimeId}
+            refs={canvasRefs}
+            visibleMessages={messages}
+            onEditDraft={setComposerDraft}
+            onOpenSettings={handleOpenRuntimeSettings}
+            onSubmit={handleMessageSubmit}
+          />
+        ))}
+        {streamingAssistantText && (
+          <Assistant className="whitespace-pre-wrap">{streamingAssistantText}</Assistant>
+        )}
 
-          {isConversationActive && (
-            <Assistant isThinking>{streamingProgress ?? t("canvas.agentPanel.thinking")}</Assistant>
-          )}
-          <div ref={messagesEndRef} />
+        {isConversationActive && (
+          <Assistant isThinking>{streamingProgress ?? t("canvas.agentPanel.thinking")}</Assistant>
+        )}
+        <div ref={messagesEndRef} />
 
-          {/* Diagnostics */}
-          {activeDiagnostics && activeDiagnostics.length > 0 && (
-            <div className="border-t">
-              <div className="flex flex-col gap-2 p-3">
-                <span className="text-xs font-medium text-muted-foreground">
-                  {t("canvas.agentPanel.diagnostics")}
-                </span>
-                {activeDiagnostics.map((d, i) => (
-                  <div
-                    key={i}
-                    className={cn(
-                      "flex items-start gap-2 rounded-md px-2.5 py-2 text-xs",
-                      d.severity === "error"
-                        ? "border border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-300"
-                        : "border border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300",
-                    )}
-                  >
-                    {d.severity === "error" ? (
-                      <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                    ) : (
-                      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                    )}
-                    <span>{d.message}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Proposal */}
-          {hasProposal && (
-            <div className="border-t">
-              <div className="flex flex-col gap-2 p-3">
-                <span className="text-xs font-medium text-muted-foreground">
-                  {t("canvas.agentPanel.proposal")}
-                </span>
-                <ProposalCard
-                  disabled={
-                    isSending || isPreparingUpload || isHistoryLoading || agentPanel.isLoading
-                  }
-                  applyDisabled={proposalNeedsAnswer}
-                  items={proposalItems}
-                  onApply={handleApply}
-                  onAskFix={hasBlockingDiagnostics ? handleAskFix : undefined}
-                  onReject={handleDiscard}
-                  onRevise={handleRevise}
-                  subtitle={t(
-                    proposalNeedsAnswer
-                      ? "canvas.agentPanel.proposalDetails.needsAnswer"
-                      : "canvas.agentPanel.proposalDetails.review",
+        {/* Diagnostics */}
+        {activeDiagnostics && activeDiagnostics.length > 0 && (
+          <div className="border-t">
+            <div className="flex flex-col gap-2 p-3">
+              <span className="text-xs font-medium text-muted-foreground">
+                {t("canvas.agentPanel.diagnostics")}
+              </span>
+              {activeDiagnostics.map((d, i) => (
+                <div
+                  key={i}
+                  className={cn(
+                    "flex items-start gap-2 rounded-md px-2.5 py-2 text-xs",
+                    d.severity === "error"
+                      ? "border border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-300"
+                      : "border border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300",
                   )}
-                  title={proposal?.summary ?? generateProposal?.purpose ?? ""}
-                />
-              </div>
+                >
+                  {d.severity === "error" ? (
+                    <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  ) : (
+                    <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  )}
+                  <span>{d.message}</span>
+                </div>
+              ))}
             </div>
-          )}
-        </div>
-      </ScrollArea>
+          </div>
+        )}
+
+        {/* Proposal */}
+        {hasProposal && (
+          <div className="border-t">
+            <div className="flex flex-col gap-2 p-3">
+              <span className="text-xs font-medium text-muted-foreground">
+                {t("canvas.agentPanel.proposal")}
+              </span>
+              <ProposalCard
+                disabled={
+                  isSending || isPreparingUpload || isHistoryLoading || agentPanel.isLoading
+                }
+                applyDisabled={proposalNeedsAnswer}
+                items={proposalItems}
+                onApply={handleApply}
+                onAskFix={hasBlockingDiagnostics ? handleAskFix : undefined}
+                onReject={handleDiscard}
+                onRevise={handleRevise}
+                subtitle={t(
+                  proposalNeedsAnswer
+                    ? "canvas.agentPanel.proposalDetails.needsAnswer"
+                    : "canvas.agentPanel.proposalDetails.review",
+                )}
+                title={proposal?.summary ?? generateProposal?.purpose ?? ""}
+              />
+            </div>
+          </div>
+        )}
+      </div>
 
       {needsRuntimeSetup && (
         <div className="border-t bg-amber-500/10">
@@ -722,7 +742,7 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
         </div>
       )}
 
-      <div className="shrink-0 border-t border-border/70 bg-surface">
+      <div className="shrink-0 border-t border-border/70">
         <Composer
           agentContext={agentContext}
           canRemoveAttachments={false}

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.unit.test.tsx
@@ -225,10 +225,15 @@ describe("AgentPanel", () => {
     mockApplyPipelineActions.mockReturnValue(ok({ nodes: [], edges: [] }));
   });
 
-  it("renders panel with title and welcome message", async () => {
+  it("renders panel with Alan-style empty guidance", async () => {
     render(<AgentPanel />, { wrapper: wrapperWithState() });
     expect(screen.getByText("canvas.agentPanel.title")).toBeInTheDocument();
-    expect(screen.getByText("canvas.agentPanel.welcome")).toBeInTheDocument();
+    expect(screen.getByText("canvas.agentPanel.empty.intro")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-empty-state")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-suggestions")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "canvas.agentPanel.empty.suggestQuiz" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("canvas.agentPanel.runtimeLabel")).toBeInTheDocument();
     expect(
       screen.getByRole("combobox", { name: "canvas.agentPanel.runtimeLabel" }),
@@ -236,20 +241,44 @@ describe("AgentPanel", () => {
     expect(screen.getByTestId("canvas-agent-panel")).toHaveClass("bg-surface");
     expect(screen.getByTestId("canvas-agent-panel")).toHaveClass("h-full", "w-full");
     expect(screen.getByTestId("canvas-agent-panel-header")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-agent-panel-header")).toHaveClass("px-3.5", "pb-2", "pt-3");
+    expect(screen.getByTestId("canvas-agent-panel-messages")).toHaveClass(
+      "min-h-0",
+      "flex-1",
+      "space-y-3.5",
+      "overflow-y-auto",
+      "px-4",
+      "py-3",
+    );
     await waitFor(() =>
       expect(screen.getByTestId("canvas-agent-panel-status-dot")).toHaveClass("bg-success"),
     );
     expect(screen.getByTestId("canvas-agent-panel-collapse")).toBeInTheDocument();
     expect(screen.getByTestId("canvas-agent-panel-runtime-context")).toHaveClass(
-      "mx-3",
-      "mb-1",
-      "rounded-lg",
-      "bg-surface-2",
+      "h-auto",
+      "w-fit",
+      "rounded-none",
+      "border-0",
+      "bg-transparent",
     );
     expect(screen.getByPlaceholderText("workspace.agentBar.composer.placeholder")).toHaveClass(
       "bg-transparent",
     );
     expect(screen.getByTestId("agent-assistant")).toHaveClass("text-[12px]");
+  });
+
+  it("seeds the Composer for the reverse-engineering suggestion without sending", async () => {
+    const user = userEvent.setup();
+    render(<AgentPanel />, { wrapper: wrapperWithState() });
+
+    await user.click(
+      screen.getByRole("button", { name: "canvas.agentPanel.empty.suggestReverse" }),
+    );
+
+    expect(
+      screen.getByRole("textbox", { name: "workspace.agentBar.composer.messageLabel" }),
+    ).toHaveValue("canvas.agentPanel.empty.suggestReverse");
+    expect(mockCreateSession).not.toHaveBeenCalled();
   });
 
   it("auto-sends the home prompt with the runtime selected on the home page", async () => {

--- a/packages/views/src/pages/CanvasPage/AgentPanel/Composer/ContextStrip.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/Composer/ContextStrip.tsx
@@ -101,6 +101,7 @@ export const ContextStrip = ({ context, defaultOpen = false }: ContextStripProps
       : anchorCount > 0
         ? t("workspace.agentBar.context.summary.annotations")
         : t("workspace.agentBar.context.summary.default");
+  const handleToggleClick = () => setOpen((value) => !value);
 
   return (
     <div className="px-3 pt-2" data-testid="agent-context-strip">
@@ -109,14 +110,14 @@ export const ContextStrip = ({ context, defaultOpen = false }: ContextStripProps
         className="flex w-full items-center gap-1.5 rounded-lg px-1.5 py-1 text-left text-[10px] text-muted-foreground transition-colors hover:bg-accent/50"
         data-testid="agent-context-toggle"
         type="button"
-        onClick={() => setOpen((value) => !value)}
+        onClick={handleToggleClick}
       >
         <Icon icon={Layers} size={11} />
         <span className="font-medium">{t("workspace.agentBar.context.title")}</span>
-        <span className="rounded-full bg-surface-2 px-1.5 py-0.5 font-mono text-[9px]">
+        <span className="rounded-full bg-surface-2 px-1.5 py-0.5 font-mono text-[9px] text-foreground/70">
           {t("workspace.agentBar.context.itemCount", { count: activeCount })}
         </span>
-        <span className="truncate text-foreground/65">{summary}</span>
+        <span className="truncate text-foreground/70">{summary}</span>
         <Icon className="ml-auto shrink-0" icon={open ? ChevronDown : ChevronUp} size={11} />
       </button>
       {open ? (
@@ -129,7 +130,7 @@ export const ContextStrip = ({ context, defaultOpen = false }: ContextStripProps
               key={item.id}
               className={cn(
                 "flex items-center gap-2 rounded-lg px-1.5 py-1 text-[10.5px]",
-                !item.on && "opacity-60",
+                !item.on && "opacity-40",
               )}
               data-context-on={item.on ? "true" : "false"}
               data-testid={`agent-context-item-${item.id}`}
@@ -154,12 +155,12 @@ export const ContextStrip = ({ context, defaultOpen = false }: ContextStripProps
               >
                 {item.label}
               </span>
-              <span className="shrink-0 font-mono text-[9px] text-muted-foreground">
+              <span className="shrink-0 font-mono text-[9px] text-muted-foreground/70">
                 {item.rule}
               </span>
             </div>
           ))}
-          <div className="px-1.5 pt-1 text-[9px] leading-snug text-muted-foreground">
+          <div className="px-1.5 pt-1 text-[9px] leading-snug text-muted-foreground/70">
             {running
               ? t("workspace.agentBar.context.footer.running")
               : t("workspace.agentBar.context.footer.editing")}

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
@@ -322,7 +322,7 @@ export const useAgentConversation = ({
             role: "user",
           });
           if (!persisted) {
-            throw new Error(t("canvas.agentPanel.error"));
+            throw new Error(t("canvas.agentPanel.requestFailed"));
           }
           await client.appendMessage(sessionId, {
             content: trimmedContent,
@@ -357,7 +357,7 @@ export const useAgentConversation = ({
           if (streamedTerminalEvent.current) {
             const persistedTerminal = await Promise.all(terminalPersistences);
             if (persistedTerminal.some((value) => !value)) {
-              throw new Error(t("canvas.agentPanel.error"));
+              throw new Error(t("canvas.agentPanel.requestFailed"));
             }
 
             return !streamFailed;
@@ -373,7 +373,7 @@ export const useAgentConversation = ({
               type: "proposal_ready",
             });
             if (!persistedProposal) {
-              throw new Error(t("canvas.agentPanel.error"));
+              throw new Error(t("canvas.agentPanel.requestFailed"));
             }
 
             return true;
@@ -386,7 +386,7 @@ export const useAgentConversation = ({
               type: "question",
             });
             if (!persistedQuestion) {
-              throw new Error(t("canvas.agentPanel.error"));
+              throw new Error(t("canvas.agentPanel.requestFailed"));
             }
           }
 

--- a/packages/views/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.tsx
@@ -1,28 +1,26 @@
-import { useEffect, useRef, useState, type DragEvent, type ElementType } from "react";
+import { Fragment, useEffect, useRef, useState, type DragEvent } from "react";
 import { Link } from "@tanstack/react-router";
 import { useList } from "@refinedev/core";
-import type { BuiltinNodeType, Operation, Skill } from "@repo/schemas";
+import type { Operation, Skill } from "@repo/schemas";
 import {
-  ChevronDown,
-  ChevronRight,
-  FileCode,
-  Folder,
-  FolderOutput,
+  Boxes,
+  File,
+  FolderGit2,
+  FolderOpen,
   HardDrive,
-  MessageSquareText,
+  MessageSquare,
   Plus,
   Search,
   Sparkles,
-  Zap,
+  Workflow,
+  X,
+  type LucideIcon,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import type { XYPosition } from "@xyflow/system";
-import { Badge } from "@repo/ui/badge";
-import { Button } from "@repo/ui/button";
 import { Input } from "@repo/ui/input";
 import { cn } from "@repo/ui/lib/utils";
-import { SiGitHubIcon } from "../../../components/icons/SiGitHubIcon";
 import { ResourceName } from "../../../constants";
 import { useCanvasPageStore, type CanvasComponentCategory } from "../_store";
 import {
@@ -36,16 +34,33 @@ interface CanvasComponentPanelProps {
   getCreateNodeScreenPosition: () => XYPosition;
 }
 
-const INPUT_NODE_TYPES: BuiltinNodeType[] = ["folder", "file", "github-project", "prompt"];
-const OUTPUT_NODE_TYPES: BuiltinNodeType[] = ["output-local-path", "output-project-path"];
+type PaletteObjectType =
+  | "file"
+  | "folder"
+  | "github-project"
+  | "prompt"
+  | "output-local-path"
+  | "output-project-path";
 
-const TYPE_ICONS: Record<string, ElementType> = {
-  file: FileCode,
-  folder: Folder,
-  "github-project": SiGitHubIcon,
-  prompt: MessageSquareText,
-  "output-project-path": FolderOutput,
+type PaletteEntry = {
+  icon: LucideIcon;
+  iconBg: string;
+  id: string;
+  label: string;
+  payload: CanvasComponentDragPayload;
+  shortLabel: string;
+};
+
+const INPUT_NODE_TYPES: PaletteObjectType[] = ["folder", "file", "github-project", "prompt"];
+const OUTPUT_NODE_TYPES: PaletteObjectType[] = ["output-local-path", "output-project-path"];
+
+const OBJECT_ICONS: Record<PaletteObjectType, LucideIcon> = {
+  file: File,
+  folder: FolderOpen,
+  "github-project": FolderGit2,
+  prompt: MessageSquare,
   "output-local-path": HardDrive,
+  "output-project-path": Boxes,
 };
 
 const normalizeSearch = (value: string) => value.trim().toLowerCase();
@@ -94,13 +109,20 @@ export const CanvasComponentPanel = ({
   const { t } = useTranslation();
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const [draggingComponentId, setDraggingComponentId] = useState<string | null>(null);
+  const [searchVisible, setSearchVisible] = useState(false);
   const store = useCanvasPageStore();
+  const isSidebarOpen = useStore(store, (state) => state.isSidebarOpen);
+  const sidebarPanel = useStore(store, (state) => state.sidebarPanel);
+  const agentPanelIsOpen = useStore(store, (state) => state.agentPanel.isOpen);
+  const handleToggleSidebar = useStore(store, (state) => state.handleToggleSidebar);
+  const handleSidebarPanelChange = useStore(store, (state) => state.handleSidebarPanelChange);
   const componentSearchQuery = useStore(store, (state) => state.componentSearchQuery);
   const collapsedComponentCategories = useStore(
     store,
     (state) => state.collapsedComponentCategories,
   );
   const handleComponentSearchChange = useStore(store, (state) => state.handleComponentSearchChange);
+  const setComponentSearchQuery = useStore(store, (state) => state.setComponentSearchQuery);
   const toggleComponentCategory = useStore(store, (state) => state.toggleComponentCategory);
   const handleCreateObjectNode = useStore(store, (state) => state.handleCreateObjectNode);
   const handleCreateOperationNode = useStore(store, (state) => state.handleCreateOperationNode);
@@ -142,6 +164,21 @@ export const CanvasComponentPanel = ({
   const newCustomOperationLabel = t("canvas.componentPanel.newCustomOperation", {
     defaultValue: "New Custom Operation",
   });
+  const compoundCategoryLabel = t("canvas.componentPanel.categories.compound", {
+    defaultValue: "Compound",
+  });
+  const compoundEntry: PaletteEntry = {
+    icon: Boxes,
+    iconBg: "bg-surface-2",
+    id: "object-compound",
+    label: getNodeTypeLabel(t, "compound"),
+    payload: { kind: "object", type: "compound" },
+    shortLabel: getNodeTypeShortLabel(t, "compound"),
+  };
+  const panelOpen = isSidebarOpen && sidebarPanel === "components";
+  const panelToggleLabel = panelOpen
+    ? t("canvas.operationsPanel.collapse")
+    : t("canvas.operationsPanel.expand");
 
   useEffect(() => {
     const handleSearchShortcut = (event: KeyboardEvent) => {
@@ -161,7 +198,7 @@ export const CanvasComponentPanel = ({
       }
 
       event.preventDefault();
-      searchInputRef.current?.focus();
+      setSearchVisible(true);
     };
 
     globalThis.addEventListener("keydown", handleSearchShortcut);
@@ -171,20 +208,26 @@ export const CanvasComponentPanel = ({
     };
   }, []);
 
+  useEffect(() => {
+    if (searchVisible) {
+      searchInputRef.current?.focus();
+    }
+  }, [searchVisible]);
+
   const handleCategoryHeaderClick = (category: CanvasComponentCategory) => () => {
     toggleComponentCategory(category);
   };
 
-  const handleNodeTypeItemClick = (type: BuiltinNodeType) => () => {
-    handleCreateObjectNode(type, getCreateNodeScreenPosition());
-  };
+  const handleEntryClick = (payload: CanvasComponentDragPayload) => () => {
+    const position = getCreateNodeScreenPosition();
 
-  const handleOperationItemClick = (operation: Operation) => () => {
-    handleCreateOperationNode(operation, getCreateNodeScreenPosition());
-  };
-
-  const handleSkillItemClick = (skill: Skill) => () => {
-    void handleCreateSkillOperationNode(skill, getCreateNodeScreenPosition());
+    if (payload.kind === "object") {
+      handleCreateObjectNode(payload.type, position);
+    } else if (payload.kind === "operation") {
+      handleCreateOperationNode(payload.operation, position);
+    } else {
+      void handleCreateSkillOperationNode(payload.skill, position);
+    }
   };
 
   const handleComponentDragStart =
@@ -218,215 +261,264 @@ export const CanvasComponentPanel = ({
   const handleComponentDragEnd = () => {
     setDraggingComponentId(null);
   };
+  const handleSearchClose = () => {
+    setComponentSearchQuery("");
+    setSearchVisible(false);
+  };
+  const handlePanelToggle = () => {
+    if (panelOpen) {
+      handleToggleSidebar();
 
-  const objectItems = INPUT_NODE_TYPES.filter((type) => {
+      return;
+    }
+    handleSidebarPanelChange("components");
+    if (!isSidebarOpen) {
+      handleToggleSidebar();
+    }
+  };
+
+  const createObjectEntry = (type: PaletteObjectType): PaletteEntry => {
+    const meta = getNodeMeta(type);
+    const label = getNodeTypeLabel(t, type);
+
+    return {
+      icon: OBJECT_ICONS[type],
+      iconBg: meta?.iconBg ?? "bg-surface-2",
+      id: `object-${type}`,
+      label,
+      payload: { kind: "object", type },
+      shortLabel: getNodeTypeShortLabel(t, type),
+    };
+  };
+
+  const objectItems: PaletteEntry[] = INPUT_NODE_TYPES.filter((type) => {
     const meta = getNodeMeta(type);
     const label = getNodeTypeLabel(t, type);
     const shortLabel = getNodeTypeShortLabel(t, type);
 
     return search === "" || includesSearch([label, shortLabel, meta?.label, type], search);
-  });
+  }).map(createObjectEntry);
 
-  const outputItems = OUTPUT_NODE_TYPES.filter((type) => {
+  const outputItems: PaletteEntry[] = OUTPUT_NODE_TYPES.filter((type) => {
     const meta = getNodeMeta(type);
     const label = getNodeTypeLabel(t, type);
     const shortLabel = getNodeTypeShortLabel(t, type);
 
     return search === "" || includesSearch([label, shortLabel, meta?.label, type], search);
-  });
+  }).map(createObjectEntry);
 
-  const operationItems = operations.filter((operation) =>
-    search === ""
-      ? true
-      : includesSearch([operation.name, operation.description, "operation"], search),
-  );
+  const operationItems: PaletteEntry[] = operations
+    .filter((operation) =>
+      search === ""
+        ? true
+        : includesSearch([operation.name, operation.description, "operation"], search),
+    )
+    .map((operation) => ({
+      icon: Workflow,
+      iconBg: "bg-violet-500",
+      id: `operation-${operation.id}`,
+      label: operation.name,
+      payload: { kind: "operation", operation },
+      shortLabel: operationShortLabel,
+    }));
 
-  const skillItems = skills.filter((skill) =>
-    search === ""
-      ? true
-      : includesSearch([skill.name, skill.label, skill.description, ...skill.tags], search),
-  );
+  const skillItems: PaletteEntry[] = skills
+    .filter((skill) =>
+      search === ""
+        ? true
+        : includesSearch([skill.name, skill.label, skill.description, ...skill.tags], search),
+    )
+    .map((skill) => ({
+      icon: Sparkles,
+      iconBg: "bg-amber-500",
+      id: `skill-${skill.id}`,
+      label: skill.label,
+      payload: { kind: "skill", skill },
+      shortLabel: skill.tags[0] ?? skillFallbackLabel,
+    }));
 
-  const renderCategoryHeader = (
-    category: CanvasComponentCategory,
-    label: string,
-    count: number,
-  ) => {
+  const compoundItems: PaletteEntry[] =
+    search === "" ||
+    includesSearch([compoundEntry.label, compoundEntry.shortLabel, "compound"], search)
+      ? [compoundEntry]
+      : [];
+
+  const groups: ReadonlyArray<{
+    category: CanvasComponentCategory;
+    entries: PaletteEntry[];
+    label: string;
+  }> = [
+    { category: "input", entries: objectItems, label: inputCategoryLabel },
+    { category: "operations", entries: operationItems, label: operationsCategoryLabel },
+    { category: "skills", entries: skillItems, label: skillsCategoryLabel },
+    { category: "output", entries: outputItems, label: outputCategoryLabel },
+  ];
+
+  const renderCategoryHeader = (category: CanvasComponentCategory, label: string) => {
     const collapsed = collapsedComponentCategories[category];
-    const ChevronIcon = collapsed ? ChevronRight : ChevronDown;
 
     return (
-      <Button
+      <button
         aria-expanded={!collapsed}
         aria-label={t("canvas.componentPanel.categoryAriaLabel", {
           label,
           defaultValue: "{{label}} category",
         })}
-        className="h-9 w-full justify-start gap-2 rounded-none border-t bg-surface-2/80 px-5 text-sm font-semibold hover:bg-surface-3"
+        className="px-1 pb-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground"
         type="button"
-        variant="ghost"
         onClick={handleCategoryHeaderClick(category)}
       >
-        <ChevronIcon className="size-3.5" />
-        <span className="flex-1 text-left">{label}</span>
-        <span className="text-xs text-muted-foreground">{count}</span>
-      </Button>
+        {label}
+      </button>
     );
   };
 
-  const renderNodeTypeItem = (type: BuiltinNodeType) => {
-    const Icon = TYPE_ICONS[type];
-    const meta = getNodeMeta(type);
-    const label = getNodeTypeLabel(t, type);
-    const shortLabel = getNodeTypeShortLabel(t, type);
-    if (!meta) return null;
-
-    return (
-      <Button
-        key={type}
-        draggable
-        className={cn(
-          "h-10 w-full cursor-grab justify-start gap-2 rounded-md px-2 text-left transition-[opacity,transform,background-color] active:cursor-grabbing",
-          draggingComponentId === type && "scale-[0.98] opacity-60",
-        )}
-        type="button"
-        variant="ghost"
-        onClick={handleNodeTypeItemClick(type)}
-        onDragEnd={handleComponentDragEnd}
-        onDragStart={handleComponentDragStart({
-          dragId: type,
-          iconBg: meta.iconBg,
-          label,
-          payload: { kind: "object", type },
-          shortLabel,
-        })}
-      >
-        <span
-          className={cn("flex size-6 shrink-0 items-center justify-center rounded", meta.iconBg)}
-        >
-          <Icon className="size-3.5 text-white" />
-        </span>
-        <span className="min-w-0 flex-1 truncate text-sm font-medium">{label}</span>
-        <span className="text-xs text-muted-foreground">{shortLabel}</span>
-        <Plus className="size-3 text-muted-foreground" />
-      </Button>
-    );
-  };
+  const renderEntry = (entry: PaletteEntry) => (
+    <button
+      key={entry.id}
+      draggable
+      className={cn(
+        "flex w-full cursor-grab items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs ring-1 ring-transparent transition-colors hover:bg-accent/60 hover:ring-border",
+        draggingComponentId === entry.id && "scale-[0.98] opacity-60",
+      )}
+      data-testid={
+        entry.payload.kind === "operation"
+          ? `canvas-operation-${entry.payload.operation.id}`
+          : entry.payload.kind === "skill"
+            ? `canvas-skill-${entry.payload.skill.id}`
+            : `canvas-component-${entry.id}`
+      }
+      type="button"
+      onClick={handleEntryClick(entry.payload)}
+      onDragEnd={handleComponentDragEnd}
+      onDragStart={handleComponentDragStart({
+        dragId: entry.id,
+        iconBg: entry.iconBg,
+        label: entry.label,
+        payload: entry.payload,
+        shortLabel: entry.shortLabel,
+      })}
+    >
+      <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+        <entry.icon className="size-3 text-foreground/70" />
+      </span>
+      <span className="min-w-0 flex-1 truncate">{entry.label}</span>
+      <Plus className="size-3 text-muted-foreground/50" />
+    </button>
+  );
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-surface" data-testid="canvas-component-panel">
-      <div className="border-b p-4">
-        <div className="flex h-10 items-center gap-2 rounded-lg border bg-background px-3 shadow-none">
-          <Search className="size-4 text-muted-foreground" />
-          <Input
-            ref={searchInputRef}
-            aria-label={componentSearchLabel}
-            className="h-8 border-none bg-transparent px-0 shadow-none focus-visible:ring-0"
-            name="canvasComponentSearch"
-            placeholder={componentSearchPlaceholder}
-            value={componentSearchQuery}
-            onChange={handleComponentSearchChange}
-          />
-          <kbd className="rounded border bg-background px-1.5 py-0.5 text-[10px] text-muted-foreground">
-            /
-          </kbd>
-        </div>
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        {renderCategoryHeader("input", inputCategoryLabel, objectItems.length)}
-        {!collapsedComponentCategories.input && (
-          <div className="space-y-1 p-3">{objectItems.map(renderNodeTypeItem)}</div>
+    <div
+      className={cn(
+        "pointer-events-auto absolute left-3 top-16 z-10",
+        agentPanelIsOpen && "max-[1180px]:hidden",
+      )}
+      data-testid="canvas-component-panel-root"
+    >
+      <button
+        aria-label={panelToggleLabel}
+        aria-pressed={panelOpen}
+        className={cn(
+          "flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs shadow-pill ring-1 transition-colors",
+          panelOpen
+            ? "bg-foreground text-background ring-foreground"
+            : "bg-surface ring-border hover:ring-border-strong",
         )}
+        data-testid="canvas-component-panel-toggle"
+        type="button"
+        onClick={handlePanelToggle}
+      >
+        <Boxes className="size-3.5" />
+        {t("nav.items.components")}
+      </button>
 
-        {renderCategoryHeader("operations", operationsCategoryLabel, operationItems.length)}
-        {!collapsedComponentCategories.operations && (
-          <div className="space-y-1 p-3">
-            {operationItems.map((operation) => (
-              <Button
-                key={operation.id}
-                draggable
-                className={cn(
-                  "h-10 w-full cursor-grab justify-start gap-2 rounded-md px-2 text-left transition-[opacity,transform,background-color] active:cursor-grabbing",
-                  draggingComponentId === operation.id && "scale-[0.98] opacity-60",
-                )}
-                data-testid={`canvas-operation-${operation.id}`}
-                type="button"
-                variant="ghost"
-                onClick={handleOperationItemClick(operation)}
-                onDragEnd={handleComponentDragEnd}
-                onDragStart={handleComponentDragStart({
-                  dragId: operation.id,
-                  iconBg: "bg-violet-500",
-                  label: operation.name,
-                  payload: { kind: "operation", operation },
-                  shortLabel: operationShortLabel,
-                })}
-              >
-                <span className="flex size-6 shrink-0 items-center justify-center rounded bg-violet-500">
-                  <Zap className="size-3.5 text-white" />
-                </span>
-                <span className="min-w-0 flex-1 truncate text-sm font-medium">
-                  {operation.name}
-                </span>
-                <Plus className="size-3 text-muted-foreground" />
-              </Button>
-            ))}
-          </div>
-        )}
-
-        {renderCategoryHeader("skills", skillsCategoryLabel, skillItems.length)}
-        {!collapsedComponentCategories.skills && (
-          <div className="space-y-1 p-3">
-            {skillItems.map((skill) => (
-              <Button
-                key={skill.id}
-                draggable
-                className={cn(
-                  "h-auto min-h-10 w-full cursor-grab justify-start gap-2 rounded-md px-2 py-2 text-left transition-[opacity,transform,background-color] active:cursor-grabbing",
-                  draggingComponentId === skill.id && "scale-[0.98] opacity-60",
-                )}
-                type="button"
-                variant="ghost"
-                onClick={handleSkillItemClick(skill)}
-                onDragEnd={handleComponentDragEnd}
-                onDragStart={handleComponentDragStart({
-                  dragId: skill.id,
-                  iconBg: "bg-amber-500",
-                  label: skill.label,
-                  payload: { kind: "skill", skill },
-                  shortLabel: skill.tags[0] ?? skillFallbackLabel,
-                })}
-              >
-                <span className="flex size-6 shrink-0 items-center justify-center rounded bg-amber-500">
-                  <Sparkles className="size-3.5 text-white" />
-                </span>
-                <span className="min-w-0 flex-1 truncate text-sm font-medium">{skill.label}</span>
-                {skill.tags.slice(0, 1).map((tag) => (
-                  <Badge key={tag} className="shrink-0 text-[10px]" variant="secondary">
-                    {tag}
-                  </Badge>
-                ))}
-              </Button>
-            ))}
-          </div>
-        )}
-
-        {renderCategoryHeader("output", outputCategoryLabel, outputItems.length)}
-        {!collapsedComponentCategories.output && (
-          <div className="space-y-1 p-3">{outputItems.map(renderNodeTypeItem)}</div>
-        )}
-      </div>
-
-      <div className="border-t p-3">
-        <Link
-          className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted"
-          to="/pipelines/operations/new"
+      {panelOpen ? (
+        <div
+          className="mt-2 max-h-[60vh] w-[230px] overflow-y-auto rounded-2xl bg-surface p-2.5 shadow-float ring-1 ring-border"
+          data-testid="canvas-component-panel"
         >
-          <Plus className="size-4" />
-          {newCustomOperationLabel}
-        </Link>
-      </div>
+          <div className="mb-1.5 px-1 text-[10px] leading-snug text-muted-foreground">
+            {t("canvas.componentPanel.hint", {
+              defaultValue: "Click to place in the canvas center, or drag it in.",
+            })}
+          </div>
+
+          {searchVisible && (
+            <div className="mb-2 flex h-8 items-center gap-1.5 rounded-lg bg-surface-2 px-2 ring-1 ring-border">
+              <Search className="size-3 text-muted-foreground" />
+              <Input
+                ref={searchInputRef}
+                aria-label={componentSearchLabel}
+                className="h-7 min-w-0 border-none bg-transparent px-0 text-xs shadow-none focus-visible:ring-0"
+                name="canvasComponentSearch"
+                placeholder={componentSearchPlaceholder}
+                value={componentSearchQuery}
+                onChange={handleComponentSearchChange}
+              />
+              <button
+                aria-label={t("common.clearSearch")}
+                className="flex size-6 shrink-0 items-center justify-center rounded-full hover:bg-accent/60"
+                type="button"
+                onClick={handleSearchClose}
+              >
+                <X className="size-3" />
+              </button>
+            </div>
+          )}
+
+          <div className="pr-0.5">
+            {groups.map((group) => (
+              <Fragment key={group.category}>
+                <div className="mb-2 last:mb-0">
+                  {renderCategoryHeader(group.category, group.label)}
+                  {!collapsedComponentCategories[group.category] && (
+                    <div className="space-y-0.5">
+                      {group.entries.length === 0 ? (
+                        <div className="px-2 py-1 text-[11px] text-muted-foreground/70">
+                          {t("canvas.componentPanel.emptyGroup", {
+                            defaultValue: "No components",
+                          })}
+                        </div>
+                      ) : (
+                        group.entries.map(renderEntry)
+                      )}
+                    </div>
+                  )}
+                </div>
+                {group.category === "operations" && (
+                  <div className="mb-2 last:mb-0">
+                    <div
+                      className="px-1 pb-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground"
+                      data-testid="canvas-component-category-compound"
+                    >
+                      {compoundCategoryLabel}
+                    </div>
+                    <div className="space-y-0.5">
+                      {compoundItems.length === 0 ? (
+                        <div className="px-2 py-1 text-[11px] text-muted-foreground/70">
+                          {t("canvas.componentPanel.emptyGroup", {
+                            defaultValue: "No components",
+                          })}
+                        </div>
+                      ) : (
+                        compoundItems.map(renderEntry)
+                      )}
+                    </div>
+                  </div>
+                )}
+              </Fragment>
+            ))}
+          </div>
+
+          <Link
+            className="mt-1 flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs text-foreground/80 ring-1 ring-transparent transition-colors hover:bg-accent/60 hover:ring-border"
+            to="/pipelines/operations/new"
+          >
+            <Plus className="size-3" />
+            {newCustomOperationLabel}
+          </Link>
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/packages/views/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasComponentPanel/CanvasComponentPanel.unit.test.tsx
@@ -5,7 +5,10 @@ import userEvent from "@testing-library/user-event";
 import type { Operation, Skill } from "@repo/schemas";
 import { describe, expect, it, vi } from "vitest";
 import { createCanvasPageStore, CanvasPageStoreContext } from "../_store";
-import { CANVAS_COMPONENT_DRAG_MIME } from "../utils/canvasComponentDragPayload";
+import {
+  CANVAS_COMPONENT_DRAG_MIME,
+  decodeCanvasComponentDragPayload,
+} from "../utils/canvasComponentDragPayload";
 import { CanvasComponentPanel } from "./CanvasComponentPanel";
 
 const operations = [
@@ -60,6 +63,51 @@ const renderPanel = () => {
 };
 
 describe("CanvasComponentPanel", () => {
+  it("toggles the panel through the current sidebar state", async () => {
+    const user = userEvent.setup();
+    const store = renderPanel();
+    const toggle = screen.getByTestId("canvas-component-panel-toggle");
+
+    expect(screen.getByTestId("canvas-component-panel")).toBeInTheDocument();
+
+    await user.click(toggle);
+
+    expect(store.getState().isSidebarOpen).toBe(false);
+    expect(screen.queryByTestId("canvas-component-panel")).not.toBeInTheDocument();
+
+    await user.click(toggle);
+
+    expect(store.getState().isSidebarOpen).toBe(true);
+    expect(store.getState().sidebarPanel).toBe("components");
+    expect(screen.getByTestId("canvas-component-panel")).toBeInTheDocument();
+  });
+
+  it("keeps operation creation on the current develop handler", async () => {
+    const user = userEvent.setup();
+    const store = renderPanel();
+    const handleCreateOperationNode = vi.fn();
+    store.setState({ handleCreateOperationNode });
+
+    await user.click(screen.getByRole("button", { name: /Review Code/i }));
+
+    expect(handleCreateOperationNode).toHaveBeenCalledWith(operations[0], { x: 400, y: 300 });
+  });
+
+  it("renders a non-collapsible generic compound entry", async () => {
+    const user = userEvent.setup();
+    const store = renderPanel();
+    const handleCreateObjectNode = vi.fn();
+    store.setState({ handleCreateObjectNode });
+
+    const compoundCategory = screen.getByTestId("canvas-component-category-compound");
+    expect(compoundCategory).toBeInTheDocument();
+    expect(compoundCategory).not.toHaveAttribute("aria-expanded");
+
+    await user.click(screen.getByTestId("canvas-component-object-compound"));
+
+    expect(handleCreateObjectNode).toHaveBeenCalledWith("compound", { x: 400, y: 300 });
+  });
+
   it("renders collapsible component categories", async () => {
     const user = userEvent.setup();
     renderPanel();
@@ -70,6 +118,16 @@ describe("CanvasComponentPanel", () => {
     expect(screen.getByRole("button", { name: /Output category/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Review Code/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Error Handling/i })).toBeInTheDocument();
+    expect(screen.queryByTestId("canvas-component-search-toggle")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Input Objects category/i })).toHaveClass(
+      "px-1",
+      "pb-1",
+      "text-[9.5px]",
+      "font-medium",
+      "uppercase",
+      "tracking-[0.1em]",
+      "text-muted-foreground",
+    );
 
     await user.click(screen.getByRole("button", { name: /Operations category/i }));
 
@@ -89,6 +147,12 @@ describe("CanvasComponentPanel", () => {
 
     expect(screen.queryByRole("button", { name: /Review Code/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Error Handling/i })).toBeInTheDocument();
+
+    await user.clear(searchInput);
+    await user.type(searchInput, "compound");
+
+    expect(screen.getByTestId("canvas-component-object-compound")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Error Handling/i })).not.toBeInTheDocument();
   });
 
   it("serializes palette items for drag creation", () => {
@@ -115,5 +179,25 @@ describe("CanvasComponentPanel", () => {
       operation: { id: "review-code" },
     });
     expect(dataTransfer.setDragImage).toHaveBeenCalled();
+  });
+
+  it("serializes the generic Compound entry as an object payload", () => {
+    renderPanel();
+
+    const data = new Map<string, string>();
+    const dataTransfer = {
+      effectAllowed: "none",
+      setData: vi.fn((type: string, value: string) => data.set(type, value)),
+      setDragImage: vi.fn(),
+    };
+
+    fireEvent.dragStart(screen.getByTestId("canvas-component-object-compound"), {
+      dataTransfer,
+    });
+
+    expect(decodeCanvasComponentDragPayload(data.get(CANVAS_COMPONENT_DRAG_MIME) ?? "")).toEqual({
+      kind: "object",
+      type: "compound",
+    });
   });
 });

--- a/packages/views/src/pages/CanvasPage/CanvasContextMenu/CanvasContextMenu.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasContextMenu/CanvasContextMenu.tsx
@@ -8,6 +8,7 @@ import {
   Group,
   GitBranch,
   MessageSquareText,
+  Plus,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
@@ -25,8 +26,7 @@ import { useList } from "@refinedev/core";
 import { ResourceName } from "../../../constants";
 import type { Operation, BuiltinNodeType } from "@repo/schemas";
 import { getAllowedConnections } from "../utils/getAllowedConnections";
-import { getNodeMeta, getNodeTypeLabel } from "../utils/nodeTypeMeta";
-import { cn } from "@repo/ui/lib/utils";
+import { getNodeTypeLabel } from "../utils/nodeTypeMeta";
 
 const TYPE_ICONS: Record<string, React.ElementType> = {
   operation: Zap,
@@ -154,23 +154,18 @@ export const CanvasContextMenu = () => {
         align="start"
         alignOffset={0}
         anchor={virtualAnchor}
-        className="max-h-[80vh] min-w-50"
+        className="max-h-[80vh] min-w-50 rounded-2xl border border-border bg-surface p-2 shadow-float ring-1 ring-border"
         positionMethod="fixed"
         side="bottom"
         sideOffset={0}
       >
         {isConnectMode && sourceNodeInfo ? (
-          <div className="flex items-center gap-2 px-1.5 py-1.5">
-            <span
-              className={cn(
-                "flex size-4 shrink-0 items-center justify-center rounded",
-                getNodeMeta(sourceNodeInfo.type)!.iconBg,
-              )}
-            >
+          <div className="mb-1 flex items-center gap-2 border-b border-border px-2 pb-2 pt-1">
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
               {(() => {
                 const Icon = TYPE_ICONS[sourceNodeInfo.type];
 
-                return <Icon className="size-2.5 text-white" />;
+                return <Icon className="size-3 text-foreground/70" />;
               })()}
             </span>
             <ArrowRight className="size-3 text-muted-foreground" />
@@ -179,7 +174,7 @@ export const CanvasContextMenu = () => {
             </span>
           </div>
         ) : (
-          <div className="px-1.5 py-1 text-xs font-medium text-muted-foreground">
+          <div className="mb-1 border-b border-border px-2 pb-2 pt-1 text-xs font-medium text-muted-foreground">
             {t("canvas.contextMenu.newNode")}
           </div>
         )}
@@ -187,27 +182,25 @@ export const CanvasContextMenu = () => {
         {/* Object types group */}
         {visibleObjectTypes.length > 0 && (
           <ContextMenuGroup>
-            <ContextMenuLabel>{t("canvas.contextMenu.objectTypes")}</ContextMenuLabel>
+            <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+              {t("canvas.contextMenu.objectTypes")}
+            </ContextMenuLabel>
             {visibleObjectTypes.map((type) => {
               const Icon = TYPE_ICONS[type];
-              const typeMeta = getNodeMeta(type)!;
               const typeLabel = getNodeTypeLabel(t, type);
 
               return (
                 <ContextMenuItem
                   key={type}
+                  className="rounded-lg px-2 py-1.5 text-xs"
                   closeOnClick={false}
                   onClick={() => handleCreateObjectNode(type)}
                 >
-                  <span
-                    className={cn(
-                      "flex size-4 shrink-0 items-center justify-center rounded",
-                      typeMeta.iconBg,
-                    )}
-                  >
-                    <Icon className="size-2.5 text-white" />
+                  <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+                    <Icon className="size-3 text-foreground/70" />
                   </span>
                   <span className="text-xs font-medium">{typeLabel}</span>
+                  <Plus className="ml-auto size-3 text-muted-foreground/50" />
                 </ContextMenuItem>
               );
             })}
@@ -217,19 +210,23 @@ export const CanvasContextMenu = () => {
         {/* Operations group */}
         {canAddOperation && availableOperations.length > 0 && (
           <>
-            <ContextMenuSeparator />
+            <ContextMenuSeparator className="my-1 bg-border/70" />
             <ContextMenuGroup>
-              <ContextMenuLabel>{t("canvas.contextMenu.operationNodes")}</ContextMenuLabel>
+              <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                {t("canvas.contextMenu.operationNodes")}
+              </ContextMenuLabel>
               {availableOperations.map((operation) => (
                 <ContextMenuItem
                   key={operation.id}
+                  className="rounded-lg px-2 py-1.5 text-xs"
                   closeOnClick={false}
                   onClick={() => handleCreateOperation(operation.id)}
                 >
-                  <span className="flex size-4 shrink-0 items-center justify-center rounded bg-violet-500">
-                    <Zap className="size-2.5 text-white" />
+                  <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+                    <Zap className="size-3 text-foreground/70" />
                   </span>
                   <span className="truncate text-xs font-medium">{operation.name}</span>
+                  <Plus className="ml-auto size-3 text-muted-foreground/50" />
                 </ContextMenuItem>
               ))}
             </ContextMenuGroup>
@@ -239,10 +236,12 @@ export const CanvasContextMenu = () => {
         {/* Empty state for operations */}
         {canAddOperation && availableOperations.length === 0 && (
           <>
-            <ContextMenuSeparator />
+            <ContextMenuSeparator className="my-1 bg-border/70" />
             <ContextMenuGroup>
-              <ContextMenuLabel>{t("canvas.contextMenu.operationNodes")}</ContextMenuLabel>
-              <p className="px-1.5 py-1 text-xs text-muted-foreground">
+              <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                {t("canvas.contextMenu.operationNodes")}
+              </ContextMenuLabel>
+              <p className="px-2 py-1 text-xs text-muted-foreground">
                 {t("canvas.contextMenu.noOperationsForType")}
               </p>
             </ContextMenuGroup>
@@ -250,22 +249,33 @@ export const CanvasContextMenu = () => {
         )}
 
         {/* Compound / Group section */}
-        <ContextMenuSeparator />
+        <ContextMenuSeparator className="my-1 bg-border/70" />
         <ContextMenuGroup>
-          <ContextMenuLabel>{t("canvas.contextMenu.group")}</ContextMenuLabel>
-          <ContextMenuItem closeOnClick={false} onClick={() => handleCreateObjectNode("compound")}>
-            <span className="flex size-4 shrink-0 items-center justify-center rounded bg-indigo-500">
-              <Group className="size-2.5 text-white" />
+          <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+            {t("canvas.contextMenu.group")}
+          </ContextMenuLabel>
+          <ContextMenuItem
+            className="rounded-lg px-2 py-1.5 text-xs"
+            closeOnClick={false}
+            onClick={() => handleCreateObjectNode("compound")}
+          >
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+              <Group className="size-3 text-foreground/70" />
             </span>
             <span className="text-xs font-medium">{t("canvas.contextMenu.newCompoundNode")}</span>
+            <Plus className="ml-auto size-3 text-muted-foreground/50" />
           </ContextMenuItem>
           {(() => {
             if (selectedIds.length < 2) return null;
 
             return (
-              <ContextMenuItem closeOnClick={false} onClick={handleGroupSelected}>
-                <span className="flex size-4 shrink-0 items-center justify-center rounded bg-indigo-500">
-                  <Group className="size-2.5 text-white" />
+              <ContextMenuItem
+                className="rounded-lg px-2 py-1.5 text-xs"
+                closeOnClick={false}
+                onClick={handleGroupSelected}
+              >
+                <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+                  <Group className="size-3 text-foreground/70" />
                 </span>
                 <span className="text-xs font-medium">
                   {t("canvas.contextMenu.groupSelected", { count: selectedIds.length })}

--- a/packages/views/src/pages/CanvasPage/CanvasEdgeInspector/CanvasEdgeInspector.stories.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasEdgeInspector/CanvasEdgeInspector.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { PipelineEdgeData } from "@repo/schemas";
+import {
+  CanvasPageStoreContext,
+  createCanvasPageStore,
+  type PipelineEdge,
+  type PipelineNode,
+} from "../_store";
+import { CanvasEdgeInspector } from "./CanvasEdgeInspector";
+
+const sourceNode = {
+  data: {
+    description: "Pipeline source",
+    filePath: "src/index.ts",
+    label: "Source File",
+    language: "typescript",
+    nodeType: "file",
+  },
+  id: "source-file",
+  position: { x: 80, y: 120 },
+  type: "file",
+} as PipelineNode;
+
+const targetNode = {
+  data: {
+    config: {},
+    label: "Review Code",
+    nodeType: "operation",
+    operationId: "review-code",
+    operationName: "Review Code",
+    status: "idle",
+  },
+  id: "review-op",
+  position: { x: 420, y: 120 },
+  type: "operation",
+} as PipelineNode;
+
+const renderInspector = (data: PipelineEdgeData) => {
+  const edge = {
+    data,
+    id: "source-to-review",
+    source: sourceNode.id,
+    target: targetNode.id,
+  } as PipelineEdge;
+  const store = createCanvasPageStore([sourceNode, targetNode], [edge]);
+  store.setState({ selectedEdgeId: edge.id });
+
+  return (
+    <CanvasPageStoreContext.Provider value={store}>
+      <div className="relative h-[620px] w-full bg-canvas-bg">
+        <CanvasEdgeInspector />
+      </div>
+    </CanvasPageStoreContext.Provider>
+  );
+};
+
+const meta: Meta<typeof CanvasEdgeInspector> = {
+  component: CanvasEdgeInspector,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Alan-style edge inspector driven exclusively by the current develop selectedEdgeId, PipelineEdgeData, and updateEdgeData contract.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  title: "CanvasPage/CanvasEdgeInspector",
+};
+
+export default meta;
+type Story = StoryObj<typeof CanvasEdgeInspector>;
+
+export const RuntimeInferred: Story = {
+  render: () => renderInspector({ label: "source" }),
+};
+
+export const MappedAndGated: Story = {
+  render: () =>
+    renderInspector({
+      condition: { expression: 'content.includes("approved")' },
+      dataContract: {
+        mappings: [
+          { enabled: true, fromField: "content", toInput: "source", type: "string" },
+          { enabled: false, fromField: "metadata", toInput: "context", type: "object" },
+        ],
+      },
+      label: "review payload",
+      qualityGate: { criteria: "non-empty", maxRetries: 2, onFail: "retry" },
+      transform: { steps: [{ config: {}, type: "trim" }] },
+    }),
+};

--- a/packages/views/src/pages/CanvasPage/CanvasEdgeInspector/CanvasEdgeInspector.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasEdgeInspector/CanvasEdgeInspector.tsx
@@ -1,0 +1,300 @@
+import { ArrowRightLeft, Info, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import type { PipelineEdgeData } from "@repo/schemas";
+import { Button } from "@repo/ui/button";
+import { Input } from "@repo/ui/input";
+import { Label } from "@repo/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui/select";
+import { cn } from "@repo/ui/lib/utils";
+import { useCanvasPageStore } from "../_store";
+
+const TRANSFORM_OPTIONS = ["trim", "uppercase", "lowercase"] as const;
+const ON_FAIL_OPTIONS = ["retry", "skip", "fail"] as const;
+
+export const CanvasEdgeInspector = () => {
+  const { t } = useTranslation();
+  const store = useCanvasPageStore();
+  const selectedEdgeId = useStore(store, (state) => state.selectedEdgeId);
+  const edges = useStore(store, (state) => state.edges);
+  const nodes = useStore(store, (state) => state.nodes);
+  const updateEdgeData = useStore(store, (state) => state.updateEdgeData);
+  const clearSelection = useStore(store, (state) => state.clearSelection);
+  const edge = edges.find((item) => item.id === selectedEdgeId);
+
+  if (!edge) {
+    return null;
+  }
+
+  const edgeData: PipelineEdgeData = { label: edge.data?.label ?? "", ...edge.data };
+  const mappings = edgeData.dataContract?.mappings ?? [];
+  const sourceLabel = nodes.find((node) => node.id === edge.source)?.data.label ?? edge.source;
+  const targetLabel = nodes.find((node) => node.id === edge.target)?.data.label ?? edge.target;
+  const enabledCount = mappings.filter((mapping) => mapping.enabled).length;
+  const handleClose = () => clearSelection();
+
+  const handleMappingToggle = (mappingIndex: number) => {
+    const nextMappings = mappings.map((mapping, index) =>
+      index === mappingIndex ? { ...mapping, enabled: !mapping.enabled } : mapping,
+    );
+    updateEdgeData(edge.id, {
+      dataContract: { ...edgeData.dataContract, mappings: nextMappings },
+    });
+  };
+
+  const handleConditionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const expression = event.currentTarget.value.trim();
+    updateEdgeData(edge.id, {
+      condition: expression ? { ...edgeData.condition, expression } : undefined,
+    });
+  };
+
+  const handleTransformAdd = (type: (typeof TRANSFORM_OPTIONS)[number]) => {
+    updateEdgeData(edge.id, {
+      transform: {
+        steps: [...(edgeData.transform?.steps ?? []), { config: {}, type }],
+      },
+    });
+  };
+
+  const handleTransformClear = () => updateEdgeData(edge.id, { transform: undefined });
+
+  const handleQualityCriteriaChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const criteria = event.currentTarget.value.trim();
+    updateEdgeData(edge.id, {
+      qualityGate: criteria
+        ? {
+            criteria,
+            maxRetries: edgeData.qualityGate?.maxRetries,
+            onFail: edgeData.qualityGate?.onFail ?? "skip",
+          }
+        : undefined,
+    });
+  };
+
+  const handleQualityRetriesChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const maxRetries = event.currentTarget.valueAsNumber;
+    if (!Number.isFinite(maxRetries) || !edgeData.qualityGate) {
+      return;
+    }
+
+    updateEdgeData(edge.id, {
+      qualityGate: {
+        ...edgeData.qualityGate,
+        maxRetries: Math.max(0, Math.floor(maxRetries)),
+      },
+    });
+  };
+
+  const handleQualityFailureChange = (value: string | null) => {
+    if (!value || !edgeData.qualityGate) {
+      return;
+    }
+
+    updateEdgeData(edge.id, {
+      qualityGate: {
+        ...edgeData.qualityGate,
+        onFail: value as (typeof ON_FAIL_OPTIONS)[number],
+      },
+    });
+  };
+
+  return (
+    <aside
+      className="absolute bottom-20 left-1/2 z-30 flex w-[420px] max-w-[calc(100vw-2rem)] -translate-x-1/2 flex-col overflow-hidden rounded-2xl bg-surface shadow-float ring-1 ring-border-strong"
+      data-testid="canvas-edge-inspector"
+    >
+      <div className="flex items-center gap-2 border-b border-border/70 px-3.5 py-2.5">
+        <div className="flex size-6 items-center justify-center rounded-md bg-surface-2">
+          <ArrowRightLeft className="size-3.5 text-foreground/80" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-semibold">
+            {t("canvas.edgeInspector.title", { defaultValue: "Data Contract" })}
+          </div>
+          <div className="truncate text-[10px] text-muted-foreground">
+            {sourceLabel} <span className="px-1 text-foreground/40">→</span> {targetLabel}
+          </div>
+        </div>
+        <Button
+          aria-label={t("canvas.edgeInspector.close", { defaultValue: "Close" })}
+          data-testid="canvas-edge-inspector-close"
+          size="icon"
+          variant="ghost"
+          onClick={handleClose}
+        >
+          <X className="size-3.5" />
+        </Button>
+      </div>
+
+      <div className="max-h-[50vh] space-y-3 overflow-y-auto px-3.5 py-3">
+        {mappings.length > 0 ? (
+          <div>
+            <div className="mb-2 grid grid-cols-[1fr_auto_1fr] gap-2 px-1 text-[9.5px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+              <span>{t("canvas.edgeInspector.sourceField", { defaultValue: "Source field" })}</span>
+              <span>{t("canvas.edgeInspector.flow", { defaultValue: "Flow" })}</span>
+              <span>{t("canvas.edgeInspector.targetInput", { defaultValue: "Target input" })}</span>
+            </div>
+            <div className="space-y-1.5">
+              {mappings.map((mapping, index) => (
+                <button
+                  key={`${mapping.fromField}-${mapping.toInput}-${index}`}
+                  className={cn(
+                    "grid w-full grid-cols-[1fr_auto_1fr] items-center gap-2 rounded-xl px-2.5 py-2 text-left ring-1 transition-all",
+                    mapping.enabled
+                      ? "bg-surface-2 ring-border hover:ring-border-strong"
+                      : "bg-surface opacity-55 ring-border/60 hover:opacity-80",
+                  )}
+                  data-testid={`canvas-edge-mapping-${index}`}
+                  type="button"
+                  onClick={() => handleMappingToggle(index)}
+                >
+                  <span className="min-w-0">
+                    <span className="block truncate font-mono text-[11px] font-medium">
+                      {mapping.fromField}
+                    </span>
+                    {mapping.type && (
+                      <span className="block truncate text-[9.5px] text-muted-foreground">
+                        {mapping.type}
+                      </span>
+                    )}
+                  </span>
+                  <span
+                    className={cn(
+                      "flex h-4 w-7 items-center rounded-full p-0.5 transition-colors",
+                      mapping.enabled ? "bg-foreground" : "bg-surface-3",
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "size-3 rounded-full bg-surface transition-transform",
+                        mapping.enabled && "translate-x-3",
+                      )}
+                    />
+                  </span>
+                  <span
+                    className={cn(
+                      "truncate font-mono text-[11px]",
+                      !mapping.enabled && "line-through",
+                    )}
+                  >
+                    {mapping.enabled
+                      ? mapping.toInput
+                      : t("canvas.edgeInspector.dropped", { defaultValue: "dropped" })}
+                  </span>
+                </button>
+              ))}
+            </div>
+            <div className="mt-2 flex items-center gap-1.5 text-[10.5px] text-muted-foreground">
+              <Info className="size-3" />
+              {t("canvas.edgeInspector.toggleHint", {
+                defaultValue: "Tap a field to toggle downstream flow · {{enabled}}/{{total}} on",
+                enabled: enabledCount,
+                total: mappings.length,
+              })}
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-xl bg-surface-2 p-3 text-xs text-muted-foreground ring-1 ring-border">
+            {t("canvas.edgeInspector.noMappings", {
+              defaultValue: "New connection · fields are inferred at run time.",
+            })}
+          </div>
+        )}
+
+        <div className="space-y-2 rounded-xl bg-surface-2/60 px-2.5 py-2 ring-1 ring-border">
+          <Label className="text-[11px] font-medium text-muted-foreground" htmlFor="edge-condition">
+            {t("canvas.edgeInspector.condition", { defaultValue: "Condition" })}
+          </Label>
+          <Input
+            data-testid="canvas-edge-condition"
+            id="edge-condition"
+            placeholder='content.includes("approved")'
+            value={edgeData.condition?.expression ?? ""}
+            onChange={handleConditionChange}
+          />
+        </div>
+
+        <div className="space-y-2 rounded-xl bg-surface-2/60 px-2.5 py-2 ring-1 ring-border">
+          <div className="text-[11px] font-medium text-muted-foreground">
+            {t("canvas.edgeInspector.transform", { defaultValue: "Transform" })}
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {TRANSFORM_OPTIONS.map((type) => (
+              <Button
+                key={type}
+                className="h-7 px-2 text-[11px]"
+                size="sm"
+                type="button"
+                variant="secondary"
+                onClick={() => handleTransformAdd(type)}
+              >
+                {type}
+              </Button>
+            ))}
+            <Button
+              className="h-7 px-2 text-[11px]"
+              size="sm"
+              type="button"
+              variant="ghost"
+              onClick={handleTransformClear}
+            >
+              {t("canvas.edgeInspector.clear", { defaultValue: "Clear" })}
+            </Button>
+          </div>
+          <div className="text-[11px] text-muted-foreground">
+            {(edgeData.transform?.steps ?? []).map((step) => step.type).join(" → ") ||
+              t("canvas.edgeInspector.noTransform", { defaultValue: "No transform steps." })}
+          </div>
+        </div>
+
+        <div className="space-y-2 rounded-xl bg-surface-2/60 px-2.5 py-2 ring-1 ring-border">
+          <Label className="text-[11px] font-medium text-muted-foreground" htmlFor="edge-quality">
+            {t("canvas.edgeInspector.qualityGate", { defaultValue: "Quality Gate" })}
+          </Label>
+          <Input
+            data-testid="canvas-edge-quality"
+            id="edge-quality"
+            placeholder={t("canvas.edgeInspector.qualityPlaceholder", {
+              defaultValue: "non-empty or required text",
+            })}
+            value={edgeData.qualityGate?.criteria ?? ""}
+            onChange={handleQualityCriteriaChange}
+          />
+          {edgeData.qualityGate && (
+            <div className="grid grid-cols-[1fr_1.4fr] gap-2">
+              <Input
+                aria-label={t("canvas.edgeInspector.maxRetries", {
+                  defaultValue: "Max retries",
+                })}
+                inputMode="numeric"
+                min={0}
+                step={1}
+                type="number"
+                value={edgeData.qualityGate.maxRetries ?? 0}
+                onChange={handleQualityRetriesChange}
+              />
+              <Select
+                value={edgeData.qualityGate.onFail}
+                onValueChange={handleQualityFailureChange}
+              >
+                <SelectTrigger
+                  aria-label={t("canvas.edgeInspector.onFail", { defaultValue: "On fail" })}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ON_FAIL_OPTIONS.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+};

--- a/packages/views/src/pages/CanvasPage/CanvasEdgeInspector/CanvasEdgeInspector.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasEdgeInspector/CanvasEdgeInspector.unit.test.tsx
@@ -1,0 +1,87 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { render } from "../../../test/test-wrapper";
+import {
+  CanvasPageStoreContext,
+  createCanvasPageStore,
+  type PipelineEdge,
+  type PipelineNode,
+} from "../_store";
+import { CanvasEdgeInspector } from "./CanvasEdgeInspector";
+
+const nodes: PipelineNode[] = [
+  {
+    data: { description: "", label: "Source", nodeType: "prompt", prompt: "" },
+    id: "node-a",
+    position: { x: 0, y: 0 },
+    type: "prompt",
+  },
+  {
+    data: {
+      config: {},
+      label: "Parse",
+      maxLoopCount: 3,
+      nodeType: "operation",
+      operationId: "op-1",
+      operationName: "Parse",
+      status: "idle",
+    },
+    id: "node-b",
+    position: { x: 200, y: 0 },
+    type: "operation",
+  },
+];
+
+const edge: PipelineEdge = {
+  data: {
+    dataContract: {
+      mappings: [
+        { enabled: true, fromField: "vocabulary", toInput: "source_terms", type: "Term[]" },
+      ],
+    },
+    label: "vocabulary",
+  },
+  id: "edge-1",
+  source: "node-a",
+  target: "node-b",
+};
+
+const renderInspector = () => {
+  const store = createCanvasPageStore(nodes, [edge]);
+  store.setState({ selectedEdgeId: "edge-1" });
+  render(
+    <CanvasPageStoreContext.Provider value={store}>
+      <CanvasEdgeInspector />
+    </CanvasPageStoreContext.Provider>,
+  );
+
+  return store;
+};
+
+describe("CanvasEdgeInspector", () => {
+  it("renders from develop edge selection without a second inspector state", () => {
+    renderInspector();
+
+    expect(screen.getByTestId("canvas-edge-inspector")).toHaveClass(
+      "w-[420px]",
+      "max-w-[calc(100vw-2rem)]",
+    );
+    expect(screen.getByTestId("canvas-edge-inspector")).toHaveTextContent("Source");
+    expect(screen.getByTestId("canvas-edge-inspector")).toHaveTextContent("Parse");
+  });
+
+  it("updates the existing develop edge data and closes through clearSelection", async () => {
+    const user = userEvent.setup();
+    const store = renderInspector();
+
+    await user.click(screen.getByTestId("canvas-edge-mapping-0"));
+    expect(store.getState().edges[0]?.data?.dataContract?.mappings[0]?.enabled).toBe(false);
+
+    await user.type(screen.getByTestId("canvas-edge-condition"), "approved");
+    expect(store.getState().edges[0]?.data?.condition?.expression).toBe("approved");
+
+    await user.click(screen.getByTestId("canvas-edge-inspector-close"));
+    expect(store.getState().selectedEdgeId).toBeNull();
+  });
+});

--- a/packages/views/src/pages/CanvasPage/CanvasEdgeInspector/index.ts
+++ b/packages/views/src/pages/CanvasPage/CanvasEdgeInspector/index.ts
@@ -1,0 +1,1 @@
+export * from "./CanvasEdgeInspector";

--- a/packages/views/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.stories.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof CanvasEmptyState> = {
     docs: {
       description: {
         component:
-          "Empty-canvas entry card shown when the pipeline has no nodes. It gives first-time users a quick-add action and a right-click creation hint without blocking canvas interactions outside the card.",
+          "Centered empty-canvas entry state shown when the pipeline has no nodes. It gives first-time users the same quick-add action used by the canvas toolbar.",
       },
     },
   },
@@ -33,7 +33,7 @@ export const Default: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Centered first-run card with the same quick-add action used by the toolbar.",
+        story: "Centered first-run empty state with the same quick-add action used by the toolbar.",
       },
     },
   },

--- a/packages/views/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.tsx
@@ -1,30 +1,39 @@
-import { MousePointer2, Plus } from "lucide-react";
+import { Plus, Sparkles } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { Button } from "@repo/ui/button";
+import { cn } from "@repo/ui/lib/utils";
 import { useCanvasPageStore } from "../_store";
 
 export const CanvasEmptyState = () => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const handleOpenQuickAdd = useStore(store, (state) => state.handleOpenQuickAdd);
+  const isComponentPanelOpen = useStore(
+    store,
+    (state) => state.isSidebarOpen && state.sidebarPanel === "components",
+  );
 
   return (
-    <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center px-4">
-      <div className="pointer-events-auto w-[min(24rem,100%)] rounded-xl border border-dashed border-border-strong bg-surface/92 px-5 py-5 text-center shadow-soft backdrop-blur-sm">
-        <div className="mx-auto mb-3 flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
-          <Plus className="size-5" />
+    <div
+      className={cn(
+        "pointer-events-none absolute inset-0 z-10 grid place-items-center px-6",
+        isComponentPanelOpen && "min-[1181px]:pl-[246px]",
+      )}
+      data-testid="canvas-v2-empty-state"
+    >
+      <div className="pointer-events-auto flex w-[min(28rem,100%)] flex-col items-center text-center">
+        <div className="mb-4 flex size-11 items-center justify-center rounded-lg bg-foreground text-background shadow-soft">
+          <Sparkles className="size-5" />
         </div>
-        <h2 className="text-sm font-semibold text-foreground">{t("canvas.emptyState.title")}</h2>
-        <p className="mt-1 text-sm text-muted-foreground">{t("canvas.emptyState.description")}</p>
-        <Button className="mt-4" size="sm" onClick={handleOpenQuickAdd}>
+        <h2 className="text-base font-semibold text-foreground">{t("canvas.emptyState.title")}</h2>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          {t("canvas.emptyState.description")}
+        </p>
+        <Button className="mt-5" size="sm" type="button" onClick={handleOpenQuickAdd}>
           <Plus className="size-3.5" />
           {t("canvas.emptyState.quickAdd")}
         </Button>
-        <div className="mt-3 flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
-          <MousePointer2 className="size-3.5" />
-          <span>{t("canvas.emptyState.contextHint")}</span>
-        </div>
       </div>
     </div>
   );

--- a/packages/views/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.unit.test.tsx
@@ -26,9 +26,25 @@ describe("CanvasEmptyState", () => {
     expect(store.getState().isQuickAddOpen).toBe(true);
   });
 
-  it("shows the right-click creation hint", () => {
+  it("uses the centered Alan empty-state layout without the context hint", () => {
     renderEmptyState();
 
-    expect(screen.getByText(/right-click blank canvas|画布空白处右键/)).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-v2-empty-state")).toHaveClass(
+      "pointer-events-none",
+      "absolute",
+      "inset-0",
+      "z-10",
+      "grid",
+      "place-items-center",
+      "px-6",
+    );
+    expect(screen.getByRole("heading")).toHaveClass("text-base");
+    expect(screen.queryByText(/right-click blank canvas|画布空白处右键/)).not.toBeInTheDocument();
+  });
+
+  it("leaves room for the open component panel on desktop", () => {
+    renderEmptyState();
+
+    expect(screen.getByTestId("canvas-v2-empty-state")).toHaveClass("min-[1181px]:pl-[246px]");
   });
 });

--- a/packages/views/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
@@ -26,6 +26,7 @@ import {
 } from "../utils/canvasComponentDragPayload";
 import { DEFAULT_CANVAS_VIEWPORT } from "../utils/canvasViewport";
 import { decorateEdgesWithPortHandles } from "../NodeCard";
+import { SemanticEdge } from "../SemanticEdge";
 
 // Must be defined outside the component to prevent React Flow infinite re-renders
 const nodeTypes = {
@@ -40,10 +41,12 @@ const nodeTypes = {
   "output-local-path": OutputLocalPathNode,
 };
 
+const edgeTypes = {
+  semantic: SemanticEdge,
+};
+
 const defaultEdgeOptions = {
-  type: "default" as const,
-  animated: true,
-  style: { stroke: "var(--edge)", strokeWidth: 1.5 },
+  type: "semantic" as const,
 };
 
 const proOpts = { hideAttribution: false };
@@ -73,6 +76,10 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
   const portRoutedEdges = useMemo(
     () => decorateEdgesWithPortHandles(nodes, edges, connectStart),
     [connectStart, edges, nodes],
+  );
+  const semanticEdges = useMemo<typeof portRoutedEdges>(
+    () => portRoutedEdges.map((edge) => ({ ...edge, animated: false, type: "semantic" as const })),
+    [portRoutedEdges],
   );
   const isConsoleOpen = useStore(store, (s) => s.isConsoleOpen);
   const canvasSettings = useStore(store, (s) => s.canvasSettings);
@@ -242,7 +249,7 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
   return (
     <div
       ref={viewportRef}
-      className="h-full w-full"
+      className="canvas-container h-full w-full"
       data-testid="canvas-flow-viewport"
       onDragOver={handleComponentDragOver}
       onDrop={handleDrop}
@@ -252,14 +259,15 @@ export const CanvasFlow = ({ viewportRef }: CanvasFlowProps) => {
         defaultEdgeOptions={defaultEdgeOptions}
         defaultViewport={DEFAULT_CANVAS_VIEWPORT}
         deleteKeyCode={isCanvasInteractive ? ["Backspace", "Delete"] : null}
-        edges={portRoutedEdges}
+        edges={semanticEdges}
+        edgeTypes={edgeTypes}
         elementsSelectable={isCanvasInteractive}
+        minZoom={0.1}
         nodes={nodes}
         nodesConnectable={isCanvasInteractive}
         nodesDraggable={isCanvasInteractive}
         nodeTypes={nodeTypes}
-        minZoom={0.1}
-        panOnDrag={!isCanvasInteractive ? false : canvasTool === "hand" ? true : [1, 2]}
+        panOnDrag={isCanvasInteractive ? (canvasTool === "hand" ? true : [1, 2]) : false}
         panOnScroll={false}
         proOptions={proOpts}
         selectionOnDrag={isCanvasInteractive && canvasTool === "select"}

--- a/packages/views/src/pages/CanvasPage/CanvasFlow/CanvasFlow.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasFlow/CanvasFlow.unit.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ReactFlowProvider } from "@xyflow/react";
 import type * as XyFlowReact from "@xyflow/react";
-import type { PipelineNode } from "../_store/canvasSlice";
+import type { PipelineEdge, PipelineNode } from "../_store/canvasSlice";
 import { createCanvasPageStore, CanvasPageStoreContext, CanvasPageStoreProvider } from "../_store";
 import {
   CANVAS_COMPONENT_DRAG_MIME,
@@ -28,6 +28,9 @@ vi.mock("@xyflow/react", async (importOriginal) => {
     ReactFlow: ({
       children,
       defaultViewport,
+      defaultEdgeOptions,
+      edgeTypes,
+      edges,
       fitView,
       onMove,
       elementsSelectable,
@@ -56,6 +59,9 @@ vi.mock("@xyflow/react", async (importOriginal) => {
       snapToGrid,
     }: React.PropsWithChildren<{
       defaultViewport?: { zoom: number };
+      defaultEdgeOptions?: { animated?: boolean; type?: string };
+      edgeTypes?: Record<string, unknown>;
+      edges?: unknown[];
       fitView?: boolean;
       onMove?: XyFlowReact.OnMove;
       elementsSelectable?: boolean;
@@ -89,6 +95,12 @@ vi.mock("@xyflow/react", async (importOriginal) => {
       return (
         <div
           data-auto-fit={String(fitView ?? false)}
+          data-edge-animated={String(defaultEdgeOptions?.animated ?? false)}
+          data-edge-render-types={JSON.stringify(
+            edges?.map((edge) => (edge as { type?: string }).type ?? "default") ?? [],
+          )}
+          data-edge-types={Object.keys(edgeTypes ?? {}).join(",")}
+          data-default-edge-type={defaultEdgeOptions?.type}
           data-delete-key-code={JSON.stringify(deleteKeyCode)}
           data-elements-selectable={String(elementsSelectable ?? true)}
           data-has-on-connect={String(typeof onConnect === "function")}
@@ -147,8 +159,12 @@ const wrapper = ({ children }: React.PropsWithChildren) => (
   </CanvasPageStoreProvider>
 );
 
-const renderWithStore = (nodes: PipelineNode[], isConsoleOpen = false) => {
-  const store = createCanvasPageStore(nodes, []);
+const renderWithStore = (
+  nodes: PipelineNode[],
+  isConsoleOpen = false,
+  edges: PipelineEdge[] = [],
+) => {
+  const store = createCanvasPageStore(nodes, edges);
   store.setState({ isConsoleOpen });
 
   render(
@@ -191,6 +207,26 @@ describe("CanvasFlow", () => {
     expect(screen.getByTestId("react-flow")).toHaveAttribute("data-min-zoom", "0.1");
     expect(screen.getByTestId("react-flow")).toHaveAttribute("data-has-on-node-drag-start", "true");
     expect(screen.queryByTestId("flow-controls")).not.toBeInTheDocument();
+  });
+
+  it("routes every current edge through the semantic renderer without global animation", () => {
+    renderWithStore([makeNode("source"), makeNode("target")], false, [
+      {
+        id: "edge-1",
+        source: "source",
+        target: "target",
+        type: "default",
+        data: { label: "document" },
+      },
+    ]);
+
+    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-edge-types", "semantic");
+    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-default-edge-type", "semantic");
+    expect(screen.getByTestId("react-flow")).toHaveAttribute(
+      "data-edge-render-types",
+      '["semantic"]',
+    );
+    expect(screen.getByTestId("react-flow")).toHaveAttribute("data-edge-animated", "false");
   });
 
   it("defaults to the hand tool and uses the wheel for zoom", () => {

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useRef, type MouseEvent as ReactMouseEvent } from "react";
+import { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { PanelRightOpen } from "lucide-react";
-import { Button } from "@repo/ui/button";
+import { cn } from "@repo/ui/lib/utils";
 import { ResizeHandle } from "../../../components/ResizeHandle";
 import {
   MAX_AGENT_PANEL_WIDTH,
@@ -12,6 +12,7 @@ import {
 } from "../_store";
 import { CanvasFlow } from "../CanvasFlow";
 import { CanvasContextMenu } from "../CanvasContextMenu";
+import { CanvasEdgeInspector } from "../CanvasEdgeInspector";
 import { ConnectionMenu } from "../ConnectionMenu";
 import { NodeContextMenu } from "../NodeContextMenu";
 import { RunConsole } from "../RunConsole";
@@ -19,9 +20,9 @@ import { AgentPanel } from "../AgentPanel";
 import { LlmContentCard } from "../LlmContentCard/LlmContentCard";
 import { CanvasEmptyState } from "../CanvasEmptyState";
 import { CanvasNodeCreationPalette } from "../CanvasNodeCreationPalette";
-import { CanvasStatusBar } from "../CanvasStatusBar";
 import { CanvasSettingsDrawer } from "../CanvasSettingsDrawer";
 import { CanvasTopChrome } from "../CanvasTopChrome";
+import { CanvasToolbar } from "../CanvasToolbar";
 import { CanvasMiniSidebar } from "../CanvasMiniSidebar";
 import { CanvasComponentPanel } from "../CanvasComponentPanel";
 import { CanvasNodePropertiesPanel } from "../CanvasNodePropertiesPanel";
@@ -31,15 +32,16 @@ import { getScreenViewportCenter, getViewportRectCenter } from "../utils/nodePos
 const AGENT_PANEL_COLLAPSE_AT = 248;
 
 export const CanvasInner = ({
-  onGeneratedPipeline,
+  onGeneratedPipeline: handleGeneratedPipeline,
+  showCanvasMiniSidebar = true,
 }: {
   onGeneratedPipeline?: (pipelineId: string) => Promise<void> | void;
+  showCanvasMiniSidebar?: boolean;
 }) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
   const flowViewportRef = useRef<HTMLDivElement>(null);
   const agentPanelShellRef = useRef<HTMLDivElement>(null);
-  const sidebarResizeStateRef = useRef<{ startClientX: number; startWidth: number } | null>(null);
   const agentPanelResizeStartWidthRef = useRef(0);
 
   const contextMenu = useStore(store, (state) => state.contextMenu);
@@ -53,9 +55,6 @@ export const CanvasInner = ({
   const toggleAgentPanel = useStore(store, (state) => state.toggleAgentPanel);
   const nodes = useStore(store, (state) => state.nodes);
   const sidebarPanel = useStore(store, (state) => state.sidebarPanel);
-  const isSidebarOpen = useStore(store, (state) => state.isSidebarOpen);
-  const workspacePanelWidth = useStore(store, (state) => state.workspacePanelWidth);
-  const setWorkspacePanelWidth = useStore(store, (state) => state.setWorkspacePanelWidth);
   const selectedNode = useStore(store, selectSelectedNode);
   const showPropertiesPanel = sidebarPanel === "properties" && !!selectedNode;
 
@@ -65,106 +64,42 @@ export const CanvasInner = ({
     return rect ? getViewportRectCenter(rect) : getScreenViewportCenter();
   }, []);
 
-  const stopSidebarResize = useCallback(() => {
-    if (!sidebarResizeStateRef.current) {
-      return;
-    }
-
-    sidebarResizeStateRef.current = null;
-    document.body.style.removeProperty("cursor");
-    document.body.style.removeProperty("user-select");
-  }, []);
-
-  useEffect(() => {
-    const handleMouseMove = (event: MouseEvent) => {
-      const resizeState = sidebarResizeStateRef.current;
-      if (!resizeState) {
-        return;
-      }
-
-      const delta = event.clientX - resizeState.startClientX;
-      setWorkspacePanelWidth(resizeState.startWidth + delta);
-    };
-
-    const handleMouseUp = () => {
-      stopSidebarResize();
-    };
-
-    globalThis.addEventListener("mousemove", handleMouseMove);
-    globalThis.addEventListener("mouseup", handleMouseUp);
-
-    return () => {
-      globalThis.removeEventListener("mousemove", handleMouseMove);
-      globalThis.removeEventListener("mouseup", handleMouseUp);
-      stopSidebarResize();
-    };
-  }, [setWorkspacePanelWidth, stopSidebarResize]);
-
-  const handleWorkspacePanelResizeStart = useCallback(
-    (event: ReactMouseEvent<HTMLButtonElement>) => {
-      event.preventDefault();
-      sidebarResizeStateRef.current = {
-        startClientX: event.clientX,
-        startWidth: workspacePanelWidth,
-      };
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-    },
-    [workspacePanelWidth],
-  );
-
   const handleAgentPanelDelta = useCallback(
     (delta: number) => {
       const nextWidth = agentPanelResizeStartWidthRef.current + delta;
       if (nextWidth < AGENT_PANEL_COLLAPSE_AT) {
         toggleAgentPanel();
+
         return;
       }
       setAgentPanelWidth(nextWidth);
     },
     [setAgentPanelWidth, toggleAgentPanel],
   );
+  const handleToggleAgentPanel = toggleAgentPanel;
+  const handleAgentPanelDragStart = () => {
+    const renderedWidth = agentPanelShellRef.current?.getBoundingClientRect().width ?? 0;
+    agentPanelResizeStartWidthRef.current = renderedWidth || agentPanelWidth;
+  };
 
   return (
     <div
-      className="relative flex h-full min-h-0 w-full overflow-hidden bg-background"
+      className="canvas-container relative flex h-full min-h-0 w-full overflow-hidden bg-background"
       data-testid="canvas-langflow-shell"
     >
-      <CanvasMiniSidebar />
+      {showCanvasMiniSidebar && <CanvasMiniSidebar />}
 
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        <CanvasTopChrome />
-
+      <div className="relative flex min-w-0 flex-1 overflow-hidden">
         <div className="relative flex min-h-0 flex-1 overflow-hidden">
-          {isSidebarOpen && (
-            <div className="relative shrink-0 max-[1180px]:pointer-events-auto max-[1180px]:absolute max-[1180px]:inset-y-0 max-[1180px]:left-0 max-[1180px]:z-30">
-              <aside
-                className="h-full shrink-0 border-r bg-background shadow-none max-[1180px]:max-w-[calc(100vw-4rem)] max-[1180px]:shadow-float"
-                data-testid="canvas-work-panel"
-                style={{ width: `${workspacePanelWidth}px` }}
-              >
-                {showPropertiesPanel ? (
-                  <CanvasNodePropertiesPanel />
-                ) : (
-                  <CanvasComponentPanel getCreateNodeScreenPosition={getFlowViewportScreenCenter} />
-                )}
-              </aside>
-              <Button
-                aria-label={t("canvas.operationsPanel.resize", {
-                  defaultValue: "Resize operations panel",
-                })}
-                className="absolute inset-y-0 -right-3 z-10 h-full w-6 cursor-col-resize touch-none rounded-none px-0 max-[1180px]:hidden"
-                data-testid="canvas-work-panel-resizer"
-                size="icon"
-                variant="ghost"
-                onMouseDown={handleWorkspacePanelResizeStart}
-              >
-                <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border transition-colors hover:bg-primary" />
-              </Button>
-            </div>
-          )}
-
-          <main className="relative min-w-0 flex-1 overflow-hidden">
+          <main
+            className={cn(
+              "relative min-w-0 flex-1 overflow-hidden",
+              agentPanelIsOpen && "max-[1180px]:z-40",
+            )}
+          >
+            <CanvasComponentPanel getCreateNodeScreenPosition={getFlowViewportScreenCenter} />
+            {showPropertiesPanel && <CanvasNodePropertiesPanel />}
+            <CanvasToolbar />
             <CanvasFlow viewportRef={flowViewportRef} />
 
             {nodes.length === 0 && <CanvasEmptyState />}
@@ -175,11 +110,11 @@ export const CanvasInner = ({
               />
             )}
 
-            <CanvasStatusBar />
-
             {contextMenu && <CanvasContextMenu />}
 
             {connectionMenu && <ConnectionMenu />}
+
+            <CanvasEdgeInspector />
 
             {nodeContextMenu && <NodeContextMenu />}
 
@@ -190,41 +125,54 @@ export const CanvasInner = ({
         </div>
       </div>
 
+      <CanvasTopChrome />
+
       {agentPanelIsOpen ? (
         <div
-          className="pointer-events-none absolute bottom-0 right-0 top-14 z-40 flex w-[calc(100%_-_3.5rem)] justify-end min-[1181px]:static min-[1181px]:inset-y-0 min-[1181px]:z-auto min-[1181px]:w-auto min-[1181px]:shrink-0 min-[1181px]:self-stretch"
-          data-testid="canvas-agent-panel-region"
+          className={cn(
+            "pointer-events-none absolute bottom-0 right-0 top-16 z-40 flex justify-end min-[1181px]:static min-[1181px]:inset-y-0 min-[1181px]:z-auto min-[1181px]:h-full min-[1181px]:w-auto min-[1181px]:shrink-0 min-[1181px]:self-stretch",
+            showCanvasMiniSidebar ? "w-[calc(100%_-_3.5rem)] max-[480px]:!w-full" : "w-full",
+          )}
+          data-testid="canvas-agent-panel-region-wrapper"
         >
-          <ResizeHandle
-            ariaLabel={t("canvas.agentPanel.resize")}
-            max={MAX_AGENT_PANEL_WIDTH}
-            min={MIN_AGENT_PANEL_WIDTH}
-            side="right"
-            value={agentPanelWidth}
-            onCollapse={toggleAgentPanel}
-            onDelta={handleAgentPanelDelta}
-            onDragStart={() => {
-              const renderedWidth = agentPanelShellRef.current?.getBoundingClientRect().width ?? 0;
-              agentPanelResizeStartWidthRef.current = renderedWidth || agentPanelWidth;
-            }}
-          />
           <div
-            ref={agentPanelShellRef}
-            className="pointer-events-auto min-h-0 min-w-0 shrink overflow-hidden border-l border-border bg-surface"
-            data-testid="canvas-agent-panel-shell"
-            style={{ width: `${agentPanelWidth}px`, maxWidth: "calc(100% - 1px)" }}
+            className="pointer-events-none flex w-px shrink-0 justify-center min-[1181px]:h-full min-[1181px]:w-1.5"
+            data-testid="canvas-agent-panel-resize-gutter"
           >
-            <AgentPanel onGeneratedPipeline={onGeneratedPipeline} />
+            <ResizeHandle
+              ariaLabel={t("canvas.agentPanel.resize")}
+              line={false}
+              max={MAX_AGENT_PANEL_WIDTH}
+              min={MIN_AGENT_PANEL_WIDTH}
+              side="right"
+              value={agentPanelWidth}
+              onCollapse={handleToggleAgentPanel}
+              onDelta={handleAgentPanelDelta}
+              onDragStart={handleAgentPanelDragStart}
+            />
+          </div>
+          <div
+            className="pointer-events-none min-h-0 min-w-0 overflow-hidden max-[480px]:flex-1 min-[1181px]:h-full min-[1181px]:shrink-0 min-[1181px]:py-1.5 min-[1181px]:pr-1.5"
+            data-testid="canvas-agent-panel-region"
+          >
+            <div
+              ref={agentPanelShellRef}
+              className="pointer-events-auto h-full min-h-0 min-w-0 w-full shrink overflow-hidden rounded-2xl bg-surface shadow-float ring-1 ring-border-strong max-[480px]:!w-full"
+              data-testid="canvas-agent-panel-shell"
+              style={{ width: `${agentPanelWidth}px`, maxWidth: "100%" }}
+            >
+              <AgentPanel onGeneratedPipeline={handleGeneratedPipeline} />
+            </div>
           </div>
         </div>
       ) : (
         <button
           aria-label={t("canvas.agentPanel.reopen")}
-          className="absolute bottom-0 right-0 top-14 z-30 flex w-12 shrink-0 items-center justify-center border-l border-border bg-surface text-muted-foreground hover:bg-accent hover:text-foreground min-[1181px]:static min-[1181px]:inset-y-0 min-[1181px]:z-auto"
+          className="absolute bottom-0 right-0 top-16 z-30 flex w-12 shrink-0 items-center justify-center border-l border-border bg-surface text-muted-foreground hover:bg-accent hover:text-foreground min-[1181px]:static min-[1181px]:inset-y-0 min-[1181px]:z-auto"
           data-testid="canvas-agent-panel-reopen"
           title={t("canvas.agentPanel.reopen")}
           type="button"
-          onClick={toggleAgentPanel}
+          onClick={handleToggleAgentPanel}
         >
           <PanelRightOpen className="h-4 w-4" />
         </button>

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
@@ -95,7 +95,19 @@ const ClosedAgentPanelSetup = ({ children }: React.PropsWithChildren) => {
     initializedRef.current = true;
     store.setState((state) => ({
       agentPanel: { ...state.agentPanel, isOpen: false },
+      isSidebarOpen: true,
     }));
+  }
+
+  return children;
+};
+
+const SelectedNodeSetup = ({ children }: React.PropsWithChildren) => {
+  const store = useCanvasPageStore();
+  const initializedRef = useRef(false);
+  if (!initializedRef.current) {
+    initializedRef.current = true;
+    store.setState({ selectedNodeId: existingNode.id, sidebarPanel: "properties" });
   }
 
   return children;
@@ -118,6 +130,22 @@ const makeWrapper =
 const wrapper = makeWrapper();
 
 const wrapperWithNode = makeWrapper([existingNode]);
+
+const wrapperWithSelectedNode = ({ children }: React.PropsWithChildren) => (
+  <QueryClientProvider client={queryClient}>
+    <NotificationStoreContext.Provider value={notificationStore}>
+      <CanvasPageStoreProvider
+        pipeline={{ id: "pipe-1", name: "Pipeline", nodes: [existingNode], edges: [] }}
+      >
+        <ClosedAgentPanelSetup>
+          <SelectedNodeSetup>
+            <ReactFlowProvider>{children}</ReactFlowProvider>
+          </SelectedNodeSetup>
+        </ClosedAgentPanelSetup>
+      </CanvasPageStoreProvider>
+    </NotificationStoreContext.Provider>
+  </QueryClientProvider>
+);
 
 const wrapperWithoutPipeline = ({ children }: React.PropsWithChildren) => (
   <QueryClientProvider client={queryClient}>
@@ -144,42 +172,31 @@ describe("CanvasInner", () => {
     expect(screen.getByTestId("canvas-flow-viewport")).toBeInTheDocument();
   });
 
-  it("renders the workspace panel at the default width with a resize handle", () => {
-    render(<CanvasInner />, { wrapper });
+  it("supports the Alan workspace shell without replacing develop panel state", () => {
+    render(<CanvasInner showCanvasMiniSidebar={false} />, { wrapper: wrapperWithoutPipeline });
 
-    expect(screen.getByTestId("canvas-work-panel")).toHaveStyle({ width: "300px" });
-    expect(screen.getByTestId("canvas-work-panel-resizer")).toBeInTheDocument();
+    expect(screen.queryByTestId("canvas-mini-sidebar")).not.toBeInTheDocument();
+    expect(screen.getByTestId("canvas-component-panel")).toBeInTheDocument();
+    const canvasToolbar = screen.getByTestId("canvas-v2-toolbar");
+    expect(canvasToolbar).toHaveClass("absolute", "bottom-4", "right-4", "z-20");
+    expect(canvasToolbar.parentElement?.tagName).toBe("MAIN");
+    expect(
+      screen.getByRole("button", { name: /Collapse operations panel|收起操作面板/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-v2-state-legend-trigger").closest("main")).toBeNull();
+    expect(screen.queryByTestId("canvas-status-bar")).not.toBeInTheDocument();
   });
 
-  it("clamps the workspace panel width while dragging the resize handle", () => {
-    render(<CanvasInner />, { wrapper });
+  it("renders selected node properties as an Alan modal inside main", () => {
+    render(<CanvasInner />, { wrapper: wrapperWithSelectedNode });
 
-    const workPanel = screen.getByTestId("canvas-work-panel");
-    const resizeHandle = screen.getByTestId("canvas-work-panel-resizer");
-    const globalWindow = globalThis.window;
-    vi.spyOn(workPanel, "getBoundingClientRect").mockReturnValue({
-      x: 0,
-      y: 0,
-      width: 352,
-      height: 640,
-      top: 0,
-      right: 352,
-      bottom: 640,
-      left: 0,
-      toJSON: () => ({}),
-    });
+    const modal = screen.getByTestId("canvas-v2-node-config");
 
-    fireEvent.mouseDown(resizeHandle, { clientX: 352 });
-    fireEvent.mouseMove(globalWindow, { clientX: 120 });
-    expect(workPanel).toHaveStyle({ width: "288px" });
-
-    fireEvent.mouseMove(globalWindow, { clientX: 460 });
-    expect(workPanel).toHaveStyle({ width: "408px" });
-
-    fireEvent.mouseMove(globalWindow, { clientX: 700 });
-    expect(workPanel).toHaveStyle({ width: "560px" });
-
-    fireEvent.mouseUp(globalWindow);
+    expect(modal).toHaveClass("absolute", "inset-0", "z-40", "grid", "place-items-center", "p-6");
+    expect(screen.getByTestId("canvas-properties-panel")).toHaveClass("w-[440px]");
+    expect(modal.parentElement?.tagName).toBe("MAIN");
+    expect(screen.queryByTestId("canvas-work-panel")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("canvas-work-panel-resizer")).not.toBeInTheDocument();
   });
 
   it("opens the AgentPanel as a resizable right-hand sibling", async () => {
@@ -190,24 +207,61 @@ describe("CanvasInner", () => {
 
     await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
 
-    expect(screen.getByTestId("canvas-agent-panel-shell")).toHaveStyle({ width: "344px" });
-    expect(screen.getByTestId("resize-handle-right")).toBeInTheDocument();
+    const regionWrapper = screen.getByTestId("canvas-agent-panel-region-wrapper");
+    const resizeGutter = screen.getByTestId("canvas-agent-panel-resize-gutter");
+    const resizeHandle = screen.getByTestId("resize-handle-right");
+    const region = screen.getByTestId("canvas-agent-panel-region");
+    const shell = screen.getByTestId("canvas-agent-panel-shell");
+
+    expect(shell).toHaveStyle({ width: "344px" });
+    expect(shell).toHaveClass(
+      "h-full",
+      "w-full",
+      "overflow-hidden",
+      "rounded-2xl",
+      "bg-surface",
+      "shadow-float",
+      "ring-1",
+      "ring-border-strong",
+      "max-[480px]:!w-full",
+    );
+    expect(regionWrapper).toHaveClass(
+      "max-[480px]:!w-full",
+      "min-[1181px]:h-full",
+      "min-[1181px]:shrink-0",
+    );
+    expect(resizeGutter).toHaveClass("w-px", "min-[1181px]:h-full", "min-[1181px]:w-1.5");
+    expect(region).toHaveClass(
+      "max-[480px]:flex-1",
+      "min-[1181px]:h-full",
+      "min-[1181px]:shrink-0",
+      "min-[1181px]:py-1.5",
+      "min-[1181px]:pr-1.5",
+    );
+    expect(region).not.toHaveClass("bg-surface", "border", "shadow-float", "rounded-2xl");
+    expect(shell.parentElement).toBe(region);
+    expect(resizeGutter.nextElementSibling).toBe(region);
+    expect(resizeHandle.parentElement).toBe(resizeGutter);
+    expect(resizeHandle.querySelector(".bg-border")).toBeNull();
     expect(screen.getByTestId("canvas-agent-panel")).toBeInTheDocument();
   });
 
-  it("overlays the AgentPanel below the wide workspace breakpoint", async () => {
+  it("keeps the component library floating when the AgentPanel opens", async () => {
     const user = userEvent.setup();
     render(<CanvasInner />, { wrapper });
     await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
 
-    expect(screen.getByTestId("canvas-agent-panel-region")).toHaveClass(
+    expect(screen.getByTestId("canvas-agent-panel-region-wrapper")).toHaveClass(
       "absolute",
-      "top-14",
+      "top-16",
       "min-[1181px]:static",
     );
-    expect(screen.getByTestId("canvas-work-panel").parentElement).toHaveClass(
-      "max-[1180px]:absolute",
-      "max-[1180px]:left-0",
+    expect(screen.getByTestId("canvas-component-panel-root")).toHaveClass(
+      "absolute",
+      "left-3",
+      "top-16",
+      "z-10",
+      "max-[1180px]:hidden",
     );
   });
 
@@ -288,16 +342,14 @@ describe("CanvasInner", () => {
     expect(screen.getByTestId("canvas-agent-panel-shell")).toHaveStyle({ width: "344px" });
   });
 
-  it("toggles the AgentPanel from the canvas toolbar", async () => {
+  it("does not duplicate the Agent action in the canvas toolbar", async () => {
     const user = userEvent.setup();
     render(<CanvasInner />, { wrapper });
 
-    await user.click(screen.getByRole("button", { name: /^(AI Assistant|AI 助手)$/i }));
-
-    expect(screen.getByTestId("canvas-agent-panel-shell")).toBeInTheDocument();
-
-    await user.dblClick(screen.getByTestId("resize-handle-right"));
-
+    await user.click(screen.getByTestId("canvas-actions-menu"));
+    expect(
+      screen.queryByRole("menuitem", { name: /^(AI Assistant|AI 助手)$/i }),
+    ).not.toBeInTheDocument();
     expect(screen.getByTestId("canvas-agent-panel-reopen")).toBeInTheDocument();
   });
 
@@ -315,7 +367,9 @@ describe("CanvasInner", () => {
   it("shows the canvas empty state when there are no nodes", () => {
     render(<CanvasInner />, { wrapper });
 
-    expect(screen.getByText(/Start with a node|从一个节点开始/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /Start with a node|从一个节点开始/ }),
+    ).toBeInTheDocument();
   });
 
   it("hides the canvas empty state after nodes exist", () => {

--- a/packages/views/src/pages/CanvasPage/CanvasNodeCreationPalette/CanvasNodeCreationPalette.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasNodeCreationPalette/CanvasNodeCreationPalette.tsx
@@ -9,13 +9,13 @@ import {
   HardDrive,
   MessageSquareText,
   Search,
+  Plus,
   Zap,
   X,
 } from "lucide-react";
 import { useStore } from "zustand";
 import { Button } from "@repo/ui/button";
 import { Input } from "@repo/ui/input";
-import { cn } from "@repo/ui/lib/utils";
 import { SiGitHubIcon } from "../../../components/icons/SiGitHubIcon";
 import { ResourceName } from "../../../constants";
 import { useCanvasPageStore } from "../_store";
@@ -79,10 +79,10 @@ export const CanvasNodeCreationPalette = ({
   return (
     <div
       aria-label={t("canvas.quickAdd.title")}
-      className="absolute left-1/2 top-14 z-50 w-[min(28rem,calc(100vw-2rem))] -translate-x-1/2 rounded-lg border border-border bg-background shadow-lg"
+      className="absolute left-1/2 top-14 z-50 w-[min(28rem,calc(100vw-2rem))] -translate-x-1/2 rounded-2xl border border-border bg-surface p-2 shadow-float ring-1 ring-border"
       role="dialog"
     >
-      <div className="flex items-center gap-2 border-b px-3 py-2">
+      <div className="flex items-center gap-2 rounded-xl border-b border-border px-2 pb-2 pt-1">
         <Search className="size-4 shrink-0 text-muted-foreground" />
         <Input
           autoFocus
@@ -96,7 +96,7 @@ export const CanvasNodeCreationPalette = ({
         />
         <Button
           aria-label={t("canvas.quickAdd.close")}
-          className="size-7"
+          className="size-7 rounded-lg text-muted-foreground hover:bg-accent/60"
           size="icon"
           title={t("canvas.quickAdd.close")}
           variant="ghost"
@@ -107,10 +107,10 @@ export const CanvasNodeCreationPalette = ({
       </div>
 
       <div className="max-h-[calc(100vh-8rem)] overflow-y-auto overscroll-contain md:max-h-[22rem]">
-        <div className="space-y-3 p-2">
+        <div className="space-y-2.5 pt-2">
           {objectItems.length > 0 && (
             <section>
-              <div className="px-2 py-1 text-[11px] font-semibold uppercase text-muted-foreground">
+              <div className="px-2 pb-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
                 {t("canvas.quickAdd.objects")}
               </div>
               <div className="space-y-0.5">
@@ -124,21 +124,17 @@ export const CanvasNodeCreationPalette = ({
                   return (
                     <Button
                       key={type}
-                      className="flex h-auto w-full items-center justify-start gap-2 px-2 py-2 text-left text-sm font-normal"
+                      className="flex h-auto w-full items-center justify-start gap-2 rounded-lg px-2 py-1.5 text-left text-xs font-normal ring-1 ring-transparent transition-colors hover:bg-accent/60 hover:ring-border"
                       type="button"
                       variant="ghost"
                       onClick={() => handleCreateObjectNode(type, getCreateNodeScreenPosition())}
                     >
-                      <span
-                        className={cn(
-                          "flex size-6 shrink-0 items-center justify-center rounded",
-                          meta.iconBg,
-                        )}
-                      >
-                        <Icon className="size-3.5 text-white" />
+                      <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+                        <Icon className="size-3 text-foreground/70" />
                       </span>
                       <span className="min-w-0 flex-1 truncate font-medium">{label}</span>
-                      <span className="text-xs text-muted-foreground">{shortLabel}</span>
+                      <span className="text-[10px] text-muted-foreground">{shortLabel}</span>
+                      <Plus className="size-3 text-muted-foreground/50" />
                     </Button>
                   );
                 })}
@@ -148,27 +144,28 @@ export const CanvasNodeCreationPalette = ({
 
           {operationItems.length > 0 && (
             <section>
-              <div className="px-2 py-1 text-[11px] font-semibold uppercase text-muted-foreground">
+              <div className="px-2 pb-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
                 {t("canvas.quickAdd.operations")}
               </div>
               <div className="space-y-0.5">
                 {operationItems.map((operation) => (
                   <Button
                     key={operation.id}
-                    className="flex h-auto w-full items-center justify-start gap-2 px-2 py-2 text-left text-sm font-normal"
+                    className="flex h-auto w-full items-center justify-start gap-2 rounded-lg px-2 py-1.5 text-left text-xs font-normal ring-1 ring-transparent transition-colors hover:bg-accent/60 hover:ring-border"
                     type="button"
                     variant="ghost"
                     onClick={() =>
                       handleCreateOperationNode(operation, getCreateNodeScreenPosition())
                     }
                   >
-                    <span className="flex size-6 shrink-0 items-center justify-center rounded bg-violet-500">
-                      <Zap className="size-3.5 text-white" />
+                    <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+                      <Zap className="size-3 text-foreground/70" />
                     </span>
                     <span className="min-w-0 flex-1 truncate font-medium">{operation.name}</span>
-                    <span className="text-xs text-muted-foreground">
+                    <span className="text-[10px] text-muted-foreground">
                       {t("canvas.nodeTypes.operation.shortLabel")}
                     </span>
+                    <Plus className="size-3 text-muted-foreground/50" />
                   </Button>
                 ))}
               </div>
@@ -176,7 +173,7 @@ export const CanvasNodeCreationPalette = ({
           )}
 
           {!hasResults && (
-            <div className="px-2 py-8 text-center text-sm text-muted-foreground">
+            <div className="px-2 py-8 text-center text-xs text-muted-foreground">
               {t("canvas.quickAdd.noResults")}
             </div>
           )}

--- a/packages/views/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.tsx
@@ -1,13 +1,4 @@
-import {
-  ArrowLeft,
-  Box,
-  FileCode,
-  Folder,
-  FolderOutput,
-  HardDrive,
-  MessageSquareText,
-  Zap,
-} from "lucide-react";
+import { Settings2, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { useList } from "@refinedev/core";
@@ -26,11 +17,8 @@ import { Input } from "@repo/ui/input";
 import { Label } from "@repo/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui/select";
 import { Textarea } from "@repo/ui/textarea";
-import { cn } from "@repo/ui/lib/utils";
-import { SiGitHubIcon } from "../../../components/icons/SiGitHubIcon";
 import { ResourceName } from "../../../constants";
 import { selectSelectedNode, useCanvasPageStore } from "../_store";
-import { getNodeMeta } from "../utils/nodeTypeMeta";
 import { CanvasOperationPropertiesForm } from "./CanvasOperationPropertiesForm";
 import { ExcludedPathsField } from "./ExcludedPathsField";
 
@@ -77,33 +65,22 @@ export const CanvasNodePropertiesPanel = () => {
   const agents = agentsResult.data;
 
   if (!selectedNode) {
-    return (
-      <div className="flex h-full flex-col bg-background p-4">
-        <p className="text-sm text-muted-foreground">{t("canvas.propertiesPanel.empty")}</p>
-      </div>
-    );
+    return null;
   }
 
   const data = selectedNode.data;
-  const meta = getNodeMeta(selectedNode.type);
-  const Icon =
-    selectedNode.type === "file"
-      ? FileCode
-      : selectedNode.type === "folder"
-        ? Folder
-        : selectedNode.type === "github-project"
-          ? SiGitHubIcon
-          : selectedNode.type === "prompt"
-            ? MessageSquareText
-            : selectedNode.type === "operation"
-              ? Zap
-              : selectedNode.type === "output-project-path"
-                ? FolderOutput
-                : selectedNode.type === "output-local-path"
-                  ? HardDrive
-                  : Box;
   const handleUpdateNodeData = (patch: Record<string, unknown>) => {
     updateNodeData(selectedNode.id, patch);
+  };
+
+  const handleLabelChange = (value: string) => {
+    if (data.nodeType === "operation") {
+      handleOperationLabelChange(selectedNode.id, value);
+
+      return;
+    }
+
+    handleUpdateNodeData({ label: value });
   };
 
   const handleOperationUpdated = (operation: Operation) => {
@@ -222,177 +199,84 @@ export const CanvasNodePropertiesPanel = () => {
 
   return (
     <div
-      className="flex h-full min-h-0 flex-col bg-background"
-      data-testid="canvas-properties-panel"
+      className="absolute inset-0 z-40 grid place-items-center p-6"
+      data-testid="canvas-v2-node-config"
+      onClick={handleClearSelection}
     >
-      <div className="border-b p-4">
-        <Button
-          className="mb-3 h-8 gap-2 px-2 text-muted-foreground"
-          type="button"
-          variant="ghost"
-          onClick={handleClearSelection}
-        >
-          <ArrowLeft className="size-4" />
-          {t("canvas.propertiesPanel.backToComponents")}
-        </Button>
-        <div className="flex items-center gap-3">
-          <span
-            className={cn(
-              "flex size-9 items-center justify-center rounded-md",
-              meta?.iconBg ?? "bg-muted",
-            )}
-          >
-            <Icon className="size-4 text-white" />
-          </span>
-          <div className="min-w-0">
-            <p className="truncate text-sm font-semibold">{data.label}</p>
-            <p className="text-xs text-muted-foreground">{selectedNode.type}</p>
+      <div
+        className="absolute inset-0 bg-foreground/10 backdrop-blur-[1px]"
+        data-testid="node-config-backdrop"
+      />
+      <div
+        className="relative flex max-h-full w-[440px] max-w-[calc(100vw-3rem)] flex-col overflow-hidden rounded-2xl bg-surface shadow-float ring-1 ring-border-strong"
+        data-testid="canvas-properties-panel"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center gap-2.5 border-b border-border/70 px-4 py-3">
+          <div className="flex size-8 items-center justify-center rounded-lg bg-surface-2">
+            <Settings2 className="size-4 text-muted-foreground" />
           </div>
-        </div>
-      </div>
-
-      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
-        {renderTextField({
-          field: "label",
-          label: t("canvas.propertiesPanel.fields.label"),
-          value: String(data.label ?? ""),
-          onChangeValue:
-            data.nodeType === "operation"
-              ? (value) => handleOperationLabelChange(selectedNode.id, value)
-              : undefined,
-        })}
-
-        {data.nodeType === "file" && (
-          <>
-            {renderTextField({
-              field: "filePath",
-              label: t("canvas.propertiesPanel.fields.filePath"),
-              placeholder: t("canvas.propertiesPanel.placeholders.filePath"),
-              value: data.filePath,
-            })}
-            {renderTextField({
-              field: "language",
-              label: t("canvas.propertiesPanel.fields.language"),
-              placeholder: t("canvas.propertiesPanel.placeholders.language"),
-              value: data.language ?? "",
-            })}
-            {renderTextareaField({
-              field: "description",
-              label: t("canvas.propertiesPanel.fields.description"),
-              value: data.description ?? "",
-            })}
-          </>
-        )}
-
-        {data.nodeType === "folder" && (
-          <>
-            {renderTextField({
-              field: "folderPath",
-              label: t("canvas.propertiesPanel.fields.folderPath"),
-              placeholder: t("canvas.propertiesPanel.placeholders.folderPath"),
-              value: data.folderPath,
-            })}
-            <div className="space-y-1.5">
-              <Label className="text-xs font-medium text-muted-foreground">
-                {t("canvas.propertiesPanel.fields.disclosureMode")}
-              </Label>
-              <Select
-                value={data.disclosureMode ?? DISCLOSURE_MODE_ENUM.TREE}
-                onValueChange={(value) =>
-                  handleUpdateNodeData({ disclosureMode: value as DisclosureMode })
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {(Object.values(DISCLOSURE_MODE_ENUM) as DisclosureMode[]).map((mode) => (
-                    <SelectItem key={mode} value={mode}>
-                      {t(disclosureModeLabelKeys[mode])}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-1.5">
-              <Label
-                className="text-xs font-medium text-muted-foreground"
-                htmlFor={fieldId(selectedNode.id, "includedExtensions")}
-              >
-                {t("canvas.propertiesPanel.fields.includedExtensions")}
-              </Label>
-              <Input
-                className="h-8 text-sm"
-                id={fieldId(selectedNode.id, "includedExtensions")}
-                placeholder="ts,tsx,js,jsx"
-                value={(data.includedExtensions ?? []).join(",")}
-                onChange={(e) =>
-                  handleUpdateNodeData({
-                    includedExtensions: e.target.value
-                      .split(",")
-                      .map((s) => s.trim())
-                      .filter(Boolean),
-                  })
-                }
-              />
-            </div>
-            <ExcludedPathsField
-              excludedPaths={data.excludedPaths}
-              nodeId={selectedNode.id}
-              onAdd={handleNodeAddExcludedPath}
-              onRemove={handleNodeRemoveExcludedPath}
+          <div className="min-w-0 flex-1">
+            <input
+              className="-mx-1 w-full truncate rounded-md bg-transparent px-1 text-sm font-semibold hover:bg-surface-2 focus:bg-surface-2 focus:outline-none focus:ring-1 focus:ring-border-strong"
+              data-testid="node-config-label"
+              value={String(data.label ?? "")}
+              onChange={(event) => handleLabelChange(event.target.value)}
             />
-            {renderTextareaField({
-              field: "description",
-              label: t("canvas.propertiesPanel.fields.description"),
-              value: data.description ?? "",
-            })}
-          </>
-        )}
-
-        {data.nodeType === "github-project" && (
-          <>
-            <div className="space-y-1.5">
-              <Label className="text-xs font-medium text-muted-foreground">
-                {t("canvas.propertiesPanel.fields.sourceType")}
-              </Label>
-              <Select
-                value={data.sourceType ?? SOURCE_TYPE_ENUM.GITHUB}
-                onValueChange={(value) => handleUpdateNodeData({ sourceType: value as SourceType })}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {(Object.values(SOURCE_TYPE_ENUM) as SourceType[]).map((type) => (
-                    <SelectItem key={type} value={type}>
-                      {t(sourceTypeLabelKeys[type])}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+            <div className="px-1 text-[10.5px] text-muted-foreground">
+              {selectedNode.type} ·{" "}
+              {t("workspace.canvas.nodeConfig.editable", { defaultValue: "Editable" })}
             </div>
-            {renderTextField({
-              field: "owner",
-              label: t("canvas.propertiesPanel.fields.owner"),
-              value: data.owner,
-            })}
-            {renderTextField({
-              field: "repo",
-              label: t("canvas.propertiesPanel.fields.repository"),
-              value: data.repo,
-            })}
-            {renderTextField({
-              field: "branch",
-              label: t("canvas.propertiesPanel.fields.branch"),
-              value: data.branch ?? "",
-            })}
-            {renderTextField({
-              field: "localPath",
-              label: t("canvas.propertiesPanel.fields.localPath"),
-              value: data.localPath ?? "",
-            })}
-            {data.sourceType !== SOURCE_TYPE_ENUM.LOCAL && (
+          </div>
+          <Button
+            aria-label={t("workspace.canvas.nodeConfig.close", { defaultValue: "Close" })}
+            data-testid="node-config-close"
+            size="icon"
+            variant="ghost"
+            onClick={handleClearSelection}
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+
+        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-3">
+          {renderTextField({
+            field: "label",
+            label: t("canvas.propertiesPanel.fields.label"),
+            value: String(data.label ?? ""),
+            onChangeValue: handleLabelChange,
+          })}
+
+          {data.nodeType === "file" && (
+            <>
+              {renderTextField({
+                field: "filePath",
+                label: t("canvas.propertiesPanel.fields.filePath"),
+                placeholder: t("canvas.propertiesPanel.placeholders.filePath"),
+                value: data.filePath,
+              })}
+              {renderTextField({
+                field: "language",
+                label: t("canvas.propertiesPanel.fields.language"),
+                placeholder: t("canvas.propertiesPanel.placeholders.language"),
+                value: data.language ?? "",
+              })}
+              {renderTextareaField({
+                field: "description",
+                label: t("canvas.propertiesPanel.fields.description"),
+                value: data.description ?? "",
+              })}
+            </>
+          )}
+
+          {data.nodeType === "folder" && (
+            <>
+              {renderTextField({
+                field: "folderPath",
+                label: t("canvas.propertiesPanel.fields.folderPath"),
+                placeholder: t("canvas.propertiesPanel.placeholders.folderPath"),
+                value: data.folderPath,
+              })}
               <div className="space-y-1.5">
                 <Label className="text-xs font-medium text-muted-foreground">
                   {t("canvas.propertiesPanel.fields.disclosureMode")}
@@ -415,155 +299,267 @@ export const CanvasNodePropertiesPanel = () => {
                   </SelectContent>
                 </Select>
               </div>
-            )}
-            <ExcludedPathsField
-              excludedPaths={data.excludedPaths}
-              nodeId={selectedNode.id}
-              onAdd={handleNodeAddExcludedPath}
-              onRemove={handleNodeRemoveExcludedPath}
-            />
-            {renderTextareaField({
-              field: "description",
-              label: t("canvas.propertiesPanel.fields.description"),
-              value: data.description ?? "",
-            })}
-          </>
-        )}
-
-        {data.nodeType === "prompt" && (
-          <>
-            {renderTextareaField({
-              field: "prompt",
-              label: t("canvas.propertiesPanel.fields.prompt"),
-              value: data.prompt,
-            })}
-            {renderTextareaField({
-              field: "description",
-              label: t("canvas.propertiesPanel.fields.description"),
-              value: data.description ?? "",
-            })}
-          </>
-        )}
-
-        {data.nodeType === "operation" && (
-          <>
-            <div className="space-y-1.5">
-              <Label htmlFor={fieldId(selectedNode.id, "agentId")}>
-                {t("canvas.propertiesPanel.fields.agentId")}
-              </Label>
-              <Select
-                value={data.agentId ?? "__default__"}
-                onValueChange={(value) =>
-                  handleOperationAgentChange(
-                    selectedNode.id,
-                    value === "__default__" ? null : value,
-                  )
-                }
-              >
-                <SelectTrigger id={fieldId(selectedNode.id, "agentId")}>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__default__">{t("nodes.operation.defaultAgent")}</SelectItem>
-                  {agents.map((agent) => (
-                    <SelectItem key={agent.id} value={agent.id}>
-                      {agent.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            {renderIntegerField({
-              field: "maxLoopCount",
-              label: t("canvas.propertiesPanel.fields.maxLoopCount"),
-              max: 20,
-              min: 1,
-              value: data.maxLoopCount ?? 3,
-              handleValueChange: (value) => handleOperationMaxLoopChange(selectedNode.id, value),
-            })}
-            {renderTextareaField({
-              field: "loopConditionPrompt",
-              label: t("canvas.propertiesPanel.fields.loopCondition"),
-              value: data.loopConditionPrompt ?? "",
-            })}
-
-            <div className="border-t pt-4">
-              <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                {t("canvas.propertiesPanel.operationDefinition")}
-              </p>
-              <CanvasOperationPropertiesForm
-                operationId={data.operationId}
-                onOperationUpdated={handleOperationUpdated}
+              <div className="space-y-1.5">
+                <Label
+                  className="text-xs font-medium text-muted-foreground"
+                  htmlFor={fieldId(selectedNode.id, "includedExtensions")}
+                >
+                  {t("canvas.propertiesPanel.fields.includedExtensions")}
+                </Label>
+                <Input
+                  className="h-8 text-sm"
+                  id={fieldId(selectedNode.id, "includedExtensions")}
+                  placeholder="ts,tsx,js,jsx"
+                  value={(data.includedExtensions ?? []).join(",")}
+                  onChange={(e) =>
+                    handleUpdateNodeData({
+                      includedExtensions: e.target.value
+                        .split(",")
+                        .map((s) => s.trim())
+                        .filter(Boolean),
+                    })
+                  }
+                />
+              </div>
+              <ExcludedPathsField
+                excludedPaths={data.excludedPaths}
+                nodeId={selectedNode.id}
+                onAdd={handleNodeAddExcludedPath}
+                onRemove={handleNodeRemoveExcludedPath}
               />
-            </div>
-          </>
-        )}
+              {renderTextareaField({
+                field: "description",
+                label: t("canvas.propertiesPanel.fields.description"),
+                value: data.description ?? "",
+              })}
+            </>
+          )}
 
-        {data.nodeType === "output-project-path" && (
-          <>
-            {renderTextField({
-              field: "projectId",
-              label: t("canvas.propertiesPanel.fields.projectId"),
-              value: data.projectId ?? "",
-            })}
-            {renderTextField({
-              field: "path",
-              label: t("canvas.propertiesPanel.fields.outputPath"),
-              value: data.path,
-            })}
-            {renderTextareaField({
+          {data.nodeType === "github-project" && (
+            <>
+              <div className="space-y-1.5">
+                <Label className="text-xs font-medium text-muted-foreground">
+                  {t("canvas.propertiesPanel.fields.sourceType")}
+                </Label>
+                <Select
+                  value={data.sourceType ?? SOURCE_TYPE_ENUM.GITHUB}
+                  onValueChange={(value) =>
+                    handleUpdateNodeData({ sourceType: value as SourceType })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(Object.values(SOURCE_TYPE_ENUM) as SourceType[]).map((type) => (
+                      <SelectItem key={type} value={type}>
+                        {t(sourceTypeLabelKeys[type])}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {renderTextField({
+                field: "owner",
+                label: t("canvas.propertiesPanel.fields.owner"),
+                value: data.owner,
+              })}
+              {renderTextField({
+                field: "repo",
+                label: t("canvas.propertiesPanel.fields.repository"),
+                value: data.repo,
+              })}
+              {renderTextField({
+                field: "branch",
+                label: t("canvas.propertiesPanel.fields.branch"),
+                value: data.branch ?? "",
+              })}
+              {renderTextField({
+                field: "localPath",
+                label: t("canvas.propertiesPanel.fields.localPath"),
+                value: data.localPath ?? "",
+              })}
+              {data.sourceType !== SOURCE_TYPE_ENUM.LOCAL && (
+                <div className="space-y-1.5">
+                  <Label className="text-xs font-medium text-muted-foreground">
+                    {t("canvas.propertiesPanel.fields.disclosureMode")}
+                  </Label>
+                  <Select
+                    value={data.disclosureMode ?? DISCLOSURE_MODE_ENUM.TREE}
+                    onValueChange={(value) =>
+                      handleUpdateNodeData({ disclosureMode: value as DisclosureMode })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(Object.values(DISCLOSURE_MODE_ENUM) as DisclosureMode[]).map((mode) => (
+                        <SelectItem key={mode} value={mode}>
+                          {t(disclosureModeLabelKeys[mode])}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+              <ExcludedPathsField
+                excludedPaths={data.excludedPaths}
+                nodeId={selectedNode.id}
+                onAdd={handleNodeAddExcludedPath}
+                onRemove={handleNodeRemoveExcludedPath}
+              />
+              {renderTextareaField({
+                field: "description",
+                label: t("canvas.propertiesPanel.fields.description"),
+                value: data.description ?? "",
+              })}
+            </>
+          )}
+
+          {data.nodeType === "prompt" && (
+            <>
+              {renderTextareaField({
+                field: "prompt",
+                label: t("canvas.propertiesPanel.fields.prompt"),
+                value: data.prompt,
+              })}
+              {renderTextareaField({
+                field: "description",
+                label: t("canvas.propertiesPanel.fields.description"),
+                value: data.description ?? "",
+              })}
+            </>
+          )}
+
+          {data.nodeType === "operation" && (
+            <>
+              <div className="space-y-1.5">
+                <Label htmlFor={fieldId(selectedNode.id, "agentId")}>
+                  {t("canvas.propertiesPanel.fields.agentId")}
+                </Label>
+                <Select
+                  value={data.agentId ?? "__default__"}
+                  onValueChange={(value) =>
+                    handleOperationAgentChange(
+                      selectedNode.id,
+                      value === "__default__" ? null : value,
+                    )
+                  }
+                >
+                  <SelectTrigger id={fieldId(selectedNode.id, "agentId")}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__default__">{t("nodes.operation.defaultAgent")}</SelectItem>
+                    {agents.map((agent) => (
+                      <SelectItem key={agent.id} value={agent.id}>
+                        {agent.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {renderIntegerField({
+                field: "maxLoopCount",
+                label: t("canvas.propertiesPanel.fields.maxLoopCount"),
+                max: 20,
+                min: 1,
+                value: data.maxLoopCount ?? 3,
+                handleValueChange: (value) => handleOperationMaxLoopChange(selectedNode.id, value),
+              })}
+              {renderTextareaField({
+                field: "loopConditionPrompt",
+                label: t("canvas.propertiesPanel.fields.loopCondition"),
+                value: data.loopConditionPrompt ?? "",
+              })}
+
+              <div className="border-t pt-4">
+                <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  {t("canvas.propertiesPanel.operationDefinition")}
+                </p>
+                <CanvasOperationPropertiesForm
+                  operationId={data.operationId}
+                  onOperationUpdated={handleOperationUpdated}
+                />
+              </div>
+            </>
+          )}
+
+          {data.nodeType === "output-project-path" && (
+            <>
+              {renderTextField({
+                field: "projectId",
+                label: t("canvas.propertiesPanel.fields.projectId"),
+                value: data.projectId ?? "",
+              })}
+              {renderTextField({
+                field: "path",
+                label: t("canvas.propertiesPanel.fields.outputPath"),
+                value: data.path,
+              })}
+              {renderTextareaField({
+                field: "description",
+                label: t("canvas.propertiesPanel.fields.description"),
+                value: data.description ?? "",
+              })}
+            </>
+          )}
+
+          {data.nodeType === "output-local-path" && (
+            <>
+              {renderTextField({
+                field: "localPath",
+                label: t("canvas.propertiesPanel.fields.localPath"),
+                value: data.localPath,
+              })}
+              {renderTextField({
+                field: "outputFileName",
+                label: t("canvas.propertiesPanel.fields.outputFileName"),
+                value: data.outputFileName ?? "",
+              })}
+              <div className="space-y-1.5">
+                <Label>{t("canvas.propertiesPanel.fields.writeMode")}</Label>
+                <Select
+                  value={data.outputMode ?? "overwrite"}
+                  onValueChange={(value) =>
+                    handleUpdateNodeData({ outputMode: value as OutputMode })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Object.values(OUTPUT_MODE_ENUM).map((mode) => (
+                      <SelectItem key={mode} value={mode}>
+                        {t(outputModeLabelKeys[mode])}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {renderTextareaField({
+                field: "description",
+                label: t("canvas.propertiesPanel.fields.description"),
+                value: data.description ?? "",
+              })}
+            </>
+          )}
+
+          {data.nodeType === "compound" &&
+            renderTextareaField({
               field: "description",
               label: t("canvas.propertiesPanel.fields.description"),
               value: data.description ?? "",
             })}
-          </>
-        )}
+        </div>
 
-        {data.nodeType === "output-local-path" && (
-          <>
-            {renderTextField({
-              field: "localPath",
-              label: t("canvas.propertiesPanel.fields.localPath"),
-              value: data.localPath,
-            })}
-            {renderTextField({
-              field: "outputFileName",
-              label: t("canvas.propertiesPanel.fields.outputFileName"),
-              value: data.outputFileName ?? "",
-            })}
-            <div className="space-y-1.5">
-              <Label>{t("canvas.propertiesPanel.fields.writeMode")}</Label>
-              <Select
-                value={data.outputMode ?? "overwrite"}
-                onValueChange={(value) => handleUpdateNodeData({ outputMode: value as OutputMode })}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.values(OUTPUT_MODE_ENUM).map((mode) => (
-                    <SelectItem key={mode} value={mode}>
-                      {t(outputModeLabelKeys[mode])}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {renderTextareaField({
-              field: "description",
-              label: t("canvas.propertiesPanel.fields.description"),
-              value: data.description ?? "",
-            })}
-          </>
-        )}
-
-        {data.nodeType === "compound" &&
-          renderTextareaField({
-            field: "description",
-            label: t("canvas.propertiesPanel.fields.description"),
-            value: data.description ?? "",
-          })}
+        <div className="flex items-center gap-2 border-t border-border/70 px-4 py-3">
+          <Button className="flex-1" data-testid="node-config-done" onClick={handleClearSelection}>
+            {t("workspace.canvas.nodeConfig.done", { defaultValue: "Done" })}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/packages/views/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasNodePropertiesPanel/CanvasNodePropertiesPanel.unit.test.tsx
@@ -111,7 +111,26 @@ const renderPanel = (node: PipelineNode = fileNode) => {
 };
 
 describe("CanvasNodePropertiesPanel", () => {
-  it("edits selected file node data from the left panel", async () => {
+  it("renders the selected node in the Alan modal shell", () => {
+    renderPanel();
+
+    const modal = screen.getByTestId("canvas-v2-node-config");
+    const panel = screen.getByTestId("canvas-properties-panel");
+
+    expect(modal).toHaveClass("absolute", "inset-0", "z-40", "grid", "place-items-center", "p-6");
+    expect(panel).toHaveClass(
+      "relative",
+      "w-[440px]",
+      "max-w-[calc(100vw-3rem)]",
+      "rounded-2xl",
+      "bg-surface",
+    );
+    expect(screen.getByTestId("node-config-label")).toHaveValue("Source File");
+    expect(screen.getByTestId("node-config-close")).toBeInTheDocument();
+    expect(screen.getByTestId("node-config-done")).toBeInTheDocument();
+  });
+
+  it("edits the selected file node from the modal fields", async () => {
     const user = userEvent.setup();
     const store = renderPanel();
 
@@ -127,14 +146,39 @@ describe("CanvasNodePropertiesPanel", () => {
     );
   });
 
-  it("returns to the component panel from properties", async () => {
+  it("keeps the Alan header label editable through the current update action", async () => {
+    const user = userEvent.setup();
+    const store = renderPanel();
+    const labelInput = screen.getByTestId("node-config-label");
+
+    await user.clear(labelInput);
+    await user.type(labelInput, "Renamed Source");
+
+    expect(store.getState().nodes[0]?.data).toEqual(
+      expect.objectContaining({ label: "Renamed Source" }),
+    );
+  });
+
+  it("closes from the modal footer and clears the selected node", async () => {
     const user = userEvent.setup();
     const store = renderPanel();
 
-    await user.click(screen.getByRole("button", { name: /Back to components/i }));
+    await user.click(screen.getByTestId("node-config-done"));
 
     expect(store.getState().sidebarPanel).toBe("components");
     expect(store.getState().selectedNodeId).toBeNull();
+  });
+
+  it("closes from the header and backdrop", async () => {
+    const user = userEvent.setup();
+    const store = renderPanel();
+
+    await user.click(screen.getByTestId("node-config-close"));
+    expect(store.getState().selectedNodeId).toBeNull();
+
+    const backdropStore = renderPanel();
+    await user.click(screen.getByTestId("node-config-backdrop"));
+    expect(backdropStore.getState().selectedNodeId).toBeNull();
   });
 
   it("stores operation max loop count edits as a number", () => {

--- a/packages/views/src/pages/CanvasPage/CanvasPage.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasPage.tsx
@@ -11,10 +11,16 @@ interface CanvasPageProps {
   // Pipeline id to load, read from the route's search params by each app.
   id?: string;
   embedded?: boolean;
+  showCanvasMiniSidebar?: boolean;
   onGeneratedPipeline?: (pipelineId: string) => Promise<void> | void;
 }
 
-export const CanvasPage = ({ embedded = false, id, onGeneratedPipeline }: CanvasPageProps) => {
+export const CanvasPage = ({
+  embedded = false,
+  id,
+  onGeneratedPipeline: handleGeneratedPipeline,
+  showCanvasMiniSidebar = true,
+}: CanvasPageProps) => {
   const { result: pipelineResult, query: pipelineQuery } = useOne<PipelineData>({
     resource: ResourceName.pipelines,
     id: id ?? "",
@@ -34,7 +40,10 @@ export const CanvasPage = ({ embedded = false, id, onGeneratedPipeline }: Canvas
     <CanvasLayout embedded={embedded}>
       <CanvasPageStoreProvider pipeline={pipeline}>
         <RunStateRestorer />
-        <CanvasPageContent onGeneratedPipeline={onGeneratedPipeline} />
+        <CanvasPageContent
+          showCanvasMiniSidebar={showCanvasMiniSidebar}
+          onGeneratedPipeline={handleGeneratedPipeline}
+        />
       </CanvasPageStoreProvider>
     </CanvasLayout>
   );

--- a/packages/views/src/pages/CanvasPage/CanvasPageContent/CanvasPageContent.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasPageContent/CanvasPageContent.tsx
@@ -4,14 +4,19 @@ import "../canvas.css";
 import { CanvasInner } from "../CanvasInner";
 
 export const CanvasPageContent = ({
-  onGeneratedPipeline,
+  onGeneratedPipeline: handleGeneratedPipeline,
+  showCanvasMiniSidebar = true,
 }: {
   onGeneratedPipeline?: (pipelineId: string) => Promise<void> | void;
+  showCanvasMiniSidebar?: boolean;
 }) => {
   return (
     <div className="h-full w-full overflow-hidden">
       <ReactFlowProvider>
-        <CanvasInner onGeneratedPipeline={onGeneratedPipeline} />
+        <CanvasInner
+          showCanvasMiniSidebar={showCanvasMiniSidebar}
+          onGeneratedPipeline={handleGeneratedPipeline}
+        />
       </ReactFlowProvider>
     </div>
   );

--- a/packages/views/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasSettingsDrawer/CanvasSettingsDrawer.tsx
@@ -16,13 +16,7 @@ import { Link } from "@tanstack/react-router";
 import { Button } from "@repo/ui/button";
 import { Label } from "@repo/ui/label";
 import { Textarea } from "@repo/ui/textarea";
-import {
-  Sheet,
-  SheetClose,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "@repo/ui/sheet";
+import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle } from "@repo/ui/sheet";
 import { cn } from "@repo/ui/lib/utils";
 import { useCanvasPageStore, type CanvasSettingsState } from "../_store";
 
@@ -80,7 +74,7 @@ export const CanvasSettingsDrawer = () => {
   return (
     <Sheet open={isOpen} onOpenChange={handleOpenChange}>
       <SheetContent
-        className="w-[min(24rem,calc(100vw-1rem))] max-w-sm gap-0 border-l bg-surface/95 p-0 backdrop-blur"
+        className="drawer-in w-[min(24rem,calc(100vw-1rem))] max-w-sm gap-0 border-l bg-surface/95 p-0 backdrop-blur"
         showCloseButton={false}
         side="right"
       >

--- a/packages/views/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.stories.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.stories.tsx
@@ -52,7 +52,7 @@ const renderStatusBar = (
 
   return (
     <CanvasPageStoreContext.Provider value={store}>
-      <div className="relative h-24 w-full bg-slate-50">
+      <div className="relative flex h-24 w-full items-start justify-end bg-slate-50 p-3">
         <CanvasStatusBar />
       </div>
     </CanvasPageStoreContext.Provider>
@@ -67,7 +67,7 @@ const meta: Meta<typeof CanvasStatusBar> = {
     docs: {
       description: {
         component:
-          "Small canvas state readout pinned to the bottom of the canvas. It shows node count, edge count, current zoom, and the selected node label.",
+          "Alan-style state legend trigger with the current node, edge, zoom, and selection summary in the popover footer.",
       },
     },
   },
@@ -81,7 +81,7 @@ export const EmptyCanvas: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Empty-canvas state at the default 125% zoom.",
+        story: "Empty-canvas state at the default 125% zoom with no selected node.",
       },
     },
   },

--- a/packages/views/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.tsx
@@ -1,7 +1,43 @@
+import { CircleDashed } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
+import type { NodeRunStatus } from "@repo/schemas";
+import { Popover, PopoverContent, PopoverTrigger } from "@repo/ui/popover";
 import { useCanvasPageStore, selectSelectedNode } from "../_store";
 import { formatZoomPercent } from "../utils/canvasViewport";
+
+type LegendTone = "err" | "fg" | "neutral" | "ok" | "warn";
+
+const STATE_DEFS: ReadonlyArray<readonly [NodeRunStatus, LegendTone]> = [
+  ["idle", "neutral"],
+  ["queued", "neutral"],
+  ["running", "fg"],
+  ["retrying", "warn"],
+  ["waitingForUser", "warn"],
+  ["done", "ok"],
+  ["failed", "err"],
+  ["skipped", "neutral"],
+  ["cancelled", "neutral"],
+];
+
+const STATE_LABELS: Record<NodeRunStatus, string> = {
+  cancelled: "Cancelled",
+  done: "Done",
+  failed: "Failed",
+  idle: "Idle",
+  queued: "Queued",
+  retrying: "Retrying",
+  running: "Running",
+  skipped: "Skipped",
+  waitingForUser: "Waiting for user",
+};
+
+const TONE_CLASS: Record<Exclude<LegendTone, "neutral">, string> = {
+  err: "bg-destructive",
+  fg: "bg-foreground",
+  ok: "bg-success",
+  warn: "bg-warning",
+};
 
 export const CanvasStatusBar = () => {
   const { t } = useTranslation();
@@ -10,31 +46,68 @@ export const CanvasStatusBar = () => {
   const edges = useStore(store, (state) => state.edges);
   const viewportZoom = useStore(store, (state) => state.viewportZoom);
   const selectedNode = useStore(store, selectSelectedNode);
+  const getStateLabel = (status: NodeRunStatus) => {
+    const stateKey = `workspace.canvas.chrome.states.${status}`;
+    const translatedLabel = t(stateKey, { defaultValue: STATE_LABELS[status] });
+
+    return translatedLabel === stateKey ? STATE_LABELS[status] : translatedLabel;
+  };
 
   return (
-    <div className="pointer-events-none absolute bottom-3 left-1/2 z-20 -translate-x-1/2">
-      <div
-        className="flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-full bg-surface/90 px-3 py-1 text-xs text-muted-foreground shadow-pill ring-1 ring-border backdrop-blur-sm"
-        data-testid="canvas-status-bar"
+    <Popover>
+      <PopoverTrigger
+        className="pointer-events-auto flex items-center gap-1.5 rounded-full bg-surface px-3 py-1.5 text-xs text-foreground shadow-soft ring-1 ring-border transition-colors hover:ring-border-strong data-[popup-open]:bg-foreground data-[popup-open]:text-background max-[480px]:px-2"
+        data-testid="canvas-v2-state-legend-trigger"
       >
-        <span className="whitespace-nowrap">
-          {t("canvas.status.nodeCount", { count: nodes.length })}
+        <CircleDashed className="size-3.5" />
+        <span className="max-[480px]:sr-only">
+          {t("workspace.canvas.chrome.states.trigger", { defaultValue: "States" })}
         </span>
-        <span className="text-border">|</span>
-        <span className="whitespace-nowrap">
-          {t("canvas.status.edgeCount", { count: edges.length })}
-        </span>
-        <span className="text-border">|</span>
-        <span className="whitespace-nowrap">
-          {t("canvas.status.zoom", { zoom: formatZoomPercent(viewportZoom) })}
-        </span>
-        <span className="text-border">|</span>
-        <span className="max-w-56 truncate">
-          {selectedNode
-            ? t("canvas.status.selectedNode", { label: selectedNode.data.label })
-            : t("canvas.status.noSelection")}
-        </span>
-      </div>
-    </div>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-52 rounded-2xl p-2.5" sideOffset={8}>
+        <div
+          className="px-1 pb-1.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground"
+          data-testid="canvas-v2-state-legend"
+        >
+          {t("workspace.canvas.chrome.states.title", { defaultValue: "Node run states" })}
+        </div>
+        <div className="space-y-0.5">
+          {STATE_DEFS.map(([status, tone]) => (
+            <div key={status} className="flex items-center gap-2 rounded-lg px-1.5 py-1 text-xs">
+              <span className="relative inline-flex size-2 items-center justify-center">
+                {tone === "neutral" ? (
+                  <span className="size-2 rounded-full bg-surface shadow-[inset_0_0_0_1.5px_var(--color-muted-foreground)]" />
+                ) : (
+                  <span className={`size-2 rounded-full ${TONE_CLASS[tone]}`} />
+                )}
+              </span>
+              <span className="flex-1">{getStateLabel(status)}</span>
+              <span className="font-mono text-[9px] text-muted-foreground/70">{status}</span>
+            </div>
+          ))}
+        </div>
+        <div className="mt-2 border-t border-border px-1 pt-2" data-testid="canvas-status-bar">
+          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[10px] text-muted-foreground">
+            <span className="whitespace-nowrap">
+              {t("canvas.status.nodeCount", { count: nodes.length })}
+            </span>
+            <span className="text-border">|</span>
+            <span className="whitespace-nowrap">
+              {t("canvas.status.edgeCount", { count: edges.length })}
+            </span>
+            <span className="text-border">|</span>
+            <span className="whitespace-nowrap">
+              {t("canvas.status.zoom", { zoom: formatZoomPercent(viewportZoom) })}
+            </span>
+            <span className="text-border">|</span>
+            <span className="max-w-56 truncate">
+              {selectedNode
+                ? t("canvas.status.selectedNode", { label: selectedNode.data.label })
+                : t("canvas.status.noSelection")}
+            </span>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 };

--- a/packages/views/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasStatusBar/CanvasStatusBar.unit.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "../../../test/test-wrapper";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import type { PipelineEdge, PipelineNode } from "../_store/canvasSlice";
 import { createCanvasPageStore, CanvasPageStoreContext } from "../_store/canvasPageStore";
@@ -26,7 +27,8 @@ const edge = {
 } as PipelineEdge;
 
 describe("CanvasStatusBar", () => {
-  it("shows node count, edge count, zoom, and selected node label", () => {
+  it("opens Alan's complete state legend and keeps the current summary in its footer", async () => {
+    const user = userEvent.setup();
     const store = createCanvasPageStore([node], [edge]);
     store.setState({ selectedNodeId: "node-1", viewportZoom: 1.25 });
 
@@ -36,6 +38,30 @@ describe("CanvasStatusBar", () => {
       </CanvasPageStoreContext.Provider>,
     );
 
+    expect(screen.getByTestId("canvas-v2-state-legend-trigger")).toHaveClass(
+      "rounded-full",
+      "shadow-soft",
+      "ring-1",
+      "max-[480px]:px-2",
+    );
+    expect(screen.getByTestId("canvas-v2-state-legend-trigger").querySelector("span")).toHaveClass(
+      "max-[480px]:sr-only",
+    );
+    expect(screen.queryByTestId("canvas-status-bar")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("canvas-v2-state-legend-trigger"));
+
+    expect(screen.getByTestId("canvas-v2-state-legend")).toBeInTheDocument();
+    expect(screen.getByText(/Idle|空闲/)).toBeInTheDocument();
+    expect(screen.getByText(/Queued|排队中/)).toBeInTheDocument();
+    expect(screen.getByText(/Running|运行中/)).toBeInTheDocument();
+    expect(screen.getByText(/Retrying|重试中/)).toBeInTheDocument();
+    expect(screen.getByText(/Waiting for user|Awaiting you|等待确认/)).toBeInTheDocument();
+    expect(screen.getByText(/Done|完成/)).toBeInTheDocument();
+    expect(screen.getByText(/Failed|失败/)).toBeInTheDocument();
+    expect(screen.getByText(/Skipped|已跳过/)).toBeInTheDocument();
+    expect(screen.getByText(/Cancelled|已取消/)).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-status-bar")).toBeInTheDocument();
     expect(screen.getByText(/1 (nodes|个节点)/)).toBeInTheDocument();
     expect(screen.getByText(/1 (edges|条连线)/)).toBeInTheDocument();
     expect(screen.getByText(/(Zoom|缩放) 125%/)).toBeInTheDocument();

--- a/packages/views/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.tsx
@@ -1,29 +1,28 @@
 import { useStore } from "zustand";
-import { useList } from "@refinedev/core";
-import type { AgentRuntimeConfig } from "@repo/schemas";
-import { useCanvasPageStore } from "../_store";
 import {
-  ZoomIn,
-  ZoomOut,
-  Maximize2,
+  AlignLeft,
+  Hand,
+  Lock,
+  Minus,
+  MoreHorizontal,
+  MousePointer2,
+  Plus,
+  Redo2,
   Trash2,
   Undo2,
-  Redo2,
-  Play,
-  AlignLeft,
-  Plus,
-  Bot,
-  Lock,
   Unlock,
-  Hand,
-  MousePointer2,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@repo/ui/button";
-import { Separator } from "@repo/ui/separator";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@repo/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@repo/ui/dropdown-menu";
 import { cn } from "@repo/ui/lib/utils";
-import { ResourceName } from "../../../constants";
+import { useCanvasPageStore } from "../_store";
 
 export const CanvasToolbar = () => {
   const { t } = useTranslation();
@@ -35,287 +34,132 @@ export const CanvasToolbar = () => {
   const handleZoomIn = useStore(store, (state) => state.handleZoomIn);
   const handleZoomOut = useStore(store, (state) => state.handleZoomOut);
   const canvasTool = useStore(store, (state) => state.canvasTool);
+  const viewportZoom = useStore(store, (state) => state.viewportZoom);
   const setCanvasTool = useStore(store, (state) => state.setCanvasTool);
   const isCanvasInteractive = useStore(store, (state) => state.isCanvasInteractive);
   const handleToggleCanvasInteractive = useStore(
     store,
     (state) => state.handleToggleCanvasInteractive,
   );
-  const isQuickAddOpen = useStore(store, (state) => state.isQuickAddOpen);
   const handleToggleQuickAdd = useStore(store, (state) => state.handleToggleQuickAdd);
-  const pipelineId = useStore(store, (state) => state.pipelineId);
-  const isRunning = useStore(store, (state) => state.isRunning);
   const handleDeleteSelected = useStore(store, (state) => state.handleDeleteSelected);
   const handleUndo = useStore(store, (state) => state.handleUndo);
   const handleRedo = useStore(store, (state) => state.handleRedo);
   const handleFormatLayout = useStore(store, (state) => state.formatLayout);
-  const handleRunTest = useStore(store, (state) => state.handleRunTest);
-  const handleToggleAgentPanel = useStore(store, (state) => state.toggleAgentPanel);
-  const agentPanelIsOpen = useStore(store, (state) => state.agentPanel.isOpen);
-  const { result: runtimesResult, query: runtimesQuery } = useList<AgentRuntimeConfig>({
-    resource: ResourceName.agentRuntimes,
-  });
-  const runtimeConfigured =
-    !(runtimesQuery?.isLoading ?? false) && (runtimesResult?.data.length ?? 0) > 0;
   const interactivityActionLabel = isCanvasInteractive
     ? t("canvas.disableInteractivity")
     : t("canvas.enableInteractivity");
   const InteractivityIcon = isCanvasInteractive ? Unlock : Lock;
 
   return (
-    <div className="pointer-events-auto shrink-0 w-max max-w-full" data-testid="canvas-toolbar">
-      <div className="flex h-10 w-max items-center gap-0.5 rounded-md bg-surface px-1.5 py-1 shadow-soft ring-1 ring-border max-[420px]:gap-0 max-[420px]:px-1">
-        {/* Canvas tools */}
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                aria-label={t("canvas.selectTool")}
-                aria-pressed={canvasTool === "select"}
-                className={cn(
-                  "h-7 w-7",
-                  canvasTool === "select" ? "bg-accent text-foreground" : "text-muted-foreground",
-                )}
-                size="icon"
-                title={t("canvas.selectTool")}
-                variant="ghost"
-                onClick={() => setCanvasTool("select")}
-              />
-            }
-          >
-            <MousePointer2 className="h-4 w-4" />
-          </TooltipTrigger>
-          <TooltipContent>{t("canvas.selectTool")}</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                aria-label={t("canvas.handTool")}
-                aria-pressed={canvasTool === "hand"}
-                className={cn(
-                  "h-7 w-7",
-                  canvasTool === "hand" ? "bg-accent text-foreground" : "text-muted-foreground",
-                )}
-                size="icon"
-                title={t("canvas.handTool")}
-                variant="ghost"
-                onClick={() => setCanvasTool("hand")}
-              />
-            }
-          >
-            <Hand className="h-4 w-4" />
-          </TooltipTrigger>
-          <TooltipContent>{t("canvas.handTool")}</TooltipContent>
-        </Tooltip>
+    <div
+      className="pointer-events-auto absolute bottom-4 right-4 z-20 flex items-center gap-0.5 rounded-full bg-surface p-1 shadow-pill ring-1 ring-border"
+      data-testid="canvas-v2-toolbar"
+    >
+      <button
+        className={cn(
+          "rounded-full p-1.5 transition-colors",
+          canvasTool === "select"
+            ? "bg-accent text-foreground"
+            : "text-muted-foreground hover:bg-accent/60",
+        )}
+        data-testid="canvas-v2-tool-select"
+        aria-pressed={canvasTool === "select"}
+        title={t("canvas.selectTool")}
+        type="button"
+        onClick={() => setCanvasTool("select")}
+      >
+        <MousePointer2 className="size-3.5" />
+      </button>
+      <button
+        className={cn(
+          "rounded-full p-1.5 transition-colors",
+          canvasTool === "hand"
+            ? "bg-accent text-foreground"
+            : "text-muted-foreground hover:bg-accent/60",
+        )}
+        data-testid="canvas-v2-tool-hand"
+        aria-pressed={canvasTool === "hand"}
+        title={t("canvas.handTool")}
+        type="button"
+        onClick={() => setCanvasTool("hand")}
+      >
+        <Hand className="size-3.5" />
+      </button>
+      <div className="mx-0.5 h-4 w-px bg-border-strong" />
+      <button
+        className="rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+        data-testid="canvas-v2-zoom-out"
+        title={t("canvas.zoomOut")}
+        type="button"
+        onClick={handleZoomOut}
+      >
+        <Minus className="size-3.5" />
+      </button>
+      <button
+        aria-label={t("canvas.fitView")}
+        className="px-1 font-mono text-[11px] tabular-nums text-muted-foreground transition-colors hover:text-foreground"
+        data-testid="canvas-v2-zoom-reset"
+        title={t("canvas.fitView")}
+        type="button"
+        onClick={handleFitView}
+      >
+        {Math.round(viewportZoom * 100)}%
+      </button>
+      <button
+        className="rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+        data-testid="canvas-v2-zoom-in"
+        title={t("canvas.zoomIn")}
+        type="button"
+        onClick={handleZoomIn}
+      >
+        <Plus className="size-3.5" />
+      </button>
 
-        <Separator className="mx-1 h-7" orientation="vertical" />
-
-        {/* Zoom controls */}
-        <div className="contents max-[1180px]:hidden">
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  aria-label={t("canvas.zoomOut")}
-                  className="h-7 w-7"
-                  size="icon"
-                  title={t("canvas.zoomOut")}
-                  variant="ghost"
-                  onClick={handleZoomOut}
-                />
-              }
-            >
-              <ZoomOut className="h-4 w-4" />
-            </TooltipTrigger>
-            <TooltipContent>{t("canvas.zoomOut")}</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  aria-label={t("canvas.zoomIn")}
-                  className="h-7 w-7"
-                  size="icon"
-                  title={t("canvas.zoomIn")}
-                  variant="ghost"
-                  onClick={handleZoomIn}
-                />
-              }
-            >
-              <ZoomIn className="h-4 w-4" />
-            </TooltipTrigger>
-            <TooltipContent>{t("canvas.zoomIn")}</TooltipContent>
-          </Tooltip>
-        </div>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                aria-label={t("canvas.fitView")}
-                className="h-7 w-7"
-                size="icon"
-                title={t("canvas.fitView")}
-                variant="ghost"
-                onClick={handleFitView}
-              />
-            }
-          >
-            <Maximize2 className="h-4 w-4" />
-          </TooltipTrigger>
-          <TooltipContent>{t("canvas.fitView")}</TooltipContent>
-        </Tooltip>
-        <div className="contents max-[1180px]:hidden">
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  aria-label={interactivityActionLabel}
-                  aria-pressed={isCanvasInteractive}
-                  className="h-7 w-7"
-                  size="icon"
-                  title={interactivityActionLabel}
-                  variant="ghost"
-                  onClick={handleToggleCanvasInteractive}
-                />
-              }
-            >
-              <InteractivityIcon className="h-4 w-4" />
-            </TooltipTrigger>
-            <TooltipContent>{interactivityActionLabel}</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  aria-label={t("canvas.formatLayout")}
-                  className="h-7 w-7"
-                  size="icon"
-                  title={t("canvas.formatLayout")}
-                  variant="ghost"
-                  onClick={handleFormatLayout}
-                />
-              }
-            >
-              <AlignLeft className="h-4 w-4" />
-            </TooltipTrigger>
-            <TooltipContent>{t("canvas.formatLayout")}</TooltipContent>
-          </Tooltip>
-        </div>
-
-        <Separator className="mx-1 h-7" orientation="vertical" />
-
-        {/* History controls */}
-        <Button
-          className="h-7 w-7"
-          disabled={!canUndo}
-          size="icon"
-          title={t("canvas.undo")}
-          variant="ghost"
-          onClick={handleUndo}
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              aria-label={t("canvas.floatingMenu.menu")}
+              className="absolute bottom-0 right-[calc(100%+0.25rem)] size-8 rounded-full bg-surface shadow-pill ring-1 ring-border"
+              data-testid="canvas-actions-menu"
+              size="icon"
+              title={t("canvas.floatingMenu.menu")}
+              variant="ghost"
+            />
+          }
         >
-          <Undo2 className="h-4 w-4" />
-        </Button>
-        <Button
-          className="h-7 w-7"
-          disabled={!canRedo}
-          size="icon"
-          title={t("canvas.redo")}
-          variant="ghost"
-          onClick={handleRedo}
-        >
-          <Redo2 className="h-4 w-4" />
-        </Button>
-
-        <Separator className="mx-1 h-7" orientation="vertical" />
-
-        {/* Quick add */}
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                aria-label={t("canvas.quickAdd.open")}
-                aria-pressed={isQuickAddOpen}
-                className="h-7 w-7 text-primary hover:bg-primary/10"
-                size="icon"
-                title={t("canvas.quickAdd.open")}
-                variant="ghost"
-                onClick={handleToggleQuickAdd}
-              />
-            }
-          >
-            <Plus className="h-4 w-4" />
-          </TooltipTrigger>
-          <TooltipContent>{t("canvas.quickAdd.open")}</TooltipContent>
-        </Tooltip>
-
-        {/* AI Assistant */}
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                aria-label={t("canvas.agentPanel.toggle")}
-                aria-pressed={agentPanelIsOpen}
-                className="h-7 w-7 text-primary hover:bg-primary/10"
-                size="icon"
-                title={t("canvas.agentPanel.toggle")}
-                variant="ghost"
-                onClick={handleToggleAgentPanel}
-              />
-            }
-          >
-            <Bot className="h-4 w-4" />
-          </TooltipTrigger>
-          <TooltipContent>{t("canvas.agentPanel.toggle")}</TooltipContent>
-        </Tooltip>
-
-        <Separator className="mx-1 h-7" orientation="vertical" />
-
-        {/* Delete */}
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                aria-label={t("canvas.deleteNode")}
-                className="h-7 w-7 text-destructive hover:bg-destructive/10 disabled:text-muted-foreground/30"
-                disabled={!selectedNodeId}
-                size="icon"
-                title={t("canvas.deleteNode")}
-                variant="ghost"
-                onClick={handleDeleteSelected}
-              />
-            }
-          >
-            <Trash2 className="h-4 w-4" />
-          </TooltipTrigger>
-          <TooltipContent>{t("canvas.deleteNode")}</TooltipContent>
-        </Tooltip>
-
-        <Separator className="mx-1 h-7" orientation="vertical" />
-
-        {/* Run Test */}
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                aria-label={t("canvas.runTest")}
-                className="h-7 gap-1.5 px-2 text-xs text-emerald-600 hover:bg-emerald-500/10 hover:text-emerald-700 disabled:text-muted-foreground/30 dark:text-emerald-400 dark:hover:text-emerald-300 max-[420px]:w-7 max-[420px]:gap-0 max-[420px]:px-0"
-                disabled={isRunning || !pipelineId || !runtimeConfigured}
-                size="sm"
-                title={
-                  runtimeConfigured ? t("canvas.runTest") : t("pipelineAgentErrors.runtimeNotFound")
-                }
-                variant="ghost"
-                onClick={handleRunTest}
-              />
-            }
-          >
-            <Play className="h-3.5 w-3.5" />
-            <span className="max-[420px]:hidden">{t("canvas.run")}</span>
-          </TooltipTrigger>
-          <TooltipContent>{t("canvas.runTest")}</TooltipContent>
-        </Tooltip>
-      </div>
+          <MoreHorizontal className="size-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56" side="top" sideOffset={8}>
+          <DropdownMenuItem onClick={handleToggleCanvasInteractive}>
+            <InteractivityIcon className="size-4" />
+            {interactivityActionLabel}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={handleFormatLayout}>
+            <AlignLeft className="size-4" />
+            {t("canvas.formatLayout")}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem disabled={!canUndo} onClick={handleUndo}>
+            <Undo2 className="size-4" />
+            {t("canvas.undo")}
+          </DropdownMenuItem>
+          <DropdownMenuItem disabled={!canRedo} onClick={handleRedo}>
+            <Redo2 className="size-4" />
+            {t("canvas.redo")}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={handleToggleQuickAdd}>
+            <Plus className="size-4" />
+            {t("canvas.quickAdd.open")}
+          </DropdownMenuItem>
+          <DropdownMenuItem disabled={!selectedNodeId} onClick={handleDeleteSelected}>
+            <Trash2 className="size-4 text-destructive" />
+            {t("canvas.deleteNode")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 };

--- a/packages/views/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasToolbar/CanvasToolbar.unit.test.tsx
@@ -1,14 +1,11 @@
-import { canvasTestDataProvider, render } from "../../../test/test-wrapper";
+import { render } from "../../../test/test-wrapper";
 import i18n from "i18next";
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { CanvasToolbar } from "./CanvasToolbar";
 import { CanvasPageStoreProvider } from "../_store";
-import { toastStore } from "../../../store/toastStore";
 
-const mockTrpcUpdate = vi.fn();
-const mockTrpcRun = vi.fn();
 vi.mock("@repo/ui/button", () => ({
   Button: ({
     children,
@@ -29,44 +26,15 @@ vi.mock("@repo/ui/button", () => ({
     </button>
   ),
 }));
-vi.mock("@repo/ui/separator", () => ({
-  Separator: ({
-    orientation,
-    ...props
-  }: React.ComponentProps<"hr"> & { orientation?: "horizontal" | "vertical" }) => (
-    <hr data-orientation={orientation} {...props} />
-  ),
-}));
-vi.mock("@repo/ui/tooltip", () => ({
-  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
-  TooltipTrigger: ({
-    children,
-    render: renderProp,
-  }: {
-    children?: React.ReactNode;
-    render?: React.ReactElement;
-  }) => (
-    <>
-      {renderProp}
-      {children}
-    </>
-  ),
-  TooltipContent: ({ children }: React.PropsWithChildren) => (
-    <span data-testid="tooltip">{children}</span>
-  ),
-}));
 
 const wrapper = ({ children }: React.PropsWithChildren) => (
   <CanvasPageStoreProvider pipeline={null}>{children}</CanvasPageStoreProvider>
 );
 
-const wrapperWithPipeline = ({ children }: React.PropsWithChildren) => (
-  <CanvasPageStoreProvider
-    pipeline={{ id: "pipe-test", name: "Test Pipeline", nodes: [], edges: [] }}
-  >
-    {children}
-  </CanvasPageStoreProvider>
-);
+const openCanvasActions = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByTestId("canvas-actions-menu"));
+  await screen.findByRole("menu");
+};
 
 describe("CanvasToolbar - export removed", () => {
   it("does NOT render export tooltip/button in any locale", () => {
@@ -81,16 +49,24 @@ describe("CanvasToolbar - export removed", () => {
 });
 
 describe("CanvasToolbar - viewport controls", () => {
-  it("uses the same medium radius as the title input and full-height separators", () => {
+  it("uses the Alan-style pill for primary viewport controls", () => {
     render(<CanvasToolbar />, { wrapper });
 
-    const toolbarShell = screen.getByTestId("canvas-toolbar").firstElementChild;
-    expect(toolbarShell).toHaveClass("rounded-md");
-    expect(toolbarShell).not.toHaveClass("rounded-full");
-    expect(screen.getAllByRole("separator")).toHaveLength(5);
-    for (const separator of screen.getAllByRole("separator")) {
-      expect(separator).toHaveClass("h-7");
-    }
+    const toolbar = screen.getByTestId("canvas-v2-toolbar");
+    expect(toolbar).toHaveClass(
+      "absolute",
+      "bottom-4",
+      "right-4",
+      "z-20",
+      "gap-0.5",
+      "rounded-full",
+      "bg-surface",
+      "p-1",
+      "shadow-pill",
+      "ring-1",
+      "ring-border",
+    );
+    expect(toolbar.querySelector(".bg-border-strong")).toHaveClass("h-4", "w-px");
   });
 
   it("keeps zoom and fit view available through accessible custom controls", () => {
@@ -99,122 +75,7 @@ describe("CanvasToolbar - viewport controls", () => {
     expect(screen.getByRole("button", { name: i18n.t("canvas.zoomOut") })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: i18n.t("canvas.zoomIn") })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: i18n.t("canvas.fitView") })).toBeInTheDocument();
-  });
-});
-
-describe("CanvasToolbar - Run Test button", () => {
-  beforeEach(() => {
-    mockTrpcUpdate.mockReset();
-    mockTrpcUpdate.mockResolvedValue({ data: { id: "pipe-test" } });
-    mockTrpcRun.mockReset();
-    mockTrpcRun.mockResolvedValue({ data: { jobId: "job-123" } });
-    canvasTestDataProvider.update = mockTrpcUpdate;
-    canvasTestDataProvider.custom = mockTrpcRun;
-    canvasTestDataProvider.getList = vi.fn(async ({ resource }) => ({
-      data:
-        resource === "agentRuntimes"
-          ? [
-              {
-                id: "runtime-codex",
-                name: "Codex Local",
-                type: "codex",
-                connection: { mode: "local" },
-              },
-            ]
-          : [],
-      total: resource === "agentRuntimes" ? 1 : 0,
-    })) as never;
-    toastStore.setState({ toasts: [] });
-  });
-
-  it("renders the Run Test button", () => {
-    render(<CanvasToolbar />, { wrapper });
-    expect(screen.getByRole("button", { name: i18n.t("canvas.runTest") })).toBeInTheDocument();
-  });
-
-  it("Run Test button is disabled without pipelineId", () => {
-    render(<CanvasToolbar />, { wrapper });
-    expect(screen.getByRole("button", { name: i18n.t("canvas.runTest") })).toBeDisabled();
-  });
-
-  it("Run Test button is enabled when pipelineId and runtime exist", async () => {
-    render(<CanvasToolbar />, { wrapper: wrapperWithPipeline });
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: i18n.t("canvas.runTest") })).not.toBeDisabled(),
-    );
-  });
-
-  it("Run Test button stays disabled when no runtime is configured", async () => {
-    canvasTestDataProvider.getList = vi.fn(async () => ({ data: [], total: 0 })) as never;
-    render(<CanvasToolbar />, { wrapper: wrapperWithPipeline });
-
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: i18n.t("canvas.runTest") })).toBeDisabled(),
-    );
-  });
-
-  it("clicking Run saves pipeline then calls run API", async () => {
-    const user = userEvent.setup();
-    render(<CanvasToolbar />, { wrapper: wrapperWithPipeline });
-    const runButton = screen.getByRole("button", { name: i18n.t("canvas.runTest") });
-    await waitFor(() => expect(runButton).not.toBeDisabled());
-    await user.click(runButton);
-
-    await waitFor(() => {
-      expect(mockTrpcUpdate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: "pipe-test",
-        }),
-      );
-    });
-
-    await waitFor(() => {
-      expect(mockTrpcRun).toHaveBeenCalledWith(
-        expect.objectContaining({ payload: { id: "pipe-test" } }),
-      );
-    });
-  });
-
-  it("shows success toast after successful run", async () => {
-    const user = userEvent.setup();
-    render(<CanvasToolbar />, { wrapper: wrapperWithPipeline });
-    const runButton = screen.getByRole("button", { name: i18n.t("canvas.runTest") });
-    await waitFor(() => expect(runButton).not.toBeDisabled());
-    await user.click(runButton);
-    await waitFor(() => {
-      expect(toastStore.getState().toasts).toEqual(
-        expect.arrayContaining([expect.objectContaining({ type: "success" })]),
-      );
-    });
-  });
-
-  it("shows error toast when save fails", async () => {
-    mockTrpcUpdate.mockRejectedValue(new Error("save failed"));
-    const user = userEvent.setup();
-    render(<CanvasToolbar />, { wrapper: wrapperWithPipeline });
-    const runButton = screen.getByRole("button", { name: i18n.t("canvas.runTest") });
-    await waitFor(() => expect(runButton).not.toBeDisabled());
-    await user.click(runButton);
-    await waitFor(() => {
-      expect(toastStore.getState().toasts).toEqual(
-        expect.arrayContaining([expect.objectContaining({ type: "error" })]),
-      );
-    });
-    expect(mockTrpcRun).not.toHaveBeenCalled();
-  });
-
-  it("shows error toast when run API fails", async () => {
-    mockTrpcRun.mockRejectedValue(new Error("Internal Server Error"));
-    const user = userEvent.setup();
-    render(<CanvasToolbar />, { wrapper: wrapperWithPipeline });
-    const runButton = screen.getByRole("button", { name: i18n.t("canvas.runTest") });
-    await waitFor(() => expect(runButton).not.toBeDisabled());
-    await user.click(runButton);
-    await waitFor(() => {
-      expect(toastStore.getState().toasts).toEqual(
-        expect.arrayContaining([expect.objectContaining({ type: "error" })]),
-      );
-    });
+    expect(screen.getByTestId("canvas-v2-zoom-reset")).toHaveTextContent("125%");
   });
 });
 
@@ -238,15 +99,33 @@ describe("CanvasToolbar - interactive state", () => {
   it("toggles the custom canvas interactivity control", async () => {
     const user = userEvent.setup();
     render(<CanvasToolbar />, { wrapper });
+    await openCanvasActions(user);
+    await user.click(screen.getByRole("menuitem", { name: i18n.t("canvas.disableInteractivity") }));
+    await openCanvasActions(user);
+    expect(
+      screen.getByRole("menuitem", { name: i18n.t("canvas.enableInteractivity") }),
+    ).toBeInTheDocument();
+  });
 
-    const toggle = screen.getByRole("button", { name: i18n.t("canvas.disableInteractivity") });
-
-    expect(toggle).toHaveAttribute("aria-pressed", "true");
-
-    await user.click(toggle);
+  it("keeps develop actions in the overflow without duplicating Run or Agent", async () => {
+    const user = userEvent.setup();
+    render(<CanvasToolbar />, { wrapper });
+    await openCanvasActions(user);
 
     expect(
-      screen.getByRole("button", { name: i18n.t("canvas.enableInteractivity") }),
-    ).toHaveAttribute("aria-pressed", "false");
+      screen.getByRole("menuitem", { name: i18n.t("canvas.formatLayout") }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: i18n.t("canvas.undo") })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: i18n.t("canvas.redo") })).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: i18n.t("canvas.quickAdd.open") }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: i18n.t("canvas.deleteNode") })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: i18n.t("canvas.runTest") }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: i18n.t("canvas.agentPanel.toggle") }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/views/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.tsx
@@ -1,46 +1,129 @@
+import { useList } from "@refinedev/core";
+import { Bot, Loader2, Play, Save, Settings2, Workflow } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { CSSProperties } from "react";
 import { useStore } from "zustand";
-import { Input } from "@repo/ui/input";
-import { CanvasToolbar } from "../CanvasToolbar";
+import { cn } from "@repo/ui/lib/utils";
+import { ResourceName } from "../../../constants";
 import { useCanvasPageStore } from "../_store";
+import { CanvasStatusBar } from "../CanvasStatusBar";
+import { useCanvasWorkspacePersistence } from "../useCanvasWorkspacePersistence";
 
 export const CanvasTopChrome = () => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
+  const pipelineId = useStore(store, (state) => state.pipelineId);
   const pipelineName = useStore(store, (state) => state.pipelineName);
-  const isSidebarOpen = useStore(store, (state) => state.isSidebarOpen);
-  const workspacePanelWidth = useStore(store, (state) => state.workspacePanelWidth);
+  const isRunning = useStore(store, (state) => state.isRunning);
+  const isTestRunning = useStore(store, (state) => state.isTestRunning);
+  const agentPanelIsOpen = useStore(store, (state) => state.agentPanel.isOpen);
+  const agentPanelWidth = useStore(store, (state) => state.agentPanelWidth);
+  const handleOpenCanvasSettings = useStore(store, (state) => state.openCanvasSettings);
   const handlePipelineNameChange = useStore(store, (state) => state.handlePipelineNameChange);
+  const handleRunTest = useStore(store, (state) => state.handleRunTest);
+  const toggleAgentPanel = useStore(store, (state) => state.toggleAgentPanel);
+  const { result: runtimesResult } = useList({ resource: ResourceName.agentRuntimes });
+  const { handleSave: handleSaveCanvas, isPending: isSavePending } =
+    useCanvasWorkspacePersistence();
+
+  const hasAvailableRuntime = runtimesResult.data.length > 0;
+  const isRunPending = isRunning || isTestRunning;
+  const canRun = Boolean(pipelineId && hasAvailableRuntime && !isRunPending);
+  const pipelineTitleLabel = t("canvas.pipelineTitle", { defaultValue: "Pipeline name" });
+  const saveLabel = t("canvas.floatingMenu.save", { defaultValue: "Save" });
+  const settingsLabel = t("canvas.settingsDrawer.menuLabel", { defaultValue: "Settings" });
+  const runLabel = t("canvas.run", { defaultValue: "Run" });
+  const runningLabel = t("canvas.running", { defaultValue: "Running" });
+  const agentLabel = t("canvas.agent", { defaultValue: "Agent" });
 
   return (
     <div
-      className="flex h-14 min-w-0 shrink-0 items-center gap-3 border-b bg-background/95 px-3 py-2 backdrop-blur"
+      className="pointer-events-none absolute inset-x-0 top-0 z-20 flex items-start justify-between gap-2 p-3 min-[1181px]:pr-[calc(var(--canvas-agent-offset)+0.75rem)] max-[480px]:gap-1 max-[480px]:p-2 max-[480px]:pl-12"
+      data-canvas-v2-top-pill="true"
       data-testid="canvas-top-chrome"
+      style={
+        {
+          "--canvas-agent-offset": agentPanelIsOpen ? `${agentPanelWidth}px` : "0px",
+        } as CSSProperties
+      }
     >
-      <div
-        className="w-[var(--canvas-title-width)] min-w-0 shrink-0 max-[1180px]:w-40"
-        data-testid="canvas-title-desktop"
-        style={
-          {
-            "--canvas-title-width": isSidebarOpen ? `${workspacePanelWidth}px` : "min(18rem, 38%)",
-          } as CSSProperties
-        }
-      >
-        <div className="flex h-10 w-full min-w-0 items-center rounded-md bg-surface px-3 shadow-soft ring-1 ring-border">
-          <Input
-            aria-label={t("canvas.pipelineTitle")}
-            className="h-7 min-w-0 w-full border-none bg-transparent px-0 text-sm font-medium text-foreground shadow-none outline-none placeholder:text-muted-foreground focus-visible:ring-0"
-            name="pipelineName"
-            placeholder={t("canvas.pipelineTitlePlaceholder")}
-            value={pipelineName}
-            onChange={handlePipelineNameChange}
-          />
+      <div className="pointer-events-auto flex min-w-0 items-center gap-2 max-[480px]:gap-1">
+        <div
+          className="min-w-0 max-w-64 flex-1 max-[480px]:max-w-[7.5rem]"
+          data-testid="canvas-title-desktop"
+        >
+          <div
+            className="flex min-w-0 items-center gap-1 rounded-full bg-surface px-2.5 py-1.5 shadow-pill ring-1 ring-border max-[480px]:gap-0.5 max-[480px]:px-2 max-[480px]:py-1"
+            data-testid="canvas-top-left-pill"
+          >
+            <Workflow className="size-3.5 shrink-0 text-muted-foreground" />
+            <input
+              aria-label={pipelineTitleLabel}
+              className="min-w-0 flex-1 truncate bg-transparent px-1 py-0.5 text-xs font-semibold text-foreground outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-border-strong max-[480px]:w-16"
+              name="pipelineName"
+              placeholder={t("canvas.pipelineTitlePlaceholder", { defaultValue: "Pipeline name" })}
+              value={pipelineName}
+              onChange={handlePipelineNameChange}
+            />
+            <div className="flex shrink-0 items-center gap-0.5">
+              <button
+                aria-label={saveLabel}
+                className="flex size-7 items-center justify-center rounded-full p-0 text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-strong disabled:opacity-70"
+                data-testid="canvas-v2-save"
+                disabled={isSavePending}
+                type="button"
+                onClick={handleSaveCanvas}
+              >
+                <Save className="size-3.5" />
+              </button>
+              <button
+                aria-label={settingsLabel}
+                className="flex size-7 items-center justify-center rounded-full p-0 text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-strong"
+                data-testid="canvas-v2-settings"
+                type="button"
+                onClick={handleOpenCanvasSettings}
+              >
+                <Settings2 className="size-3.5" />
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
-      <div className="min-w-0 max-w-full flex-1 overflow-x-auto [scrollbar-width:none]">
-        <CanvasToolbar />
+      <div className="pointer-events-auto flex shrink-0 items-center gap-2 max-[480px]:gap-1">
+        <CanvasStatusBar />
+        <button
+          aria-label={isRunPending ? runningLabel : runLabel}
+          className={cn(
+            "flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs font-medium shadow-pill transition-all disabled:opacity-70 max-[480px]:px-2",
+            canRun
+              ? "bg-foreground text-background hover:opacity-90"
+              : "cursor-not-allowed bg-surface text-muted-foreground ring-1 ring-border",
+          )}
+          data-testid="canvas-v2-run"
+          disabled={!canRun}
+          type="button"
+          onClick={() => void handleRunTest()}
+        >
+          {isRunPending ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <Play className="size-3.5 fill-current" />
+          )}
+          <span className="max-[480px]:sr-only">{isRunPending ? runningLabel : runLabel}</span>
+        </button>
+        {!agentPanelIsOpen ? (
+          <button
+            aria-label={agentLabel}
+            className="flex items-center gap-1.5 rounded-full bg-surface px-3 py-1.5 text-xs text-foreground shadow-pill ring-1 ring-border transition-colors hover:ring-border-strong max-[480px]:px-2"
+            data-testid="canvas-v2-agent-reopen"
+            type="button"
+            onClick={toggleAgentPanel}
+          >
+            <Bot className="size-3.5" />
+            {agentLabel}
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/packages/views/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasTopChrome/CanvasTopChrome.unit.test.tsx
@@ -1,13 +1,21 @@
 import { render } from "../../../test/test-wrapper";
 import i18n from "i18next";
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type * as RefineCore from "@refinedev/core";
 import { describe, expect, it, vi } from "vitest";
 import { createCanvasPageStore, CanvasPageStoreContext } from "../_store";
 import { CanvasTopChrome } from "./CanvasTopChrome";
 
-vi.mock("../CanvasToolbar", () => ({
-  CanvasToolbar: () => <div data-testid="canvas-toolbar">Toolbar</div>,
+const handleSaveMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@refinedev/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof RefineCore>()),
+  useList: () => ({ result: { data: [{ id: "runtime-1" }] } }),
+}));
+
+vi.mock("../useCanvasWorkspacePersistence", () => ({
+  useCanvasWorkspacePersistence: () => ({ handleSave: handleSaveMock, isPending: false }),
 }));
 
 const renderTopChrome = () => {
@@ -23,24 +31,65 @@ const renderTopChrome = () => {
 };
 
 describe("CanvasTopChrome", () => {
-  it("renders the shell top bar with title and toolbar", () => {
+  it("renders the Alan-style top pill with the current title and actions", () => {
     renderTopChrome();
 
     expect(screen.getByTestId("canvas-top-chrome")).toHaveClass(
-      "border-b",
-      "bg-background/95",
-      "backdrop-blur",
+      "absolute",
+      "pointer-events-none",
+      "z-20",
+      "items-start",
+      "justify-between",
+      "gap-2",
+      "p-3",
+      "min-[1181px]:pr-[calc(var(--canvas-agent-offset)+0.75rem)]",
+      "max-[480px]:gap-1",
+      "max-[480px]:p-2",
+      "max-[480px]:pl-12",
     );
-    const toolbarSlot = screen.getByTestId("canvas-toolbar").parentElement;
-    expect(toolbarSlot).not.toBeNull();
-    expect(toolbarSlot as HTMLElement).toHaveClass("min-w-0", "max-w-full", "overflow-x-auto");
-    expect(screen.getByTestId("canvas-title-desktop")).toHaveClass("min-w-0", "shrink-0");
+    expect(screen.getByTestId("canvas-top-chrome")).toHaveStyle({
+      "--canvas-agent-offset": "344px",
+    });
+    expect(screen.getByTestId("canvas-title-desktop")).toHaveClass("min-w-0", "max-w-64", "flex-1");
     expect(screen.getByTestId("canvas-title-desktop").firstElementChild).toHaveClass(
       "min-w-0",
-      "shadow-soft",
+      "shadow-pill",
       "ring-1",
+      "rounded-full",
     );
-    expect(toolbarSlot as HTMLElement).toHaveClass("flex-1");
+    expect(screen.getByTestId("canvas-top-left-pill")).toContainElement(
+      screen.getByTestId("canvas-v2-save"),
+    );
+    expect(screen.getByTestId("canvas-top-left-pill")).toContainElement(
+      screen.getByTestId("canvas-v2-settings"),
+    );
+    expect(screen.getByRole("textbox", { name: i18n.t("canvas.pipelineTitle") })).toHaveClass(
+      "truncate",
+      "flex-1",
+      "max-[480px]:w-16",
+    );
+    const stateLegendTrigger = screen.getByTestId("canvas-v2-state-legend-trigger");
+    expect(stateLegendTrigger).toBeInTheDocument();
+    expect(stateLegendTrigger).toHaveClass("max-[480px]:px-2");
+    expect(screen.getByTestId("canvas-v2-run")).toHaveClass("max-[480px]:px-2");
+    expect(stateLegendTrigger.querySelector("span")).toHaveClass("max-[480px]:sr-only");
+    expect(screen.getByTestId("canvas-v2-run").querySelector("span")).toHaveClass(
+      "max-[480px]:sr-only",
+    );
+    expect(stateLegendTrigger.compareDocumentPosition(screen.getByTestId("canvas-v2-run"))).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(screen.getByRole("button", { name: /Save|保存/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Run|运行/i })).toBeDisabled();
+  });
+
+  it("saves through the current workspace persistence action", async () => {
+    const user = userEvent.setup();
+
+    renderTopChrome();
+    await user.click(screen.getByTestId("canvas-v2-save"));
+
+    expect(handleSaveMock).toHaveBeenCalledOnce();
   });
 
   it("preserves pipeline title editing", async () => {
@@ -54,5 +103,42 @@ describe("CanvasTopChrome", () => {
     await user.type(desktopTitleInput, "Aligned pipeline");
 
     expect(store.getState().pipelineName).toBe("Aligned pipeline");
+  });
+
+  it("wires settings and run to current store actions", async () => {
+    const user = userEvent.setup();
+    const handleRunTest = vi.fn(async () => {});
+    const store = renderTopChrome();
+
+    act(() => {
+      store.setState({ handleRunTest, pipelineId: "pipeline-1" });
+    });
+
+    await user.click(screen.getByRole("button", { name: /Settings|设置/i }));
+    expect(store.getState().isCanvasSettingsOpen).toBe(true);
+
+    const runButton = screen.getByRole("button", { name: /Run|运行/i });
+    expect(runButton).toBeEnabled();
+    await user.click(runButton);
+    expect(handleRunTest).toHaveBeenCalledOnce();
+
+    act(() => {
+      store.setState({ isRunning: true });
+    });
+    expect(screen.getByRole("button", { name: /Running|运行中/i })).toBeDisabled();
+  });
+
+  it("shows the agent reopen pill and uses the current toggle action", async () => {
+    const user = userEvent.setup();
+    const store = renderTopChrome();
+
+    act(() => {
+      store.getState().toggleAgentPanel();
+    });
+
+    const agentButton = screen.getByRole("button", { name: /Agent|智能体/i });
+    expect(agentButton).toBeInTheDocument();
+    await user.click(agentButton);
+    expect(store.getState().agentPanel.isOpen).toBe(true);
   });
 });

--- a/packages/views/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
+++ b/packages/views/src/pages/CanvasPage/CodeFileNode/CodeFileNode.tsx
@@ -5,7 +5,7 @@ import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
 import type { FileObjectNodeData } from "@repo/schemas";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodeCardActions } from "../NodeCard";
 import { FolderBrowserDialog } from "../../../components/FolderBrowserDialog/FolderBrowserDialog";
 
 export interface FileNodeProps {
@@ -19,6 +19,7 @@ const handleStopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
 export const FileNode = ({ id, data, selected }: FileNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
+  const nodeCardActions = useNodeCardActions(id);
   const {
     runStatus,
     dimmed,
@@ -77,8 +78,10 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
     <div className="group relative w-fit overflow-visible">
       <NodeCard
         rightHandle
+        actions={nodeCardActions}
         bodyClassName="space-y-2"
-        compact={nodeCardMode === "compact"}
+        compact={nodeCardMode === "compact" && !selected}
+        detail={data.language ?? t("canvas.nodeTypes.file.label")}
         description={t("canvas.nodeTypes.file.label")}
         dimmed={dimmed}
         icon={FileCode}
@@ -93,10 +96,10 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
         theme="orange"
         onLabelChange={handleLabelChange}
       >
-        <div className="flex items-center gap-1 rounded-md bg-surface-2 px-2 py-1 ring-1 ring-border">
+        <div className="flex items-center gap-1 rounded-md bg-surface-2 px-1.5 py-1 ring-1 ring-border">
           <input
             aria-label={t("nodes.codeFile.pathLabel")}
-            className="nodrag nopan min-w-0 flex-1 bg-transparent font-mono text-[11px] font-semibold text-foreground focus:outline-none"
+            className="nodrag nopan min-w-0 flex-1 truncate bg-transparent font-mono text-[9.5px] text-muted-foreground focus:outline-none focus:text-foreground"
             name={`${id}-filePath`}
             placeholder="src/file.tsx"
             value={data.filePath}
@@ -106,7 +109,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
             onMouseDown={handleStopPropagation}
           />
           <button
-            className="nodrag nopan shrink-0 rounded p-0.5 text-orange-500 transition-colors hover:bg-orange-500/10 hover:text-orange-700 dark:hover:text-orange-300"
+            className="nodrag nopan shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             title={t("nodes.codeFile.browseFile")}
             type="button"
             onClick={handleBrowseButtonClick}
@@ -116,7 +119,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
           </button>
           <input
             aria-label={t("nodes.codeFile.languageLabel")}
-            className="nodrag nopan w-12 shrink-0 rounded bg-orange-500/10 px-1 py-0.5 text-right font-mono text-[10px] font-medium text-orange-700 focus:outline-none focus:bg-orange-500/15 dark:text-orange-300"
+            className="nodrag nopan w-12 shrink-0 truncate rounded bg-surface-2 px-1 py-0.5 text-right font-mono text-[9.5px] text-muted-foreground focus:bg-muted focus:outline-none focus:text-foreground"
             name={`${id}-language`}
             placeholder="ts"
             value={data.language ?? ""}

--- a/packages/views/src/pages/CanvasPage/CompoundNode/CompoundNode.stories.tsx
+++ b/packages/views/src/pages/CanvasPage/CompoundNode/CompoundNode.stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof CompoundNode> = {
     docs: {
       description: {
         component:
-          "Compound node frame used to group related Canvas nodes. Docs stories check selected and child-count states.",
+          "Variable-size compound parent frame with Alan's neutral node surface, editable label, child count, and edge ports.",
       },
     },
   },
@@ -43,7 +43,7 @@ export const Default: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Group frame with two child nodes.",
+        story: "Neutral variable-size group frame with two child nodes.",
       },
     },
   },
@@ -56,7 +56,7 @@ export const Selected: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Selected group frame state.",
+        story: "Selected group frame with the neutral selection ring.",
       },
     },
   },

--- a/packages/views/src/pages/CanvasPage/CompoundNode/CompoundNode.tsx
+++ b/packages/views/src/pages/CanvasPage/CompoundNode/CompoundNode.tsx
@@ -1,9 +1,9 @@
-import { Handle, Position } from "@xyflow/react";
 import { Group } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@repo/ui/lib/utils";
 import { useStore } from "zustand";
 import { useCanvasPageStore } from "../_store";
+import { NodeCardPorts } from "../NodeCard/NodeCardPorts";
 import type { CompoundNodeData } from "@repo/schemas";
 
 export interface CompoundNodeProps {
@@ -31,31 +31,33 @@ export const CompoundNode = ({ id, data, selected }: CompoundNodeProps) => {
   return (
     <div
       className={cn(
-        "relative size-full min-h-30 min-w-50 rounded-xl border-2 border-dashed bg-indigo-50/30 transition-all duration-200",
-        selected ? "border-indigo-500 shadow-lg" : "border-indigo-300/60",
-        isHovered && "border-indigo-400 bg-indigo-50/50 shadow-md",
+        "relative size-full min-h-30 min-w-50 rounded-xl bg-surface/80 shadow-soft ring-1 ring-border transition-all duration-150",
+        selected
+          ? "shadow-float ring-2 ring-foreground/40"
+          : "hover:shadow-float hover:ring-border-strong",
+        isHovered && "shadow-float ring-2 ring-foreground/30",
       )}
+      data-testid="canvas-v2-node-shell-root"
     >
-      <Handle className="bg-indigo-400! w-3! h-3!" position={Position.Left} type="target" />
-
-      <div className="flex items-center gap-1.5 px-3 py-2">
-        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-indigo-100">
-          <Group className="h-3.5 w-3.5 text-indigo-600" />
+      <div className="flex items-center gap-2 border-b border-border/70 px-2.5 py-2">
+        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-surface-2">
+          <Group className="h-3.5 w-3.5 text-foreground/80" />
         </div>
-        <input
-          className="nodrag nopan bg-transparent text-xs font-semibold text-indigo-700 w-full focus:outline-none"
-          value={data.label}
-          onChange={handleLabelChange}
-          onMouseDown={handleMouseDown}
-        />
-        {data.childNodeIds.length > 0 && (
-          <span className="text-[10px] text-indigo-400 whitespace-nowrap">
+        <div className="min-w-0 flex-1">
+          <input
+            aria-label={t("canvas.nodeLabel")}
+            className="nodrag nopan w-full min-w-0 truncate border-0 bg-transparent p-0 text-[12px] font-semibold leading-tight text-foreground focus:outline-none"
+            value={data.label}
+            onChange={handleLabelChange}
+            onMouseDown={handleMouseDown}
+          />
+          <div className="truncate text-[10px] text-muted-foreground">
             {t("canvas.compoundNode.childCount", { count: data.childNodeIds.length })}
-          </span>
-        )}
+          </div>
+        </div>
       </div>
 
-      <Handle className="bg-indigo-400! w-3! h-3!" position={Position.Right} type="source" />
+      <NodeCardPorts leftHandle leftHandleCount={1} rightHandle rightHandleCount={1} />
     </div>
   );
 };

--- a/packages/views/src/pages/CanvasPage/CompoundNode/CompoundNode.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CompoundNode/CompoundNode.unit.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CompoundNode } from "./CompoundNode";
+
+const mocks = vi.hoisted(() => ({
+  hoveredCompoundId: null as string | null,
+  updateNodeData: vi.fn(),
+}));
+
+vi.mock("@xyflow/react", () => ({
+  Handle: ({
+    className,
+    id,
+    position,
+    style,
+    type,
+    "data-testid": _dataTestId,
+    ...rest
+  }: {
+    className?: string;
+    id?: string;
+    position?: string;
+    style?: React.CSSProperties;
+    type?: string;
+    [key: `data-${string}`]: string | undefined;
+  }) => (
+    <div
+      className={className}
+      data-handleid={id}
+      data-offset={style?.["--node-port-offset" as keyof React.CSSProperties]}
+      data-position={position}
+      data-testid={`${type}-handle`}
+      {...rest}
+    />
+  ),
+  Position: { Left: "left", Right: "right" },
+  useNodeId: vi.fn(() => "compound-1"),
+  useUpdateNodeInternals: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) => {
+      if (key === "canvas.compoundNode.childCount") {
+        return `${options?.count ?? 0} nodes`;
+      }
+
+      if (key === "canvas.nodeLabel") {
+        return "Node label";
+      }
+
+      return key;
+    },
+  }),
+}));
+
+vi.mock("zustand", () => ({
+  useStore: (_store: unknown, selector: (state: typeof mocks) => unknown) => selector(mocks),
+}));
+
+vi.mock("../_store", () => ({
+  useCanvasPageStore: () => ({ mocked: true }),
+}));
+
+const data = {
+  label: "Review Group",
+  nodeType: "compound" as const,
+  childNodeIds: ["source-file", "review-op"],
+};
+
+describe("CompoundNode", () => {
+  beforeEach(() => {
+    mocks.hoveredCompoundId = null;
+    mocks.updateNodeData.mockReset();
+  });
+
+  it("keeps the variable-size parent shell and renders neutral header and ports", () => {
+    const { container } = render(<CompoundNode data={data} id="compound-1" />);
+    const root = screen.getByTestId("canvas-v2-node-shell-root");
+
+    expect(root).toHaveClass("size-full", "min-h-30", "min-w-50", "bg-surface/80");
+    expect(root).toHaveClass("shadow-soft", "ring-1", "ring-border");
+    expect(screen.getByDisplayValue("Review Group")).toBeInTheDocument();
+    expect(screen.getByText("2 nodes")).toBeInTheDocument();
+    expect(screen.getByTestId("target-handle")).toHaveClass(
+      "before:h-3",
+      "before:w-3",
+      "before:border-border-strong",
+      "before:bg-surface",
+    );
+    expect(screen.getByTestId("source-handle")).toHaveClass(
+      "before:h-3",
+      "before:w-3",
+      "before:border-border-strong",
+      "before:bg-surface",
+    );
+    expect(container.querySelector(".border-indigo-500")).not.toBeInTheDocument();
+    expect(container.querySelector(".bg-red-50")).not.toBeInTheDocument();
+  });
+
+  it("preserves editable labels and selected or hovered visual states", () => {
+    const { rerender } = render(<CompoundNode data={data} id="compound-1" selected />);
+    const root = screen.getByTestId("canvas-v2-node-shell-root");
+
+    expect(root).toHaveClass("shadow-float", "ring-2", "ring-foreground/40");
+    fireEvent.change(screen.getByRole("textbox", { name: "Node label" }), {
+      target: { value: "Updated Group" },
+    });
+    expect(mocks.updateNodeData).toHaveBeenCalledWith("compound-1", { label: "Updated Group" });
+
+    mocks.hoveredCompoundId = "compound-1";
+    rerender(<CompoundNode data={data} id="compound-1" />);
+    expect(root).toHaveClass("shadow-float", "ring-2", "ring-foreground/30");
+  });
+});

--- a/packages/views/src/pages/CanvasPage/ConnectionMenu/ConnectionMenu.tsx
+++ b/packages/views/src/pages/CanvasPage/ConnectionMenu/ConnectionMenu.tsx
@@ -25,8 +25,7 @@ import { useList } from "@refinedev/core";
 import { ResourceName } from "../../../constants";
 import type { Operation, BuiltinNodeType } from "@repo/schemas";
 import { getAllowedConnections } from "../utils/getAllowedConnections";
-import { getNodeMeta, getNodeTypeLabel } from "../utils/nodeTypeMeta";
-import { cn } from "@repo/ui/lib/utils";
+import { getNodeTypeLabel } from "../utils/nodeTypeMeta";
 
 const TYPE_ICONS: Record<string, React.ElementType> = {
   operation: Zap,
@@ -90,7 +89,6 @@ export const ConnectionMenu = () => {
 
   if (!connectionMenu || !sourceNode || availableTypes.length === 0) return null;
 
-  const sourceMeta = getNodeMeta(sourceNode.type)!;
   const SourceIcon = TYPE_ICONS[sourceNode.type];
 
   // Clamp to viewport edges
@@ -119,20 +117,15 @@ export const ConnectionMenu = () => {
         align="start"
         alignOffset={0}
         anchor={virtualAnchor}
-        className="max-h-[80vh] min-w-50"
+        className="max-h-[80vh] min-w-50 rounded-2xl border border-border bg-surface p-2 shadow-float ring-1 ring-border"
         positionMethod="fixed"
         side="bottom"
         sideOffset={0}
       >
         {/* Header */}
-        <div className="flex items-center gap-1.5 border-b border-border px-1.5 py-1.5">
-          <span
-            className={cn(
-              "flex size-4 shrink-0 items-center justify-center rounded",
-              sourceMeta.iconBg,
-            )}
-          >
-            <SourceIcon className="size-2.5 text-white" />
+        <div className="mb-1 flex items-center gap-1.5 border-b border-border px-2 pb-2 pt-1">
+          <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+            <SourceIcon className="size-3 text-foreground/70" />
           </span>
           <span className="text-xs font-medium text-foreground">
             {getNodeTypeLabel(t, sourceNode.type)}
@@ -147,26 +140,23 @@ export const ConnectionMenu = () => {
           availableTypes.includes(t as BuiltinNodeType),
         ) && (
           <ContextMenuGroup>
-            <ContextMenuLabel>{t("canvas.contextMenu.processingObject")}</ContextMenuLabel>
+            <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+              {t("canvas.contextMenu.processingObject")}
+            </ContextMenuLabel>
             {["file", "folder", "github-project"]
               .filter((t) => availableTypes.includes(t as BuiltinNodeType))
               .map((type) => {
                 const Icon = TYPE_ICONS[type as BuiltinNodeType];
-                const typeMeta = getNodeMeta(type)!;
 
                 return (
                   <ContextMenuItem
                     key={type}
+                    className="rounded-lg px-2 py-1.5 text-xs"
                     closeOnClick={false}
                     onClick={() => handleConnectObjectNode(type as BuiltinNodeType)}
                   >
-                    <span
-                      className={cn(
-                        "flex size-4 shrink-0 items-center justify-center rounded",
-                        typeMeta.iconBg,
-                      )}
-                    >
-                      <Icon className="size-2.5 text-white" />
+                    <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+                      <Icon className="size-3 text-foreground/70" />
                     </span>
                     <span className="text-xs font-medium text-foreground">
                       {getNodeTypeLabel(t, type)}
@@ -181,17 +171,20 @@ export const ConnectionMenu = () => {
         {/* Operations */}
         {canAddOperation && availableOperations.length > 0 && (
           <>
-            <ContextMenuSeparator />
+            <ContextMenuSeparator className="my-1 bg-border/70" />
             <ContextMenuGroup>
-              <ContextMenuLabel>{t("canvas.contextMenu.operationNode")}</ContextMenuLabel>
+              <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                {t("canvas.contextMenu.operationNode")}
+              </ContextMenuLabel>
               {availableOperations.map((operation) => (
                 <ContextMenuItem
                   key={operation.id}
+                  className="rounded-lg px-2 py-1.5 text-xs"
                   closeOnClick={false}
                   onClick={() => handleSelectOperation(operation.id)}
                 >
-                  <span className="flex size-4 shrink-0 items-center justify-center rounded bg-violet-500">
-                    <Zap className="size-2.5 text-white" />
+                  <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+                    <Zap className="size-3 text-foreground/70" />
                   </span>
                   <span className="truncate text-xs font-medium text-foreground">
                     {operation.name}
@@ -206,10 +199,12 @@ export const ConnectionMenu = () => {
         {/* Empty state */}
         {canAddOperation && availableOperations.length === 0 && (
           <>
-            <ContextMenuSeparator />
+            <ContextMenuSeparator className="my-1 bg-border/70" />
             <ContextMenuGroup>
-              <ContextMenuLabel>{t("canvas.contextMenu.operationNode")}</ContextMenuLabel>
-              <p className="px-1.5 py-1 text-xs text-muted-foreground">
+              <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                {t("canvas.contextMenu.operationNode")}
+              </ContextMenuLabel>
+              <p className="px-2 py-1 text-xs text-muted-foreground">
                 {t("canvas.contextMenu.noOperationsForType")}
               </p>
             </ContextMenuGroup>
@@ -221,28 +216,25 @@ export const ConnectionMenu = () => {
           availableTypes.includes(t),
         ) && (
           <>
-            <ContextMenuSeparator />
+            <ContextMenuSeparator className="my-1 bg-border/70" />
             <ContextMenuGroup>
-              <ContextMenuLabel>{t("canvas.contextMenu.outputEndpoint")}</ContextMenuLabel>
+              <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                {t("canvas.contextMenu.outputEndpoint")}
+              </ContextMenuLabel>
               {(["output-project-path", "output-local-path"] as BuiltinNodeType[])
                 .filter((t) => availableTypes.includes(t))
                 .map((type) => {
                   const Icon = TYPE_ICONS[type];
-                  const typeMeta = getNodeMeta(type)!;
 
                   return (
                     <ContextMenuItem
                       key={type}
+                      className="rounded-lg px-2 py-1.5 text-xs"
                       closeOnClick={false}
                       onClick={() => handleConnectObjectNode(type)}
                     >
-                      <span
-                        className={cn(
-                          "flex size-4 shrink-0 items-center justify-center rounded",
-                          typeMeta.iconBg,
-                        )}
-                      >
-                        <Icon className="size-2.5 text-white" />
+                      <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+                        <Icon className="size-3 text-foreground/70" />
                       </span>
                       <span className="text-xs font-medium text-foreground">
                         {getNodeTypeLabel(t, type)}

--- a/packages/views/src/pages/CanvasPage/ErrorNode/ErrorNode.stories.tsx
+++ b/packages/views/src/pages/CanvasPage/ErrorNode/ErrorNode.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof ErrorNode> = {
     docs: {
       description: {
         component:
-          "Fallback node shown when the Canvas receives an unknown or unsupported node type.",
+          "Neutral Alan-style fallback card with destructive status detail for an unknown or unsupported node type.",
       },
     },
   },
@@ -37,7 +37,7 @@ export const Default: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Unknown-node fallback with type and id visible.",
+        story: "Unknown-node fallback with type, id, and failed status detail visible.",
       },
     },
   },
@@ -50,7 +50,7 @@ export const Selected: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Selected fallback node state.",
+        story: "Selected fallback card with the neutral selection ring.",
       },
     },
   },

--- a/packages/views/src/pages/CanvasPage/ErrorNode/ErrorNode.tsx
+++ b/packages/views/src/pages/CanvasPage/ErrorNode/ErrorNode.tsx
@@ -1,7 +1,6 @@
-import { Handle, Position } from "@xyflow/react";
 import { AlertTriangle } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { cn } from "@repo/ui/lib/utils";
+import { NodeCard } from "../NodeCard";
 
 export interface ErrorNodeProps {
   id: string;
@@ -12,29 +11,18 @@ export interface ErrorNodeProps {
 
 export const ErrorNode = ({ id, type, selected }: ErrorNodeProps) => {
   const { t } = useTranslation();
+  const detail = `type: ${type ?? "undefined"} | id: ${id}`;
 
   return (
-    <div
-      className={cn(
-        "min-w-50 rounded-lg border-2 bg-red-50 px-4 py-3 shadow-sm transition-all duration-200",
-        selected ? "border-red-500 shadow-md" : "border-red-300",
-      )}
-    >
-      <Handle className="bg-red-400! w-3! h-3!" position={Position.Left} type="target" />
-
-      <div className="flex items-center gap-2">
-        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-red-100">
-          <AlertTriangle className="h-4 w-4 text-red-600" />
-        </div>
-        <div className="flex flex-col min-w-0">
-          <span className="text-xs font-semibold text-red-700">{t("canvas.unknownNode")}</span>
-          <span className="text-[10px] text-red-400 truncate">
-            type: {type ?? "undefined"} | id: {id}
-          </span>
-        </div>
-      </div>
-
-      <Handle className="bg-red-400! w-3! h-3!" position={Position.Right} type="source" />
-    </div>
+    <NodeCard
+      detail={detail}
+      icon={AlertTriangle}
+      label={t("canvas.unknownNode")}
+      leftHandle
+      rightHandle
+      runStatus="failed"
+      selected={selected}
+      theme="indigo"
+    />
   );
 };

--- a/packages/views/src/pages/CanvasPage/ErrorNode/ErrorNode.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/ErrorNode/ErrorNode.unit.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ErrorNode } from "./ErrorNode";
+
+vi.mock("@xyflow/react", () => ({
+  Handle: ({
+    className,
+    id,
+    position,
+    style,
+    type,
+    "data-testid": _dataTestId,
+    ...rest
+  }: {
+    className?: string;
+    id?: string;
+    position?: string;
+    style?: React.CSSProperties;
+    type?: string;
+    [key: `data-${string}`]: string | undefined;
+  }) => (
+    <div
+      className={className}
+      data-handleid={id}
+      data-offset={style?.["--node-port-offset" as keyof React.CSSProperties]}
+      data-position={position}
+      data-testid={`${type}-handle`}
+      {...rest}
+    />
+  ),
+  Position: { Left: "left", Right: "right" },
+  useNodeId: vi.fn(() => "unknown-node"),
+  useUpdateNodeInternals: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => {
+      if (key === "canvas.unknownNode") {
+        return "Unknown node";
+      }
+
+      if (key === "workspace.canvas.nodes.status.failed") {
+        return "Failed";
+      }
+
+      return options?.defaultValue ?? key;
+    },
+  }),
+}));
+
+describe("ErrorNode", () => {
+  it("uses neutral card grammar with failed status and both connectivity ports", () => {
+    const { container } = render(
+      <ErrorNode data={{}} id="unknown-node" selected type="legacy-node" />,
+    );
+
+    expect(screen.getByText("Unknown node")).toBeInTheDocument();
+    expect(screen.getByText("type: legacy-node | id: unknown-node")).toBeInTheDocument();
+    expect(screen.getByTitle("Failed")).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="card"]')).toHaveClass(
+      "bg-surface",
+      "shadow-float",
+      "ring-2",
+      "ring-foreground/40",
+    );
+    expect(screen.getByTestId("target-handle")).toHaveClass(
+      "before:h-3",
+      "before:w-3",
+      "before:border-border-strong",
+      "before:bg-surface",
+    );
+    expect(screen.getByTestId("source-handle")).toHaveClass(
+      "before:h-3",
+      "before:w-3",
+      "before:border-border-strong",
+      "before:bg-surface",
+    );
+    expect(container.querySelector(".bg-red-50")).not.toBeInTheDocument();
+  });
+
+  it("keeps undefined type visible in fallback detail", () => {
+    render(<ErrorNode data={{}} id="missing-type" />);
+
+    expect(screen.getByText("type: undefined | id: missing-type")).toBeInTheDocument();
+  });
+});

--- a/packages/views/src/pages/CanvasPage/FileNode/FileNode.tsx
+++ b/packages/views/src/pages/CanvasPage/FileNode/FileNode.tsx
@@ -5,7 +5,7 @@ import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
 import type { FileObjectNodeData } from "@repo/schemas";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodeCardActions } from "../NodeCard";
 import { FolderBrowserDialog } from "../../../components/FolderBrowserDialog/FolderBrowserDialog";
 
 export interface FileNodeProps {
@@ -19,6 +19,7 @@ const handleStopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
 export const FileNode = ({ id, data, selected }: FileNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
+  const nodeCardActions = useNodeCardActions(id);
   const {
     runStatus,
     dimmed,
@@ -73,8 +74,10 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
     <div className="group relative w-fit overflow-visible">
       <NodeCard
         rightHandle
+        actions={nodeCardActions}
         bodyClassName="space-y-2"
         compact={nodeCardMode === "compact"}
+        detail={data.language ?? t("canvas.nodeTypes.file.label")}
         description={t("canvas.nodeTypes.file.label")}
         dimmed={dimmed}
         icon={FileCode}
@@ -85,10 +88,10 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
         theme="orange"
         onLabelChange={handleLabelChange}
       >
-        <div className="flex items-center gap-1 rounded-md bg-surface-2 px-2 py-1 ring-1 ring-border">
+        <div className="flex items-center gap-1 rounded-md bg-surface-2 px-1.5 py-1 ring-1 ring-border">
           <input
             aria-label={t("nodes.codeFile.pathLabel")}
-            className="nodrag nopan min-w-0 flex-1 bg-transparent font-mono text-[11px] font-semibold text-foreground focus:outline-none"
+            className="nodrag nopan min-w-0 flex-1 truncate bg-transparent font-mono text-[9.5px] text-muted-foreground focus:outline-none focus:text-foreground"
             name={`${id}-filePath`}
             placeholder="src/file.tsx"
             value={data.filePath}
@@ -98,7 +101,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
             onMouseDown={handleStopPropagation}
           />
           <button
-            className="nodrag nopan shrink-0 rounded p-0.5 text-orange-500 transition-colors hover:bg-orange-500/10 hover:text-orange-700 dark:hover:text-orange-300"
+            className="nodrag nopan shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             title={t("nodes.codeFile.browseFile")}
             type="button"
             onClick={handleBrowseButtonClick}
@@ -108,7 +111,7 @@ export const FileNode = ({ id, data, selected }: FileNodeProps) => {
           </button>
           <input
             aria-label={t("nodes.codeFile.languageLabel")}
-            className="nodrag nopan w-12 shrink-0 rounded bg-orange-500/10 px-1 py-0.5 text-right font-mono text-[10px] font-medium text-orange-700 focus:outline-none focus:bg-orange-500/15 dark:text-orange-300"
+            className="nodrag nopan w-12 shrink-0 truncate rounded bg-surface-2 px-1 py-0.5 text-right font-mono text-[9.5px] text-muted-foreground focus:bg-muted focus:outline-none focus:text-foreground"
             name={`${id}-language`}
             placeholder="ts"
             value={data.language ?? ""}

--- a/packages/views/src/pages/CanvasPage/FolderNode/FolderNode.tsx
+++ b/packages/views/src/pages/CanvasPage/FolderNode/FolderNode.tsx
@@ -5,7 +5,7 @@ import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
 import type { FolderObjectNodeData } from "@repo/schemas";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodeCardActions } from "../NodeCard";
 import { FolderBrowserDialog } from "../../../components/FolderBrowserDialog/FolderBrowserDialog";
 import { FolderTreePreview } from "./FolderTreePreview";
 import { Input } from "@repo/ui/input";
@@ -23,6 +23,7 @@ const handleStopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
 export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
+  const nodeCardActions = useNodeCardActions(id);
   const {
     runStatus,
     dimmed,
@@ -81,8 +82,10 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
     <div className="group relative w-fit overflow-visible">
       <NodeCard
         rightHandle
+        actions={nodeCardActions}
         bodyClassName="space-y-2"
         compact={nodeCardMode === "compact"}
+        detail={data.disclosureMode ?? t("canvas.nodeTypes.folder.label")}
         description={t("canvas.nodeTypes.folder.label")}
         dimmed={dimmed}
         icon={Folder}
@@ -97,9 +100,9 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
         theme="orange"
         onLabelChange={handleLabelChange}
       >
-        <div className="flex items-center gap-1 rounded-md bg-surface-2 px-2 py-1 ring-1 ring-border">
+        <div className="flex items-center gap-1 rounded-md bg-surface-2 px-1.5 py-1 ring-1 ring-border">
           <Input
-            className="nodrag nopan h-auto min-w-0 flex-1 border-none bg-transparent p-0 font-mono text-[11px] font-semibold text-foreground shadow-none focus:outline-none"
+            className="nodrag nopan h-auto min-w-0 flex-1 truncate border-none bg-transparent p-0 font-mono text-[9.5px] text-muted-foreground shadow-none focus:outline-none focus:text-foreground"
             placeholder="src/components/"
             value={data.folderPath}
             onChange={handleFolderPathInputChange}
@@ -108,7 +111,7 @@ export const FolderNode = ({ id, data, selected }: FolderNodeProps) => {
             onMouseDown={handleStopPropagation}
           />
           <Button
-            className="nodrag nopan h-auto shrink-0 rounded p-0.5 text-orange-500 transition-colors hover:bg-orange-500/10 hover:text-orange-700 dark:hover:text-orange-300"
+            className="nodrag nopan h-auto shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             title={t("canvas.browseFolder")}
             type="button"
             variant="ghost"

--- a/packages/views/src/pages/CanvasPage/FolderNode/FolderTreePreview.tsx
+++ b/packages/views/src/pages/CanvasPage/FolderNode/FolderTreePreview.tsx
@@ -58,7 +58,7 @@ export const FolderTreePreview = ({
             data-excluded={isExcluded}
           >
             {entry.type === "directory" ? (
-              <Folder className="h-3 w-3 shrink-0 text-orange-400" />
+              <Folder className="h-3 w-3 shrink-0 text-muted-foreground" />
             ) : (
               <File className="h-3 w-3 shrink-0 text-muted-foreground" />
             )}

--- a/packages/views/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx
+++ b/packages/views/src/pages/CanvasPage/GitHubProjectNode/GitHubProjectNode.tsx
@@ -5,7 +5,7 @@ import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
 import type { GithubProjectObjectNodeData } from "@repo/schemas";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodeCardActions } from "../NodeCard";
 import { FolderTreePreview } from "../FolderNode/FolderTreePreview";
 import { SiGitHubIcon } from "../../../components/icons/SiGitHubIcon";
 import { GitHubConnectDialog, type ConnectedRepoInfo } from "./GitHubConnectDialog";
@@ -26,6 +26,7 @@ const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
 export const GitHubProjectNode = ({ id, data, selected }: GitHubProjectNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
+  const nodeCardActions = useNodeCardActions(id);
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
   const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const [pickOpen, setPickOpen] = useState(false);
@@ -84,8 +85,10 @@ export const GitHubProjectNode = ({ id, data, selected }: GitHubProjectNodeProps
     <div className="group relative w-fit overflow-visible">
       <NodeCard
         rightHandle
+        actions={nodeCardActions}
         bodyClassName="space-y-2"
         compact={nodeCardMode === "compact"}
+        detail={data.sourceType ?? t("canvas.nodeTypes.github-project.label")}
         description={t("canvas.nodeTypes.github-project.label")}
         dimmed={dimmed}
         icon={SiGitHubIcon}
@@ -105,34 +108,34 @@ export const GitHubProjectNode = ({ id, data, selected }: GitHubProjectNodeProps
           isLocal ? (
             /* Local folder connected */
             <div
-              className="flex cursor-pointer items-center gap-1.5 rounded-md bg-surface-2 px-2.5 py-1.5 ring-1 ring-border transition-colors hover:bg-orange-500/10 hover:ring-orange-500/25"
+              className="flex cursor-pointer items-center gap-1.5 rounded-md bg-surface-2 px-1.5 py-1 ring-1 ring-border transition-colors hover:bg-muted hover:ring-border-strong"
               title={t("canvas.clickToSwitchLocalFolder")}
               onClick={handleLocalFolderOpen}
               onMouseDown={handleMouseDown}
             >
-              <FolderOpen className="h-3 w-3 shrink-0 text-orange-500" />
-              <span className="min-w-0 flex-1 truncate font-mono text-[11px] font-semibold text-foreground">
+              <FolderOpen className="h-3 w-3 shrink-0 text-muted-foreground" />
+              <span className="min-w-0 flex-1 truncate font-mono text-[9.5px] text-muted-foreground">
                 {data.localPath}
               </span>
             </div>
           ) : (
             /* GitHub repo connected */
             <div
-              className="flex cursor-pointer items-center gap-1.5 rounded-md bg-surface-2 px-2.5 py-1.5 ring-1 ring-border transition-colors hover:bg-orange-500/10 hover:ring-orange-500/25"
+              className="flex cursor-pointer items-center gap-1.5 rounded-md bg-surface-2 px-1.5 py-1 ring-1 ring-border transition-colors hover:bg-muted hover:ring-border-strong"
               title={t("canvas.clickToSwitchRepo")}
               onClick={handlePickOpen}
               onMouseDown={handleMouseDown}
             >
               {data.isPrivate ? (
-                <Lock className="h-3 w-3 shrink-0 text-orange-500" />
+                <Lock className="h-3 w-3 shrink-0 text-muted-foreground" />
               ) : (
                 <Globe className="h-3 w-3 shrink-0 text-muted-foreground" />
               )}
-              <span className="min-w-0 flex-1 truncate font-mono text-[11px] font-semibold text-foreground">
+              <span className="min-w-0 flex-1 truncate font-mono text-[9.5px] text-muted-foreground">
                 {data.owner}/{data.repo}
               </span>
               {data.branch && (
-                <span className="shrink-0 rounded bg-orange-500/10 px-1 py-0.5 font-mono text-[10px] font-medium text-orange-700 dark:text-orange-300">
+                <span className="shrink-0 rounded bg-surface-2 px-1 py-0.5 font-mono text-[9.5px] text-muted-foreground ring-1 ring-border">
                   {data.branch}
                 </span>
               )}
@@ -141,7 +144,7 @@ export const GitHubProjectNode = ({ id, data, selected }: GitHubProjectNodeProps
         ) : (
           <div className="space-y-1.5" onMouseDown={handleMouseDown}>
             <Button
-              className="nodrag nopan flex h-auto w-full items-center justify-center gap-1.5 rounded-md border border-orange-500/25 bg-orange-500/10 py-1.5 text-[11px] font-medium text-orange-700 transition-colors hover:bg-orange-500/15 dark:text-orange-300"
+              className="nodrag nopan flex h-auto w-full items-center justify-center gap-1.5 rounded-md border border-border bg-surface-2 py-1.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               type="button"
               variant="ghost"
               onClick={handlePickOpen}
@@ -185,7 +188,7 @@ export const GitHubProjectNode = ({ id, data, selected }: GitHubProjectNodeProps
         {/* Connected repo link */}
         {repoUrl && (
           <a
-            className="nodrag nopan flex items-center gap-1 text-[10px] text-muted-foreground transition-colors hover:text-orange-500"
+            className="nodrag nopan flex items-center gap-1 text-[10px] text-muted-foreground transition-colors hover:text-foreground"
             href={repoUrl}
             rel="noopener noreferrer"
             target="_blank"

--- a/packages/views/src/pages/CanvasPage/NodeCard/NodeCard.tsx
+++ b/packages/views/src/pages/CanvasPage/NodeCard/NodeCard.tsx
@@ -1,8 +1,18 @@
-import { memo, useLayoutEffect, useRef, useState } from "react";
+import { memo, useLayoutEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { Copy, Settings2, Sparkles, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { NodeRunStatus } from "@repo/schemas";
+import { cn } from "@repo/ui/lib/utils";
 import { NodeCardFrame, type NodeCardFrameProps } from "./NodeCardFrame";
 import { NodeCardPorts } from "./NodeCardPorts";
 
 export interface NodeCardProps extends NodeCardFrameProps {
+  actions?: {
+    onAsk?: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+    onConfigure?: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+    onDelete?: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+    onDuplicate?: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+  };
   leftActivePortCount?: number;
   leftActivePortMask?: number;
   leftConnectedPortCount?: number;
@@ -60,6 +70,18 @@ const useCardMaxPortSpread = (
   return cardMaxPortSpread;
 };
 
+const statusDot: Record<NodeRunStatus, { className: string; pulse?: boolean }> = {
+  cancelled: { className: "bg-muted-foreground/45" },
+  done: { className: "bg-success" },
+  failed: { className: "bg-destructive" },
+  idle: { className: "bg-transparent ring-1 ring-muted-foreground/55" },
+  queued: { className: "bg-muted-foreground/45", pulse: true },
+  retrying: { className: "bg-warning", pulse: true },
+  running: { className: "bg-foreground", pulse: true },
+  skipped: { className: "bg-muted-foreground/45" },
+  waitingForUser: { className: "bg-warning", pulse: true },
+};
+
 export const NodeCard = memo(
   ({
     leftActivePortCount,
@@ -79,6 +101,7 @@ export const NodeCard = memo(
     theme,
     icon,
     label,
+    detail,
     headerRight,
     children,
     bodyClassName,
@@ -86,25 +109,132 @@ export const NodeCard = memo(
     onLabelChange: handleLabelChange,
     runStatus,
     dimmed,
+    actions,
   }: NodeCardProps) => {
+    const { t } = useTranslation();
+    const normalizedStatus = runStatus ?? "idle";
+    const statusConfig = statusDot[normalizedStatus];
+    const statusLabel = t(`workspace.canvas.nodes.status.${normalizedStatus}`, {
+      defaultValue: normalizedStatus,
+    });
+    const {
+      onAsk: handleAsk,
+      onConfigure: handleConfigure,
+      onDelete: handleDelete,
+      onDuplicate: handleDuplicate,
+    } = actions ?? {};
     const hasPorts = Boolean(leftHandle || rightHandle);
+    const hasActions = Boolean(handleAsk || handleConfigure || handleDelete || handleDuplicate);
     const wrapperRef = useRef<HTMLDivElement | null>(null);
     const cardMaxPortSpread = useCardMaxPortSpread(wrapperRef, hasPorts);
 
     return (
       <div
         ref={wrapperRef}
-        className="canvas-node-pop group/node-card relative w-fit"
+        className="canvas-node-pop group/node-card relative w-[214px]"
         data-card-mode={compact ? "compact" : "expanded"}
         data-selected={selected ? "true" : "false"}
+        data-theme={theme}
+        data-testid="canvas-v2-node-shell-root"
       >
+        <span
+          aria-label={statusLabel}
+          className="absolute right-2 top-2 z-10 inline-flex h-[9px] w-[9px]"
+          title={statusLabel}
+        >
+          {statusConfig.pulse && (
+            <span
+              className={cn(
+                "absolute h-full w-full animate-ping rounded-full",
+                statusConfig.className,
+              )}
+            />
+          )}
+          <span
+            className={cn(
+              "relative inline-flex h-[9px] w-[9px] rounded-full shadow-[0_0_0_2px_var(--color-surface)]",
+              statusConfig.className,
+            )}
+          />
+        </span>
+        {hasActions ? (
+          <div
+            className="absolute -top-3 right-1.5 z-20 hidden items-center gap-0.5 rounded-full bg-surface px-1 py-0.5 shadow-pill ring-1 ring-border group-hover/node-card:flex"
+            data-testid="canvas-node-actions"
+          >
+            {handleConfigure ? (
+              <button
+                aria-label={t("workspace.canvas.nodes.actions.configure", {
+                  defaultValue: "Configure node",
+                })}
+                className="rounded-full p-1 text-foreground/70 hover:bg-accent/70"
+                data-testid="canvas-node-configure"
+                title={t("workspace.canvas.nodes.actions.configure", {
+                  defaultValue: "Configure node",
+                })}
+                type="button"
+                onClick={handleConfigure}
+              >
+                <Settings2 className="h-3 w-3" />
+              </button>
+            ) : null}
+            {handleAsk ? (
+              <button
+                aria-label={t("workspace.canvas.nodes.actions.ask", {
+                  defaultValue: "Ask AI assistant",
+                })}
+                className="rounded-full p-1 text-foreground/70 hover:bg-accent/70"
+                data-testid="canvas-node-ask"
+                title={t("workspace.canvas.nodes.actions.ask", {
+                  defaultValue: "Ask AI assistant",
+                })}
+                type="button"
+                onClick={handleAsk}
+              >
+                <Sparkles className="h-3 w-3" />
+              </button>
+            ) : null}
+            {handleDuplicate ? (
+              <button
+                aria-label={t("workspace.canvas.nodes.actions.duplicate", {
+                  defaultValue: "Duplicate node",
+                })}
+                className="rounded-full p-1 text-foreground/70 hover:bg-accent/70"
+                data-testid="canvas-node-duplicate"
+                title={t("workspace.canvas.nodes.actions.duplicate", {
+                  defaultValue: "Duplicate node",
+                })}
+                type="button"
+                onClick={handleDuplicate}
+              >
+                <Copy className="h-3 w-3" />
+              </button>
+            ) : null}
+            {handleDelete ? (
+              <button
+                aria-label={t("workspace.canvas.nodes.actions.delete", {
+                  defaultValue: "Delete node",
+                })}
+                className="rounded-full p-1 text-foreground/70 hover:bg-destructive/10 hover:text-destructive"
+                data-testid="canvas-node-delete"
+                title={t("workspace.canvas.nodes.actions.delete", { defaultValue: "Delete node" })}
+                type="button"
+                onClick={handleDelete}
+              >
+                <Trash2 className="h-3 w-3" />
+              </button>
+            ) : null}
+          </div>
+        ) : null}
         <NodeCardFrame
           bodyClassName={bodyClassName}
           description={description}
+          detail={compact ? undefined : detail}
           dimmed={dimmed}
           headerRight={headerRight}
           icon={icon}
           label={label}
+          compact={compact}
           runStatus={runStatus}
           selected={selected}
           theme={theme}
@@ -127,7 +257,6 @@ export const NodeCard = memo(
             rightConnectedPortMask={rightConnectedPortMask}
             rightHandle={rightHandle}
             rightHandleCount={rightHandleCount}
-            theme={theme}
           />
         )}
       </div>

--- a/packages/views/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/NodeCard/NodeCard.unit.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@xyflow/react", () => ({
     position,
     style,
     type,
+    "data-testid": _dataTestId,
     ...rest
   }: {
     className?: string;
@@ -83,9 +84,9 @@ describe("NodeCard", () => {
   it("does not render body wrapper when no children", () => {
     const { container } = render(<NodeCard icon={Box} label="Node" theme="emerald" />);
     const wrapper = container.firstElementChild;
-    const card = wrapper?.firstElementChild;
+    const card = container.querySelector('[data-slot="card"]');
 
-    expect(wrapper).toHaveClass("relative", "w-fit");
+    expect(wrapper).toHaveClass("relative", "w-[214px]");
     expect(card).toHaveAttribute("data-slot", "card");
     expect(card?.childNodes).toHaveLength(1);
   });
@@ -93,6 +94,45 @@ describe("NodeCard", () => {
   it("renders headerRight slot", () => {
     render(<NodeCard headerRight={<span>Status</span>} icon={Box} label="Node" theme="violet" />);
     expect(screen.getByText("Status")).toBeInTheDocument();
+  });
+
+  it("uses Alan's status dot and running indicator", () => {
+    const { container, rerender } = render(
+      <NodeCard
+        detail="Executing"
+        icon={Box}
+        label="Running node"
+        runStatus="running"
+        theme="violet"
+      >
+        <span>Body content</span>
+      </NodeCard>,
+    );
+
+    const statusDot = container.querySelector(
+      '[data-testid="canvas-v2-node-shell-root"] > span[aria-label]',
+    );
+    expect(statusDot).toHaveClass("inline-flex", "h-[9px]", "w-[9px]");
+    expect(statusDot?.querySelector(".bg-foreground")).toBeInTheDocument();
+    expect(statusDot?.querySelector(".animate-ping")).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="card-content"]')).toHaveTextContent("Executing");
+    expect(container.querySelector('[data-slot="card-content"]')).toHaveTextContent(
+      /执行中|running/i,
+    );
+
+    rerender(
+      <NodeCard detail="Complete" icon={Box} label="Done node" runStatus="done" theme="violet" />,
+    );
+    expect(
+      container.querySelector(
+        '[data-testid="canvas-v2-node-shell-root"] > span[aria-label] .bg-success',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(
+        '[data-testid="canvas-v2-node-shell-root"] > span[aria-label] .animate-ping',
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps header affordances visible for long labels", () => {
@@ -106,26 +146,28 @@ describe("NodeCard", () => {
       />,
     );
 
-    expect(container.firstElementChild).toHaveClass("relative", "w-fit");
+    expect(container.firstElementChild).toHaveClass("relative", "w-[214px]");
     expect(container.querySelector('[data-slot="card"]')).toHaveClass(
-      "w-[214px]",
-      "data-[size=sm]:py-0",
+      "relative",
+      "overflow-hidden",
+      "rounded-xl",
+      "bg-surface",
+      "ring-1",
+      "ring-border",
     );
-    expect(container.querySelector('[data-slot="card-header"] > div')).toHaveClass(
-      "w-full",
-      "min-w-0",
+    expect(container.querySelector('[data-slot="card-header"]')).toHaveClass(
+      "flex",
+      "items-center",
+      "gap-2",
+      "border-b",
+      "border-border/70",
     );
     expect(container.querySelector('[data-slot="card-description"]')).toHaveClass(
-      "w-full",
-      "max-w-full",
       "truncate",
+      "text-[10px]",
+      "text-muted-foreground",
     );
-    expect(container.querySelector('[data-slot="card-header"]')).toHaveClass("min-h-12");
-    expect(container.querySelector('[data-slot="card-action"]')).toHaveClass(
-      "ml-auto",
-      "shrink-0",
-      "self-center",
-    );
+    expect(container.querySelector('[data-slot="card-action"]')).toHaveClass("shrink-0");
   });
 
   it("applies the neutral Alan selection ring for every theme", () => {
@@ -144,6 +186,41 @@ describe("NodeCard", () => {
     expect(container.querySelector('[data-slot="card"]')).toHaveClass("ring-foreground/40");
   });
 
+  it("uses Alan hover-only action pill visibility", () => {
+    const handleAsk = vi.fn();
+    const handleConfigure = vi.fn();
+    const handleDelete = vi.fn();
+    const handleDuplicate = vi.fn();
+    render(
+      <NodeCard
+        selected
+        actions={{
+          onAsk: handleAsk,
+          onConfigure: handleConfigure,
+          onDelete: handleDelete,
+          onDuplicate: handleDuplicate,
+        }}
+        icon={Box}
+        label="Node"
+        theme="violet"
+      />,
+    );
+
+    expect(screen.getByTestId("canvas-node-actions")).toHaveClass(
+      "hidden",
+      "group-hover/node-card:flex",
+      "rounded-full",
+    );
+    fireEvent.click(screen.getByTestId("canvas-node-configure"));
+    fireEvent.click(screen.getByTestId("canvas-node-ask"));
+    fireEvent.click(screen.getByTestId("canvas-node-duplicate"));
+    fireEvent.click(screen.getByTestId("canvas-node-delete"));
+    expect(handleConfigure).toHaveBeenCalled();
+    expect(handleAsk).toHaveBeenCalled();
+    expect(handleDuplicate).toHaveBeenCalled();
+    expect(handleDelete).toHaveBeenCalled();
+  });
+
   it("renders one small center port per enabled side by default", () => {
     render(<NodeCard leftHandle rightHandle icon={Box} label="Node" theme="orange" />);
 
@@ -157,10 +234,11 @@ describe("NodeCard", () => {
       "before:left-1/2",
       "after:h-5",
       "after:w-5",
-      "before:opacity-30",
-      "before:scale-75",
-      "group-hover/node-card:before:opacity-75",
-      "before:!bg-orange-500",
+      "before:h-3",
+      "before:w-3",
+      "before:border-border-strong",
+      "before:bg-surface",
+      "hover:before:scale-150",
     );
     expect(screen.getByTestId("source-handle")).toHaveClass(
       "!right-0",
@@ -172,10 +250,11 @@ describe("NodeCard", () => {
       "before:left-1/2",
       "after:h-5",
       "after:w-5",
-      "before:opacity-30",
-      "before:scale-75",
-      "group-hover/node-card:before:opacity-75",
-      "before:!bg-orange-500",
+      "before:h-3",
+      "before:w-3",
+      "before:border-border-strong",
+      "before:bg-surface",
+      "hover:before:scale-150",
     );
     expect(screen.getByTestId("target-handle")).toHaveAttribute("data-handleid", "left-port-0");
     expect(screen.getByTestId("target-handle")).toHaveAttribute("data-port-state", "idle");
@@ -215,13 +294,10 @@ describe("NodeCard", () => {
     expect(targetHandles[1]).toHaveAttribute("data-port-state", "connected");
     expect(targetHandles[1]).toHaveAttribute("data-connected", "true");
     expect(sourceHandle).toHaveAttribute("data-port-state", "connected");
-    expect(sourceHandle).toHaveClass(
-      "data-[connected=true]:before:opacity-90",
-      "data-[connected=true]:before:scale-100",
-    );
+    expect(sourceHandle).toHaveClass("data-[connected=true]:before:border-foreground/60");
     expect(targetHandles[0]).toHaveClass(
-      "data-[active=true]:before:opacity-100",
       "data-[active=true]:before:scale-125",
+      "data-[active=true]:before:border-foreground",
     );
   });
 

--- a/packages/views/src/pages/CanvasPage/NodeCard/NodeCardFrame.tsx
+++ b/packages/views/src/pages/CanvasPage/NodeCard/NodeCardFrame.tsx
@@ -1,22 +1,16 @@
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-  CardAction,
-} from "@repo/ui/card";
 import { cn } from "@repo/ui/lib/utils";
 import type { NodeRunStatus } from "@repo/schemas";
 import { memo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { themeMap, type NodeTheme } from "./nodeCardTheme";
+import type { NodeTheme } from "./nodeCardTheme";
 
 export interface NodeCardFrameProps {
   selected?: boolean;
   theme: NodeTheme;
   icon: React.ElementType;
   label: string;
+  detail?: string;
+  compact?: boolean;
   headerRight?: React.ReactNode;
   children?: React.ReactNode;
   bodyClassName?: string;
@@ -31,9 +25,10 @@ const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
 export const NodeCardFrame = memo(
   ({
     selected,
-    theme,
     icon: Icon,
     label,
+    detail,
+    compact = false,
     headerRight,
     children,
     bodyClassName,
@@ -43,7 +38,10 @@ export const NodeCardFrame = memo(
     dimmed,
   }: NodeCardFrameProps) => {
     const { t: translate } = useTranslation();
-    const t = themeMap[theme] ?? themeMap.emerald;
+    const normalizedStatus = runStatus ?? "idle";
+    const statusLabel = translate(`workspace.canvas.nodes.status.${normalizedStatus}`, {
+      defaultValue: normalizedStatus,
+    });
     const [isLabelEditing, setIsLabelEditing] = useState(false);
     const handleChange = onLabelChange
       ? (e: React.ChangeEvent<HTMLInputElement>) => onLabelChange(e.target.value)
@@ -52,78 +50,103 @@ export const NodeCardFrame = memo(
     const handleLabelFocus = () => setIsLabelEditing(true);
     const handleLabelBlur = () => setIsLabelEditing(false);
 
+    const hasBody =
+      !compact &&
+      Boolean(
+        detail || children || normalizedStatus === "running" || normalizedStatus === "retrying",
+      );
+
     return (
-      <Card
+      <div
+        data-slot="card"
         className={cn(
-          "w-[214px] shrink-0 gap-0 rounded-xl bg-surface py-0 shadow-soft transition-all duration-200 data-[size=sm]:gap-0 data-[size=sm]:py-0",
-          selected
-            ? "shadow-float ring-2 ring-foreground/40"
-            : "ring-1 ring-border hover:shadow-float hover:ring-border-strong",
-          runStatus === "running" &&
-            "ring-2 ring-blue-500 shadow-[0_0_12px_rgba(59,130,246,0.4)] animate-pulse",
-          runStatus === "done" && "ring-2 ring-green-500",
-          runStatus === "failed" && "ring-2 ring-red-500",
-          dimmed && "opacity-40 pointer-events-none",
+          "relative overflow-hidden rounded-xl bg-surface shadow-soft ring-1 ring-border transition-all duration-150",
+          selected && "shadow-float ring-2 ring-foreground/40",
+          !selected && "hover:shadow-float hover:ring-border-strong",
+          dimmed && "opacity-45",
         )}
-        size="sm"
+        data-testid="canvas-v2-node-card"
       >
-        <CardHeader className={cn("flex min-h-12 items-center px-2.5 py-2", t.headerBg)}>
-          <div className="flex w-full min-w-0 items-center gap-2">
-            <div
-              className={cn(
-                "flex size-6 shrink-0 items-center justify-center rounded-md",
-                t.iconBg,
-              )}
-            >
-              <Icon className={cn("size-3.5", t.iconColor)} />
-            </div>
-            <div className="flex min-h-6 min-w-0 flex-1 flex-col items-start justify-center overflow-hidden">
-              {handleChange ? (
-                <span className="relative inline-block max-w-full min-w-0 overflow-hidden align-top">
-                  <span
-                    aria-hidden="true"
-                    className="invisible block max-w-full truncate whitespace-pre text-xs font-semibold leading-tight"
-                  >
-                    {label || " "}
-                  </span>
-                  <input
-                    aria-label={translate("canvas.nodeLabel")}
-                    className={cn(
-                      "nodrag nopan absolute inset-0 h-full w-full min-w-0 max-w-full truncate border-0 bg-transparent p-0 text-xs font-semibold leading-tight focus:outline-none",
-                      isLabelEditing ? "select-text" : "cursor-inherit select-none",
-                    )}
-                    name="nodeLabel"
-                    readOnly={!isLabelEditing}
-                    value={label}
-                    onBlur={handleLabelBlur}
-                    onChange={handleChange}
-                    onClick={handleLabelClick}
-                    onFocus={handleLabelFocus}
-                    onMouseDown={handleMouseDown}
-                  />
+        <div
+          className="flex items-center gap-2 border-b border-border/70 px-2.5 py-2"
+          data-slot="card-header"
+        >
+          <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-surface-2">
+            <Icon className="h-3.5 w-3.5 text-foreground/80" />
+          </div>
+          <div className="min-w-0 flex-1">
+            {handleChange ? (
+              <span className="relative inline-block max-w-full min-w-0 overflow-hidden align-top">
+                <span
+                  aria-hidden="true"
+                  className="invisible block max-w-full truncate whitespace-pre text-[12px] font-semibold leading-tight"
+                >
+                  {label || " "}
                 </span>
-              ) : (
-                <CardTitle className="w-full max-w-full truncate text-xs font-semibold leading-tight">
-                  {label}
-                </CardTitle>
-              )}
-              {description && (
-                <CardDescription className="w-full max-w-full truncate text-[10px] leading-tight">
-                  {description}
-                </CardDescription>
-              )}
-            </div>
-            {headerRight && (
-              <CardAction className="ml-auto shrink-0 self-center">{headerRight}</CardAction>
+                <input
+                  aria-label={translate("canvas.nodeLabel")}
+                  className={cn(
+                    "nodrag nopan absolute inset-0 h-full w-full min-w-0 max-w-full truncate border-0 bg-transparent p-0 text-[12px] font-semibold leading-tight focus:outline-none",
+                    isLabelEditing ? "select-text" : "cursor-inherit select-none",
+                  )}
+                  name="nodeLabel"
+                  readOnly={!isLabelEditing}
+                  value={label}
+                  onBlur={handleLabelBlur}
+                  onChange={handleChange}
+                  onClick={handleLabelClick}
+                  onFocus={handleLabelFocus}
+                  onMouseDown={handleMouseDown}
+                />
+              </span>
+            ) : (
+              <div
+                className="truncate text-[12px] font-semibold leading-tight"
+                data-slot="card-title"
+              >
+                {label}
+              </div>
+            )}
+            {description && (
+              <div
+                className="truncate text-[10px] text-muted-foreground"
+                data-slot="card-description"
+              >
+                {description}
+              </div>
             )}
           </div>
-        </CardHeader>
-        {children && (
-          <CardContent className={cn("border-t border-border/70 px-2.5 py-2.5", bodyClassName)}>
+          {headerRight && (
+            <div className="shrink-0" data-slot="card-action">
+              {headerRight}
+            </div>
+          )}
+        </div>
+        {hasBody && (
+          <div className={cn("space-y-1.5 px-2.5 py-2", bodyClassName)} data-slot="card-content">
+            {detail ? (
+              <div className="flex min-w-0 items-center gap-1.5 text-[10.5px] text-muted-foreground">
+                <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/55" />
+                <span className="truncate">{detail}</span>
+              </div>
+            ) : null}
+            {normalizedStatus === "running" || normalizedStatus === "retrying" ? (
+              <div className="space-y-1 pt-0.5">
+                <div className="h-1 overflow-hidden rounded-full bg-surface-2">
+                  <div
+                    className={cn(
+                      "h-1 w-full animate-pulse rounded-full",
+                      normalizedStatus === "retrying" ? "bg-warning" : "bg-foreground",
+                    )}
+                  />
+                </div>
+                <div className="truncate text-[10px] text-foreground/70">{statusLabel}</div>
+              </div>
+            ) : null}
             {children}
-          </CardContent>
+          </div>
         )}
-      </Card>
+      </div>
     );
   },
 );

--- a/packages/views/src/pages/CanvasPage/NodeCard/NodeCardPorts.tsx
+++ b/packages/views/src/pages/CanvasPage/NodeCard/NodeCardPorts.tsx
@@ -6,8 +6,8 @@ import {
 } from "@xyflow/react";
 import { cn } from "@repo/ui/lib/utils";
 import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { getNodePortOffsets, makeNodePortId, type NodePortSide } from "./nodePorts";
-import { themeMap, type NodeTheme } from "./nodeCardTheme";
 
 export interface NodeCardPortsProps {
   cardMaxPortSpread?: number;
@@ -23,11 +23,10 @@ export interface NodeCardPortsProps {
   rightConnectedPortMask?: number;
   rightHandle?: boolean;
   rightHandleCount: number;
-  theme: NodeTheme;
 }
 
 const nodePortClassName =
-  "node-card-port absolute !top-[calc(50%+var(--node-port-offset))] !z-10 !h-0 !min-h-0 !w-0 !min-w-0 !border-0 !bg-transparent !opacity-100 transition-opacity duration-150 ease-out before:content-[''] before:absolute before:left-1/2 before:top-1/2 before:h-2 before:w-2 before:-translate-x-1/2 before:-translate-y-1/2 before:scale-75 before:rounded-full before:opacity-30 before:shadow-[0_0_0_2px_rgba(255,255,255,0.8),0_1px_4px_rgba(15,23,42,0.12)] before:transition-[opacity,transform,box-shadow] before:duration-200 before:ease-out after:content-[''] after:absolute after:left-1/2 after:top-1/2 after:h-5 after:w-5 after:-translate-x-1/2 after:-translate-y-1/2 after:rounded-full hover:before:scale-125 hover:before:opacity-100 hover:before:shadow-[0_0_0_3px_rgba(255,255,255,0.95),0_2px_8px_rgba(15,23,42,0.28)] group-hover/node-card:before:scale-100 group-hover/node-card:before:opacity-75 group-data-[selected=true]/node-card:before:scale-110 group-data-[selected=true]/node-card:before:opacity-100 data-[connected=true]:before:scale-100 data-[connected=true]:before:opacity-90 data-[active=true]:before:scale-125 data-[active=true]:before:opacity-100";
+  "node-card-port absolute !top-[calc(50%+var(--node-port-offset))] !z-10 !h-0 !min-h-0 !w-0 !min-w-0 !border-0 !bg-transparent !opacity-100 cursor-crosshair before:content-[''] before:absolute before:left-1/2 before:top-1/2 before:h-3 before:w-3 before:-translate-x-1/2 before:-translate-y-1/2 before:rounded-full before:border before:border-border-strong before:bg-surface before:shadow-[0_1px_2px_rgba(15,23,42,0.12)] before:transition-transform before:duration-150 before:ease-out after:content-[''] after:absolute after:left-1/2 after:top-1/2 after:h-5 after:w-5 after:-translate-x-1/2 after:-translate-y-1/2 after:rounded-full hover:before:scale-150 hover:before:border-foreground data-[connected=true]:before:border-foreground/60 data-[active=true]:before:scale-125 data-[active=true]:before:border-foreground";
 
 const getNodePortStyle = (offset: number) =>
   ({
@@ -105,15 +104,14 @@ export const NodeCardPorts = ({
   rightConnectedPortMask,
   rightHandle,
   rightHandleCount,
-  theme,
 }: NodeCardPortsProps) => {
-  const t = themeMap[theme] ?? themeMap.emerald;
+  const { t } = useTranslation();
   const nodeId = useNodeId();
   const updateNodeInternals = useUpdateNodeInternals();
   const leftPortOffsets = getNodePortOffsets(leftHandleCount, cardMaxPortSpread);
   const rightPortOffsets = getNodePortOffsets(rightHandleCount, cardMaxPortSpread);
-  const leftPortClassName = cn(nodePortClassName, "!left-0", t.handleColor);
-  const rightPortClassName = cn(nodePortClassName, "!right-0", t.handleColor);
+  const leftPortClassName = cn(nodePortClassName, "!left-0");
+  const rightPortClassName = cn(nodePortClassName, "!right-0");
 
   useEffect(() => {
     if (!nodeId) {
@@ -162,10 +160,15 @@ export const NodeCardPorts = ({
 
           return (
             <ReactFlowPort
+              aria-label={t("workspace.canvas.nodes.ports.left", {
+                defaultValue: `Input port ${index + 1}`,
+                index: index + 1,
+              })}
               key={makeNodePortId("left", index)}
               className={leftPortClassName}
               data-active={visualState.active ? "true" : "false"}
               data-connected={visualState.connected ? "true" : "false"}
+              data-testid="canvas-v2-node-left-port"
               data-port-state={visualState.state}
               id={makeNodePortId("left", index)}
               position={getNodePortPosition("left")}
@@ -191,10 +194,15 @@ export const NodeCardPorts = ({
 
           return (
             <ReactFlowPort
+              aria-label={t("workspace.canvas.nodes.ports.right", {
+                defaultValue: `Output port ${index + 1}`,
+                index: index + 1,
+              })}
               key={makeNodePortId("right", index)}
               className={rightPortClassName}
               data-active={visualState.active ? "true" : "false"}
               data-connected={visualState.connected ? "true" : "false"}
+              data-testid="canvas-v2-node-right-port"
               data-port-state={visualState.state}
               id={makeNodePortId("right", index)}
               position={getNodePortPosition("right")}

--- a/packages/views/src/pages/CanvasPage/NodeCard/index.ts
+++ b/packages/views/src/pages/CanvasPage/NodeCard/index.ts
@@ -1,3 +1,4 @@
 export * from "./NodeCard";
+export * from "./useNodeCardActions";
 export * from "./nodeCardTheme";
 export * from "./nodePorts";

--- a/packages/views/src/pages/CanvasPage/NodeCard/useNodeCardActions.ts
+++ b/packages/views/src/pages/CanvasPage/NodeCard/useNodeCardActions.ts
@@ -1,0 +1,39 @@
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { useStore } from "zustand";
+import { useCanvasPageStore } from "../_store";
+
+export const useNodeCardActions = (nodeId: string) => {
+  const store = useCanvasPageStore();
+  const focusNode = useStore(store, (state) => state.focusNode);
+  const duplicateNode = useStore(store, (state) => state.duplicateNode);
+  const removeNode = useStore(store, (state) => state.removeNode);
+  const agentPanelIsOpen = useStore(store, (state) => state.agentPanel.isOpen);
+  const toggleAgentPanel = useStore(store, (state) => state.toggleAgentPanel);
+
+  const handleConfigure = (event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    focusNode(nodeId);
+  };
+  const handleAsk = (event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    focusNode(nodeId);
+    if (!agentPanelIsOpen) {
+      toggleAgentPanel();
+    }
+  };
+  const handleDuplicate = (event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    duplicateNode(nodeId);
+  };
+  const handleDelete = (event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    removeNode(nodeId);
+  };
+
+  return {
+    onAsk: handleAsk,
+    onConfigure: handleConfigure,
+    onDelete: handleDelete,
+    onDuplicate: handleDuplicate,
+  };
+};

--- a/packages/views/src/pages/CanvasPage/NodeContextMenu/NodeContextMenu.tsx
+++ b/packages/views/src/pages/CanvasPage/NodeContextMenu/NodeContextMenu.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import {
   Copy,
   Trash2,
+  Plus,
   Zap,
   FileCode,
   Folder,
@@ -31,8 +32,7 @@ import { useList } from "@refinedev/core";
 import { ResourceName } from "../../../constants";
 import type { Operation, BuiltinNodeType } from "@repo/schemas";
 import { getAllowedConnections } from "../utils/getAllowedConnections";
-import { getNodeMeta, getNodeTypeLabel, getNodeTypeShortLabel } from "../utils/nodeTypeMeta";
-import { cn } from "@repo/ui/lib/utils";
+import { getNodeTypeLabel, getNodeTypeShortLabel } from "../utils/nodeTypeMeta";
 
 const TYPE_ICONS: Record<string, React.ElementType> = {
   operation: Zap,
@@ -79,7 +79,6 @@ export const NodeContextMenu = () => {
 
   if (!nodeContextMenu || !node) return null;
 
-  const meta = getNodeMeta(node.type)!;
   const allowedConnections = getAllowedConnections(operations);
   const availableTypes = allowedConnections[node.type as BuiltinNodeType] ?? [];
 
@@ -133,19 +132,14 @@ export const NodeContextMenu = () => {
       <ContextMenuContent
         align="start"
         anchor={virtualAnchor}
-        className="w-56"
+        className="w-56 rounded-2xl border border-border bg-surface p-2 shadow-float ring-1 ring-border"
         positionMethod="fixed"
         side="bottom"
         sideOffset={0}
       >
         {/* Node type header */}
-        <div className="mb-1 flex items-center gap-2 border-b border-border px-1.5 py-1.5">
-          <span
-            className={cn(
-              "flex h-5 w-5 items-center justify-center rounded text-[9px] font-bold text-white",
-              meta.iconBg,
-            )}
-          >
+        <div className="mb-1 flex items-center gap-2 border-b border-border px-2 pb-2 pt-1">
+          <span className="flex size-5 items-center justify-center rounded-md bg-surface-2 text-[9px] font-bold text-foreground/70">
             {getNodeTypeShortLabel(t, node.type).charAt(0)}
           </span>
           <span className="text-xs font-medium text-foreground">
@@ -155,13 +149,17 @@ export const NodeContextMenu = () => {
 
         {/* Actions submenu */}
         <ContextMenuSub>
-          <ContextMenuSubTrigger>
-            <Zap className="size-4 text-muted-foreground" />
+          <ContextMenuSubTrigger className="rounded-lg px-2 py-1.5 text-xs">
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+              <Zap className="size-3 text-foreground/70" />
+            </span>
             {t("canvas.contextMenu.actions")}
           </ContextMenuSubTrigger>
-          <ContextMenuSubContent className="min-w-52">
+          <ContextMenuSubContent className="min-w-52 rounded-2xl border border-border bg-surface p-2 shadow-float ring-1 ring-border">
             <ContextMenuGroup>
-              <ContextMenuLabel>{t("canvas.contextMenu.connectNewNode")}</ContextMenuLabel>
+              <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                {t("canvas.contextMenu.connectNewNode")}
+              </ContextMenuLabel>
             </ContextMenuGroup>
 
             {/* Object types */}
@@ -169,28 +167,26 @@ export const NodeContextMenu = () => {
               availableTypes.includes(t as BuiltinNodeType),
             ) && (
               <ContextMenuGroup>
-                <ContextMenuLabel>{t("canvas.contextMenu.processingObject")}</ContextMenuLabel>
+                <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                  {t("canvas.contextMenu.processingObject")}
+                </ContextMenuLabel>
                 {["file", "folder", "github-project", "prompt"]
                   .filter((t) => availableTypes.includes(t as BuiltinNodeType))
                   .map((type) => {
                     const Icon = TYPE_ICONS[type as BuiltinNodeType];
-                    const m = getNodeMeta(type)!;
 
                     return (
                       <ContextMenuItem
                         key={type}
+                        className="rounded-lg px-2 py-1.5 text-xs"
                         closeOnClick={false}
                         onClick={() => handleNodeContextAddObject(type as BuiltinNodeType)}
                       >
-                        <span
-                          className={cn(
-                            "flex size-4 shrink-0 items-center justify-center rounded",
-                            m.iconBg,
-                          )}
-                        >
-                          <Icon className="size-2.5 text-white" />
+                        <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+                          <Icon className="size-3 text-foreground/70" />
                         </span>
                         {getNodeTypeShortLabel(t, type)}
+                        <Plus className="ml-auto size-3 text-muted-foreground/50" />
                       </ContextMenuItem>
                     );
                   })}
@@ -200,19 +196,23 @@ export const NodeContextMenu = () => {
             {/* Operations */}
             {canAddOperation && availableOperations.length > 0 && (
               <>
-                <ContextMenuSeparator />
+                <ContextMenuSeparator className="my-1 bg-border/70" />
                 <ContextMenuGroup>
-                  <ContextMenuLabel>{t("canvas.contextMenu.operationNode")}</ContextMenuLabel>
+                  <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                    {t("canvas.contextMenu.operationNode")}
+                  </ContextMenuLabel>
                   {availableOperations.map((operation) => (
                     <ContextMenuItem
                       key={operation.id}
+                      className="rounded-lg px-2 py-1.5 text-xs"
                       closeOnClick={false}
                       onClick={() => handleAddOperation(operation.id)}
                     >
-                      <span className="flex size-4 shrink-0 items-center justify-center rounded bg-violet-500">
-                        <Zap className="size-2.5 text-white" />
+                      <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+                        <Zap className="size-3 text-foreground/70" />
                       </span>
                       <span className="truncate">{operation.name}</span>
+                      <Plus className="ml-auto size-3 text-muted-foreground/50" />
                     </ContextMenuItem>
                   ))}
                 </ContextMenuGroup>
@@ -222,10 +222,12 @@ export const NodeContextMenu = () => {
             {/* Empty state */}
             {canAddOperation && availableOperations.length === 0 && (
               <>
-                <ContextMenuSeparator />
+                <ContextMenuSeparator className="my-1 bg-border/70" />
                 <ContextMenuGroup>
-                  <ContextMenuLabel>{t("canvas.contextMenu.operationNode")}</ContextMenuLabel>
-                  <p className="px-1.5 py-1 text-xs text-muted-foreground">
+                  <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                    {t("canvas.contextMenu.operationNode")}
+                  </ContextMenuLabel>
+                  <p className="px-2 py-1 text-xs text-muted-foreground">
                     {t("canvas.contextMenu.noOperationsForType")}
                   </p>
                 </ContextMenuGroup>
@@ -237,30 +239,28 @@ export const NodeContextMenu = () => {
               availableTypes.includes(t),
             ) && (
               <>
-                <ContextMenuSeparator />
+                <ContextMenuSeparator className="my-1 bg-border/70" />
                 <ContextMenuGroup>
-                  <ContextMenuLabel>{t("canvas.contextMenu.outputEndpoint")}</ContextMenuLabel>
+                  <ContextMenuLabel className="px-2 py-1 text-[9.5px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                    {t("canvas.contextMenu.outputEndpoint")}
+                  </ContextMenuLabel>
                   {(["output-project-path", "output-local-path"] as BuiltinNodeType[])
                     .filter((t) => availableTypes.includes(t))
                     .map((type) => {
                       const Icon = TYPE_ICONS[type];
-                      const m = getNodeMeta(type)!;
 
                       return (
                         <ContextMenuItem
                           key={type}
+                          className="rounded-lg px-2 py-1.5 text-xs"
                           closeOnClick={false}
                           onClick={() => handleNodeContextAddObject(type)}
                         >
-                          <span
-                            className={cn(
-                              "flex size-4 shrink-0 items-center justify-center rounded",
-                              m.iconBg,
-                            )}
-                          >
-                            <Icon className="size-2.5 text-white" />
+                          <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+                            <Icon className="size-3 text-foreground/70" />
                           </span>
                           {getNodeTypeLabel(t, type)}
+                          <Plus className="ml-auto size-3 text-muted-foreground/50" />
                         </ContextMenuItem>
                       );
                     })}
@@ -271,45 +271,73 @@ export const NodeContextMenu = () => {
         </ContextMenuSub>
 
         {/* Duplicate */}
-        <ContextMenuItem closeOnClick={false} onClick={handleNodeContextDuplicate}>
-          <Copy className="size-4 text-muted-foreground" />
+        <ContextMenuItem
+          className="rounded-lg px-2 py-1.5 text-xs"
+          closeOnClick={false}
+          onClick={handleNodeContextDuplicate}
+        >
+          <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+            <Copy className="size-3 text-foreground/70" />
+          </span>
           {t("canvas.contextMenu.duplicate")}
           <span className="ml-auto text-xs tracking-widest text-muted-foreground">⌘D</span>
         </ContextMenuItem>
 
         {/* Group selected nodes */}
         {selectedIds.length >= 2 && (
-          <ContextMenuItem closeOnClick={false} onClick={handleNodeContextGroupSelected}>
-            <Group className="size-4 text-muted-foreground" />
+          <ContextMenuItem
+            className="rounded-lg px-2 py-1.5 text-xs"
+            closeOnClick={false}
+            onClick={handleNodeContextGroupSelected}
+          >
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+              <Group className="size-3 text-foreground/70" />
+            </span>
             {t("canvas.contextMenu.groupSelected", { count: selectedIds.length })}
           </ContextMenuItem>
         )}
 
         {/* Ungroup (compound only) */}
         {node.type === "compound" && (
-          <ContextMenuItem closeOnClick={false} onClick={handleNodeContextUngroup}>
-            <Ungroup className="size-4 text-muted-foreground" />
+          <ContextMenuItem
+            className="rounded-lg px-2 py-1.5 text-xs"
+            closeOnClick={false}
+            variant="destructive"
+            onClick={handleNodeContextUngroup}
+          >
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-destructive/10">
+              <Ungroup className="size-3 text-destructive" />
+            </span>
             {t("canvas.contextMenu.ungroup")}
           </ContextMenuItem>
         )}
 
         {/* Detach from compound (child nodes only) */}
         {node.parentId && (
-          <ContextMenuItem closeOnClick={false} onClick={handleNodeContextDetach}>
-            <Ungroup className="size-4 text-muted-foreground" />
+          <ContextMenuItem
+            className="rounded-lg px-2 py-1.5 text-xs"
+            closeOnClick={false}
+            onClick={handleNodeContextDetach}
+          >
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-surface-2">
+              <Ungroup className="size-3 text-foreground/70" />
+            </span>
             {t("canvas.contextMenu.detachFromGroup")}
           </ContextMenuItem>
         )}
 
-        <ContextMenuSeparator />
+        <ContextMenuSeparator className="my-1 bg-border/70" />
 
         {/* Delete */}
         <ContextMenuItem
+          className="rounded-lg px-2 py-1.5 text-xs"
           closeOnClick={false}
           variant="destructive"
           onClick={handleNodeContextDelete}
         >
-          <Trash2 className="size-4" />
+          <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-destructive/10">
+            <Trash2 className="size-3 text-destructive" />
+          </span>
           {t("canvas.contextMenu.delete")}
           <span className="ml-auto text-xs tracking-widest text-destructive/40">⌫</span>
         </ContextMenuItem>

--- a/packages/views/src/pages/CanvasPage/OperationNode/OperationNode.tsx
+++ b/packages/views/src/pages/CanvasPage/OperationNode/OperationNode.tsx
@@ -27,7 +27,7 @@ import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "..
 import type { OperationNodeData, NodeRunStatus, Operation, Agent } from "@repo/schemas";
 import { useList } from "@refinedev/core";
 import { ResourceName } from "../../../constants";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodeCardActions } from "../NodeCard";
 
 export interface OperationNodeProps {
   id: string;
@@ -89,6 +89,7 @@ const stopCanvasInteraction = (event: SyntheticEvent) => event.stopPropagation()
 export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
+  const nodeCardActions = useNodeCardActions(id);
   const { runStatus: nodeRunStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
   const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const { result: operationsResult } = useList<Operation>({
@@ -200,8 +201,10 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
       <NodeCard
         leftHandle
         rightHandle
+        actions={nodeCardActions}
         bodyClassName="space-y-2"
         compact={nodeCardMode === "compact"}
+        detail={data.agentRuntime ?? data.agentId ?? data.operationName}
         description={operation?.description || t("nodes.operation.customDescription")}
         dimmed={dimmed}
         headerRight={
@@ -265,7 +268,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
               {operation.acceptedObjectTypes.map((type) => (
                 <span
                   key={type}
-                  className="rounded bg-violet-500/10 px-1.5 py-0.5 text-[9px] font-medium text-violet-700 dark:text-violet-300"
+                  className="rounded bg-surface-2 px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground ring-1 ring-border"
                 >
                   {objectTypeLabels[type] ?? type}
                 </span>
@@ -316,7 +319,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
         </div>
 
         {hasLlmContent && (
-          <div className="flex items-center gap-1 rounded-md border border-violet-500/20 bg-violet-500/10 px-2 py-1 text-[10px] text-violet-700 dark:text-violet-300">
+          <div className="flex items-center gap-1 rounded-md border border-border bg-surface-2 px-2 py-1 text-[10px] text-muted-foreground">
             <Brain className="h-3 w-3 shrink-0" />
             <span>{t("nodes.operation.inspectLlmOutput")}</span>
           </div>
@@ -327,7 +330,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
             className={cn(
               "nodrag nopan flex h-8 w-full items-center gap-1.5 rounded-md border px-2.5 text-[11px] font-medium transition-colors",
               data.loopEnabled
-                ? "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+                ? "border-border bg-surface-2 text-foreground ring-1 ring-ring"
                 : "border-border bg-surface-2 text-muted-foreground hover:bg-muted",
             )}
             type="button"
@@ -338,14 +341,14 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
           </button>
 
           {data.loopEnabled && (
-            <div className="space-y-2 rounded-md border border-amber-500/20 bg-amber-500/10 p-2.5">
+            <div className="space-y-2 rounded-md border border-border bg-surface-2 p-2.5">
               <div className="flex items-center gap-2">
-                <span className="whitespace-nowrap text-[11px] font-medium text-amber-700 dark:text-amber-300">
+                <span className="whitespace-nowrap text-[11px] font-medium text-muted-foreground">
                   {t("nodes.operation.maxLoopCount")}
                 </span>
                 <input
                   aria-label={t("nodes.operation.maxLoopCountAria")}
-                  className="nodrag nopan h-7 w-16 rounded border border-amber-500/25 bg-background px-2 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-amber-500/40"
+                  className="nodrag nopan h-7 w-16 rounded border border-border bg-background px-2 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                   max={20}
                   min={1}
                   name={`${id}-maxLoopCount`}
@@ -357,12 +360,12 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
                 />
               </div>
               <div className="space-y-1">
-                <span className="text-[11px] font-medium text-amber-700 dark:text-amber-300">
+                <span className="text-[11px] font-medium text-muted-foreground">
                   {t("nodes.operation.acceptanceCondition")}
                 </span>
                 <textarea
                   aria-label={t("nodes.operation.loopConditionAria")}
-                  className="nodrag nopan min-h-16 w-full rounded border border-amber-500/25 bg-background px-2 py-1.5 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-amber-500/40"
+                  className="nodrag nopan min-h-16 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                   name={`${id}-loopCondition`}
                   placeholder={t("nodes.operation.loopConditionPlaceholder")}
                   rows={2}

--- a/packages/views/src/pages/CanvasPage/OperationNode/OperationNode.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/OperationNode/OperationNode.unit.test.tsx
@@ -67,6 +67,7 @@ const renderOperationNode = (
     handleParentClick?: () => void;
     handleParentMouseDown?: () => void;
   } = {},
+  selected = false,
 ) => {
   const node = {
     id: nodeId,
@@ -88,7 +89,7 @@ const renderOperationNode = (
     </CanvasPageStoreContext.Provider>
   );
 
-  render(<OperationNode data={data} id={nodeId} />, { wrapper });
+  render(<OperationNode data={data} id={nodeId} selected={selected} />, { wrapper });
 
   return store;
 };
@@ -124,6 +125,30 @@ describe("OperationNode", () => {
     expect(runningLabel).toBeInTheDocument();
     expect(runningLabel.parentElement?.querySelector("svg")).not.toHaveClass("animate-spin");
     expect(screen.queryByText("待运行")).not.toBeInTheDocument();
+  });
+
+  it("keeps a compact card compact when the node is selected", () => {
+    const store = createCanvasPageStore([
+      {
+        id: nodeId,
+        type: "operation",
+        position: { x: 0, y: 0 },
+        data: baseData,
+      } as PipelineNode,
+    ]);
+    store.setState({ nodeCardMode: "compact" });
+
+    render(<OperationNode data={baseData} id={nodeId} selected />, {
+      wrapper: ({ children }) => (
+        <CanvasPageStoreContext.Provider value={store}>{children}</CanvasPageStoreContext.Provider>
+      ),
+    });
+
+    expect(screen.getByTestId("canvas-v2-node-shell-root")).toHaveAttribute(
+      "data-card-mode",
+      "compact",
+    );
+    expect(screen.queryByText("Agent")).not.toBeInTheDocument();
   });
 
   it("updates runtime selection without bubbling canvas interactions", async () => {

--- a/packages/views/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
+++ b/packages/views/src/pages/CanvasPage/OutputLocalPathNode/OutputLocalPathNode.tsx
@@ -5,7 +5,7 @@ import { OUTPUT_MODE_ENUM, type OutputMode, type LocalPathOutputNodeData } from 
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodeCardActions } from "../NodeCard";
 import { FolderBrowserDialog } from "../../../components/FolderBrowserDialog/FolderBrowserDialog";
 import { Button } from "@repo/ui/button";
 import { Input } from "@repo/ui/input";
@@ -29,6 +29,7 @@ const MODE_LABEL_KEYS: Record<OutputMode, string> = {
 export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
+  const nodeCardActions = useNodeCardActions(id);
   const {
     runStatus,
     dimmed,
@@ -97,8 +98,10 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
     <div className="group relative w-fit overflow-visible">
       <NodeCard
         leftHandle
+        actions={nodeCardActions}
         bodyClassName="space-y-2"
         compact={nodeCardMode === "compact"}
+        detail={data.outputMode ?? t("canvas.nodeTypes.output-local-path.label")}
         description={t("nodes.outputLocalPathNode.description")}
         dimmed={dimmed}
         icon={HardDrive}
@@ -113,12 +116,12 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
         theme="teal"
         onLabelChange={handleLabelChange}
       >
-        <div className="flex items-center gap-1 rounded-md bg-teal-500/10 px-2 py-1 ring-1 ring-teal-500/20">
-          <span className="shrink-0 text-[10px] font-medium text-teal-700 dark:text-teal-300">
+        <div className="flex items-center gap-1 rounded-md bg-surface-2 px-1.5 py-1 ring-1 ring-border">
+          <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
             {t("nodes.outputLocalPathNode.pathLabel")}
           </span>
           <Input
-            className="nodrag nopan h-auto min-w-0 flex-1 border-none bg-transparent p-0 font-mono text-[11px] font-semibold text-foreground shadow-none focus:outline-none"
+            className="nodrag nopan h-auto min-w-0 flex-1 truncate border-none bg-transparent p-0 font-mono text-[9.5px] text-muted-foreground shadow-none focus:outline-none focus:text-foreground"
             placeholder="/Users/you/Desktop/output"
             value={data.localPath}
             onChange={handleLocalPathInputChange}
@@ -127,7 +130,7 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
             onMouseDown={handleStopPropagation}
           />
           <Button
-            className="nodrag nopan h-auto shrink-0 rounded p-0.5 text-teal-500 transition-colors hover:bg-teal-500/10 hover:text-teal-700 dark:hover:text-teal-300"
+            className="nodrag nopan h-auto shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             title={t("nodes.outputLocalPathNode.browseFolder")}
             type="button"
             variant="ghost"
@@ -138,12 +141,12 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
           </Button>
         </div>
 
-        <div className="flex items-center gap-1 rounded-md bg-teal-500/10 px-2 py-1 ring-1 ring-teal-500/20">
-          <span className="shrink-0 text-[10px] font-medium text-teal-700 dark:text-teal-300">
+        <div className="flex items-center gap-1 rounded-md bg-surface-2 px-1.5 py-1 ring-1 ring-border">
+          <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
             {t("nodes.outputLocalPathNode.filenameLabel")}
           </span>
           <Input
-            className="nodrag nopan h-auto min-w-0 flex-1 border-none bg-transparent p-0 font-mono text-[11px] font-semibold text-foreground shadow-none focus:outline-none"
+            className="nodrag nopan h-auto min-w-0 flex-1 truncate border-none bg-transparent p-0 font-mono text-[9.5px] text-muted-foreground shadow-none focus:outline-none focus:text-foreground"
             placeholder="output.md"
             value={data.outputFileName ?? ""}
             onChange={handleFileNameInputChange}
@@ -153,13 +156,13 @@ export const OutputLocalPathNode = ({ id, data, selected }: OutputLocalPathNodeP
           />
         </div>
 
-        <div className="flex items-center gap-1 rounded-md bg-teal-500/10 px-2 py-1 ring-1 ring-teal-500/20">
-          <span className="shrink-0 text-[10px] font-medium text-teal-700 dark:text-teal-300">
+        <div className="flex items-center gap-1 rounded-md bg-surface-2 px-1.5 py-1 ring-1 ring-border">
+          <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
             {t("nodes.outputLocalPathNode.writeModeLabel")}
           </span>
           <Select value={currentMode} onValueChange={handleOutputModeChange}>
             <SelectTrigger
-              className="nodrag nopan h-6 min-w-0 flex-1 border-none bg-transparent px-0 py-0 text-[11px] font-semibold text-foreground shadow-none focus:ring-0"
+              className="nodrag nopan h-6 min-w-0 flex-1 border-none bg-transparent px-0 py-0 font-mono text-[9.5px] text-muted-foreground shadow-none focus:text-foreground focus:ring-0"
               onClick={handleStopPropagation}
               onMouseDown={handleStopPropagation}
             >

--- a/packages/views/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.tsx
+++ b/packages/views/src/pages/CanvasPage/OutputProjectPathNode/OutputProjectPathNode.tsx
@@ -4,7 +4,7 @@ import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
 import type { ProjectPathOutputNodeData } from "@repo/schemas";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodeCardActions } from "../NodeCard";
 import { Input } from "@repo/ui/input";
 import { Textarea } from "@repo/ui/textarea";
 
@@ -19,6 +19,7 @@ const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
 export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathNodeProps) => {
   const { t } = useTranslation();
   const store = useCanvasPageStore();
+  const nodeCardActions = useNodeCardActions(id);
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
   const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
@@ -42,8 +43,10 @@ export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathN
     <div className="group relative w-fit overflow-visible">
       <NodeCard
         leftHandle
+        actions={nodeCardActions}
         bodyClassName="space-y-2"
         compact={nodeCardMode === "compact"}
+        detail={data.projectId ?? t("canvas.nodeTypes.output-project-path.label")}
         description={t("nodes.outputProjectPath.description")}
         dimmed={dimmed}
         icon={FolderOutput}
@@ -59,24 +62,24 @@ export const OutputProjectPathNode = ({ id, data, selected }: OutputProjectPathN
         onLabelChange={handleLabelChange}
       >
         <div className="space-y-1.5">
-          <div className="flex items-center gap-1 rounded-md bg-surface-2 px-2.5 py-1 ring-1 ring-border">
+          <div className="flex items-center gap-1 rounded-md bg-surface-2 px-1.5 py-1 ring-1 ring-border">
             <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
               {t("nodes.outputProjectPath.projectIdLabel")}
             </span>
             <Input
-              className="nodrag nopan h-auto min-w-0 flex-1 border-none bg-transparent p-0 font-mono text-[11px] text-foreground shadow-none focus:outline-none"
+              className="nodrag nopan h-auto min-w-0 flex-1 truncate border-none bg-transparent p-0 font-mono text-[9.5px] text-muted-foreground shadow-none focus:outline-none focus:text-foreground"
               placeholder="project-id"
               value={data.projectId ?? ""}
               onChange={handleProjectIdChange}
               onMouseDown={handleMouseDown}
             />
           </div>
-          <div className="flex items-center gap-1 rounded-md bg-teal-500/10 px-2.5 py-1 ring-1 ring-teal-500/20">
-            <span className="shrink-0 text-[10px] font-medium text-teal-700 dark:text-teal-300">
+          <div className="flex items-center gap-1 rounded-md bg-surface-2 px-1.5 py-1 ring-1 ring-border">
+            <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
               {t("nodes.outputProjectPath.pathLabel")}
             </span>
             <Input
-              className="nodrag nopan h-auto min-w-0 flex-1 border-none bg-transparent p-0 font-mono text-[11px] font-semibold text-foreground shadow-none focus:outline-none"
+              className="nodrag nopan h-auto min-w-0 flex-1 truncate border-none bg-transparent p-0 font-mono text-[9.5px] text-muted-foreground shadow-none focus:outline-none focus:text-foreground"
               placeholder="src/output/"
               value={data.path}
               onChange={handlePathChange}

--- a/packages/views/src/pages/CanvasPage/PromptNode/PromptNode.tsx
+++ b/packages/views/src/pages/CanvasPage/PromptNode/PromptNode.tsx
@@ -3,7 +3,7 @@ import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "../_store";
 import type { PromptObjectNodeData } from "@repo/schemas";
-import { NodeCard } from "../NodeCard";
+import { NodeCard, useNodeCardActions } from "../NodeCard";
 import { Textarea } from "@repo/ui/textarea";
 
 export interface PromptNodeProps {
@@ -16,6 +16,7 @@ const handleStopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
 
 export const PromptNode = ({ id, data, selected }: PromptNodeProps) => {
   const store = useCanvasPageStore();
+  const nodeCardActions = useNodeCardActions(id);
   const { runStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
   const nodeCardMode = useStore(store, (s) => s.nodeCardMode);
   const updateNodeData = useStore(store, (s) => s.updateNodeData);
@@ -28,8 +29,10 @@ export const PromptNode = ({ id, data, selected }: PromptNodeProps) => {
   return (
     <NodeCard
       rightHandle
+      actions={nodeCardActions}
       bodyClassName="space-y-2"
       compact={nodeCardMode === "compact"}
+      detail="Prompt"
       description="Prompt"
       dimmed={dimmed}
       icon={MessageSquareText}
@@ -41,7 +44,7 @@ export const PromptNode = ({ id, data, selected }: PromptNodeProps) => {
       onLabelChange={handleLabelChange}
     >
       <Textarea
-        className="nodrag nopan text-xs min-h-[60px] resize-none"
+        className="nodrag nopan min-h-[60px] resize-none rounded-md border-none bg-surface-2 px-1.5 py-1 text-[10px] text-muted-foreground/85 shadow-none focus:outline-none focus:ring-1 focus:ring-border"
         placeholder="Enter prompt text..."
         rows={3}
         value={data.prompt}

--- a/packages/views/src/pages/CanvasPage/RunConsole/RunConsole.stories.tsx
+++ b/packages/views/src/pages/CanvasPage/RunConsole/RunConsole.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Decorator, Meta, StoryObj } from "@storybook/react";
 import { Refine } from "@refinedev/core";
 import {
   createCanvasPageStore,
@@ -43,14 +43,26 @@ const edge = {
   data: {},
 } as PipelineEdge;
 
-const withRunConsoleStore = (Story: React.ComponentType) => {
+type RunConsoleState = "loading" | "queued" | "running" | "done" | "failed";
+
+const withRunConsoleStore: Decorator<typeof RunConsole> = (Story, context) => {
+  const state = (context.parameters.runConsoleState ?? "running") as RunConsoleState;
+  const jobIdByState: Record<RunConsoleState, string | null> = {
+    loading: null,
+    queued: "job-queued-story",
+    running: "job-story",
+    done: "job-done-story",
+    failed: "job-failed-story",
+  };
+  const jobId = jobIdByState[state];
+  const isRunning = state === "running";
   const store = createCanvasPageStore([sourceNode, operationNode], [edge]);
   store.setState({
-    activeJobId: "job-story",
+    activeJobId: jobId,
     isConsoleOpen: true,
-    isTestRunning: true,
-    runningNodeId: "review-op",
-    nodeRunStatuses: { "review-op": "running" },
+    isTestRunning: isRunning,
+    runningNodeId: isRunning ? "review-op" : null,
+    nodeRunStatuses: isRunning ? { "review-op": "running" } : {},
   });
 
   return (
@@ -84,9 +96,56 @@ type Story = StoryObj<typeof RunConsole>;
 
 export const Running: Story = {
   parameters: {
+    runConsoleState: "running",
     docs: {
       description: {
         story: "Console open with a running job, visible logs, and structured node status updates.",
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  parameters: {
+    runConsoleState: "loading",
+    docs: {
+      description: {
+        story: "Console shell mounted before the active develop Job resource has resolved.",
+      },
+    },
+  },
+};
+
+export const Queued: Story = {
+  parameters: {
+    runConsoleState: "queued",
+    docs: {
+      description: {
+        story:
+          "Queued Job state before execution begins, using the current develop JobStatus enum.",
+      },
+    },
+  },
+};
+
+export const Completed: Story = {
+  parameters: {
+    runConsoleState: "done",
+    docs: {
+      description: {
+        story:
+          "Successful terminal state with an empty timeline, preserving the current run-console layout.",
+      },
+    },
+  },
+};
+
+export const Failed: Story = {
+  parameters: {
+    runConsoleState: "failed",
+    docs: {
+      description: {
+        story: "Failed terminal state with the develop Job error rendered in the console body.",
       },
     },
   },

--- a/packages/views/src/pages/CanvasPage/RunConsole/RunConsole.tsx
+++ b/packages/views/src/pages/CanvasPage/RunConsole/RunConsole.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { Terminal, X, ChevronUp, ChevronDown, Loader2, FileText } from "lucide-react";
-import { Button } from "@repo/ui/button";
-import { ScrollArea } from "@repo/ui/scroll-area";
+import { ChevronDown, ChevronUp, FileText, Loader2, SquareTerminal, X } from "lucide-react";
 import { cn } from "@repo/ui/lib/utils";
 import { useCustom, useDataProvider, useOne } from "@refinedev/core";
 import { useStore } from "zustand";
@@ -227,158 +225,143 @@ export const RunConsole = () => {
 
   return (
     <div
-      className={cn(
-        "absolute bottom-0 left-0 right-0 z-30 border-t bg-surface shadow-float transition-all",
-        isConsoleCollapsed ? "h-9" : "h-64",
-      )}
+      className="pointer-events-auto absolute inset-x-3 bottom-16 z-30"
       data-testid="canvas-run-console"
     >
-      {/* Status bar */}
-      <div className="flex h-9 items-center justify-between border-b bg-surface-2/80 px-3">
-        <div className="flex items-center gap-2 text-xs">
-          <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="font-medium">{t("canvas.runConsole.title")}</span>
-          {job && (
-            <>
-              <span className="text-muted-foreground">|</span>
-              <StatusIcon status={job.status} />
-              <span
-                className={cn(
-                  "font-medium",
-                  job.status === "running" && "text-blue-600 dark:text-blue-400",
-                  job.status === "done" && "text-emerald-600 dark:text-emerald-400",
-                  job.status === "failed" && "text-red-600 dark:text-red-400",
-                  job.status === "expired" && "text-muted-foreground",
-                )}
-              >
-                {t(statusLabelKeys[job.status])}
-              </span>
-              {job.status === "running" && (
-                <span className="text-muted-foreground">
-                  ({t("canvas.runConsole.logs", { count: traceLogs.length })})
-                </span>
-              )}
-            </>
-          )}
-        </div>
-
-        <div className="flex items-center gap-0.5">
-          <Button
-            className="h-6 w-6"
-            size="icon"
-            variant="ghost"
+      <div className="overflow-hidden rounded-2xl bg-surface shadow-float ring-1 ring-border-strong">
+        <div className="flex w-full items-center gap-2 border-b border-border/70 px-3.5 py-2">
+          <button
+            className="flex min-w-0 flex-1 items-center gap-2 text-left"
+            data-testid="run-console-toggle"
+            type="button"
             onClick={handleToggleConsoleCollapse}
           >
-            {isConsoleCollapsed ? (
-              <ChevronUp className="h-3.5 w-3.5" />
-            ) : (
-              <ChevronDown className="h-3.5 w-3.5" />
-            )}
-          </Button>
-          <Button className="h-6 w-6" size="icon" variant="ghost" onClick={handleCloseConsole}>
-            <X className="h-3.5 w-3.5" />
-          </Button>
+            <span className="flex size-5 items-center justify-center rounded-md bg-surface-2">
+              <SquareTerminal className="size-3 text-foreground/75" />
+            </span>
+            <span className="text-xs font-semibold">{t("canvas.runConsole.title")}</span>
+            <span className="rounded-full bg-surface-2 px-1.5 py-0.5 font-mono text-[9.5px] text-muted-foreground">
+              {t("canvas.runConsole.logs", { count: traceLogs.length })}
+            </span>
+            {job ? (
+              <span className="flex min-w-0 items-center gap-1.5 truncate font-mono text-[10px] text-muted-foreground">
+                <StatusIcon status={job.status} />
+                <span className="truncate">
+                  {jobId} · {t(statusLabelKeys[job.status])}
+                </span>
+              </span>
+            ) : null}
+            <span className="ml-auto flex items-center gap-1 text-[10px] text-muted-foreground">
+              {isConsoleCollapsed ? (
+                <ChevronUp className="size-3.5" />
+              ) : (
+                <ChevronDown className="size-3.5" />
+              )}
+            </span>
+          </button>
+          <button
+            className="rounded-lg p-1 text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+            aria-label={t("common.close")}
+            data-testid="run-console-close"
+            type="button"
+            onClick={handleCloseConsole}
+          >
+            <X className="size-3.5" />
+          </button>
         </div>
-      </div>
-
-      {/* Log area */}
-      {!isConsoleCollapsed && (
-        <ScrollArea className="h-[calc(100%-2.25rem)]">
-          <div ref={scrollRef} className="h-full overflow-auto p-3 text-xs">
+        {!isConsoleCollapsed && (
+          <div
+            ref={scrollRef}
+            className="h-44 overflow-y-auto px-3.5 py-2.5 font-mono text-[10.5px] leading-relaxed"
+          >
             {!job && (
               <div className="flex items-center gap-2 text-muted-foreground">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Loader2 className="size-3.5 animate-spin" />
                 {t("canvas.runConsole.loading")}
               </div>
             )}
             {job && (
-              <div className="mb-3 grid gap-2 lg:grid-cols-[1fr_1.15fr]">
-                <section className="rounded-lg border bg-card/70 p-3">
-                  <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              <div className="mb-2 space-y-1.5 font-sans text-[10px] leading-normal">
+                <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                  <span className="font-semibold uppercase tracking-wide text-muted-foreground">
                     {t("canvas.runConsole.currentStep")}
-                  </div>
-                  <div className="mt-1 truncate text-sm font-semibold">{currentNodeLabel}</div>
-                  {runTimeline.latestProgressMessage && (
-                    <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                  </span>
+                  <span className="truncate font-semibold text-foreground">{currentNodeLabel}</span>
+                  {runTimeline.latestProgressMessage ? (
+                    <span className="min-w-0 truncate text-muted-foreground">
                       {runTimeline.latestProgressMessage}
-                    </p>
-                  )}
-                  <p className="mt-2 rounded-md bg-blue-500/10 px-2 py-1 text-[11px] text-blue-700 dark:text-blue-300">
-                    {multiInputSummary.count > 0
-                      ? t("canvas.runConsole.multiInputRuleWithCount", {
-                          count: multiInputSummary.count,
-                        })
-                      : t("canvas.runConsole.multiInputRule")}
-                  </p>
-                </section>
-
-                <section className="rounded-lg border bg-card/70 p-3">
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                      {t("canvas.runConsole.timeline")}
-                    </div>
-                    <span className="text-[11px] text-muted-foreground">
-                      {t("canvas.runConsole.timelineCount", {
-                        count: runTimeline.timeline.length,
-                      })}
                     </span>
-                  </div>
-                  <div className="mt-2 flex flex-wrap gap-1.5">
-                    {runTimeline.timeline.length === 0 ? (
-                      <span className="text-muted-foreground">
-                        {t("canvas.runConsole.timelineEmpty")}
-                      </span>
-                    ) : (
-                      runTimeline.timeline.map((item) => (
-                        <span
-                          key={item.nodeId}
-                          className={cn(
-                            "inline-flex max-w-[220px] items-center gap-1 rounded-full border px-2 py-1",
-                            item.status === "running" &&
-                              "border-blue-500/20 bg-blue-500/10 text-blue-700 dark:text-blue-300",
-                            item.status === "done" &&
-                              "border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-                            item.status === "failed" &&
-                              "border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-300",
-                          )}
-                        >
-                          <span className="truncate">
-                            {nodeLabelById.get(item.nodeId) ?? item.nodeId}
-                          </span>
-                          <span className="shrink-0 text-[10px] font-semibold uppercase">
-                            {t(timelineStatusLabelKeys[item.status])}
-                          </span>
+                  ) : null}
+                </div>
+
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className="font-semibold uppercase tracking-wide text-muted-foreground">
+                    {t("canvas.runConsole.timeline")}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {t("canvas.runConsole.timelineCount", {
+                      count: runTimeline.timeline.length,
+                    })}
+                  </span>
+                  {runTimeline.timeline.length === 0 ? (
+                    <span className="text-muted-foreground">
+                      {t("canvas.runConsole.timelineEmpty")}
+                    </span>
+                  ) : (
+                    runTimeline.timeline.map((item) => (
+                      <span
+                        key={item.nodeId}
+                        className={cn(
+                          "inline-flex max-w-[220px] items-center gap-1 rounded-full border px-1.5 py-0.5",
+                          ["running", "queued", "waitingForUser", "retrying"].includes(
+                            item.status,
+                          ) && "status-wash-muted",
+                          item.status === "done" && "status-wash-success",
+                          item.status === "failed" && "status-wash-error",
+                        )}
+                      >
+                        <span className="truncate">
+                          {nodeLabelById.get(item.nodeId) ?? item.nodeId}
                         </span>
-                      ))
-                    )}
-                  </div>
-                </section>
+                        <span className="shrink-0 font-semibold uppercase">
+                          {t(timelineStatusLabelKeys[item.status])}
+                        </span>
+                      </span>
+                    ))
+                  )}
+                </div>
+
+                <div className="rounded-lg bg-surface-2/60 px-2 py-1 text-muted-foreground ring-1 ring-border">
+                  {multiInputSummary.count > 0
+                    ? t("canvas.runConsole.multiInputRuleWithCount", {
+                        count: multiInputSummary.count,
+                      })
+                    : t("canvas.runConsole.multiInputRule")}
+                </div>
 
                 {runTimeline.artifacts.length > 0 && (
-                  <section className="rounded-lg border bg-card/70 p-3 lg:col-span-2">
-                    <div className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                      <FileText className="h-3.5 w-3.5" />
+                  <div className="flex flex-wrap items-center gap-1.5 text-muted-foreground">
+                    <span className="inline-flex items-center gap-1 font-semibold uppercase tracking-wide">
+                      <FileText className="size-3" />
                       {t("canvas.runConsole.artifacts")}
-                    </div>
-                    <div className="flex flex-col gap-1">
-                      {runTimeline.artifacts.map((artifact) => (
-                        <code
-                          key={artifact.path}
-                          className="rounded bg-muted px-2 py-1 font-mono text-[11px] text-foreground"
-                        >
-                          {artifact.path}
-                        </code>
-                      ))}
-                    </div>
-                  </section>
+                    </span>
+                    {runTimeline.artifacts.map((artifact) => (
+                      <code
+                        key={artifact.path}
+                        className="rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[10px] text-foreground"
+                      >
+                        {artifact.path}
+                      </code>
+                    ))}
+                  </div>
                 )}
               </div>
             )}
             {traceLogs
               .filter((l) => !isStructuredLog(l))
               .map((log, i) => (
-                <div key={i} className="flex gap-2 py-0.5 font-mono hover:bg-muted/30">
-                  <span className="shrink-0 text-muted-foreground tabular-nums">
+                <div key={i} className="flex gap-2">
+                  <span className="shrink-0 tabular-nums text-muted-foreground">
                     {parseTimestamp(log)}
                   </span>
                   <span
@@ -395,14 +378,12 @@ export const RunConsole = () => {
                   </span>
                 </div>
               ))}
-            {job?.status === "failed" && job.error && (
-              <div className="mt-2 rounded border border-red-500/20 bg-red-500/10 px-3 py-2 text-red-700 dark:text-red-300">
-                {job.error}
-              </div>
-            )}
+            {job?.status === "failed" && job.error ? (
+              <div className="mt-2 rounded-lg px-2 py-1.5 status-wash-error">{job.error}</div>
+            ) : null}
           </div>
-        </ScrollArea>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/views/src/pages/CanvasPage/SemanticEdge/SemanticEdge.tsx
+++ b/packages/views/src/pages/CanvasPage/SemanticEdge/SemanticEdge.tsx
@@ -1,0 +1,110 @@
+import { ArrowRightLeft, RotateCcw, ShieldCheck } from "lucide-react";
+import { BaseEdge, EdgeLabelRenderer, getBezierPath, type EdgeProps } from "@xyflow/react";
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import { cn } from "@repo/ui/lib/utils";
+import type { PipelineEdgeData } from "@repo/schemas";
+import { useCanvasPageStore } from "../_store";
+
+type SemanticEdgeState = "idle" | "pending" | "flow" | "done" | "selected";
+
+const edgeStateClass: Record<SemanticEdgeState, string> = {
+  idle: "stroke-muted-foreground/45",
+  pending: "stroke-muted-foreground/40 opacity-60",
+  flow: "stroke-foreground edge-flow",
+  done: "stroke-success",
+  selected: "stroke-foreground",
+};
+
+const edgeLabelClass: Record<SemanticEdgeState, string> = {
+  idle: "bg-surface text-foreground/80 ring-border",
+  pending: "bg-surface text-muted-foreground ring-border opacity-70",
+  flow: "bg-foreground text-primary-foreground ring-foreground",
+  done: "bg-success/10 text-success ring-success/20",
+  selected: "bg-foreground text-primary-foreground ring-foreground",
+};
+
+const getSemanticEdgeState = (
+  selected: boolean | undefined,
+  phase: string,
+  sourceStatus?: string,
+  targetStatus?: string,
+): SemanticEdgeState => {
+  if (selected) return "selected";
+  if (phase === "proposal") return "pending";
+  if (sourceStatus === "done" && targetStatus === "running") return "flow";
+  if (sourceStatus === "done" && targetStatus === "done") return "done";
+
+  return "idle";
+};
+
+export const SemanticEdge = ({
+  data,
+  id,
+  selected,
+  source,
+  sourceX,
+  sourceY,
+  sourcePosition,
+  target,
+  targetX,
+  targetY,
+  targetPosition,
+}: EdgeProps) => {
+  const { t } = useTranslation();
+  const store = useCanvasPageStore();
+  const edgeData = data as PipelineEdgeData | undefined;
+  const selectedEdgeId = useStore(store, (state) => state.selectedEdgeId);
+  const pendingProposal = useStore(store, (state) => state.agentPanel.pendingProposal);
+  const sourceStatus = useStore(store, (state) => state.nodeRunStatuses[source]);
+  const targetStatus = useStore(store, (state) => state.nodeRunStatuses[target]);
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourcePosition,
+    sourceX,
+    sourceY,
+    targetPosition,
+    targetX,
+    targetY,
+  });
+  const semanticState = getSemanticEdgeState(
+    selected || selectedEdgeId === id,
+    pendingProposal ? "proposal" : "applied",
+    sourceStatus,
+    targetStatus,
+  );
+  const label = edgeData?.label || t("workspace.canvas.edges.defaultLabel");
+  const isLoopEdge = Boolean(edgeData?.condition);
+  const Icon = edgeData?.qualityGate ? ShieldCheck : isLoopEdge ? RotateCcw : ArrowRightLeft;
+
+  return (
+    <>
+      <BaseEdge
+        className={cn(
+          "stroke-[2px]",
+          edgeStateClass[semanticState],
+          isLoopEdge && "stroke-warning [stroke-dasharray:6_4]",
+        )}
+        id={id}
+        path={edgePath}
+      />
+      <EdgeLabelRenderer>
+        <div
+          className="nodrag nopan absolute -translate-x-1/2 -translate-y-1/2"
+          style={{ transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)` }}
+        >
+          <div
+            className={cn(
+              "flex items-center gap-1 rounded-full px-2 py-0.5 text-[9.5px] shadow-soft ring-1 transition-all",
+              edgeLabelClass[semanticState],
+              isLoopEdge && "bg-warning/10 text-foreground ring-warning/30",
+            )}
+            data-testid="canvas-v2-semantic-edge-label"
+          >
+            <Icon className="h-2.5 w-2.5" />
+            <span className="max-w-28 truncate font-mono">{label}</span>
+          </div>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+};

--- a/packages/views/src/pages/CanvasPage/SemanticEdge/SemanticEdge.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/SemanticEdge/SemanticEdge.unit.test.tsx
@@ -1,0 +1,133 @@
+import { act, render, screen } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { Position, ReactFlowProvider, type EdgeProps } from "@xyflow/react";
+import type * as XyFlowReact from "@xyflow/react";
+import type { PipelineActionProposal, PipelineEdgeData } from "@repo/schemas";
+import { CanvasPageStoreContext, createCanvasPageStore, type CanvasPageState } from "../_store";
+import { SemanticEdge } from "./SemanticEdge";
+
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof XyFlowReact>();
+
+  return {
+    ...actual,
+    EdgeLabelRenderer: ({ children }: PropsWithChildren) => <>{children}</>,
+  };
+});
+
+const baseEdgeProps = {
+  data: { label: "document" } satisfies PipelineEdgeData,
+  id: "edge-1",
+  selected: false,
+  source: "source",
+  sourcePosition: Position.Right,
+  sourceX: 40,
+  sourceY: 80,
+  target: "target",
+  targetPosition: Position.Left,
+  targetX: 260,
+  targetY: 80,
+} as EdgeProps;
+
+const proposal: PipelineActionProposal = {
+  actions: [{ edgeId: "edge-1", type: "removeEdge" }],
+  summary: "Remove the edge",
+};
+
+const renderSemanticEdge = (
+  state: Partial<CanvasPageState> = {},
+  props: Partial<EdgeProps> = {},
+) => {
+  const store = createCanvasPageStore([], []);
+  store.setState(state);
+
+  render(
+    <CanvasPageStoreContext.Provider value={store}>
+      <ReactFlowProvider>
+        <svg>
+          <SemanticEdge {...baseEdgeProps} {...props} />
+        </svg>
+      </ReactFlowProvider>
+    </CanvasPageStoreContext.Provider>,
+  );
+
+  return store;
+};
+
+const edgePath = () => document.querySelector("path");
+const edgeLabel = () => screen.getByTestId("canvas-v2-semantic-edge-label");
+
+describe("SemanticEdge", () => {
+  it("renders the Alan edge path and centered data label in the idle state", () => {
+    renderSemanticEdge();
+
+    expect(edgePath()).toHaveClass("stroke-[2px]");
+    expect(edgePath()).toHaveClass("stroke-muted-foreground/45");
+    expect(edgeLabel()).toHaveTextContent("document");
+    expect(edgeLabel()).toHaveClass("bg-surface", "ring-border");
+  });
+
+  it("uses the current selectedEdgeId and keeps selection visually dominant", () => {
+    const store = renderSemanticEdge();
+
+    act(() => {
+      store.setState({ selectedEdgeId: "edge-1" });
+    });
+
+    expect(edgePath()).toHaveClass("stroke-foreground");
+    expect(edgeLabel()).toHaveClass("bg-foreground", "ring-foreground");
+  });
+
+  it("derives pending, flow, and done states from current develop state", () => {
+    const store = renderSemanticEdge({
+      agentPanel: {
+        diagnostics: null,
+        isLoading: false,
+        isOpen: true,
+        pendingProposal: proposal,
+      },
+    });
+
+    expect(edgePath()).toHaveClass("stroke-muted-foreground/40", "opacity-60");
+    expect(edgeLabel()).toHaveClass("text-muted-foreground", "opacity-70");
+
+    act(() => {
+      store.setState({
+        agentPanel: {
+          diagnostics: null,
+          isLoading: false,
+          isOpen: true,
+          pendingProposal: null,
+        },
+        nodeRunStatuses: { source: "done", target: "running" },
+      });
+    });
+
+    expect(edgePath()).toHaveClass("stroke-foreground", "edge-flow");
+    expect(edgeLabel()).toHaveClass("bg-foreground", "ring-foreground");
+
+    act(() => {
+      store.setState({ nodeRunStatuses: { source: "done", target: "done" } });
+    });
+
+    expect(edgePath()).toHaveClass("stroke-success");
+    expect(edgeLabel()).toHaveClass("bg-success/10", "text-success", "ring-success/20");
+  });
+
+  it("uses warning dashed loop styling and preserves quality-gate labels", () => {
+    renderSemanticEdge(
+      {},
+      {
+        data: {
+          condition: { expression: "retry" },
+          label: "retry",
+          qualityGate: { criteria: "valid", onFail: "retry" },
+        } satisfies PipelineEdgeData,
+      },
+    );
+
+    expect(edgePath()).toHaveClass("stroke-warning", "[stroke-dasharray:6_4]");
+    expect(edgeLabel()).toHaveTextContent("retry");
+  });
+});

--- a/packages/views/src/pages/CanvasPage/SemanticEdge/index.ts
+++ b/packages/views/src/pages/CanvasPage/SemanticEdge/index.ts
@@ -1,0 +1,1 @@
+export * from "./SemanticEdge";

--- a/packages/views/src/pages/CanvasPage/canvas.css
+++ b/packages/views/src/pages/CanvasPage/canvas.css
@@ -23,6 +23,251 @@
   height: 100%;
 }
 
+.canvas-grid {
+  background-color: var(--canvas);
+  background-image: radial-gradient(circle, var(--canvas-dot) 1px, transparent 1px);
+  background-position: -1px -1px;
+  background-size: 22px 22px;
+}
+
+.canvas-board-grid {
+  background:
+    linear-gradient(var(--canvas-dot) 1px, transparent 1px),
+    linear-gradient(90deg, var(--canvas-dot) 1px, transparent 1px), var(--background);
+  background-size: 24px 24px;
+}
+
+.react-flow__edge-path {
+  fill: none;
+  stroke: var(--edge);
+  stroke-width: 1.25;
+  transition:
+    stroke 150ms ease,
+    stroke-width 150ms ease;
+}
+
+.react-flow__edge.animated .react-flow__edge-path,
+.edge-flow {
+  animation: dash-flow 600ms linear infinite;
+  stroke-dasharray: 3 5;
+}
+
+.react-flow__edge:hover .react-flow__edge-path {
+  stroke: color-mix(in oklch, var(--foreground) 70%, transparent);
+  stroke-width: 1.75;
+}
+
+.status-wash-success {
+  background: color-mix(in oklab, var(--success) 12%, transparent);
+  color: color-mix(in oklab, var(--success) 78%, var(--foreground));
+}
+
+.status-wash-error {
+  background: color-mix(in oklab, var(--destructive) 12%, transparent);
+  color: color-mix(in oklab, var(--destructive) 78%, var(--foreground));
+}
+
+.status-wash-muted {
+  background: var(--surface-2);
+  color: var(--muted-foreground);
+}
+
+@keyframes node-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 0 rgb(0 0 0 / 5%),
+      0 4px 12px rgb(0 0 0 / 3%);
+  }
+
+  50% {
+    box-shadow:
+      0 0 0 4px rgb(0 0 0 / 4.5%),
+      0 4px 12px rgb(0 0 0 / 3%);
+  }
+}
+
+.node-running {
+  animation: node-pulse 2s ease-in-out infinite;
+}
+
+@keyframes node-appear {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.node-appear {
+  animation: node-appear 450ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+@keyframes dash-flow {
+  to {
+    stroke-dashoffset: -16;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes ping {
+  75%,
+  100% {
+    opacity: 0;
+    transform: scale(2);
+  }
+}
+
+.ping {
+  animation: ping 1.4s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+@keyframes fade-rise {
+  from {
+    transform: translateY(7px);
+  }
+
+  to {
+    transform: none;
+  }
+}
+
+.fade-rise {
+  animation: fade-rise 260ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+@keyframes page-swap {
+  from {
+    transform: translateY(8px);
+  }
+
+  to {
+    transform: none;
+  }
+}
+
+.page-swap {
+  animation: page-swap 300ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+@keyframes panel-in {
+  from {
+    transform: translateX(-6px);
+  }
+
+  to {
+    transform: none;
+  }
+}
+
+.panel-in,
+.slide-in {
+  animation: panel-in 220ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+@keyframes drawer-in {
+  from {
+    transform: translateX(24px);
+  }
+
+  to {
+    transform: none;
+  }
+}
+
+.drawer-in {
+  animation: drawer-in 240ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+.bar-grow {
+  transform-origin: bottom;
+}
+
+@keyframes cfg-pop {
+  from {
+    transform: translateY(7px) scale(0.97);
+  }
+
+  to {
+    transform: none;
+  }
+}
+
+.node-config-card {
+  animation: cfg-pop 200ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+.node-config-bg {
+  background: oklch(0.18 0 0 / 10%);
+}
+
+@keyframes cfg-rise {
+  from {
+    transform: translate(-50%, 8px);
+  }
+
+  to {
+    transform: translate(-50%, 0);
+  }
+}
+
+.edge-inspector-card {
+  animation: cfg-rise 200ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+.cfg-range {
+  appearance: none;
+  background: var(--surface-2);
+  border-radius: 9999px;
+  height: 4px;
+  outline: none;
+}
+
+.cfg-range::-webkit-slider-thumb {
+  appearance: none;
+  background: var(--foreground);
+  border: 2px solid #fff;
+  border-radius: 9999px;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 20%);
+  cursor: grab;
+  height: 14px;
+  width: 14px;
+}
+
+.cfg-range::-webkit-slider-thumb:active {
+  cursor: grabbing;
+}
+
+.cfg-range::-moz-range-thumb {
+  background: var(--foreground);
+  border: 2px solid #fff;
+  border-radius: 9999px;
+  cursor: grab;
+  height: 14px;
+  width: 14px;
+}
+
+.io-handle {
+  z-index: 5;
+}
+
+.no-bar::-webkit-scrollbar {
+  display: none;
+}
+
 @keyframes canvas-node-pop {
   0% {
     opacity: 0;
@@ -91,7 +336,11 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .canvas-node-pop {
-    animation: none;
+  .canvas-container,
+  .canvas-container * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/packages/views/src/pages/CanvasPage/storybookData.ts
+++ b/packages/views/src/pages/CanvasPage/storybookData.ts
@@ -468,6 +468,14 @@ export const canvasStoryJobTraces: JobTrace[] = [
       "[2026-04-08T16:00:03.000Z] @@LLM_CONTENT::review-op::### Review\nNo blocking issues in this Storybook scenario.",
     createdAt: new Date("2026-04-08T16:00:03.000Z"),
   },
+  {
+    id: 5,
+    jobId: "job-story",
+    level: "info",
+    message:
+      "[2026-04-08T16:00:04.000Z] Wrote output to: /workspace/ordine/output/review-report.md (120 chars)",
+    createdAt: new Date("2026-04-08T16:00:04.000Z"),
+  },
 ];
 
 export const canvasStoryPipeline: PipelineData = {

--- a/packages/views/src/pages/ComponentsPage/ComponentsPageContent/ComponentsPageContent.tsx
+++ b/packages/views/src/pages/ComponentsPage/ComponentsPageContent/ComponentsPageContent.tsx
@@ -99,6 +99,24 @@ export const ComponentsPageContent = () => {
     editingItem?.source === "asset"
       ? assets.find((asset) => asset.id === editingItem.id)
       : undefined;
+  const handleFindClick = () => setFindOpen(true);
+  const handleNewOperationClick = () => void navigate({ to: "/pipelines/operations/new" });
+  const handleDistillSkillClick = () => void navigate({ to: "/distillations" });
+  const handleCategoryClick = (category: ActiveCategory) => () => setActive(category);
+  const handleSearchChange = (value: string) => setSearch(value);
+  const handleSearchClear = () => setSearch("");
+  const handleEditorOpenChange = (open: boolean) => {
+    if (!open) setEditingItem(null);
+  };
+  const handleDeleteConfirm = () => void handleConfirmDelete();
+  const handleDeleteOpenChange = (open: boolean) => {
+    if (!open) {
+      deleteUsageRequestId.current += 1;
+      setPendingDelete(null);
+      setDeleteUsageCount(null);
+    }
+  };
+  const handleFindOpenChange = (open: boolean) => setFindOpen(open);
 
   const handleEdit = (item: ComponentCardItem) => {
     if (item.source === "operation") {
@@ -169,7 +187,7 @@ export const ComponentsPageContent = () => {
       <PageHeader
         actions={
           <>
-            <Button size="sm" variant="ghost" onClick={() => setFindOpen(true)}>
+            <Button size="sm" variant="ghost" onClick={handleFindClick}>
               <Search className="h-3.5 w-3.5" />
               {t("components.findForMe.title")}
             </Button>
@@ -179,13 +197,11 @@ export const ComponentsPageContent = () => {
                 {t("components.newComponent")}
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-56">
-                <DropdownMenuItem
-                  onClick={() => void navigate({ to: "/pipelines/operations/new" })}
-                >
+                <DropdownMenuItem onClick={handleNewOperationClick}>
                   <Cpu className="h-4 w-4" />
                   {t("components.newOperation")}
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => void navigate({ to: "/distillations" })}>
+                <DropdownMenuItem onClick={handleDistillSkillClick}>
                   <Workflow className="h-4 w-4" />
                   {t("components.distillSkill")}
                 </DropdownMenuItem>
@@ -199,7 +215,10 @@ export const ComponentsPageContent = () => {
         title={t("components.title")}
       />
 
-      <div className="flex shrink-0 flex-col gap-2 border-b border-border px-4 py-3 sm:flex-row sm:items-center sm:px-7">
+      <div
+        className="flex shrink-0 flex-col gap-2 px-4 pb-3.5 sm:flex-row sm:items-center sm:px-7"
+        data-testid="components-toolbar"
+      >
         <div className="flex min-w-0 items-center gap-0.5 overflow-x-auto pb-1 sm:pb-0">
           {CATEGORIES.map((category) => (
             <Chip
@@ -207,7 +226,7 @@ export const ComponentsPageContent = () => {
               active={active === category}
               className="shrink-0"
               count={counts[category]}
-              onClick={() => setActive(category)}
+              onClick={handleCategoryClick(category)}
             >
               {t(`components.categories.${category}`)}
             </Chip>
@@ -219,12 +238,12 @@ export const ComponentsPageContent = () => {
           label={t("components.searchLabel")}
           placeholder={t("components.searchPlaceholder")}
           value={search}
-          onChange={setSearch}
-          onClear={() => setSearch("")}
+          onChange={handleSearchChange}
+          onClear={handleSearchClear}
         />
       </div>
 
-      <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-4 pb-8 pt-4 sm:px-7">
+      <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-4 pb-8 sm:px-7">
         {sections.map(({ category, items: sectionItems }) =>
           sectionItems.length > 0 ? (
             <section key={category} aria-labelledby={`component-section-${category}`}>
@@ -238,7 +257,7 @@ export const ComponentsPageContent = () => {
                   {sectionItems.length}
                 </span>
               </div>
-              <div className="grid grid-cols-1 gap-3 md:grid-cols-2 2xl:grid-cols-3">
+              <div className="grid grid-cols-1 gap-3 xl:grid-cols-2 2xl:grid-cols-3">
                 {sectionItems.map((item) => (
                   <ComponentCard
                     key={`${item.source}-${item.id}`}
@@ -252,7 +271,7 @@ export const ComponentsPageContent = () => {
           ) : null,
         )}
         {filteredItems.length === 0 && (
-          <div className="grid min-h-52 place-items-center py-10 text-center">
+          <div className="grid min-h-52 place-items-center rounded-2xl bg-surface-2/50 py-10 text-center">
             <div>
               <Boxes className="mx-auto h-7 w-7 text-muted-foreground/40" />
               <p className="mt-3 text-[13px] font-medium">{t("components.empty.title")}</p>
@@ -266,29 +285,21 @@ export const ComponentsPageContent = () => {
 
       {editingItem && editingAsset && (
         <ComponentEditor
+          open
           key={editingItem.id}
           asset={editingAsset}
           item={editingItem}
-          open
-          onOpenChange={(open) => {
-            if (!open) setEditingItem(null);
-          }}
+          onOpenChange={handleEditorOpenChange}
         />
       )}
       <DeleteComponentDialog
         item={pendingDelete}
         open={!!pendingDelete}
         usageCount={deleteUsageCount}
-        onConfirm={() => void handleConfirmDelete()}
-        onOpenChange={(open) => {
-          if (!open) {
-            deleteUsageRequestId.current += 1;
-            setPendingDelete(null);
-            setDeleteUsageCount(null);
-          }
-        }}
+        onConfirm={handleDeleteConfirm}
+        onOpenChange={handleDeleteOpenChange}
       />
-      <FindForMeModal open={findOpen} operations={operations} onOpenChange={setFindOpen} />
+      <FindForMeModal open={findOpen} operations={operations} onOpenChange={handleFindOpenChange} />
     </div>
   );
 };

--- a/packages/views/src/pages/ComponentsPage/ComponentsPageContent/ComponentsPageContent.unit.test.tsx
+++ b/packages/views/src/pages/ComponentsPage/ComponentsPageContent/ComponentsPageContent.unit.test.tsx
@@ -115,6 +115,7 @@ describe("ComponentsPageContent", () => {
     render(<ComponentsPageContent />);
 
     expect(screen.getByRole("heading", { name: "Components" })).toBeInTheDocument();
+    expect(screen.getByTestId("components-toolbar")).not.toHaveClass("border-b");
     expect(screen.getByText("Folder")).toBeInTheDocument();
     expect(screen.getByText("Review Code")).toBeInTheDocument();
     expect(screen.getByText("Release Review")).toBeInTheDocument();

--- a/packages/views/src/pages/JobsPage/JobsPageContent/JobsPageContent.tsx
+++ b/packages/views/src/pages/JobsPage/JobsPageContent/JobsPageContent.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type MouseEvent as ReactMouseEvent } from "react";
 import { useStore } from "zustand";
 import { useNavigate } from "@tanstack/react-router";
 import { CalendarDays, Clock, ListChecks, Play, Rows3, X } from "lucide-react";
@@ -98,8 +98,35 @@ export const JobsPageContent = () => {
   const handleOpenJob = (job: Job) => {
     setDetailJob(job);
   };
-  const refetchAll = () => {
+  const handleJobsChanged = () => {
     void jobsQuery?.refetch?.();
+  };
+  const handleNewRoutineClick = () => setScheduling("pick");
+  const handleNewRunClick = () => void navigate({ to: "/pipelines" });
+  const handleViewClick = (candidate: JobsView) => () => setView(candidate);
+  const handleEditRoutine = (routine: Routine) => {
+    const pipeline = pipelines.find((item) => item.id === routine.pipelineId);
+    setScheduling({
+      pipelineId: routine.pipelineId,
+      pipelineName: pipeline?.name ?? routine.name,
+      routine,
+    });
+  };
+  const handleDetailClose = () => setDetailJob(null);
+  const handlePickerClose = () => setScheduling(null);
+  const handlePickerContentClick = (event: ReactMouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+  };
+  const handlePipelinePick = (pipeline: PipelineData) => () => {
+    setScheduling({
+      pipelineId: pipeline.id,
+      pipelineName: pipeline.name,
+      routine: null,
+    });
+  };
+  const handleScheduleEditorClose = () => {
+    setScheduling(null);
+    void routinesQuery?.refetch?.();
   };
 
   if (jobsQuery?.isLoading || routinesQuery?.isLoading) {
@@ -125,16 +152,12 @@ export const JobsPageContent = () => {
               className="flex items-center gap-1.5"
               size="sm"
               variant="outline"
-              onClick={() => setScheduling("pick")}
+              onClick={handleNewRoutineClick}
             >
               <Clock className="h-3.5 w-3.5" />
               {t("jobs.newRoutine")}
             </Button>
-            <Button
-              className="flex items-center gap-1.5"
-              size="sm"
-              onClick={() => void navigate({ to: "/pipelines" })}
-            >
+            <Button className="flex items-center gap-1.5" size="sm" onClick={handleNewRunClick}>
               <Play className="h-3.5 w-3.5" />
               {t("jobs.newRun")}
             </Button>
@@ -142,15 +165,14 @@ export const JobsPageContent = () => {
         }
         eyebrow={t("jobs.eyebrow")}
         icon={<Icon className="text-muted-foreground" icon={ListChecks} size={18} />}
-        sub={t("jobs.subtitle")}
         title={t("jobs.title")}
       />
 
       <div
-        className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-border bg-background px-4 py-3 sm:px-7"
+        className="flex shrink-0 flex-wrap items-center gap-3 px-4 pb-3.5 sm:px-7"
         data-testid="jobs-toolbar"
       >
-        <div className="flex gap-1 rounded-lg bg-surface-2 p-1" data-testid="jobs-view-toggle">
+        <div className="flex gap-1 rounded-xl bg-surface-2 p-1" data-testid="jobs-view-toggle">
           {(
             [
               ["list", Rows3],
@@ -167,7 +189,7 @@ export const JobsPageContent = () => {
               )}
               data-testid={`jobs-view-${candidate}`}
               type="button"
-              onClick={() => setView(candidate)}
+              onClick={handleViewClick(candidate)}
             >
               <IconComponent className="size-3.5" />
               {t(`jobs.views.${candidate}`)}
@@ -175,7 +197,7 @@ export const JobsPageContent = () => {
           ))}
         </div>
         {view === "list" ? (
-          <div className="flex w-full min-w-0 flex-col gap-2 lg:w-auto lg:flex-row lg:items-center">
+          <div className="ml-auto flex w-full min-w-0 flex-col gap-2 lg:w-auto lg:flex-row lg:items-center">
             <div className="flex max-w-full items-center gap-0.5 overflow-x-auto pb-1 lg:pb-0">
               {JOB_STATUS_FILTERS.map((filter) => (
                 <Chip
@@ -200,10 +222,10 @@ export const JobsPageContent = () => {
         ) : null}
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-8 pt-4 sm:px-7">
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-8 sm:px-7">
         {view === "list" ? (
           filtered.length === 0 ? (
-            <div className="grid place-items-center py-16 text-center text-muted-foreground">
+            <div className="grid place-items-center rounded-2xl bg-surface-2/50 py-16 text-center text-muted-foreground">
               <ListChecks className="h-8 w-8 text-muted-foreground/30" />
               <p className="mt-2 text-[13px] font-medium text-foreground">
                 {jobs.length === 0 ? t("jobs.emptyTitle") : t("jobs.noMatchTitle")}
@@ -214,7 +236,7 @@ export const JobsPageContent = () => {
             <JobsTable
               jobs={filtered}
               pipelineNameById={pipelineNameById}
-              onChanged={refetchAll}
+              onChanged={handleJobsChanged}
               onOpen={handleOpenJob}
             />
           )
@@ -223,15 +245,8 @@ export const JobsPageContent = () => {
             jobs={jobs}
             pipelineNameById={pipelineNameById}
             routines={routines}
-            onEditRoutine={(routine) => {
-              const pipeline = pipelines.find((item) => item.id === routine.pipelineId);
-              setScheduling({
-                pipelineId: routine.pipelineId,
-                pipelineName: pipeline?.name ?? routine.name,
-                routine,
-              });
-            }}
-            onNewRoutine={() => setScheduling("pick")}
+            onEditRoutine={handleEditRoutine}
+            onNewRoutine={handleNewRoutineClick}
             onOpenJob={handleOpenJob}
           />
         )}
@@ -240,20 +255,20 @@ export const JobsPageContent = () => {
       {detailJob ? (
         <JobDetailDrawer
           job={detailJob}
-          onChanged={refetchAll}
-          onClose={() => setDetailJob(null)}
+          onChanged={handleJobsChanged}
+          onClose={handleDetailClose}
         />
       ) : null}
       {scheduling === "pick" ? (
         <div
           className="absolute inset-0 z-50 grid place-items-center p-6"
           data-testid="jobs-pipeline-picker"
-          onClick={() => setScheduling(null)}
+          onClick={handlePickerClose}
         >
           <div className="absolute inset-0 bg-foreground/10 backdrop-blur-[1px]" />
           <div
-            className="relative w-[min(380px,calc(100vw_-_2rem))] overflow-hidden rounded-lg bg-surface shadow-float ring-1 ring-border-strong"
-            onClick={(event) => event.stopPropagation()}
+            className="relative w-[min(380px,calc(100vw_-_2rem))] overflow-hidden rounded-2xl bg-surface shadow-float ring-1 ring-border-strong"
+            onClick={handlePickerContentClick}
           >
             <div className="flex items-center gap-2 border-b border-border/70 px-4 py-3">
               <Clock className="size-3.5 text-foreground/75" />
@@ -262,7 +277,7 @@ export const JobsPageContent = () => {
                 aria-label={t("jobs.closePipelinePicker")}
                 size="icon"
                 variant="ghost"
-                onClick={() => setScheduling(null)}
+                onClick={handlePickerClose}
               >
                 <X className="size-3.5" />
               </Button>
@@ -279,13 +294,7 @@ export const JobsPageContent = () => {
                   className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs hover:bg-accent/60"
                   data-testid={`jobs-pick-${pipeline.id}`}
                   type="button"
-                  onClick={() =>
-                    setScheduling({
-                      pipelineId: pipeline.id,
-                      pipelineName: pipeline.name,
-                      routine: null,
-                    })
-                  }
+                  onClick={handlePipelinePick(pipeline)}
                 >
                   <span className="min-w-0 flex-1 truncate font-medium">{pipeline.name}</span>
                   {(routines.some((routine) => routine.pipelineId === pipeline.id) && (
@@ -306,10 +315,7 @@ export const JobsPageContent = () => {
           pipelineName={scheduling.pipelineName}
           routine={scheduling.routine}
           routines={routines.filter((routine) => routine.pipelineId === scheduling.pipelineId)}
-          onClose={() => {
-            setScheduling(null);
-            void routinesQuery?.refetch?.();
-          }}
+          onClose={handleScheduleEditorClose}
         />
       ) : null}
     </div>

--- a/packages/views/src/pages/JobsPage/JobsPageContent/JobsPageContent.unit.test.tsx
+++ b/packages/views/src/pages/JobsPage/JobsPageContent/JobsPageContent.unit.test.tsx
@@ -156,12 +156,8 @@ describe("JobsPageContent", () => {
   it("renders current jobs and flags work waiting for review", () => {
     renderContent();
 
-    expect(screen.getByTestId("jobs-toolbar")).toHaveClass(
-      "border-b",
-      "bg-background",
-      "px-4",
-      "py-3",
-    );
+    expect(screen.getByTestId("jobs-toolbar")).toHaveClass("gap-3", "px-4", "pb-3.5");
+    expect(screen.getByTestId("jobs-toolbar")).not.toHaveClass("border-b");
     expect(screen.queryByTestId("jobs-summary")).not.toBeInTheDocument();
     expect(screen.getByTestId("jobs-table")).toBeInTheDocument();
     expect(screen.getByTestId("jobs-table-row-job-1")).toBeInTheDocument();

--- a/packages/views/src/pages/ObjectsPage/ObjectsPageContent/ObjectsPageContent.stories.tsx
+++ b/packages/views/src/pages/ObjectsPage/ObjectsPageContent/ObjectsPageContent.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ObjectsPageContent } from "./ObjectsPageContent";
+
+const meta: Meta<typeof ObjectsPageContent> = {
+  title: "Pages/ObjectsPage/ObjectsPageContent",
+  component: ObjectsPageContent,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Develop-owned object catalog surface. The story covers built-in file/folder entries and plugin-provided object type cards without introducing Alan state.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ObjectsPageContent>;
+
+export const Default: Story = {};

--- a/packages/views/src/pages/OperationsPage/OperationsPageContent/OperationsPageContent.tsx
+++ b/packages/views/src/pages/OperationsPage/OperationsPageContent/OperationsPageContent.tsx
@@ -20,7 +20,6 @@ import {
   SelectValue,
 } from "@repo/ui/select";
 import { cn } from "@repo/ui/lib/utils";
-import { surfaceCardVariants } from "@repo/ui/card";
 import { useOperationsPageStore } from "../_store";
 import { OperationCard } from "../OperationCard";
 import { OperationListRow } from "../OperationListRow";
@@ -139,11 +138,14 @@ export const OperationsPageContent = () => {
       />
 
       {/* Search + filter toolbar */}
-      <div className="flex shrink-0 items-center gap-3 border-b border-border bg-background px-4 py-3 sm:px-7">
-        <div className="relative flex-1 max-w-sm">
+      <div
+        className="flex shrink-0 items-center gap-3 bg-muted/30 px-6 py-2.5"
+        data-testid="operations-toolbar"
+      >
+        <div className="relative max-w-sm flex-1">
           <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input
-            className="h-8 pl-8 text-sm bg-background"
+            className="h-8 bg-background pl-8 text-sm"
             placeholder={t("operations.searchPlaceholder")}
             type="text"
             value={searchQuery}
@@ -162,7 +164,7 @@ export const OperationsPageContent = () => {
         >
           <SelectTrigger
             aria-label={t("common.actions")}
-            className="h-8 w-36 text-xs bg-background"
+            className="h-8 w-36 bg-background text-xs"
             id="sort-select"
             onClick={handleSortSelectTriggerClick}
           >
@@ -205,7 +207,7 @@ export const OperationsPageContent = () => {
       {/* Content area */}
       <div className="min-h-0 flex-1 overflow-auto">
         {filteredOperations.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-32 text-center px-6">
+          <div className="flex flex-col items-center justify-center px-6 py-32 text-center">
             <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl border-2 border-dashed border-border">
               <Zap className="h-7 w-7 text-muted-foreground/50" />
             </div>
@@ -226,7 +228,7 @@ export const OperationsPageContent = () => {
                 <p className="text-sm font-semibold text-foreground">
                   {t("operations.noOperations")}
                 </p>
-                <p className="mt-1 text-xs text-muted-foreground max-w-xs">
+                <p className="mt-1 max-w-xs text-xs text-muted-foreground">
                   {t("operations.createNew")}
                 </p>
                 <Button className="mt-4" size="sm" onClick={handleNavigateToNew}>
@@ -237,18 +239,13 @@ export const OperationsPageContent = () => {
             )}
           </div>
         ) : viewMode === "grid" ? (
-          <div className="grid grid-cols-1 gap-3 px-4 pb-8 pt-4 sm:grid-cols-2 sm:px-7 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 p-6 sm:grid-cols-2 lg:grid-cols-3">
             {filteredOperations.map((op) => (
               <OperationCard key={op.id} operation={op} />
             ))}
           </div>
         ) : (
-          <div
-            className={cn(
-              surfaceCardVariants(),
-              "mx-4 mb-8 mt-4 divide-y divide-border overflow-hidden sm:mx-7",
-            )}
-          >
+          <div className="divide-y divide-border">
             {filteredOperations.map((op) => (
               <OperationListRow key={op.id} operation={op} />
             ))}

--- a/packages/views/src/pages/PipelinesPage/PipelineCard/PipelineCard.tsx
+++ b/packages/views/src/pages/PipelinesPage/PipelineCard/PipelineCard.tsx
@@ -120,10 +120,7 @@ export const PipelineCard = ({ metrics, onSchedule, pipeline }: PipelineCardProp
             <StatusPill label={t(`pipelines.status.${pipeline.status}`)} status={pipeline.status} />
           )}
           {Object.entries(typeCounts).map(([type, count]) => (
-            <Tag
-              key={type}
-              className={cn(NODE_TYPE_COLORS[type] ?? "bg-muted text-muted-foreground")}
-            >
+            <Tag key={type} className={cn(NODE_TYPE_COLORS[type] ?? "bg-muted text-foreground/70")}>
               {count} {t(`pipelines.nodeTypes.${type}`, { defaultValue: type })}
             </Tag>
           ))}

--- a/packages/views/src/pages/PipelinesPage/PipelinesPageContent/PipelinesPageContent.tsx
+++ b/packages/views/src/pages/PipelinesPage/PipelinesPageContent/PipelinesPageContent.tsx
@@ -66,6 +66,21 @@ export const PipelinesPageContent = () => {
     return [...tagSet].sort();
   }, [pipelinesData]);
 
+  const filterCounts = useMemo(() => {
+    const items = pipelinesData ?? [];
+
+    return {
+      all: items.length,
+      drafts: items.filter((pipeline) => pipeline.status === "draft").length,
+      savedSkills: items.filter(
+        (pipeline) => metricsByPipeline.get(pipeline.id)?.isSavedSkill === true,
+      ).length,
+      scheduled: items.filter(
+        (pipeline) => metricsByPipeline.get(pipeline.id)?.isScheduled === true,
+      ).length,
+    };
+  }, [metricsByPipeline, pipelinesData]);
+
   const filtered = useMemo(() => {
     return filterPipelines({
       pipelines: pipelinesData ?? [],
@@ -141,17 +156,18 @@ export const PipelinesPageContent = () => {
       />
 
       {/* Toolbar */}
-      <div className="flex flex-col gap-2 border-b border-border bg-background px-4 py-3 sm:px-7">
-        <div className="flex flex-wrap items-center justify-between gap-2">
+      <div className="flex flex-col gap-2 px-7 pb-3.5">
+        <div className="flex flex-wrap items-center gap-2">
           <div
             aria-label={t("pipelines.filters.label")}
-            className="flex flex-wrap gap-1"
+            className="flex items-center gap-0.5"
             role="group"
           >
             {filterKeys.map((filter) => (
               <Chip
                 key={filter}
                 active={activeFilter === filter}
+                count={filterCounts[filter]}
                 onClick={() => handleFilterChange(filter)}
               >
                 {t(`pipelines.filters.${filter}`)}
@@ -159,10 +175,12 @@ export const PipelinesPageContent = () => {
             ))}
           </div>
           <SearchInput
-            className="w-full sm:w-64"
+            className="ml-auto w-full sm:w-60"
             clearLabel={t("common.clearSearch")}
             label={t("common.search")}
-            placeholder={t("common.search")}
+            placeholder={t("pipelines.searchPlaceholder", {
+              defaultValue: "Search pipelines...",
+            })}
             value={search}
             onChange={handleSearchInputChange}
             onClear={handleClearSearchButtonClick}
@@ -194,28 +212,36 @@ export const PipelinesPageContent = () => {
       </div>
 
       {/* Grid */}
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-8 pt-4 sm:px-7">
+      <div className="min-h-0 flex-1 overflow-y-auto px-7 pb-8">
         {filtered.length === 0 ? (
-          <div className="flex h-40 flex-col items-center justify-center gap-3 text-center text-muted-foreground">
+          <div className="grid place-items-center rounded-2xl bg-surface-2/50 py-16 text-center text-muted-foreground">
             <Layers className="h-8 w-8 text-muted-foreground/30" />
-            <p className="text-sm">
+            <p className="mt-2 text-[13px] font-medium text-foreground">
               {pipelines.length === 0 ? t("pipelines.noPipelines") : t("common.noResults")}
+            </p>
+            <p className="mt-0.5 text-[11.5px] text-muted-foreground">
+              {t("pipelines.emptyDescription", {
+                defaultValue: "Create a draft or try a different search term.",
+              })}
             </p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {filtered.map((p) => (
-              <PipelineCard
-                key={p.id}
-                metrics={metricsByPipeline.get(p.id)!}
-                pipeline={p}
-                onSchedule={
-                  routinesQuery?.isLoading || routinesQuery?.isError
-                    ? undefined
-                    : handleScheduleOpen(p.id)
-                }
-              />
-            ))}
+          <div className="grid grid-cols-1 gap-3.5 xl:grid-cols-2 2xl:grid-cols-3">
+            {filtered.map((p) => {
+              const handlePipelineSchedule =
+                routinesQuery?.isLoading || routinesQuery?.isError
+                  ? undefined
+                  : handleScheduleOpen(p.id);
+
+              return (
+                <PipelineCard
+                  key={p.id}
+                  metrics={metricsByPipeline.get(p.id)!}
+                  pipeline={p}
+                  onSchedule={handlePipelineSchedule}
+                />
+              );
+            })}
           </div>
         )}
       </div>

--- a/packages/views/src/pages/SettingsPage/SettingsPageContent/SettingsPageContent.tsx
+++ b/packages/views/src/pages/SettingsPage/SettingsPageContent/SettingsPageContent.tsx
@@ -78,9 +78,7 @@ export const SettingsPageContent = () => {
             <span className="hidden sm:inline">{t("settings.sections.keyboard")}</span>
           </Button>
         }
-        eyebrow={t("nav.workspace")}
         icon={<Settings className="h-4 w-4 text-primary" />}
-        sub={t("settings.subtitle")}
         title={t("settings.title")}
       />
       <Dialog open={keyboardOpen} onOpenChange={handleKeyboardOpenChange}>
@@ -133,7 +131,7 @@ export const SettingsPageContent = () => {
         </nav>
 
         <main className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">
-          <div className="mx-auto max-w-2xl space-y-6">
+          <div className="mx-auto max-w-lg space-y-6">
             {active === "language" && <LanguageSection />}
             {active === "notifications" && <NotificationsSection />}
             {active === "defaults" && <DefaultsSection />}

--- a/packages/views/src/pages/SettingsPage/SettingsPageContent/SettingsPageContent.unit.test.tsx
+++ b/packages/views/src/pages/SettingsPage/SettingsPageContent/SettingsPageContent.unit.test.tsx
@@ -17,6 +17,9 @@ describe("SettingsPageContent", () => {
   it("renders settings header", () => {
     render(<SettingsPageContent />);
     expect(screen.getByText("设置")).toBeTruthy();
+    expect(
+      screen.queryByText("配置工作区默认项、自主性、通知与本地开发环境。"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders navigation sidebar items", () => {


### PR DESCRIPTION
## Summary

- 以当前 `upstream/develop` 为业务基线，迁移 Alan 风格的 Web/Desktop 共享前端体验。
- 统一 AppLayout、侧边栏、项目切换、搜索/空态、Pipelines、Jobs、Operations、Settings 等页面的层级、密度和交互反馈。
- 对 Canvas、AgentPanel、组件面板、TopChrome、NodeCard、Edge、Properties、RunConsole 做视觉和响应式对齐，同时保留当前 develop 的数据、Store、Agent 会话、运行态和安全边界。
- 新增 Canvas EdgeInspector、SemanticEdge、NodeCard 行为回归以及 COD-355 前端 acceptance / visual Playwright 场景和迁移 ADR。

## Rebase / scope

- Base: `upstream/develop` `0e74a6defd86ed94ba2272c90cba4d13f18a95e1`
- Head commit: `6a74d7fe`
- 97 files changed; the branch was rebased after PR #181 and #182.
- PR #181 proposal/追问 and Canvas run-state restoration behavior are retained in the conflict resolution.

## Validation

- `packages/views`: `bun run test` — 92 files / 403 tests passed
- `packages/views`: `bun run check-types` — passed
- `packages/ui`: `bun run check-types`, `bun run lint` — passed
- `apps/app`: `bun run test` — 114 files / 531 tests passed
- `apps/app`: `bun run check-types`, `bun run build` — passed
- `apps/desktop-app`: `bun run build` — passed
- Changed-file `oxfmt --check` — 96 files passed
- `git diff --check` — passed

## Known environment / baseline notes

- Local frontend acceptance E2E could not start because Docker Desktop/PostgreSQL is unavailable; `drizzle-kit push` exited before browser tests.
- Full app lint currently fails on unchanged upstream files (`PipelineCreationWorkspace` / `HomePage`); the latest `upstream/develop` CI run `32340558040` also failed at the existing Lint step before tests. No unrelated baseline cleanup is included here.

## Review evidence

Detailed migration scope, route/component mapping, visual evidence paths, and acceptance notes are in `docs/frontend-alan-migration.md`.