### PR TITLE
fix(agent): bind Agent Bar model to selected runtime

### DIFF
--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
@@ -120,6 +120,15 @@ const createRuntimeNotFoundError = (runtimeId?: string) => {
   return error;
 };
 
+const createRuntimeModelMismatchError = (runtimeId: string, model: string) => {
+  const error = new Error(
+    `Configured model ${model} is not available for Agent runtime ${runtimeId}`,
+  ) as Error & { code: string };
+  error.code = "PIPELINE_AGENT_RUNTIME_MODEL_MISMATCH";
+
+  return error;
+};
+
 const isCancellationError = (error: Error) =>
   (error as Error & { code?: string }).code === "PIPELINE_AGENT_CANCELLED";
 
@@ -1219,8 +1228,19 @@ export const createPipelineAgentSessionsService = (
       const runtimePreference = settings.agentRuntimePreferences?.[runtimeId];
       const effectiveFirstOutputTimeoutSeconds =
         input?.firstOutputTimeoutSeconds ?? runtimePreference?.firstOutputTimeoutSeconds;
-      const effectiveModel =
-        input?.model ?? runtimePreference?.model ?? settings.defaultModel ?? undefined;
+      const effectiveModel = input?.model ?? runtimePreference?.model;
+      const runtimeModels =
+        selectedRuntime?.connection.mode === "local"
+          ? (selectedRuntime.connection.models ?? [])
+          : [];
+      if (
+        effectiveModel &&
+        runtimeModels.length > 0 &&
+        !runtimeModels.some((candidate) => candidate.id === effectiveModel)
+      ) {
+        finishActivity(sessionId, activity);
+        throw createRuntimeModelMismatchError(runtimeId, effectiveModel);
+      }
       const effectiveReasoningEffort = input?.reasoningEffort ?? runtimePreference?.reasoningEffort;
       const effectiveSpeed = input?.speed ?? runtimePreference?.speed;
       const effectiveFirstOutputTimeoutMs =

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
@@ -1005,6 +1005,59 @@ describe("createPipelineAgentSessionsService", () => {
     expect(startInput?.systemPrompt).toContain("不要把所有 Operation 默认串成一条直线");
   });
 
+  it("does not pass the global default model to an explicitly selected runtime", async () => {
+    mockSettingsDao.get.mockResolvedValueOnce({
+      defaultAgentRuntime: "mastra",
+      defaultApiKey: "test-key",
+      defaultModel: "kimi-for-coding/k2p6",
+    });
+    mockAgentRuntimesDao.findMany.mockResolvedValueOnce([
+      {
+        id: "runtime-codex",
+        name: "Codex Local",
+        type: "codex",
+        connection: {
+          mode: "local",
+          models: [{ id: "gpt-5.6-sol", displayName: "GPT-5.6 Sol", isDefault: true }],
+        },
+      },
+    ]);
+    const service = createPipelineAgentSessionsServiceFactory(mockDb as never, {
+      agentRunsService: mockAgentRunsService as never,
+    });
+
+    await service.startPlanningRun("session-1", { runtimeId: "runtime-codex" });
+
+    expect(mockAgentRunsService.start).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeConfigId: "runtime-codex", model: undefined }),
+    );
+  });
+
+  it("rejects a model outside the selected runtime catalog before starting an Agent Run", async () => {
+    mockAgentRuntimesDao.findMany.mockResolvedValueOnce([
+      {
+        id: "runtime-codex",
+        name: "Codex Local",
+        type: "codex",
+        connection: {
+          mode: "local",
+          models: [{ id: "gpt-5.6-sol", displayName: "GPT-5.6 Sol", isDefault: true }],
+        },
+      },
+    ]);
+    const service = createPipelineAgentSessionsServiceFactory(mockDb as never, {
+      agentRunsService: mockAgentRunsService as never,
+    });
+
+    await expect(
+      service.startPlanningRun("session-1", {
+        runtimeId: "runtime-codex",
+        model: "kimi-for-coding/k2p6",
+      }),
+    ).rejects.toMatchObject({ code: "PIPELINE_AGENT_RUNTIME_MODEL_MISMATCH" });
+    expect(mockAgentRunsService.start).not.toHaveBeenCalled();
+  });
+
   it("reseeds the full planning prompt after a completed run failed projection", async () => {
     mockSessionsDao.findById.mockResolvedValueOnce({
       id: "session-1",

--- a/packages/views/src/components/AgentExecutionPicker/agentExecutionChoice.ts
+++ b/packages/views/src/components/AgentExecutionPicker/agentExecutionChoice.ts
@@ -15,6 +15,9 @@ export const DEFAULT_FIRST_OUTPUT_TIMEOUT_SECONDS = 45;
 const defaultModelId = (entry: AgentRuntimeCatalogEntry): string | undefined =>
   entry.models.find((model) => model.isDefault)?.id ?? entry.models[0]?.id;
 
+const catalogContainsModel = (entry: AgentRuntimeCatalogEntry, model: string): boolean =>
+  entry.models.some((candidate) => candidate.id === model);
+
 export const executionChoiceForRuntime = (
   entry: AgentRuntimeCatalogEntry,
   preference?: AgentRuntimePreference,
@@ -22,7 +25,10 @@ export const executionChoiceForRuntime = (
 ): AgentExecutionChoice | null => {
   if (!entry.runtimeConfigId) return null;
   const legacyModel = legacyDefaultModel?.trim();
-  const model = preference?.model || legacyModel || defaultModelId(entry);
+  const model =
+    preference?.model ||
+    (legacyModel && catalogContainsModel(entry, legacyModel) ? legacyModel : undefined) ||
+    defaultModelId(entry);
   const selectedModel = entry.models.find((candidate) => candidate.id === model);
   const reasoningEffort = preference?.reasoningEffort ?? selectedModel?.defaultReasoningEffort;
   const speed = preference?.speed ?? selectedModel?.defaultSpeed;

--- a/packages/views/src/components/AgentExecutionPicker/agentExecutionChoice.unit.test.ts
+++ b/packages/views/src/components/AgentExecutionPicker/agentExecutionChoice.unit.test.ts
@@ -100,6 +100,22 @@ describe("agent execution choice", () => {
     });
   });
 
+  it("does not leak an incompatible legacy default model into the selected runtime", () => {
+    expect(
+      resolveAgentExecutionChoice(catalog, {
+        ...settings,
+        agentRuntimePreferences: {},
+        defaultModel: "kimi-for-coding/k2p6",
+      }),
+    ).toEqual({
+      runtimeConfigId: "local-codex",
+      model: "gpt-5.6",
+      reasoningEffort: "medium",
+      speed: "standard",
+      firstOutputTimeoutSeconds: 45,
+    });
+  });
+
   it("clears stale reasoning and speed when a model changes", () => {
     expect(
       changeExecutionModel(


### PR DESCRIPTION
## 做了什么

- Agent Bar 只在全局默认模型属于所选 runtime 的模型目录时才沿用它，否则回退到该 runtime 的默认模型。
- Pipeline Agent 服务端不再把全局默认模型透传给显式选择的 runtime。
- 对本地 runtime 增加模型目录校验，在启动 Agent Run 前返回稳定的 PIPELINE_AGENT_RUNTIME_MODEL_MISMATCH 错误。
- 补充前后端回归测试，覆盖全局 Kimi 默认模型与 Codex runtime 冲突的场景。

## 问题与修复

此前 Agent Bar 已经能按 runtime 选择主 Agent，但模型仍会从全局 defaultModel 回退，导致 Codex 收到 kimi-for-coding/k2p6，并以 Pipeline agent request failed 暴露给用户。本 PR 将模型选择约束为 runtime-scoped preference 或该 runtime 的模型目录，服务端同时做最终防线校验。

## 验证

- packages/services：Vitest 45/45 通过
- packages/views：Vitest 4/4 通过
- 根目录 bun run check-types：21/21 通过
- 修改文件 oxfmt 检查与 git diff --check 通过
- 真实浏览器：Agent Bar 选择 Codex CLI / GPT-5.6-Sol，规划与动作投影两个 Agent Run 均 completed；操作建议成功应用到 Canvas，未出现 Pipeline agent request failed
- 数据库运行证据：两个 Agent Run 均记录 runtime=codex、model=gpt-5.6-sol、status=completed
- 真实模型预检：codex exec --model gpt-5.6-sol 返回 OK

无视觉样式截图差异；本次为 runtime/model 行为修复。

Linear: https://linear.app/code-forge-official/issue/COD-373/bugagent作为流水线作者我希望-agent-bar-按所选-runtime-使用兼容模型-bind-agent-bar-model
