### PR TITLE
fix: 保持 Pipeline 与 Operation registry 同步

### DIFF
--- a/apps/app/src/integrations/trpc/router.unit.test.ts
+++ b/apps/app/src/integrations/trpc/router.unit.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   connectorsGetAll: vi.fn(),
   agentsGetAll: vi.fn(),
   operationsCreate: vi.fn(),
+  operationsDelete: vi.fn(),
   projectsCreate: vi.fn(),
   pipelinesGetById: vi.fn(),
   pipelineStartRun: vi.fn(),
@@ -44,7 +45,7 @@ vi.mock("./services", () => ({
   jobsService: {},
   operationOutputItemTemplatesService: {},
   operationRunnerService: {},
-  operationsService: { create: mocks.operationsCreate },
+  operationsService: { create: mocks.operationsCreate, delete: mocks.operationsDelete },
   pipelineAssetsService: {
     getAll: mocks.pipelineAssetsGetAll,
     getUsageCount: mocks.pipelineAssetsGetUsageCount,
@@ -103,6 +104,7 @@ beforeEach(() => {
   mocks.connectorsGetAll.mockResolvedValue(ok([]));
   mocks.agentsGetAll.mockResolvedValue([]);
   mocks.operationsCreate.mockResolvedValue(ok({ id: "op-1" }));
+  mocks.operationsDelete.mockResolvedValue(ok(undefined));
   mocks.projectsCreate.mockResolvedValue(ok({ id: "project-1", name: "Inbox" }));
   mocks.pipelinesGetById.mockResolvedValue(null);
   mocks.conversationsClearAll.mockResolvedValue(ok(undefined));
@@ -193,6 +195,17 @@ describe("domain tRPC routers", () => {
     });
   });
 
+  it("maps deleting an in-use Operation to CONFLICT", async () => {
+    const inUse = new Error("Operation op-1 is referenced by Pipeline pipeline-1");
+    inUse.name = "OperationInUseConflictError";
+    mocks.operationsDelete.mockResolvedValueOnce(err(inUse));
+    const caller = domainRouter.createCaller({ session: null });
+
+    await expect(caller.operations.delete({ id: "op-1" })).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+  });
+
   it("generates a project id at the route boundary", async () => {
     mocks.projectsCreate.mockImplementation(async (input) => ok(input));
     const caller = domainRouter.createCaller({ session: null });
@@ -224,6 +237,33 @@ describe("domain tRPC routers", () => {
       code: "NOT_FOUND",
     });
     expect(mocks.pipelineStartRun).not.toHaveBeenCalled();
+  });
+
+  it("maps missing Operation references during a run to CONFLICT", async () => {
+    const missingOperation = new Error("Pipeline references a missing Operation");
+    Object.assign(missingOperation, {
+      name: "PipelineOperationReferencesError",
+      code: "PIPELINE_OPERATION_MISSING",
+    });
+    mocks.pipelinesGetById.mockResolvedValueOnce({ id: "pipeline-1" });
+    mocks.pipelineStartRun.mockResolvedValueOnce(err(missingOperation));
+    const caller = domainRouter.createCaller({ session: null });
+
+    await expect(caller.pipelines.run({ id: "pipeline-1" })).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+  });
+
+  it("maps Operation registry lookup failures during a run to INTERNAL_SERVER_ERROR", async () => {
+    const serviceError = new Error("Check Pipeline pipeline-1 Operation references failed");
+    serviceError.name = "ServiceError";
+    mocks.pipelinesGetById.mockResolvedValueOnce({ id: "pipeline-1" });
+    mocks.pipelineStartRun.mockResolvedValueOnce(err(serviceError));
+    const caller = domainRouter.createCaller({ session: null });
+
+    await expect(caller.pipelines.run({ id: "pipeline-1" })).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+    });
   });
 
   it("exposes authenticated job controls for checkpoint handling", async () => {

--- a/apps/app/src/integrations/trpc/routers/operations.ts
+++ b/apps/app/src/integrations/trpc/routers/operations.ts
@@ -49,7 +49,7 @@ export const operationsRouter = router({
 
   delete: publicProcedure
     .input(z.object({ id: z.string() }))
-    .mutation(({ input }) => operationsService.delete(input.id)),
+    .mutation(async ({ input }) => unwrapResult(await operationsService.delete(input.id))),
 
   run: publicProcedure
     .input(

--- a/apps/app/src/integrations/trpc/routers/pipelines.ts
+++ b/apps/app/src/integrations/trpc/routers/pipelines.ts
@@ -101,11 +101,15 @@ export const pipelinesRouter = router({
       });
 
       if (result.isErr()) {
+        const errorCode = (result.error as Error & { code?: string }).code;
+        const pipelineMissing = result.error.name === "PipelineNotFoundError";
         throw new TRPCError({
           code:
-            (result.error as Error & { code?: string }).code === "AGENT_RUNTIME_NOT_FOUND"
+            errorCode === "AGENT_RUNTIME_NOT_FOUND" || errorCode === "PIPELINE_OPERATION_MISSING"
               ? "CONFLICT"
-              : "NOT_FOUND",
+              : pipelineMissing
+                ? "NOT_FOUND"
+                : "INTERNAL_SERVER_ERROR",
           message: result.error.message,
         });
       }

--- a/apps/app/src/integrations/trpc/routers/pipelines.ts
+++ b/apps/app/src/integrations/trpc/routers/pipelines.ts
@@ -43,7 +43,7 @@ export const pipelinesRouter = router({
         );
       }
 
-      return pipelinesService.create(pipeline);
+      return unwrapResult(await pipelinesService.create(pipeline));
     }),
 
   update: publicProcedure
@@ -56,12 +56,14 @@ export const pipelinesRouter = router({
         }),
       }),
     )
-    .mutation(({ input }) =>
-      pipelinesService.update(input.id, {
-        ...input.patch,
-        nodes: input.patch.nodes as never,
-        edges: input.patch.edges as never,
-      }),
+    .mutation(async ({ input }) =>
+      unwrapResult(
+        await pipelinesService.update(input.id, {
+          ...input.patch,
+          nodes: input.patch.nodes as never,
+          edges: input.patch.edges as never,
+        }),
+      ),
     ),
 
   delete: publicProcedure

--- a/apps/app/src/integrations/trpc/routers/result.ts
+++ b/apps/app/src/integrations/trpc/routers/result.ts
@@ -10,6 +10,9 @@ const codeForError = (error: unknown) => {
     return "BAD_REQUEST";
   }
   if (error instanceof Error && error.name.endsWith("NotFoundError")) return "NOT_FOUND";
+  if (error instanceof Error && error.name === "PipelineOperationReferencesError") {
+    return "CONFLICT";
+  }
   if (error instanceof Error && error.name === "ConflictError") return "CONFLICT";
   if (error instanceof Error && error.name === "InvalidJobStatusError") return "CONFLICT";
 

--- a/apps/app/src/integrations/trpc/routers/result.ts
+++ b/apps/app/src/integrations/trpc/routers/result.ts
@@ -13,7 +13,7 @@ const codeForError = (error: unknown) => {
   if (error instanceof Error && error.name === "PipelineOperationReferencesError") {
     return "CONFLICT";
   }
-  if (error instanceof Error && error.name === "ConflictError") return "CONFLICT";
+  if (error instanceof Error && error.name.endsWith("ConflictError")) return "CONFLICT";
   if (error instanceof Error && error.name === "InvalidJobStatusError") return "CONFLICT";
 
   return "INTERNAL_SERVER_ERROR";

--- a/apps/server/src/routes/operations.ts
+++ b/apps/server/src/routes/operations.ts
@@ -76,7 +76,27 @@ operationsRoutes.delete("/:id", async (c) => {
   const id = c.req.param("id");
   const existing = await operationsService.getById(id);
   if (!existing) return c.json({ error: "Operation not found" }, 404);
-  await operationsService.delete(id);
+  const result = await operationsService.delete(id);
+  if (result.isErr()) {
+    const error = result.error as Error & {
+      code?: string;
+      operationId?: string;
+      pipelineIds?: string[];
+    };
+    if (error.code === "OPERATION_IN_USE") {
+      return c.json(
+        {
+          error: error.message,
+          code: error.code,
+          operationId: error.operationId,
+          pipelineIds: error.pipelineIds,
+        },
+        409,
+      );
+    }
+
+    return c.json({ error: "Failed to delete operation" }, 500);
+  }
 
   return c.body(null, 204);
 });

--- a/apps/server/src/routes/pipelines.ts
+++ b/apps/server/src/routes/pipelines.ts
@@ -1,8 +1,9 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { ResultAsync } from "neverthrow";
 import { z } from "zod/v4";
 import {
   PipelineGraphSnapshotSchema,
+  PipelineOperationReferenceDiagnosticSchema,
   ProposeAttachmentSchema,
   ProposePendingOperationSchema,
 } from "@repo/schemas";
@@ -13,6 +14,19 @@ export const pipelinesRoutes = new Hono();
 const isOperationValidationError = (error: Error): error is Error & { issues: unknown[] } =>
   error.name === "CapabilityCatalogValidationError" ||
   error.name === "OperationConfigValidationError";
+
+const missingOperationResponse = (c: Context, error: unknown) => {
+  const diagnostic = PipelineOperationReferenceDiagnosticSchema.safeParse(error);
+  if (!diagnostic.success) return null;
+
+  return c.json(
+    {
+      ...diagnostic.data,
+      error: error instanceof Error ? error.message : "Pipeline references a missing Operation",
+    },
+    409,
+  );
+};
 
 const proposeActionsBodySchema = z.object({
   attachments: z.array(ProposeAttachmentSchema).optional(),
@@ -94,6 +108,9 @@ pipelinesRoutes.post("/", async (c) => {
       parsedPendingOperations.data,
     );
     if (result.isErr()) {
+      const missingOperation = missingOperationResponse(c, result.error);
+      if (missingOperation) return missingOperation;
+
       return isOperationValidationError(result.error)
         ? c.json({ error: result.error.message, issues: result.error.issues }, 422)
         : c.json({ error: "Failed to create pipeline" }, 500);
@@ -101,9 +118,15 @@ pipelinesRoutes.post("/", async (c) => {
 
     return c.json(result.value, 201);
   }
-  const pipeline = await pipelinesService.create(pipelineData);
+  const result = await pipelinesService.create(pipelineData);
+  if (result.isErr()) {
+    const missingOperation = missingOperationResponse(c, result.error);
+    if (missingOperation) return missingOperation;
 
-  return c.json(pipeline, 201);
+    return c.json({ error: "Failed to create pipeline" }, 500);
+  }
+
+  return c.json(result.value, 201);
 });
 
 pipelinesRoutes.put("/", async (c) => {
@@ -111,13 +134,25 @@ pipelinesRoutes.put("/", async (c) => {
   const existing = await pipelinesService.getById(body.id);
   if (existing) {
     const { id: _, ...patch } = body;
-    const updated = await pipelinesService.update(body.id, patch);
+    const result = await pipelinesService.update(body.id, patch);
+    if (result.isErr()) {
+      const missingOperation = missingOperationResponse(c, result.error);
+      if (missingOperation) return missingOperation;
 
-    return c.json(updated);
+      return c.json({ error: result.error.message }, 500);
+    }
+
+    return c.json(result.value);
   }
-  const pipeline = await pipelinesService.create(body);
+  const result = await pipelinesService.create(body);
+  if (result.isErr()) {
+    const missingOperation = missingOperationResponse(c, result.error);
+    if (missingOperation) return missingOperation;
 
-  return c.json(pipeline, 201);
+    return c.json({ error: result.error.message }, 500);
+  }
+
+  return c.json(result.value, 201);
 });
 
 pipelinesRoutes.get("/:id", async (c) => {
@@ -131,9 +166,15 @@ pipelinesRoutes.get("/:id", async (c) => {
 pipelinesRoutes.patch("/:id", async (c) => {
   const id = c.req.param("id");
   const body = await c.req.json();
-  const pipeline = await pipelinesService.update(id, body);
+  const result = await pipelinesService.update(id, body);
+  if (result.isErr()) {
+    const missingOperation = missingOperationResponse(c, result.error);
+    if (missingOperation) return missingOperation;
 
-  return c.json(pipeline);
+    return c.json({ error: result.error.message }, 500);
+  }
+
+  return c.json(result.value);
 });
 
 pipelinesRoutes.delete("/:id", async (c) => {
@@ -202,6 +243,9 @@ pipelinesRoutes.post("/:id/run", async (c) => {
   });
 
   if (result.isErr()) {
+    const missingOperation = missingOperationResponse(c, result.error);
+    if (missingOperation) return missingOperation;
+
     const runtimeMissing =
       (result.error as Error & { code?: string }).code === "AGENT_RUNTIME_NOT_FOUND";
 

--- a/apps/server/src/routes/pipelines.ts
+++ b/apps/server/src/routes/pipelines.ts
@@ -246,15 +246,20 @@ pipelinesRoutes.post("/:id/run", async (c) => {
     const missingOperation = missingOperationResponse(c, result.error);
     if (missingOperation) return missingOperation;
 
-    const runtimeMissing =
-      (result.error as Error & { code?: string }).code === "AGENT_RUNTIME_NOT_FOUND";
+    const error = result.error as Error & { code?: string };
+    const runtimeMissing = error.code === "AGENT_RUNTIME_NOT_FOUND";
+    const pipelineMissing = error.name === "PipelineNotFoundError";
 
     return c.json(
       {
-        code: runtimeMissing ? "AGENT_RUNTIME_NOT_FOUND" : "PIPELINE_NOT_FOUND",
-        error: result.error.message,
+        code: runtimeMissing
+          ? "AGENT_RUNTIME_NOT_FOUND"
+          : pipelineMissing
+            ? "PIPELINE_NOT_FOUND"
+            : "PIPELINE_RUN_FAILED",
+        error: error.message,
       },
-      runtimeMissing ? 409 : 404,
+      runtimeMissing ? 409 : pipelineMissing ? 404 : 500,
     );
   }
 

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -96,7 +96,7 @@ describe("Pipelines API", () => {
   });
 
   it("POST /api/pipelines creates pipeline", async () => {
-    mockPipelinesService.create.mockResolvedValueOnce(mockPipeline as never);
+    mockPipelinesService.create.mockResolvedValueOnce(ok(mockPipeline) as never);
     const res = await app.request("/api/pipelines", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -172,10 +172,12 @@ describe("Pipelines API", () => {
   });
 
   it("PATCH /api/pipelines/:id updates pipeline", async () => {
-    mockPipelinesService.update.mockResolvedValueOnce({
-      ...mockPipeline,
-      name: "Updated",
-    } as never);
+    mockPipelinesService.update.mockResolvedValueOnce(
+      ok({
+        ...mockPipeline,
+        name: "Updated",
+      }) as never,
+    );
     const res = await app.request("/api/pipelines/pipe-1", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -200,7 +202,7 @@ describe("Pipelines API", () => {
 
   it("PUT /api/pipelines upserts - creates when new", async () => {
     mockPipelinesService.getById.mockResolvedValueOnce(null as never);
-    mockPipelinesService.create.mockResolvedValueOnce(mockPipeline as never);
+    mockPipelinesService.create.mockResolvedValueOnce(ok(mockPipeline) as never);
     const res = await app.request("/api/pipelines", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -212,7 +214,7 @@ describe("Pipelines API", () => {
 
   it("PUT /api/pipelines upserts - updates when existing", async () => {
     mockPipelinesService.getById.mockResolvedValueOnce(mockPipeline as never);
-    mockPipelinesService.update.mockResolvedValueOnce(mockPipeline as never);
+    mockPipelinesService.update.mockResolvedValueOnce(ok(mockPipeline) as never);
     const res = await app.request("/api/pipelines", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -350,9 +350,33 @@ describe("Operations API", () => {
 
   it("DELETE /api/operations/:id removes operation", async () => {
     mockOperationsService.getById.mockResolvedValueOnce(mockOp as never);
-    mockOperationsService.delete.mockResolvedValueOnce(undefined as never);
+    mockOperationsService.delete.mockResolvedValueOnce(ok(undefined) as never);
     const res = await app.request("/api/operations/op-1", { method: "DELETE" });
     expect(res.status).toBe(204);
+  });
+
+  it("DELETE /api/operations/:id returns a structured conflict while it is in use", async () => {
+    const error = Object.assign(new Error("Operation op-1 is referenced by Pipeline pipe-1"), {
+      name: "OperationInUseConflictError",
+      code: "OPERATION_IN_USE",
+      operationId: "op-1",
+      pipelineIds: ["pipe-1"],
+    });
+    mockOperationsService.getById.mockResolvedValueOnce(mockOp as never);
+    mockOperationsService.delete.mockResolvedValueOnce({
+      isErr: () => true,
+      error,
+    } as never);
+
+    const res = await app.request("/api/operations/op-1", { method: "DELETE" });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: error.message,
+      code: "OPERATION_IN_USE",
+      operationId: "op-1",
+      pipelineIds: ["pipe-1"],
+    });
   });
 
   it("DELETE /api/operations/:id returns 404 for missing", async () => {

--- a/apps/server/tests/routes/pipelines.test.ts
+++ b/apps/server/tests/routes/pipelines.test.ts
@@ -292,4 +292,24 @@ describe("pipelinesRoutes", () => {
       missingOperations: [{ nodeId: "search-node", operationId: "op_new_search_hackathons" }],
     });
   });
+
+  it("returns an internal error when the Operation registry lookup fails", async () => {
+    const serviceError = Object.assign(new Error("Check Pipeline p1 Operation references failed"), {
+      name: "ServiceError",
+    });
+    mocks.getById.mockResolvedValue({ id: "p1" });
+    mocks.startRun.mockResolvedValue(err(serviceError));
+
+    const response = await makeApp().request("/pipelines/p1/run", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      code: "PIPELINE_RUN_FAILED",
+      error: "Check Pipeline p1 Operation references failed",
+    });
+  });
 });

--- a/apps/server/tests/routes/pipelines.test.ts
+++ b/apps/server/tests/routes/pipelines.test.ts
@@ -3,6 +3,7 @@ import { err } from "neverthrow";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
   generateStructure: vi.fn(),
   getById: vi.fn(),
   proposeActions: vi.fn(),
@@ -13,7 +14,7 @@ vi.mock("../../src/services.js", () => ({
   pipelinesService: {
     getAll: vi.fn(),
     getById: mocks.getById,
-    create: vi.fn(),
+    create: mocks.create,
     update: vi.fn(),
     delete: vi.fn(),
     generateStructure: mocks.generateStructure,
@@ -35,10 +36,42 @@ const makeApp = () => {
 
 describe("pipelinesRoutes", () => {
   beforeEach(() => {
+    mocks.create.mockReset();
     mocks.generateStructure.mockReset();
     mocks.proposeActions.mockReset();
     mocks.startRun.mockReset();
     mocks.getById.mockReset();
+  });
+
+  it("rejects saving a Pipeline that references a missing Operation", async () => {
+    const missingOperationError = Object.assign(
+      new Error('Pipeline p1 references missing Operation "op-missing" at node "operation-node"'),
+      {
+        code: "PIPELINE_OPERATION_MISSING",
+        pipelineId: "p1",
+        missingOperations: [{ nodeId: "operation-node", operationId: "op-missing" }],
+      },
+    );
+    mocks.create.mockResolvedValue(err(missingOperationError));
+
+    const response = await makeApp().request("/pipelines", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "p1",
+        name: "Broken Pipeline",
+        nodes: [],
+        edges: [],
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      code: "PIPELINE_OPERATION_MISSING",
+      error: 'Pipeline p1 references missing Operation "op-missing" at node "operation-node"',
+      pipelineId: "p1",
+      missingOperations: [{ nodeId: "operation-node", operationId: "op-missing" }],
+    });
   });
 
   it("returns 400 when generate-structure receives invalid JSON", async () => {
@@ -227,6 +260,36 @@ describe("pipelinesRoutes", () => {
     expect(await response.json()).toEqual({
       code: "AGENT_RUNTIME_NOT_FOUND",
       error: "No configured Agent runtime is available for this Pipeline run",
+    });
+  });
+
+  it("returns missing Operation details before starting a Pipeline run", async () => {
+    const missingOperationError = Object.assign(
+      new Error(
+        'Pipeline p1 references missing Operation "op_new_search_hackathons" at node "search-node"',
+      ),
+      {
+        code: "PIPELINE_OPERATION_MISSING",
+        pipelineId: "p1",
+        missingOperations: [{ nodeId: "search-node", operationId: "op_new_search_hackathons" }],
+      },
+    );
+    mocks.getById.mockResolvedValue({ id: "p1" });
+    mocks.startRun.mockResolvedValue(err(missingOperationError));
+
+    const response = await makeApp().request("/pipelines/p1/run", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      code: "PIPELINE_OPERATION_MISSING",
+      error:
+        'Pipeline p1 references missing Operation "op_new_search_hackathons" at node "search-node"',
+      pipelineId: "p1",
+      missingOperations: [{ nodeId: "search-node", operationId: "op_new_search_hackathons" }],
     });
   });
 });

--- a/packages/models/src/repositories/index.ts
+++ b/packages/models/src/repositories/index.ts
@@ -1,2 +1,3 @@
 export * from "./capabilityHarvestRepository";
+export * from "./operationRegistryRepository";
 export * from "./pipelineAgentAttachmentsRepository";

--- a/packages/models/src/repositories/operationRegistryRepository/index.ts
+++ b/packages/models/src/repositories/operationRegistryRepository/index.ts
@@ -1,0 +1,1 @@
+export * from "./operationRegistryRepository";

--- a/packages/models/src/repositories/operationRegistryRepository/operationRegistryRepository.ts
+++ b/packages/models/src/repositories/operationRegistryRepository/operationRegistryRepository.ts
@@ -1,0 +1,24 @@
+import { createOperationsDao } from "../../daos/operationsDao";
+import { createPipelinesDao } from "../../daos/pipelinesDao";
+import type { DbConnection, DbExecutor } from "../../types";
+
+export interface OperationRegistryTransaction {
+  executor: DbExecutor;
+  operationsDao: ReturnType<typeof createOperationsDao>;
+  pipelinesDao: ReturnType<typeof createPipelinesDao>;
+}
+
+export const createOperationRegistryRepository = (db: DbConnection) => ({
+  runSerializable: <T>(
+    callback: (transaction: OperationRegistryTransaction) => Promise<T>,
+  ): Promise<T> =>
+    db.transaction(
+      async (transaction) =>
+        callback({
+          executor: transaction,
+          operationsDao: createOperationsDao(transaction),
+          pipelinesDao: createPipelinesDao(transaction),
+        }),
+      { isolationLevel: "serializable" },
+    ),
+});

--- a/packages/models/src/repositories/operationRegistryRepository/operationRegistryRepository.unit.test.ts
+++ b/packages/models/src/repositories/operationRegistryRepository/operationRegistryRepository.unit.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOperationRegistryRepository } from "./operationRegistryRepository";
+
+describe("createOperationRegistryRepository", () => {
+  it("runs registry changes in a serializable transaction", async () => {
+    const transaction = vi.fn(
+      async (callback: (executor: unknown) => Promise<unknown>, config: unknown) =>
+        callback({ config }),
+    );
+    const repository = createOperationRegistryRepository({ transaction } as never);
+
+    const result = await repository.runSerializable(async ({ operationsDao, pipelinesDao }) => ({
+      hasOperationsDao: typeof operationsDao.findById === "function",
+      hasPipelinesDao: typeof pipelinesDao.findById === "function",
+    }));
+
+    expect(result).toEqual({ hasOperationsDao: true, hasPipelinesDao: true });
+    expect(transaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: "serializable",
+    });
+  });
+});

--- a/packages/schemas/src/pipeline/PipelineOperationReferenceDiagnosticSchema.ts
+++ b/packages/schemas/src/pipeline/PipelineOperationReferenceDiagnosticSchema.ts
@@ -2,7 +2,7 @@ import { z } from "zod/v4";
 
 export const MissingPipelineOperationSchema = z.object({
   nodeId: z.string().min(1),
-  operationId: z.string().min(1),
+  operationId: z.string(),
 });
 export type MissingPipelineOperation = z.infer<typeof MissingPipelineOperationSchema>;
 

--- a/packages/schemas/src/pipeline/PipelineOperationReferenceDiagnosticSchema.ts
+++ b/packages/schemas/src/pipeline/PipelineOperationReferenceDiagnosticSchema.ts
@@ -1,0 +1,16 @@
+import { z } from "zod/v4";
+
+export const MissingPipelineOperationSchema = z.object({
+  nodeId: z.string().min(1),
+  operationId: z.string().min(1),
+});
+export type MissingPipelineOperation = z.infer<typeof MissingPipelineOperationSchema>;
+
+export const PipelineOperationReferenceDiagnosticSchema = z.object({
+  code: z.literal("PIPELINE_OPERATION_MISSING"),
+  pipelineId: z.string().min(1),
+  missingOperations: z.array(MissingPipelineOperationSchema).min(1),
+});
+export type PipelineOperationReferenceDiagnostic = z.infer<
+  typeof PipelineOperationReferenceDiagnosticSchema
+>;

--- a/packages/schemas/src/pipeline/index.ts
+++ b/packages/schemas/src/pipeline/index.ts
@@ -1,6 +1,7 @@
 export * from "./PipelineSchema";
 export * from "./PipelineStatusSchema";
 export * from "./PipelineGraphSnapshotSchema";
+export * from "./PipelineOperationReferenceDiagnosticSchema";
 export * from "./PipelineActionDiagnosticSchema";
 export * from "./PipelineActionSchema";
 export * from "./PipelineActionProposalSchema";

--- a/packages/services/src/operationsService/createOperationsService.ts
+++ b/packages/services/src/operationsService/createOperationsService.ts
@@ -1,11 +1,23 @@
-import { createOperationsDao, type DbConnection } from "@repo/models";
+import { createOperationsDao, createPipelinesDao, type DbConnection } from "@repo/models";
 import { mapWithMeta, withMeta } from "@repo/schemas";
-import { okAsync, ResultAsync } from "neverthrow";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import {
   createCapabilityCatalogService,
   type CapabilityCatalogServiceOptions,
 } from "../capabilityCatalogService";
-import { toServiceError } from "../serviceErrors";
+import { ConflictError, toServiceError } from "../serviceErrors";
+
+export class OperationInUseConflictError extends ConflictError {
+  readonly code = "OPERATION_IN_USE";
+
+  constructor(
+    readonly operationId: string,
+    readonly pipelineIds: string[],
+  ) {
+    super(`Operation ${operationId} is referenced by Pipeline ${pipelineIds.join(", ")}`);
+    this.name = "OperationInUseConflictError";
+  }
+}
 
 export interface OperationsServiceOptions {
   capabilityCatalog?: ReturnType<typeof createCapabilityCatalogService>;
@@ -17,6 +29,7 @@ export const createOperationsService = (
   options: OperationsServiceOptions = {},
 ) => {
   const dao = createOperationsDao(db);
+  const pipelinesDao = createPipelinesDao(db);
   const capabilityCatalog =
     options.capabilityCatalog ??
     createCapabilityCatalogService(db, options.capabilityCatalogOptions);
@@ -54,11 +67,31 @@ export const createOperationsService = (
       .map(withMeta);
   };
 
+  const deleteOperation = (id: string) =>
+    ResultAsync.fromPromise(pipelinesDao.findMany(), (error) =>
+      toServiceError(error, `Check Operation ${id} Pipeline references`),
+    ).andThen((pipelines) => {
+      const pipelineIds = pipelines.flatMap((pipeline) =>
+        pipeline.nodes.some(
+          (node) => node.data.nodeType === "operation" && node.data.operationId === id,
+        )
+          ? [pipeline.id]
+          : [],
+      );
+      if (pipelineIds.length > 0) {
+        return errAsync(new OperationInUseConflictError(id, pipelineIds));
+      }
+
+      return ResultAsync.fromPromise(dao.delete(id), (error) =>
+        toServiceError(error, `Delete Operation ${id}`),
+      );
+    });
+
   return {
     getAll: async () => mapWithMeta(await dao.findMany()),
     getById: async (id: string) => withMeta(await dao.findById(id)),
     create,
     update,
-    delete: (id: string) => dao.delete(id),
+    delete: deleteOperation,
   };
 };

--- a/packages/services/src/operationsService/createOperationsService.ts
+++ b/packages/services/src/operationsService/createOperationsService.ts
@@ -1,6 +1,10 @@
-import { createOperationsDao, createPipelinesDao, type DbConnection } from "@repo/models";
+import {
+  createOperationRegistryRepository,
+  createOperationsDao,
+  type DbConnection,
+} from "@repo/models";
 import { mapWithMeta, withMeta } from "@repo/schemas";
-import { errAsync, okAsync, ResultAsync } from "neverthrow";
+import { okAsync, ResultAsync } from "neverthrow";
 import {
   createCapabilityCatalogService,
   type CapabilityCatalogServiceOptions,
@@ -29,7 +33,7 @@ export const createOperationsService = (
   options: OperationsServiceOptions = {},
 ) => {
   const dao = createOperationsDao(db);
-  const pipelinesDao = createPipelinesDao(db);
+  const operationRegistryRepository = createOperationRegistryRepository(db);
   const capabilityCatalog =
     options.capabilityCatalog ??
     createCapabilityCatalogService(db, options.capabilityCatalogOptions);
@@ -68,24 +72,27 @@ export const createOperationsService = (
   };
 
   const deleteOperation = (id: string) =>
-    ResultAsync.fromPromise(pipelinesDao.findMany(), (error) =>
-      toServiceError(error, `Check Operation ${id} Pipeline references`),
-    ).andThen((pipelines) => {
-      const pipelineIds = pipelines.flatMap((pipeline) =>
-        pipeline.nodes.some(
-          (node) => node.data.nodeType === "operation" && node.data.operationId === id,
-        )
-          ? [pipeline.id]
-          : [],
-      );
-      if (pipelineIds.length > 0) {
-        return errAsync(new OperationInUseConflictError(id, pipelineIds));
-      }
+    ResultAsync.fromPromise(
+      operationRegistryRepository.runSerializable(async ({ operationsDao, pipelinesDao }) => {
+        const pipelines = await pipelinesDao.findMany();
+        const pipelineIds = pipelines.flatMap((pipeline) =>
+          pipeline.nodes.some(
+            (node) => node.data.nodeType === "operation" && node.data.operationId === id,
+          )
+            ? [pipeline.id]
+            : [],
+        );
+        if (pipelineIds.length > 0) {
+          throw new OperationInUseConflictError(id, pipelineIds);
+        }
 
-      return ResultAsync.fromPromise(dao.delete(id), (error) =>
-        toServiceError(error, `Delete Operation ${id}`),
-      );
-    });
+        await operationsDao.delete(id);
+      }),
+      (error) =>
+        error instanceof OperationInUseConflictError
+          ? error
+          : toServiceError(error, `Delete Operation ${id}`),
+    );
 
   return {
     getAll: async () => mapWithMeta(await dao.findMany()),

--- a/packages/services/src/operationsService/createOperationsService.unit.test.ts
+++ b/packages/services/src/operationsService/createOperationsService.unit.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { ok } from "neverthrow";
 
 const mockDao = {
   findMany: vi
@@ -9,11 +10,15 @@ const mockDao = {
   update: vi.fn().mockResolvedValue({ id: "o1", createdAt: new Date(0), updatedAt: new Date(0) }),
   delete: vi.fn().mockResolvedValue(undefined),
 };
+const mockPipelinesDao = {
+  findMany: vi.fn().mockResolvedValue([]),
+};
 
 vi.mock("@repo/models", () => ({
   createCapabilityRiskOverridesDao: () => ({ findMany: vi.fn().mockResolvedValue([]) }),
   createConnectorsDao: () => ({ findMany: vi.fn().mockResolvedValue([]) }),
   createOperationsDao: () => mockDao,
+  createPipelinesDao: () => mockPipelinesDao,
   createSkillsDao: () => ({
     findMany: vi.fn().mockResolvedValue([]),
     seedIfEmpty: vi.fn().mockResolvedValue(undefined),
@@ -23,6 +28,12 @@ vi.mock("@repo/models", () => ({
 import { createOperationsService } from "./createOperationsService";
 
 describe("createOperationsService", () => {
+  beforeEach(() => {
+    mockDao.delete.mockClear();
+    mockPipelinesDao.findMany.mockReset();
+    mockPipelinesDao.findMany.mockResolvedValue([]);
+  });
+
   it("getAll delegates to dao.findMany", async () => {
     const svc = createOperationsService({} as never);
     const result = await svc.getAll();
@@ -77,7 +88,37 @@ describe("createOperationsService", () => {
 
   it("delete delegates to dao.delete", async () => {
     const svc = createOperationsService({} as never);
-    await svc.delete("o1");
+    const result = await svc.delete("o1");
+
+    expect(result).toEqual(ok(undefined));
     expect(mockDao.delete).toHaveBeenCalledWith("o1");
+  });
+
+  it("rejects deleting an Operation referenced by a saved Pipeline", async () => {
+    mockPipelinesDao.findMany.mockResolvedValueOnce([
+      {
+        id: "pipeline-1",
+        nodes: [
+          {
+            id: "operation-node",
+            data: { nodeType: "operation", operationId: "o1" },
+          },
+        ],
+      },
+    ]);
+    const svc = createOperationsService({} as never);
+
+    const result = await svc.delete("o1");
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toMatchObject({
+        name: "OperationInUseConflictError",
+        code: "OPERATION_IN_USE",
+        operationId: "o1",
+        pipelineIds: ["pipeline-1"],
+      });
+    }
+    expect(mockDao.delete).not.toHaveBeenCalled();
   });
 });

--- a/packages/services/src/operationsService/createOperationsService.unit.test.ts
+++ b/packages/services/src/operationsService/createOperationsService.unit.test.ts
@@ -19,6 +19,10 @@ vi.mock("@repo/models", () => ({
   createConnectorsDao: () => ({ findMany: vi.fn().mockResolvedValue([]) }),
   createOperationsDao: () => mockDao,
   createPipelinesDao: () => mockPipelinesDao,
+  createOperationRegistryRepository: () => ({
+    runSerializable: async (callback: (transaction: unknown) => Promise<unknown>) =>
+      callback({ operationsDao: mockDao, pipelinesDao: mockPipelinesDao }),
+  }),
   createSkillsDao: () => ({
     findMany: vi.fn().mockResolvedValue([]),
     seedIfEmpty: vi.fn().mockResolvedValue(undefined),

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
@@ -1707,7 +1707,7 @@ export const createPipelineAgentSessionsService = (
               assertActivityActive(sessionId, activity);
             }
 
-            const createdPipeline = await transactionalPipelinesService.create({
+            const createPipelineResult = await transactionalPipelinesService.create({
               id: crypto.randomUUID(),
               name: pipelineName,
               description: pipelineDescription,
@@ -1716,6 +1716,8 @@ export const createPipelineAgentSessionsService = (
               nodes: generated.nodes,
               edges: generated.edges,
             });
+            if (createPipelineResult.isErr()) throw createPipelineResult.error;
+            const createdPipeline = createPipelineResult.value;
             assertActivityActive(sessionId, activity);
             if (generateProposal.schedule) {
               const enabled = generateProposal.schedule.enabled;

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.ts
@@ -1690,93 +1690,96 @@ export const createPipelineAgentSessionsService = (
           pendingOperationIds.value =
             generated.pendingOperations?.map((operation) => operation.id) ?? [];
 
-          const pipeline = await db.transaction(async (tx) => {
-            const transactionalPipelinesService = createPipelinesService(
-              tx as unknown as DbConnection,
-            );
-            const transactionalRoutinesDao = createRoutinesDao(tx as unknown as DbConnection);
-            const transactionalSessionsDao = createPipelineAgentSessionsDao(tx);
-            const transactionalConversationMessagesDao = createConversationMessagesDao(tx);
-            assertActivityActive(sessionId, activity);
-            if (generated.pendingOperations && generated.pendingOperations.length > 0) {
-              const createPendingResult =
-                await transactionalPipelinesService.createPendingOperations(
-                  generated.pendingOperations,
-                );
-              if (createPendingResult.isErr()) throw createPendingResult.error;
+          const pipeline = await db.transaction(
+            async (tx) => {
+              const transactionalPipelinesService = createPipelinesService(
+                tx as unknown as DbConnection,
+              );
+              const transactionalRoutinesDao = createRoutinesDao(tx as unknown as DbConnection);
+              const transactionalSessionsDao = createPipelineAgentSessionsDao(tx);
+              const transactionalConversationMessagesDao = createConversationMessagesDao(tx);
               assertActivityActive(sessionId, activity);
-            }
-
-            const createPipelineResult = await transactionalPipelinesService.create({
-              id: crypto.randomUUID(),
-              name: pipelineName,
-              description: pipelineDescription,
-              tags: ["agent-generated"],
-              timeoutMs: null,
-              nodes: generated.nodes,
-              edges: generated.edges,
-            });
-            if (createPipelineResult.isErr()) throw createPipelineResult.error;
-            const createdPipeline = createPipelineResult.value;
-            assertActivityActive(sessionId, activity);
-            if (generateProposal.schedule) {
-              const enabled = generateProposal.schedule.enabled;
-              const nextRunAt = enabled
-                ? getNextCronRunAt(generateProposal.schedule.cronExpression, new Date())
-                : null;
-              if (enabled && !nextRunAt) {
-                throw new Error("Agent returned an invalid Pipeline schedule");
+              if (generated.pendingOperations && generated.pendingOperations.length > 0) {
+                const createPendingResult =
+                  await transactionalPipelinesService.createPendingOperations(
+                    generated.pendingOperations,
+                  );
+                if (createPendingResult.isErr()) throw createPendingResult.error;
+                assertActivityActive(sessionId, activity);
               }
-              await transactionalRoutinesDao.create({
+
+              const createPipelineResult = await transactionalPipelinesService.create({
                 id: crypto.randomUUID(),
-                pipelineId: createdPipeline.id,
-                name: generateProposal.schedule.name ?? `${pipelineName} schedule`,
-                description: `Agent-created schedule for ${pipelineName}`,
-                cronExpression: generateProposal.schedule.cronExpression,
-                inputConfig: null,
-                enabled,
-                lastRunAt: null,
-                nextRunAt,
+                name: pipelineName,
+                description: pipelineDescription,
+                tags: ["agent-generated"],
+                timeoutMs: null,
+                nodes: generated.nodes,
+                edges: generated.edges,
+              });
+              if (createPipelineResult.isErr()) throw createPipelineResult.error;
+              const createdPipeline = createPipelineResult.value;
+              assertActivityActive(sessionId, activity);
+              if (generateProposal.schedule) {
+                const enabled = generateProposal.schedule.enabled;
+                const nextRunAt = enabled
+                  ? getNextCronRunAt(generateProposal.schedule.cronExpression, new Date())
+                  : null;
+                if (enabled && !nextRunAt) {
+                  throw new Error("Agent returned an invalid Pipeline schedule");
+                }
+                await transactionalRoutinesDao.create({
+                  id: crypto.randomUUID(),
+                  pipelineId: createdPipeline.id,
+                  name: generateProposal.schedule.name ?? `${pipelineName} schedule`,
+                  description: `Agent-created schedule for ${pipelineName}`,
+                  cronExpression: generateProposal.schedule.cronExpression,
+                  inputConfig: null,
+                  enabled,
+                  lastRunAt: null,
+                  nextRunAt,
+                });
+                assertActivityActive(sessionId, activity);
+              }
+              const visibleMessages = messages.filter(
+                (message) => message.role !== "system" && message.content.trim().length > 0,
+              );
+              for (const message of visibleMessages) {
+                await transactionalConversationMessagesDao.create({
+                  id: crypto.randomUUID(),
+                  pipelineId: createdPipeline.id,
+                  role: message.role === "assistant" ? "agent" : "user",
+                  content: message.content,
+                  metadata: null,
+                  phase: "done",
+                  createdAt: message.createdAt,
+                });
+              }
+              const lastVisibleMessage = visibleMessages.at(-1);
+              if (
+                lastVisibleMessage?.role !== "assistant" ||
+                lastVisibleMessage.content.trim() !== generateProposal.purpose.trim()
+              ) {
+                await transactionalConversationMessagesDao.create({
+                  id: crypto.randomUUID(),
+                  pipelineId: createdPipeline.id,
+                  role: "agent",
+                  content: generateProposal.purpose,
+                  metadata: null,
+                  phase: "done",
+                });
+              }
+              assertActivityActive(sessionId, activity);
+              await transactionalSessionsDao.update(sessionId, {
+                status: "completed",
+                createdPipelineId: createdPipeline.id,
               });
               assertActivityActive(sessionId, activity);
-            }
-            const visibleMessages = messages.filter(
-              (message) => message.role !== "system" && message.content.trim().length > 0,
-            );
-            for (const message of visibleMessages) {
-              await transactionalConversationMessagesDao.create({
-                id: crypto.randomUUID(),
-                pipelineId: createdPipeline.id,
-                role: message.role === "assistant" ? "agent" : "user",
-                content: message.content,
-                metadata: null,
-                phase: "done",
-                createdAt: message.createdAt,
-              });
-            }
-            const lastVisibleMessage = visibleMessages.at(-1);
-            if (
-              lastVisibleMessage?.role !== "assistant" ||
-              lastVisibleMessage.content.trim() !== generateProposal.purpose.trim()
-            ) {
-              await transactionalConversationMessagesDao.create({
-                id: crypto.randomUUID(),
-                pipelineId: createdPipeline.id,
-                role: "agent",
-                content: generateProposal.purpose,
-                metadata: null,
-                phase: "done",
-              });
-            }
-            assertActivityActive(sessionId, activity);
-            await transactionalSessionsDao.update(sessionId, {
-              status: "completed",
-              createdPipelineId: createdPipeline.id,
-            });
-            assertActivityActive(sessionId, activity);
 
-            return createdPipeline;
-          });
+              return createdPipeline;
+            },
+            { isolationLevel: "serializable" },
+          );
           persistedPipeline.id = pipeline.id;
           assertActivityActive(sessionId, activity);
 

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
@@ -1557,6 +1557,9 @@ describe("createPipelineAgentSessionsService", () => {
         edges: [],
       }),
     );
+    expect(mockDb.transaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: "serializable",
+    });
     expect(mockSessionsDao.update).toHaveBeenLastCalledWith(
       "session-1",
       expect.objectContaining({

--- a/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
+++ b/packages/services/src/pipelineAgentSessionsService/createPipelineAgentSessionsService.unit.test.ts
@@ -249,12 +249,14 @@ describe("createPipelineAgentSessionsService", () => {
     mockPipelinesService.createPendingOperations.mockResolvedValue(ok(undefined));
     mockPipelinesService.updateOperationExecutors.mockResolvedValue(ok(undefined));
     mockPipelinesService.delete.mockResolvedValue(undefined);
-    mockPipelinesService.create.mockImplementation(async (data) => ({
-      id: data.id ?? "pipeline-1",
-      ...data,
-      createdAt: new Date("2026-06-03T12:00:05.000Z"),
-      updatedAt: new Date("2026-06-03T12:00:05.000Z"),
-    }));
+    mockPipelinesService.create.mockImplementation(async (data) =>
+      ok({
+        id: data.id ?? "pipeline-1",
+        ...data,
+        createdAt: new Date("2026-06-03T12:00:05.000Z"),
+        updatedAt: new Date("2026-06-03T12:00:05.000Z"),
+      }),
+    );
     mockPipelinesService.proposeActions.mockResolvedValue({
       proposal: {
         summary: "Delete invalid middle nodes",

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
@@ -25,6 +25,11 @@ import {
 import { buildMcpConnectorInjection } from "../../connectorsService";
 import { hydrateConnectorCredentials } from "../../capabilityHarvestService";
 import type { AgentRunController, McpConnectorInjectionProvider } from "@repo/agent-engine";
+import {
+  checkPipelineOperationReferences,
+  type PipelineOperationReferencesError,
+} from "../../pipelinesService/checkPipelineOperationReferences";
+import type { ServiceError } from "../../serviceErrors";
 
 export interface PipelineRunnerServiceOptions {
   encryptionSecret?: string;
@@ -204,11 +209,26 @@ export const createPipelineRunnerService = (
       reasoningEffort?: string;
       speed?: string;
       firstOutputTimeoutMs?: number;
-    }): Promise<Result<{ jobId: string }, PipelineNotFoundError | AgentRuntimeNotFoundError>> => {
+    }): Promise<
+      Result<
+        { jobId: string },
+        | PipelineNotFoundError
+        | AgentRuntimeNotFoundError
+        | PipelineOperationReferencesError
+        | ServiceError
+      >
+    > => {
       const pipeline = await pipelinesDao.findById(opts.pipelineId);
       if (!pipeline) {
         return err(new PipelineNotFoundError(opts.pipelineId));
       }
+
+      const operationReferenceCheck = await checkPipelineOperationReferences({
+        nodes: pipeline.nodes,
+        operationsDao,
+        pipelineId: pipeline.id,
+      });
+      if (operationReferenceCheck.isErr()) return err(operationReferenceCheck.error);
 
       const [settingsRecord, allRuntimes] = await Promise.all([
         settingsDao.get(),

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
@@ -425,4 +425,38 @@ describe("createPipelineRunnerService run controls", () => {
     expect(mockJobsDao.create).not.toHaveBeenCalled();
     expect(mockPipelineRunExecutorRun).not.toHaveBeenCalled();
   });
+
+  it("rejects a legacy run with a blank Operation registry id before creating a job", async () => {
+    mockPipelinesDao.findById.mockResolvedValueOnce({
+      id: "pipe-1",
+      name: "Pipe",
+      description: "Pipeline description",
+      projectId: null,
+      nodes: [
+        {
+          id: "operation-node",
+          type: "operation",
+          data: {
+            nodeType: "operation",
+            operationId: "",
+            operationName: "",
+          },
+        },
+      ],
+      edges: [],
+    });
+    const service = makeService();
+
+    const result = await service.startRun({ pipelineId: "pipe-1" });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toMatchObject({
+        code: "PIPELINE_OPERATION_MISSING",
+        missingOperations: [{ nodeId: "operation-node", operationId: "" }],
+      });
+    }
+    expect(mockJobsDao.create).not.toHaveBeenCalled();
+    expect(mockPipelineRunExecutorRun).not.toHaveBeenCalled();
+  });
 });

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
@@ -23,6 +23,7 @@ type EngineDepsBuildOptionsMock = {
 const {
   mockJobsDao,
   mockConnectorsDao,
+  mockOperationsDao,
   mockPipelinesDao,
   mockAgentRuntimesDao,
   mockMcpInjections,
@@ -45,6 +46,9 @@ const {
     },
     mockConnectorsDao: {
       findMany: vi.fn().mockResolvedValue([]),
+    },
+    mockOperationsDao: {
+      findById: vi.fn(),
     },
     mockPipelinesDao: {
       findById: vi.fn(),
@@ -77,7 +81,7 @@ vi.mock("@repo/logger", () => ({
 
 vi.mock("@repo/models", () => ({
   createAgentsDao: vi.fn(() => ({})),
-  createOperationsDao: vi.fn(() => ({})),
+  createOperationsDao: vi.fn(() => mockOperationsDao),
   createPipelinesDao: vi.fn(() => mockPipelinesDao),
   createJobsDao: vi.fn(() => mockJobsDao),
   createJobTracesDao: vi.fn(() => ({})),
@@ -127,6 +131,7 @@ describe("createPipelineRunnerService run controls", () => {
     mockJobsDao.updateStatus.mockResolvedValue(undefined);
     mockMcpInjections.length = 0;
     mockConnectorsDao.findMany.mockResolvedValue([]);
+    mockOperationsDao.findById.mockReset();
     mockPipelinesDao.findById.mockResolvedValue({
       id: "pipe-1",
       name: "Pipe",
@@ -381,6 +386,41 @@ describe("createPipelineRunnerService run controls", () => {
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(AgentRuntimeNotFoundError);
       expect(result.error.message).toContain("missing-runtime");
+    }
+    expect(mockJobsDao.create).not.toHaveBeenCalled();
+    expect(mockPipelineRunExecutorRun).not.toHaveBeenCalled();
+  });
+
+  it("rejects a run before creating a job when an Operation reference is missing", async () => {
+    mockPipelinesDao.findById.mockResolvedValueOnce({
+      id: "pipe-1",
+      name: "Pipe",
+      description: "Pipeline description",
+      projectId: null,
+      nodes: [
+        {
+          id: "search-node",
+          type: "operation",
+          data: {
+            nodeType: "operation",
+            operationId: "op_new_search_hackathons",
+            operationName: "Search recent hackathons",
+          },
+        },
+      ],
+      edges: [],
+    });
+    const service = makeService();
+
+    const result = await service.startRun({ pipelineId: "pipe-1" });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toMatchObject({
+        code: "PIPELINE_OPERATION_MISSING",
+        pipelineId: "pipe-1",
+        missingOperations: [{ nodeId: "search-node", operationId: "op_new_search_hackathons" }],
+      });
     }
     expect(mockJobsDao.create).not.toHaveBeenCalled();
     expect(mockPipelineRunExecutorRun).not.toHaveBeenCalled();

--- a/packages/services/src/pipelinesService/analyzeIntent.unit.test.ts
+++ b/packages/services/src/pipelinesService/analyzeIntent.unit.test.ts
@@ -56,6 +56,7 @@ vi.mock("@repo/models", () => ({
   createPipelineRunsDao: () => ({ findByJobId: vi.fn() }),
   createJobTracesDao: () => ({}),
   createOperationsDao: () => mockOperationsDao,
+  createOperationRegistryRepository: () => ({ runSerializable: vi.fn() }),
   createSettingsDao: () => mockSettingsDao,
 }));
 

--- a/packages/services/src/pipelinesService/checkPipelineOperationReferences.ts
+++ b/packages/services/src/pipelinesService/checkPipelineOperationReferences.ts
@@ -1,0 +1,61 @@
+import type { createOperationsDao } from "@repo/models";
+import type { PipelineNode, PipelineOperationReferenceDiagnostic } from "@repo/schemas";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
+import { ServiceError } from "../serviceErrors";
+
+export class PipelineOperationReferencesError extends Error {
+  readonly code: PipelineOperationReferenceDiagnostic["code"];
+  readonly pipelineId: string;
+  readonly missingOperations: PipelineOperationReferenceDiagnostic["missingOperations"];
+
+  constructor(diagnostic: PipelineOperationReferenceDiagnostic) {
+    const references = diagnostic.missingOperations
+      .map(({ nodeId, operationId }) => `"${operationId}" at node "${nodeId}"`)
+      .join(", ");
+    super(`Pipeline ${diagnostic.pipelineId} references missing Operation ${references}`);
+    this.name = "PipelineOperationReferencesError";
+    this.code = diagnostic.code;
+    this.pipelineId = diagnostic.pipelineId;
+    this.missingOperations = diagnostic.missingOperations;
+  }
+}
+
+export const checkPipelineOperationReferences = ({
+  nodes,
+  operationsDao,
+  pipelineId,
+}: {
+  nodes: readonly PipelineNode[];
+  operationsDao: Pick<ReturnType<typeof createOperationsDao>, "findById">;
+  pipelineId: string;
+}): ResultAsync<void, PipelineOperationReferencesError | ServiceError> => {
+  const references = nodes.flatMap((node) =>
+    node.data.nodeType === "operation" && node.data.operationId
+      ? [{ nodeId: node.id, operationId: node.data.operationId }]
+      : [],
+  );
+  if (references.length === 0) return okAsync(undefined);
+
+  const operationIds = [...new Set(references.map(({ operationId }) => operationId))];
+
+  return ResultAsync.fromPromise(
+    Promise.all(operationIds.map((operationId) => operationsDao.findById(operationId))),
+    (cause) => new ServiceError(`Check Pipeline ${pipelineId} Operation references failed`, cause),
+  ).andThen((operations) => {
+    const existingOperationIds = new Set(
+      operations.flatMap((operation) => (operation ? [operation.id] : [])),
+    );
+    const missingOperations = references.filter(
+      ({ operationId }) => !existingOperationIds.has(operationId),
+    );
+    if (missingOperations.length === 0) return okAsync(undefined);
+
+    return errAsync(
+      new PipelineOperationReferencesError({
+        code: "PIPELINE_OPERATION_MISSING",
+        pipelineId,
+        missingOperations,
+      }),
+    );
+  });
+};

--- a/packages/services/src/pipelinesService/checkPipelineOperationReferences.ts
+++ b/packages/services/src/pipelinesService/checkPipelineOperationReferences.ts
@@ -30,7 +30,7 @@ export const checkPipelineOperationReferences = ({
   pipelineId: string;
 }): ResultAsync<void, PipelineOperationReferencesError | ServiceError> => {
   const references = nodes.flatMap((node) =>
-    node.data.nodeType === "operation" && node.data.operationId
+    node.data.nodeType === "operation"
       ? [{ nodeId: node.id, operationId: node.data.operationId }]
       : [],
   );

--- a/packages/services/src/pipelinesService/createPipelinesService.ts
+++ b/packages/services/src/pipelinesService/createPipelinesService.ts
@@ -9,9 +9,11 @@ import {
   createJobsDao,
   createJobTracesDao,
   createOperationsDao,
+  createOperationRegistryRepository,
   createPipelineRunsDao,
   createPipelinesDao,
   createSettingsDao,
+  type DbConnection,
   type DbExecutor,
 } from "@repo/models";
 import { errAsync, ResultAsync } from "neverthrow";
@@ -176,7 +178,7 @@ export interface PendingOperationInput {
   sourceSkillId?: string;
 }
 
-export const createPipelinesService = (db: DbExecutor, options: PipelinesServiceOptions = {}) => {
+export const createPipelinesService = (db: DbConnection, options: PipelinesServiceOptions = {}) => {
   const agentRuntimesDao = createAgentRuntimesDao(db);
   const conversationMessagesDao = createConversationMessagesDao(db);
   const dao = createPipelinesDao(db);
@@ -185,6 +187,7 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
   const pipelineRunsDao = createPipelineRunsDao(db);
   const jobTracesDao = createJobTracesDao(db);
   const operationsDao = createOperationsDao(db);
+  const operationRegistryRepository = createOperationRegistryRepository(db);
   const settingsDao = createSettingsDao(db);
   const getCapabilityCatalog = (executor: DbExecutor) =>
     options.capabilityCatalog ??
@@ -210,14 +213,21 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
     );
 
   const create = (pipeline: Parameters<typeof dao.create>[0]) =>
-    checkPipelineOperationReferences({
-      nodes: pipeline.nodes ?? [],
-      operationsDao,
-      pipelineId: pipeline.id,
-    }).andThen(() =>
-      ResultAsync.fromPromise(dao.create(pipeline), (error) =>
-        toServiceError(error, "Create Pipeline"),
-      ),
+    ResultAsync.fromPromise(
+      operationRegistryRepository.runSerializable(async ({ operationsDao, pipelinesDao }) => {
+        const referenceCheck = await checkPipelineOperationReferences({
+          nodes: pipeline.nodes ?? [],
+          operationsDao,
+          pipelineId: pipeline.id,
+        });
+        if (referenceCheck.isErr()) throw referenceCheck.error;
+
+        return pipelinesDao.create(pipeline);
+      }),
+      (error) =>
+        error instanceof PipelineOperationReferencesError
+          ? error
+          : toServiceError(error, "Create Pipeline"),
     );
 
   const createWithPendingOperations = (
@@ -225,17 +235,17 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
     pendingOperations: PendingOperationInput[],
   ) =>
     ResultAsync.fromPromise(
-      db.transaction(async (transaction) => {
-        await insertPendingOperations(transaction, pendingOperations);
+      operationRegistryRepository.runSerializable(async (transaction) => {
+        await insertPendingOperations(transaction.executor, pendingOperations);
 
         const referenceCheck = await checkPipelineOperationReferences({
           nodes: pipeline.nodes ?? [],
-          operationsDao: createOperationsDao(transaction),
+          operationsDao: transaction.operationsDao,
           pipelineId: pipeline.id,
         });
         if (referenceCheck.isErr()) throw referenceCheck.error;
 
-        return createPipelinesDao(transaction).create(pipeline);
+        return transaction.pipelinesDao.create(pipeline);
       }),
       (error) =>
         error instanceof PipelineOperationReferencesError
@@ -244,21 +254,25 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
     );
 
   const update = (id: string, patch: Parameters<typeof dao.update>[1]) =>
-    ResultAsync.fromPromise(dao.findById(id), (error) =>
-      toServiceError(error, "Load Pipeline for update"),
-    ).andThen((pipeline) => {
-      if (!pipeline) return errAsync(new NotFoundError("Pipeline", id));
+    ResultAsync.fromPromise(
+      operationRegistryRepository.runSerializable(async ({ operationsDao, pipelinesDao }) => {
+        const pipeline = await pipelinesDao.findById(id);
+        if (!pipeline) throw new NotFoundError("Pipeline", id);
 
-      return checkPipelineOperationReferences({
-        nodes: patch.nodes ?? pipeline.nodes ?? [],
-        operationsDao,
-        pipelineId: id,
-      }).andThen(() =>
-        ResultAsync.fromPromise(dao.update(id, patch), (error) =>
-          toServiceError(error, "Update Pipeline"),
-        ),
-      );
-    });
+        const referenceCheck = await checkPipelineOperationReferences({
+          nodes: patch.nodes ?? pipeline.nodes ?? [],
+          operationsDao,
+          pipelineId: id,
+        });
+        if (referenceCheck.isErr()) throw referenceCheck.error;
+
+        return pipelinesDao.update(id, patch);
+      }),
+      (error) =>
+        error instanceof PipelineOperationReferencesError || error instanceof NotFoundError
+          ? error
+          : toServiceError(error, "Update Pipeline"),
+    );
 
   return {
     getAll: () => dao.findMany(),

--- a/packages/services/src/pipelinesService/createPipelinesService.ts
+++ b/packages/services/src/pipelinesService/createPipelinesService.ts
@@ -33,6 +33,10 @@ import {
 } from "../capabilityCatalogService";
 import { ConflictError, NotFoundError, ServiceError, toServiceError } from "../serviceErrors";
 import { PIPELINE_CANVAS_SKILL_CONTEXT } from "./pipelineCanvasSkillContext";
+import {
+  checkPipelineOperationReferences,
+  PipelineOperationReferencesError,
+} from "./checkPipelineOperationReferences";
 import { MAX_SNAPSHOT_CHARS, truncate } from "./promptText";
 import {
   CAPABILITY_ASSIGNMENT_SYSTEM_PROMPT,
@@ -205,6 +209,17 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
       (error) => toServiceError(error, "Create pending operations"),
     );
 
+  const create = (pipeline: Parameters<typeof dao.create>[0]) =>
+    checkPipelineOperationReferences({
+      nodes: pipeline.nodes ?? [],
+      operationsDao,
+      pipelineId: pipeline.id,
+    }).andThen(() =>
+      ResultAsync.fromPromise(dao.create(pipeline), (error) =>
+        toServiceError(error, "Create Pipeline"),
+      ),
+    );
+
   const createWithPendingOperations = (
     pipeline: Parameters<typeof dao.create>[0],
     pendingOperations: PendingOperationInput[],
@@ -213,15 +228,42 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
       db.transaction(async (transaction) => {
         await insertPendingOperations(transaction, pendingOperations);
 
+        const referenceCheck = await checkPipelineOperationReferences({
+          nodes: pipeline.nodes ?? [],
+          operationsDao: createOperationsDao(transaction),
+          pipelineId: pipeline.id,
+        });
+        if (referenceCheck.isErr()) throw referenceCheck.error;
+
         return createPipelinesDao(transaction).create(pipeline);
       }),
-      (error) => toServiceError(error, "Create pipeline with pending operations"),
+      (error) =>
+        error instanceof PipelineOperationReferencesError
+          ? error
+          : toServiceError(error, "Create pipeline with pending operations"),
     );
+
+  const update = (id: string, patch: Parameters<typeof dao.update>[1]) =>
+    ResultAsync.fromPromise(dao.findById(id), (error) =>
+      toServiceError(error, "Load Pipeline for update"),
+    ).andThen((pipeline) => {
+      if (!pipeline) return errAsync(new NotFoundError("Pipeline", id));
+
+      return checkPipelineOperationReferences({
+        nodes: patch.nodes ?? pipeline.nodes ?? [],
+        operationsDao,
+        pipelineId: id,
+      }).andThen(() =>
+        ResultAsync.fromPromise(dao.update(id, patch), (error) =>
+          toServiceError(error, "Update Pipeline"),
+        ),
+      );
+    });
 
   return {
     getAll: () => dao.findMany(),
     getById: (id: string) => dao.findById(id),
-    create: (...args: Parameters<typeof dao.create>) => dao.create(...args),
+    create,
     createPendingOperations,
     createWithPendingOperations,
     updateOperationExecutors: (
@@ -276,7 +318,7 @@ export const createPipelinesService = (db: DbExecutor, options: PipelinesService
           ),
       );
     },
-    update: (...args: Parameters<typeof dao.update>) => dao.update(...args),
+    update,
     delete: async (id: string) => {
       await pipelineRunsDao.deleteByPipelineId(id);
       await dao.delete(id);

--- a/packages/services/src/pipelinesService/createPipelinesService.unit.test.ts
+++ b/packages/services/src/pipelinesService/createPipelinesService.unit.test.ts
@@ -76,6 +76,29 @@ vi.mock("@repo/models", () => ({
   createAgentSpansDao: () => ({}),
   createOperationsDao: (executor: { operationsDao?: typeof mockOperationsDao }) =>
     executor?.operationsDao ?? mockOperationsDao,
+  createOperationRegistryRepository: (executor: {
+    transaction?: (
+      callback: (transaction: unknown) => Promise<unknown>,
+      config?: unknown,
+    ) => Promise<unknown>;
+    operationsDao?: typeof mockOperationsDao;
+    pipelinesDao?: typeof mockDao;
+  }) => ({
+    runSerializable: (callback: (transaction: unknown) => Promise<unknown>) => {
+      const run = (transaction: typeof executor) =>
+        callback({
+          executor: transaction,
+          operationsDao: transaction?.operationsDao ?? mockOperationsDao,
+          pipelinesDao: transaction?.pipelinesDao ?? mockDao,
+        });
+
+      return executor?.transaction
+        ? executor.transaction((transaction) => run(transaction as typeof executor), {
+            isolationLevel: "serializable",
+          })
+        : run(executor);
+    },
+  }),
   createSettingsDao: () => mockSettingsDao,
   createSkillsDao: () => ({
     findMany: vi.fn().mockResolvedValue([]),

--- a/packages/services/src/pipelinesService/createPipelinesService.unit.test.ts
+++ b/packages/services/src/pipelinesService/createPipelinesService.unit.test.ts
@@ -178,14 +178,99 @@ describe("createPipelinesService", () => {
   it("create delegates to dao.create", async () => {
     const svc = createPipelinesService({} as never);
     const data = { name: "pipeline" } as never;
-    await svc.create(data);
+    const result = await svc.create(data);
+
+    expect(result.isOk()).toBe(true);
+    expect(mockDao.create).toHaveBeenCalledWith(data);
+  });
+
+  it("rejects a Pipeline that references an Operation missing from persistence", async () => {
+    const svc = createPipelinesService({} as never);
+    const data = {
+      id: "pipeline-missing-operation",
+      name: "Broken Pipeline",
+      nodes: [
+        {
+          id: "search-node",
+          type: "operation",
+          data: {
+            nodeType: "operation",
+            operationId: "op_new_search_hackathons",
+            operationName: "Search recent hackathons",
+          },
+        },
+      ],
+    } as never;
+
+    const result = await svc.create(data);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toMatchObject({
+        name: "PipelineOperationReferencesError",
+        code: "PIPELINE_OPERATION_MISSING",
+        pipelineId: "pipeline-missing-operation",
+        missingOperations: [{ nodeId: "search-node", operationId: "op_new_search_hackathons" }],
+      });
+    }
+    expect(mockDao.create).not.toHaveBeenCalled();
+  });
+
+  it("saves a Pipeline when all referenced Operations exist", async () => {
+    mockOperationsDao.findById.mockResolvedValueOnce({ id: "op-existing" });
+    const svc = createPipelinesService({} as never);
+    const data = {
+      id: "pipeline-valid",
+      name: "Valid Pipeline",
+      nodes: [
+        {
+          id: "operation-node",
+          type: "operation",
+          data: {
+            nodeType: "operation",
+            operationId: "op-existing",
+            operationName: "Existing Operation",
+          },
+        },
+      ],
+    } as never;
+
+    const result = await svc.create(data);
+
+    expect(result.isOk()).toBe(true);
+    expect(mockOperationsDao.findById).toHaveBeenCalledWith("op-existing");
     expect(mockDao.create).toHaveBeenCalledWith(data);
   });
 
   it("update delegates to dao.update", async () => {
     const svc = createPipelinesService({} as never);
-    await svc.update("p1", { name: "updated" } as never);
+    const result = await svc.update("p1", { name: "updated" } as never);
+
+    expect(result.isOk()).toBe(true);
     expect(mockDao.update).toHaveBeenCalledWith("p1", { name: "updated" });
+  });
+
+  it("rejects an update that introduces a missing Operation reference", async () => {
+    mockDao.findById.mockResolvedValueOnce({ id: "p1", nodes: [] });
+    const svc = createPipelinesService({} as never);
+    const patch = {
+      nodes: [
+        {
+          id: "missing-node",
+          type: "operation",
+          data: {
+            nodeType: "operation",
+            operationId: "op-missing",
+            operationName: "Missing",
+          },
+        },
+      ],
+    } as never;
+
+    const result = await svc.update("p1", patch);
+
+    expect(result.isErr()).toBe(true);
+    expect(mockDao.update).not.toHaveBeenCalled();
   });
 
   it("delete delegates to dao.delete", async () => {

--- a/packages/services/src/pipelinesService/createPipelinesService.unit.test.ts
+++ b/packages/services/src/pipelinesService/createPipelinesService.unit.test.ts
@@ -216,6 +216,36 @@ describe("createPipelinesService", () => {
     expect(mockDao.create).not.toHaveBeenCalled();
   });
 
+  it("rejects an Operation node whose registry id is blank", async () => {
+    const svc = createPipelinesService({} as never);
+    const data = {
+      id: "pipeline-blank-operation",
+      name: "Incomplete Pipeline",
+      nodes: [
+        {
+          id: "operation-node",
+          type: "operation",
+          data: {
+            nodeType: "operation",
+            operationId: "",
+            operationName: "",
+          },
+        },
+      ],
+    } as never;
+
+    const result = await svc.create(data);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toMatchObject({
+        code: "PIPELINE_OPERATION_MISSING",
+        missingOperations: [{ nodeId: "operation-node", operationId: "" }],
+      });
+    }
+    expect(mockDao.create).not.toHaveBeenCalled();
+  });
+
   it("saves a Pipeline when all referenced Operations exist", async () => {
     mockOperationsDao.findById.mockResolvedValueOnce({ id: "op-existing" });
     const svc = createPipelinesService({} as never);
@@ -364,6 +394,138 @@ describe("createPipelinesService", () => {
     expect(result.isErr()).toBe(true);
     expect(transaction).toHaveBeenCalledOnce();
     expect(persistedOperations).toEqual([]);
+  });
+
+  it("saves pending Operations and their Pipeline in one transaction", async () => {
+    const persistedOperationIds: string[] = [];
+    const persistedPipelineIds: string[] = [];
+    const transaction = vi.fn(async (callback: (executor: unknown) => Promise<unknown>) => {
+      const stagedOperationIds: string[] = [];
+      const stagedPipelineIds: string[] = [];
+      const value = await callback({
+        operationsDao: {
+          ...mockOperationsDao,
+          create: vi.fn(async (operation: { id: string }) => stagedOperationIds.push(operation.id)),
+          findById: vi.fn(async (id: string) =>
+            stagedOperationIds.includes(id) ? { id } : undefined,
+          ),
+        },
+        pipelinesDao: {
+          ...mockDao,
+          create: vi.fn(async (pipeline: { id: string }) => {
+            stagedPipelineIds.push(pipeline.id);
+
+            return pipeline;
+          }),
+        },
+      });
+      persistedOperationIds.push(...stagedOperationIds);
+      persistedPipelineIds.push(...stagedPipelineIds);
+
+      return value;
+    });
+    const service = createPipelinesService({ transaction } as never, {
+      capabilityCatalog: {
+        validateOperationInputs: vi.fn().mockResolvedValue(ok(undefined)),
+      } as never,
+    });
+
+    const result = await service.createWithPendingOperations(
+      {
+        id: "pipeline-1",
+        name: "Pipeline",
+        nodes: [
+          {
+            id: "operation-node",
+            type: "operation",
+            data: {
+              nodeType: "operation",
+              operationId: "op-1",
+              operationName: "First",
+            },
+          },
+        ],
+      } as never,
+      [
+        {
+          id: "op-1",
+          name: "First",
+          description: "first",
+          config: {},
+          acceptedObjectTypes: ["file"],
+        },
+      ],
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(persistedOperationIds).toEqual(["op-1"]);
+    expect(persistedPipelineIds).toEqual(["pipeline-1"]);
+  });
+
+  it("rolls back pending Operations when the Pipeline still references a missing Operation", async () => {
+    const persistedOperationIds: string[] = [];
+    const persistedPipelineIds: string[] = [];
+    const transaction = vi.fn(async (callback: (executor: unknown) => Promise<unknown>) => {
+      const stagedOperationIds: string[] = [];
+      const stagedPipelineIds: string[] = [];
+      const value = await callback({
+        operationsDao: {
+          ...mockOperationsDao,
+          create: vi.fn(async (operation: { id: string }) => stagedOperationIds.push(operation.id)),
+          findById: vi.fn(async (id: string) =>
+            stagedOperationIds.includes(id) ? { id } : undefined,
+          ),
+        },
+        pipelinesDao: {
+          ...mockDao,
+          create: vi.fn(async (pipeline: { id: string }) => {
+            stagedPipelineIds.push(pipeline.id);
+
+            return pipeline;
+          }),
+        },
+      });
+      persistedOperationIds.push(...stagedOperationIds);
+      persistedPipelineIds.push(...stagedPipelineIds);
+
+      return value;
+    });
+    const service = createPipelinesService({ transaction } as never, {
+      capabilityCatalog: {
+        validateOperationInputs: vi.fn().mockResolvedValue(ok(undefined)),
+      } as never,
+    });
+
+    const result = await service.createWithPendingOperations(
+      {
+        id: "pipeline-1",
+        name: "Pipeline",
+        nodes: [
+          {
+            id: "missing-node",
+            type: "operation",
+            data: {
+              nodeType: "operation",
+              operationId: "op-missing",
+              operationName: "Missing",
+            },
+          },
+        ],
+      } as never,
+      [
+        {
+          id: "op-1",
+          name: "First",
+          description: "first",
+          config: {},
+          acceptedObjectTypes: ["file"],
+        },
+      ],
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(persistedOperationIds).toEqual([]);
+    expect(persistedPipelineIds).toEqual([]);
   });
 
   it("updates a shared Operation executor while preserving ports", async () => {

--- a/packages/services/src/pipelinesService/generateStructure.unit.test.ts
+++ b/packages/services/src/pipelinesService/generateStructure.unit.test.ts
@@ -39,6 +39,7 @@ vi.mock("@repo/models", () => ({
   createPipelineRunsDao: () => ({ findByJobId: vi.fn() }),
   createJobTracesDao: () => ({}),
   createOperationsDao: () => mockOperationsDao,
+  createOperationRegistryRepository: () => ({ runSerializable: vi.fn() }),
   createSettingsDao: () => mockSettingsDao,
 }));
 

--- a/packages/services/src/pipelinesService/index.ts
+++ b/packages/services/src/pipelinesService/index.ts
@@ -1,2 +1,3 @@
 export * from "./createPipelinesService";
+export * from "./checkPipelineOperationReferences";
 export * from "./proposeActions";


### PR DESCRIPTION
## Notice

Ordine is not accepting external pull requests until the beta release.

This PR implements the team issue COD-349 from the project fork.

## Summary

- Validate every Pipeline Operation reference when creating or updating a Pipeline.
- Commit pending Operations and their Pipeline in one serializable registry transaction.
- Re-check references before a run and return structured `PIPELINE_OPERATION_MISSING` diagnostics before creating a Job.
- Prevent deleting an Operation still referenced by a saved Pipeline and return `OPERATION_IN_USE`.
- Map reference conflicts to HTTP 409 / tRPC `CONFLICT`, while preserving infrastructure failures as 500 / `INTERNAL_SERVER_ERROR`.
- Route registry writes through `operationRegistryRepository` so concurrent saves and deletes cannot commit a dangling reference.

Related: COD-349

## Validation

- [x] Affected package type checks passed (`models`, `services`, `schemas`, `server`, `app`).
- [x] Unit suites passed: schemas 84, services 533 (5 skipped), server 114, app 569, registry repository 1.
- [x] Affected package lint passed; only pre-existing warnings remain.
- [x] App production build passed.
- [x] Changed-file format check and `git diff --check` passed.
- [x] Independent pre-landing review found no blocking correctness issue.

The root `bun run quality` cannot complete locally because the expected test databases (`ordine_db_schema_test` / `ordine_models_test`) are not provisioned. The repository-wide format check also reports 156 pre-existing unrelated files; all files changed by this PR pass formatting.

## Notes

- No database migration is required.
- No visual UI styles changed, so there is no screenshot difference.
- Test-path assessment: 31/39 behavior paths covered (79%), including all critical save, run-preflight, delete-guard, error-mapping, and transaction paths.
- Non-blocking follow-ups: retry PostgreSQL serialization failures, replace full Pipeline scans / N reference lookups with indexed queries, and add a real PostgreSQL concurrency integration test.
