### PR TITLE
feat: COD-343 导航重构 + 全站 Attio 视觉对齐

### DIFF
--- a/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationComposer.tsx
+++ b/apps/app/src/components/PipelineCreationWorkspace/PipelineCreationComposer.tsx
@@ -139,7 +139,9 @@ export const PipelineCreationComposer = ({
       <div
         className={cn(
           "border border-border bg-card shadow-sm transition-colors focus-within:border-foreground/25",
-          isHome ? "rounded-2xl p-3" : "rounded-xl p-2.5",
+          isHome
+            ? "rounded-[14px] p-3 shadow-soft focus-within:border-cobalt/45"
+            : "rounded-xl p-2.5",
         )}
       >
         <Textarea
@@ -222,13 +224,10 @@ export const PipelineCreationComposer = ({
             </Link>
           ) : null}
 
-          <span className="ml-auto hidden text-[11px] text-muted-foreground sm:inline">
-            {t("home.sendHint")}
-          </span>
           {phase === "planning" ? (
             <Button
               aria-label={t("newPipelineDialog.cancel")}
-              className={cn("shrink-0", isHome && "rounded-full")}
+              className={cn("ml-auto shrink-0", isHome && "rounded-[10px]")}
               disabled={isCancelling}
               size={isHome ? "icon" : "sm"}
               type="button"
@@ -245,7 +244,11 @@ export const PipelineCreationComposer = ({
           ) : proposalVisible ? null : (
             <Button
               aria-label={t("newPipelineDialog.send")}
-              className={cn("shrink-0", isHome && "rounded-full")}
+              className={cn(
+                "ml-auto shrink-0",
+                isHome &&
+                  "rounded-[7px] bg-cobalt text-white hover:bg-cobalt-bright disabled:bg-cobalt-soft disabled:text-white dark:disabled:bg-ice-wash dark:disabled:text-[#1c1d1f]",
+              )}
               disabled={inputValue.trim().length === 0 || runtimeMissing}
               size={isHome ? "icon" : "sm"}
               onClick={handleSend}
@@ -290,21 +293,21 @@ export const PipelineCreationComposer = ({
           )}
         </div>
       ) : isHome && !hasConversation ? (
-        <div className="divide-y divide-border/70">
+        <div className="mt-2 divide-y divide-border">
           {suggestions.map((suggestion) => {
             const Icon = suggestion.icon;
 
             return (
               <button
                 key={suggestion.label}
-                className="group flex w-full items-center gap-3 px-2 py-3 text-left text-sm transition-colors hover:bg-surface-2"
+                className="group flex w-full items-center gap-3 rounded-[10px] px-2 py-3 text-left text-sm transition-colors hover:bg-surface-2"
                 data-prompt={suggestion.prompt}
                 type="button"
                 onClick={handleSuggestionClick}
               >
-                <Icon className="size-4 shrink-0 text-muted-foreground" />
-                <span className="font-medium text-foreground">{suggestion.label}</span>
-                <span className="hidden truncate text-muted-foreground sm:inline">
+                <Icon className="size-4 shrink-0 text-muted-foreground" strokeWidth={1.5} />
+                <span className="font-medium tracking-[-0.01em]">{suggestion.label}</span>
+                <span className="hidden truncate text-muted-foreground/80 sm:inline">
                   {suggestion.description}
                 </span>
                 <ArrowUp className="ml-auto size-3.5 rotate-45 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />

--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -97,11 +97,14 @@
     "preview": "Preview",
     "plugins": "Plugins",
     "agents": "Agents",
+    "schedule": "Schedule",
+    "conversations": "Conversations",
     "logout": "Log out",
     "groups": {
       "assembly": "Assembly",
       "capabilities": "Capabilities",
-      "monitor": "Monitor"
+      "monitor": "Monitor",
+      "main": "Main"
     },
     "items": {
       "agents": "Agents",
@@ -114,6 +117,18 @@
       "skills": "Skills",
       "usage": "Usage"
     }
+  },
+  "schedule": {
+    "title": "Schedule",
+    "subtitle": "Run pipelines automatically on a schedule",
+    "emptyTitle": "Scheduling is coming soon",
+    "emptyDescription": "This page will list all scheduled pipeline routines, with cadence, activation state, and manual trigger."
+  },
+  "conversations": {
+    "title": "Conversations",
+    "subtitle": "Past conversations with agents",
+    "emptyTitle": "Conversations are coming soon",
+    "emptyDescription": "This page will collect your conversations with agents, so you can review and continue them."
   },
   "connectors": {
     "title": "Connectors",
@@ -273,11 +288,8 @@
     "quickActionBestPracticesSub": "View coding standards"
   },
   "home": {
-    "title": "Ordine Studio",
-    "subtitle": "Conversation-first Pipeline workspace",
-    "eyebrow": "New Pipeline",
     "heading": "What should Ordine automate today?",
-    "description": "Describe the goal, inputs, and expected output. Your local Agent will confirm a plan, then create a runnable Pipeline in the existing Canvas.",
+    "description": "Describe the goal, inputs, and expected output. Ordine will create a runnable Pipeline in the Canvas for you.",
     "agentReady": "Local Agent ready",
     "agentConfigured": "Local Agent configured",
     "selectLocalAgent": "Select local Agent",
@@ -287,7 +299,6 @@
     "connectLocalAgent": "Connect local Agent",
     "checkingAgent": "Checking local Agent…",
     "localAgentCount": "{{name}} +{{count}}",
-    "sendHint": "Ctrl ↵ to send",
     "proposalHint": "Approve this plan and the Agent will create the Pipeline in the existing Canvas.",
     "proposalSchedule": "Schedule: {{cronExpression}}",
     "suggestions": {
@@ -1426,7 +1437,8 @@
       "autonomy": "Autonomy",
       "defaults": "Defaults",
       "keyboard": "Keyboard",
-      "project": "Project"
+      "project": "Project",
+      "pages": "Pages"
     },
     "saveChanges": "Save changes",
     "saved": "Saved ✓",
@@ -1537,7 +1549,12 @@
     "groups": {
       "data": "Data",
       "execution": "Execution",
-      "workspace": "Workspace"
+      "workspace": "Workspace",
+      "pages": "Pages"
+    },
+    "pages": {
+      "title": "More pages",
+      "description": "Entries moved out of the main navigation. Routes and features are unchanged."
     },
     "keyboard": {
       "description": "Canvas shortcuts. Read-only for now.",

--- a/apps/app/src/locales/zh.json
+++ b/apps/app/src/locales/zh.json
@@ -97,11 +97,14 @@
     "preview": "预览",
     "plugins": "插件",
     "agents": "智能体",
+    "schedule": "定时任务",
+    "conversations": "对话",
     "logout": "退出登录",
     "groups": {
       "assembly": "装配",
       "capabilities": "能力",
-      "monitor": "监控"
+      "monitor": "监控",
+      "main": "主导航"
     },
     "items": {
       "agents": "智能体",
@@ -114,6 +117,18 @@
       "skills": "技能",
       "usage": "用量"
     }
+  },
+  "schedule": {
+    "title": "定时任务",
+    "subtitle": "按计划自动运行流水线",
+    "emptyTitle": "定时任务即将上线",
+    "emptyDescription": "这里将列出所有定时执行的流水线(Routine),支持查看周期、启用状态和手动触发。"
+  },
+  "conversations": {
+    "title": "对话",
+    "subtitle": "与智能体的历史对话",
+    "emptyTitle": "对话记录即将上线",
+    "emptyDescription": "这里将汇总你与智能体的对话记录,支持回看与继续。"
   },
   "connectors": {
     "title": "连接器",
@@ -268,9 +283,6 @@
     "quickActionBestPracticesSub": "查看编码规范"
   },
   "home": {
-    "title": "Ordine Studio",
-    "subtitle": "对话驱动的 Pipeline 工作区",
-    "eyebrow": "新建 Pipeline",
     "heading": "今天想让 Ordine 自动化什么？",
     "description": "描述目标、输入和期望产物。本地 Agent 会先与你确认方案，再直接生成可运行的 Pipeline。",
     "agentReady": "本地 Agent 已就绪",
@@ -282,7 +294,6 @@
     "connectLocalAgent": "连接本地 Agent",
     "checkingAgent": "正在检查本地 Agent…",
     "localAgentCount": "{{name}} +{{count}}",
-    "sendHint": "Ctrl ↵ 发送",
     "proposalHint": "确认这份方案后，Agent 会创建 Pipeline 并接入现有 Canvas。",
     "proposalSchedule": "定时：{{cronExpression}}",
     "suggestions": {
@@ -1420,7 +1431,8 @@
       "autonomy": "自主性",
       "defaults": "默认项",
       "keyboard": "快捷键",
-      "project": "项目"
+      "project": "项目",
+      "pages": "页面"
     },
     "saveChanges": "保存更改",
     "saved": "已保存 ✓",
@@ -1531,7 +1543,12 @@
     "groups": {
       "data": "数据",
       "execution": "执行",
-      "workspace": "工作区"
+      "workspace": "工作区",
+      "pages": "页面"
+    },
+    "pages": {
+      "title": "更多页面",
+      "description": "从主导航移出的页面入口,路由与功能保持不变。"
     },
     "keyboard": {
       "description": "画布快捷键速查，当前为只读。",

--- a/apps/app/src/pages/HomePage/HomePage.tsx
+++ b/apps/app/src/pages/HomePage/HomePage.tsx
@@ -37,11 +37,7 @@ export const HomePage = () => {
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
-      <header className="flex h-14 shrink-0 items-center justify-between border-b border-border/80 px-4 sm:px-6">
-        <div className="min-w-0">
-          <p className="truncate text-sm font-semibold tracking-[-0.015em]">{t("home.title")}</p>
-          <p className="truncate text-[11px] text-muted-foreground">{t("home.subtitle")}</p>
-        </div>
+      <header className="flex h-14 shrink-0 items-center justify-end border-b border-border px-4 sm:px-6">
         {runtime ? (
           <Link
             aria-label={t("home.manageLocalAgents")}
@@ -68,10 +64,13 @@ export const HomePage = () => {
 
       <main className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto flex min-h-full w-full max-w-[860px] flex-col justify-center px-4 py-10 sm:px-8 sm:py-14">
-          <div className="mb-6 text-center">
-            <h1 className="text-balance text-2xl font-semibold tracking-[-0.035em] text-foreground sm:text-[30px]">
+          <div className="mb-10 text-center">
+            <h1 className="text-balance font-heading text-4xl font-semibold leading-[1.07] tracking-[-0.015em] sm:text-[56px]">
               {t("home.heading")}
             </h1>
+            <p className="mx-auto mt-5 max-w-[520px] text-pretty text-base font-medium leading-[1.38] text-muted-foreground">
+              {t("home.description")}
+            </p>
           </div>
 
           {catalogQuery.isError ? (

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -8,980 +8,1016 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as SignUpRouteImport } from "./routes/sign-up";
-import { Route as LoginRouteImport } from "./routes/login";
-import { Route as CanvasRouteImport } from "./routes/canvas";
-import { Route as LayoutRouteImport } from "./routes/_layout";
-import { Route as LayoutIndexRouteImport } from "./routes/_layout/index";
-import { Route as ApiPipelineAgentSessionsRouteImport } from "./routes/api/pipeline-agent-sessions";
-import { Route as ApiLocalSessionRouteImport } from "./routes/api/local-session";
-import { Route as LayoutUsageRouteImport } from "./routes/_layout/usage";
-import { Route as LayoutSkillsRouteImport } from "./routes/_layout/skills";
-import { Route as LayoutSettingsRouteImport } from "./routes/_layout/settings";
-import { Route as LayoutRuntimesRouteImport } from "./routes/_layout/runtimes";
-import { Route as LayoutPluginsRouteImport } from "./routes/_layout/plugins";
-import { Route as LayoutPipelinesRouteImport } from "./routes/_layout/pipelines";
-import { Route as LayoutLocalAgentsRouteImport } from "./routes/_layout/local-agents";
-import { Route as LayoutDistillationsRouteImport } from "./routes/_layout/distillations";
-import { Route as LayoutDistillationStudioRouteImport } from "./routes/_layout/distillation-studio";
-import { Route as LayoutConnectorsRouteImport } from "./routes/_layout/connectors";
-import { Route as LayoutComponentsRouteImport } from "./routes/_layout/components";
-import { Route as LayoutAssistantRouteImport } from "./routes/_layout/assistant";
-import { Route as LayoutRuntimesIndexRouteImport } from "./routes/_layout/runtimes.index";
-import { Route as LayoutPipelinesIndexRouteImport } from "./routes/_layout/pipelines.index";
-import { Route as LayoutDistillationsIndexRouteImport } from "./routes/_layout/distillations.index";
-import { Route as LayoutAgentsIndexRouteImport } from "./routes/_layout/agents.index";
-import { Route as ApiTrpcSplatRouteImport } from "./routes/api/trpc.$";
-import { Route as ApiPipelinesSplatRouteImport } from "./routes/api/pipelines.$";
-import { Route as ApiPipelineAgentSessionsSplatRouteImport } from "./routes/api/pipeline-agent-sessions.$";
-import { Route as ApiOperationsSplatRouteImport } from "./routes/api/operations.$";
-import { Route as ApiAuthSplatRouteImport } from "./routes/api/auth.$";
-import { Route as ApiAgentRuntimesSplatRouteImport } from "./routes/api/agent-runtimes.$";
-import { Route as ApiAgentRunsSplatRouteImport } from "./routes/api/agent-runs.$";
-import { Route as LayoutPipelinesJobsRouteImport } from "./routes/_layout/pipelines.jobs";
-import { Route as LayoutPipelinesPipelineIdRouteImport } from "./routes/_layout/pipelines.$pipelineId";
-import { Route as LayoutDistillationsNewRouteImport } from "./routes/_layout/distillations.new";
-import { Route as LayoutDistillationsDistillationIdRouteImport } from "./routes/_layout/distillations.$distillationId";
-import { Route as LayoutRuntimesRuntimeIdIndexRouteImport } from "./routes/_layout/runtimes.$runtimeId.index";
-import { Route as LayoutPipelinesOperationsIndexRouteImport } from "./routes/_layout/pipelines.operations.index";
-import { Route as LayoutPipelinesObjectsIndexRouteImport } from "./routes/_layout/pipelines.objects.index";
-import { Route as LayoutPipelinesJobsIndexRouteImport } from "./routes/_layout/pipelines.jobs.index";
-import { Route as LayoutAgentsAgentIdIndexRouteImport } from "./routes/_layout/agents.$agentId.index";
-import { Route as LayoutRuntimesRuntimeIdEditRouteImport } from "./routes/_layout/runtimes.$runtimeId.edit";
-import { Route as LayoutPipelinesOperationsNewRouteImport } from "./routes/_layout/pipelines.operations.new";
-import { Route as LayoutPipelinesObjectsObjectTypeIdRouteImport } from "./routes/_layout/pipelines.objects.$objectTypeId";
-import { Route as LayoutPipelinesJobsJobIdRouteImport } from "./routes/_layout/pipelines.jobs.$jobId";
-import { Route as LayoutPipelinesOperationsOperationIdIndexRouteImport } from "./routes/_layout/pipelines.operations.$operationId.index";
-import { Route as LayoutPipelinesOperationsOperationIdEditRouteImport } from "./routes/_layout/pipelines.operations.$operationId.edit";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as SignUpRouteImport } from './routes/sign-up'
+import { Route as LoginRouteImport } from './routes/login'
+import { Route as CanvasRouteImport } from './routes/canvas'
+import { Route as LayoutRouteImport } from './routes/_layout'
+import { Route as LayoutIndexRouteImport } from './routes/_layout/index'
+import { Route as ApiPipelineAgentSessionsRouteImport } from './routes/api/pipeline-agent-sessions'
+import { Route as ApiLocalSessionRouteImport } from './routes/api/local-session'
+import { Route as LayoutUsageRouteImport } from './routes/_layout/usage'
+import { Route as LayoutSkillsRouteImport } from './routes/_layout/skills'
+import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
+import { Route as LayoutScheduleRouteImport } from './routes/_layout/schedule'
+import { Route as LayoutRuntimesRouteImport } from './routes/_layout/runtimes'
+import { Route as LayoutPluginsRouteImport } from './routes/_layout/plugins'
+import { Route as LayoutPipelinesRouteImport } from './routes/_layout/pipelines'
+import { Route as LayoutLocalAgentsRouteImport } from './routes/_layout/local-agents'
+import { Route as LayoutDistillationsRouteImport } from './routes/_layout/distillations'
+import { Route as LayoutDistillationStudioRouteImport } from './routes/_layout/distillation-studio'
+import { Route as LayoutConnectorsRouteImport } from './routes/_layout/connectors'
+import { Route as LayoutComponentsRouteImport } from './routes/_layout/components'
+import { Route as LayoutAssistantRouteImport } from './routes/_layout/assistant'
+import { Route as LayoutRuntimesIndexRouteImport } from './routes/_layout/runtimes.index'
+import { Route as LayoutPipelinesIndexRouteImport } from './routes/_layout/pipelines.index'
+import { Route as LayoutDistillationsIndexRouteImport } from './routes/_layout/distillations.index'
+import { Route as LayoutAgentsIndexRouteImport } from './routes/_layout/agents.index'
+import { Route as ApiTrpcSplatRouteImport } from './routes/api/trpc.$'
+import { Route as ApiPipelinesSplatRouteImport } from './routes/api/pipelines.$'
+import { Route as ApiPipelineAgentSessionsSplatRouteImport } from './routes/api/pipeline-agent-sessions.$'
+import { Route as ApiOperationsSplatRouteImport } from './routes/api/operations.$'
+import { Route as ApiAuthSplatRouteImport } from './routes/api/auth.$'
+import { Route as ApiAgentRuntimesSplatRouteImport } from './routes/api/agent-runtimes.$'
+import { Route as ApiAgentRunsSplatRouteImport } from './routes/api/agent-runs.$'
+import { Route as LayoutPipelinesJobsRouteImport } from './routes/_layout/pipelines.jobs'
+import { Route as LayoutPipelinesPipelineIdRouteImport } from './routes/_layout/pipelines.$pipelineId'
+import { Route as LayoutDistillationsNewRouteImport } from './routes/_layout/distillations.new'
+import { Route as LayoutDistillationsDistillationIdRouteImport } from './routes/_layout/distillations.$distillationId'
+import { Route as LayoutRuntimesRuntimeIdIndexRouteImport } from './routes/_layout/runtimes.$runtimeId.index'
+import { Route as LayoutPipelinesOperationsIndexRouteImport } from './routes/_layout/pipelines.operations.index'
+import { Route as LayoutPipelinesObjectsIndexRouteImport } from './routes/_layout/pipelines.objects.index'
+import { Route as LayoutPipelinesJobsIndexRouteImport } from './routes/_layout/pipelines.jobs.index'
+import { Route as LayoutAgentsAgentIdIndexRouteImport } from './routes/_layout/agents.$agentId.index'
+import { Route as LayoutRuntimesRuntimeIdEditRouteImport } from './routes/_layout/runtimes.$runtimeId.edit'
+import { Route as LayoutPipelinesOperationsNewRouteImport } from './routes/_layout/pipelines.operations.new'
+import { Route as LayoutPipelinesObjectsObjectTypeIdRouteImport } from './routes/_layout/pipelines.objects.$objectTypeId'
+import { Route as LayoutPipelinesJobsJobIdRouteImport } from './routes/_layout/pipelines.jobs.$jobId'
+import { Route as LayoutPipelinesOperationsOperationIdIndexRouteImport } from './routes/_layout/pipelines.operations.$operationId.index'
+import { Route as LayoutPipelinesOperationsOperationIdEditRouteImport } from './routes/_layout/pipelines.operations.$operationId.edit'
 
 const SignUpRoute = SignUpRouteImport.update({
-  id: "/sign-up",
-  path: "/sign-up",
+  id: '/sign-up',
+  path: '/sign-up',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const LoginRoute = LoginRouteImport.update({
-  id: "/login",
-  path: "/login",
+  id: '/login',
+  path: '/login',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const CanvasRoute = CanvasRouteImport.update({
-  id: "/canvas",
-  path: "/canvas",
+  id: '/canvas',
+  path: '/canvas',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const LayoutRoute = LayoutRouteImport.update({
-  id: "/_layout",
+  id: '/_layout',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const LayoutIndexRoute = LayoutIndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => LayoutRoute,
-} as any);
-const ApiPipelineAgentSessionsRoute = ApiPipelineAgentSessionsRouteImport.update({
-  id: "/api/pipeline-agent-sessions",
-  path: "/api/pipeline-agent-sessions",
-  getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
+const ApiPipelineAgentSessionsRoute =
+  ApiPipelineAgentSessionsRouteImport.update({
+    id: '/api/pipeline-agent-sessions',
+    path: '/api/pipeline-agent-sessions',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiLocalSessionRoute = ApiLocalSessionRouteImport.update({
-  id: "/api/local-session",
-  path: "/api/local-session",
+  id: '/api/local-session',
+  path: '/api/local-session',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const LayoutUsageRoute = LayoutUsageRouteImport.update({
-  id: "/usage",
-  path: "/usage",
+  id: '/usage',
+  path: '/usage',
   getParentRoute: () => LayoutRoute,
-} as any);
+} as any)
 const LayoutSkillsRoute = LayoutSkillsRouteImport.update({
-  id: "/skills",
-  path: "/skills",
+  id: '/skills',
+  path: '/skills',
   getParentRoute: () => LayoutRoute,
-} as any);
+} as any)
 const LayoutSettingsRoute = LayoutSettingsRouteImport.update({
-  id: "/settings",
-  path: "/settings",
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => LayoutRoute,
-} as any);
+} as any)
+const LayoutScheduleRoute = LayoutScheduleRouteImport.update({
+  id: '/schedule',
+  path: '/schedule',
+  getParentRoute: () => LayoutRoute,
+} as any)
 const LayoutRuntimesRoute = LayoutRuntimesRouteImport.update({
-  id: "/runtimes",
-  path: "/runtimes",
+  id: '/runtimes',
+  path: '/runtimes',
   getParentRoute: () => LayoutRoute,
-} as any);
+} as any)
 const LayoutPluginsRoute = LayoutPluginsRouteImport.update({
-  id: "/plugins",
-  path: "/plugins",
+  id: '/plugins',
+  path: '/plugins',
   getParentRoute: () => LayoutRoute,
-} as any);
+} as any)
 const LayoutPipelinesRoute = LayoutPipelinesRouteImport.update({
-  id: "/pipelines",
-  path: "/pipelines",
+  id: '/pipelines',
+  path: '/pipelines',
   getParentRoute: () => LayoutRoute,
-} as any);
+} as any)
 const LayoutLocalAgentsRoute = LayoutLocalAgentsRouteImport.update({
-  id: "/local-agents",
-  path: "/local-agents",
+  id: '/local-agents',
+  path: '/local-agents',
   getParentRoute: () => LayoutRoute,
-} as any);
+} as any)
 const LayoutDistillationsRoute = LayoutDistillationsRouteImport.update({
-  id: "/distillations",
-  path: "/distillations",
+  id: '/distillations',
+  path: '/distillations',
   getParentRoute: () => LayoutRoute,
-} as any);
-const LayoutDistillationStudioRoute = LayoutDistillationStudioRouteImport.update({
-  id: "/distillation-studio",
-  path: "/distillation-studio",
-  getParentRoute: () => LayoutRoute,
-} as any);
+} as any)
+const LayoutDistillationStudioRoute =
+  LayoutDistillationStudioRouteImport.update({
+    id: '/distillation-studio',
+    path: '/distillation-studio',
+    getParentRoute: () => LayoutRoute,
+  } as any)
 const LayoutConnectorsRoute = LayoutConnectorsRouteImport.update({
-  id: "/connectors",
-  path: "/connectors",
+  id: '/connectors',
+  path: '/connectors',
   getParentRoute: () => LayoutRoute,
-} as any);
+} as any)
 const LayoutComponentsRoute = LayoutComponentsRouteImport.update({
-  id: "/components",
-  path: "/components",
+  id: '/components',
+  path: '/components',
   getParentRoute: () => LayoutRoute,
-} as any);
+} as any)
 const LayoutAssistantRoute = LayoutAssistantRouteImport.update({
-  id: "/assistant",
-  path: "/assistant",
+  id: '/assistant',
+  path: '/assistant',
   getParentRoute: () => LayoutRoute,
-} as any);
+} as any)
 const LayoutRuntimesIndexRoute = LayoutRuntimesIndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => LayoutRuntimesRoute,
-} as any);
+} as any)
 const LayoutPipelinesIndexRoute = LayoutPipelinesIndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => LayoutPipelinesRoute,
-} as any);
-const LayoutDistillationsIndexRoute = LayoutDistillationsIndexRouteImport.update({
-  id: "/",
-  path: "/",
-  getParentRoute: () => LayoutDistillationsRoute,
-} as any);
+} as any)
+const LayoutDistillationsIndexRoute =
+  LayoutDistillationsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => LayoutDistillationsRoute,
+  } as any)
 const LayoutAgentsIndexRoute = LayoutAgentsIndexRouteImport.update({
-  id: "/agents/",
-  path: "/agents/",
+  id: '/agents/',
+  path: '/agents/',
   getParentRoute: () => LayoutRoute,
-} as any);
+} as any)
 const ApiTrpcSplatRoute = ApiTrpcSplatRouteImport.update({
-  id: "/api/trpc/$",
-  path: "/api/trpc/$",
+  id: '/api/trpc/$',
+  path: '/api/trpc/$',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ApiPipelinesSplatRoute = ApiPipelinesSplatRouteImport.update({
-  id: "/api/pipelines/$",
-  path: "/api/pipelines/$",
+  id: '/api/pipelines/$',
+  path: '/api/pipelines/$',
   getParentRoute: () => rootRouteImport,
-} as any);
-const ApiPipelineAgentSessionsSplatRoute = ApiPipelineAgentSessionsSplatRouteImport.update({
-  id: "/$",
-  path: "/$",
-  getParentRoute: () => ApiPipelineAgentSessionsRoute,
-} as any);
+} as any)
+const ApiPipelineAgentSessionsSplatRoute =
+  ApiPipelineAgentSessionsSplatRouteImport.update({
+    id: '/$',
+    path: '/$',
+    getParentRoute: () => ApiPipelineAgentSessionsRoute,
+  } as any)
 const ApiOperationsSplatRoute = ApiOperationsSplatRouteImport.update({
-  id: "/api/operations/$",
-  path: "/api/operations/$",
+  id: '/api/operations/$',
+  path: '/api/operations/$',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
-  id: "/api/auth/$",
-  path: "/api/auth/$",
+  id: '/api/auth/$',
+  path: '/api/auth/$',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ApiAgentRuntimesSplatRoute = ApiAgentRuntimesSplatRouteImport.update({
-  id: "/api/agent-runtimes/$",
-  path: "/api/agent-runtimes/$",
+  id: '/api/agent-runtimes/$',
+  path: '/api/agent-runtimes/$',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ApiAgentRunsSplatRoute = ApiAgentRunsSplatRouteImport.update({
-  id: "/api/agent-runs/$",
-  path: "/api/agent-runs/$",
+  id: '/api/agent-runs/$',
+  path: '/api/agent-runs/$',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const LayoutPipelinesJobsRoute = LayoutPipelinesJobsRouteImport.update({
-  id: "/jobs",
-  path: "/jobs",
+  id: '/jobs',
+  path: '/jobs',
   getParentRoute: () => LayoutPipelinesRoute,
-} as any);
-const LayoutPipelinesPipelineIdRoute = LayoutPipelinesPipelineIdRouteImport.update({
-  id: "/$pipelineId",
-  path: "/$pipelineId",
-  getParentRoute: () => LayoutPipelinesRoute,
-} as any);
+} as any)
+const LayoutPipelinesPipelineIdRoute =
+  LayoutPipelinesPipelineIdRouteImport.update({
+    id: '/$pipelineId',
+    path: '/$pipelineId',
+    getParentRoute: () => LayoutPipelinesRoute,
+  } as any)
 const LayoutDistillationsNewRoute = LayoutDistillationsNewRouteImport.update({
-  id: "/new",
-  path: "/new",
+  id: '/new',
+  path: '/new',
   getParentRoute: () => LayoutDistillationsRoute,
-} as any);
-const LayoutDistillationsDistillationIdRoute = LayoutDistillationsDistillationIdRouteImport.update({
-  id: "/$distillationId",
-  path: "/$distillationId",
-  getParentRoute: () => LayoutDistillationsRoute,
-} as any);
-const LayoutRuntimesRuntimeIdIndexRoute = LayoutRuntimesRuntimeIdIndexRouteImport.update({
-  id: "/$runtimeId/",
-  path: "/$runtimeId/",
-  getParentRoute: () => LayoutRuntimesRoute,
-} as any);
-const LayoutPipelinesOperationsIndexRoute = LayoutPipelinesOperationsIndexRouteImport.update({
-  id: "/operations/",
-  path: "/operations/",
-  getParentRoute: () => LayoutPipelinesRoute,
-} as any);
-const LayoutPipelinesObjectsIndexRoute = LayoutPipelinesObjectsIndexRouteImport.update({
-  id: "/objects/",
-  path: "/objects/",
-  getParentRoute: () => LayoutPipelinesRoute,
-} as any);
-const LayoutPipelinesJobsIndexRoute = LayoutPipelinesJobsIndexRouteImport.update({
-  id: "/",
-  path: "/",
-  getParentRoute: () => LayoutPipelinesJobsRoute,
-} as any);
-const LayoutAgentsAgentIdIndexRoute = LayoutAgentsAgentIdIndexRouteImport.update({
-  id: "/agents/$agentId/",
-  path: "/agents/$agentId/",
-  getParentRoute: () => LayoutRoute,
-} as any);
-const LayoutRuntimesRuntimeIdEditRoute = LayoutRuntimesRuntimeIdEditRouteImport.update({
-  id: "/$runtimeId/edit",
-  path: "/$runtimeId/edit",
-  getParentRoute: () => LayoutRuntimesRoute,
-} as any);
-const LayoutPipelinesOperationsNewRoute = LayoutPipelinesOperationsNewRouteImport.update({
-  id: "/operations/new",
-  path: "/operations/new",
-  getParentRoute: () => LayoutPipelinesRoute,
-} as any);
+} as any)
+const LayoutDistillationsDistillationIdRoute =
+  LayoutDistillationsDistillationIdRouteImport.update({
+    id: '/$distillationId',
+    path: '/$distillationId',
+    getParentRoute: () => LayoutDistillationsRoute,
+  } as any)
+const LayoutRuntimesRuntimeIdIndexRoute =
+  LayoutRuntimesRuntimeIdIndexRouteImport.update({
+    id: '/$runtimeId/',
+    path: '/$runtimeId/',
+    getParentRoute: () => LayoutRuntimesRoute,
+  } as any)
+const LayoutPipelinesOperationsIndexRoute =
+  LayoutPipelinesOperationsIndexRouteImport.update({
+    id: '/operations/',
+    path: '/operations/',
+    getParentRoute: () => LayoutPipelinesRoute,
+  } as any)
+const LayoutPipelinesObjectsIndexRoute =
+  LayoutPipelinesObjectsIndexRouteImport.update({
+    id: '/objects/',
+    path: '/objects/',
+    getParentRoute: () => LayoutPipelinesRoute,
+  } as any)
+const LayoutPipelinesJobsIndexRoute =
+  LayoutPipelinesJobsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => LayoutPipelinesJobsRoute,
+  } as any)
+const LayoutAgentsAgentIdIndexRoute =
+  LayoutAgentsAgentIdIndexRouteImport.update({
+    id: '/agents/$agentId/',
+    path: '/agents/$agentId/',
+    getParentRoute: () => LayoutRoute,
+  } as any)
+const LayoutRuntimesRuntimeIdEditRoute =
+  LayoutRuntimesRuntimeIdEditRouteImport.update({
+    id: '/$runtimeId/edit',
+    path: '/$runtimeId/edit',
+    getParentRoute: () => LayoutRuntimesRoute,
+  } as any)
+const LayoutPipelinesOperationsNewRoute =
+  LayoutPipelinesOperationsNewRouteImport.update({
+    id: '/operations/new',
+    path: '/operations/new',
+    getParentRoute: () => LayoutPipelinesRoute,
+  } as any)
 const LayoutPipelinesObjectsObjectTypeIdRoute =
   LayoutPipelinesObjectsObjectTypeIdRouteImport.update({
-    id: "/objects/$objectTypeId",
-    path: "/objects/$objectTypeId",
+    id: '/objects/$objectTypeId',
+    path: '/objects/$objectTypeId',
     getParentRoute: () => LayoutPipelinesRoute,
-  } as any);
-const LayoutPipelinesJobsJobIdRoute = LayoutPipelinesJobsJobIdRouteImport.update({
-  id: "/$jobId",
-  path: "/$jobId",
-  getParentRoute: () => LayoutPipelinesJobsRoute,
-} as any);
+  } as any)
+const LayoutPipelinesJobsJobIdRoute =
+  LayoutPipelinesJobsJobIdRouteImport.update({
+    id: '/$jobId',
+    path: '/$jobId',
+    getParentRoute: () => LayoutPipelinesJobsRoute,
+  } as any)
 const LayoutPipelinesOperationsOperationIdIndexRoute =
   LayoutPipelinesOperationsOperationIdIndexRouteImport.update({
-    id: "/operations/$operationId/",
-    path: "/operations/$operationId/",
+    id: '/operations/$operationId/',
+    path: '/operations/$operationId/',
     getParentRoute: () => LayoutPipelinesRoute,
-  } as any);
+  } as any)
 const LayoutPipelinesOperationsOperationIdEditRoute =
   LayoutPipelinesOperationsOperationIdEditRouteImport.update({
-    id: "/operations/$operationId/edit",
-    path: "/operations/$operationId/edit",
+    id: '/operations/$operationId/edit',
+    path: '/operations/$operationId/edit',
     getParentRoute: () => LayoutPipelinesRoute,
-  } as any);
+  } as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof LayoutIndexRoute;
-  "/canvas": typeof CanvasRoute;
-  "/login": typeof LoginRoute;
-  "/sign-up": typeof SignUpRoute;
-  "/assistant": typeof LayoutAssistantRoute;
-  "/components": typeof LayoutComponentsRoute;
-  "/connectors": typeof LayoutConnectorsRoute;
-  "/distillation-studio": typeof LayoutDistillationStudioRoute;
-  "/distillations": typeof LayoutDistillationsRouteWithChildren;
-  "/local-agents": typeof LayoutLocalAgentsRoute;
-  "/pipelines": typeof LayoutPipelinesRouteWithChildren;
-  "/plugins": typeof LayoutPluginsRoute;
-  "/runtimes": typeof LayoutRuntimesRouteWithChildren;
-  "/settings": typeof LayoutSettingsRoute;
-  "/skills": typeof LayoutSkillsRoute;
-  "/usage": typeof LayoutUsageRoute;
-  "/api/local-session": typeof ApiLocalSessionRoute;
-  "/api/pipeline-agent-sessions": typeof ApiPipelineAgentSessionsRouteWithChildren;
-  "/distillations/$distillationId": typeof LayoutDistillationsDistillationIdRoute;
-  "/distillations/new": typeof LayoutDistillationsNewRoute;
-  "/pipelines/$pipelineId": typeof LayoutPipelinesPipelineIdRoute;
-  "/pipelines/jobs": typeof LayoutPipelinesJobsRouteWithChildren;
-  "/api/agent-runs/$": typeof ApiAgentRunsSplatRoute;
-  "/api/agent-runtimes/$": typeof ApiAgentRuntimesSplatRoute;
-  "/api/auth/$": typeof ApiAuthSplatRoute;
-  "/api/operations/$": typeof ApiOperationsSplatRoute;
-  "/api/pipeline-agent-sessions/$": typeof ApiPipelineAgentSessionsSplatRoute;
-  "/api/pipelines/$": typeof ApiPipelinesSplatRoute;
-  "/api/trpc/$": typeof ApiTrpcSplatRoute;
-  "/agents/": typeof LayoutAgentsIndexRoute;
-  "/distillations/": typeof LayoutDistillationsIndexRoute;
-  "/pipelines/": typeof LayoutPipelinesIndexRoute;
-  "/runtimes/": typeof LayoutRuntimesIndexRoute;
-  "/pipelines/jobs/$jobId": typeof LayoutPipelinesJobsJobIdRoute;
-  "/pipelines/objects/$objectTypeId": typeof LayoutPipelinesObjectsObjectTypeIdRoute;
-  "/pipelines/operations/new": typeof LayoutPipelinesOperationsNewRoute;
-  "/runtimes/$runtimeId/edit": typeof LayoutRuntimesRuntimeIdEditRoute;
-  "/agents/$agentId/": typeof LayoutAgentsAgentIdIndexRoute;
-  "/pipelines/jobs/": typeof LayoutPipelinesJobsIndexRoute;
-  "/pipelines/objects/": typeof LayoutPipelinesObjectsIndexRoute;
-  "/pipelines/operations/": typeof LayoutPipelinesOperationsIndexRoute;
-  "/runtimes/$runtimeId/": typeof LayoutRuntimesRuntimeIdIndexRoute;
-  "/pipelines/operations/$operationId/edit": typeof LayoutPipelinesOperationsOperationIdEditRoute;
-  "/pipelines/operations/$operationId/": typeof LayoutPipelinesOperationsOperationIdIndexRoute;
+  '/': typeof LayoutIndexRoute
+  '/canvas': typeof CanvasRoute
+  '/login': typeof LoginRoute
+  '/sign-up': typeof SignUpRoute
+  '/assistant': typeof LayoutAssistantRoute
+  '/components': typeof LayoutComponentsRoute
+  '/connectors': typeof LayoutConnectorsRoute
+  '/distillation-studio': typeof LayoutDistillationStudioRoute
+  '/distillations': typeof LayoutDistillationsRouteWithChildren
+  '/local-agents': typeof LayoutLocalAgentsRoute
+  '/pipelines': typeof LayoutPipelinesRouteWithChildren
+  '/plugins': typeof LayoutPluginsRoute
+  '/runtimes': typeof LayoutRuntimesRouteWithChildren
+  '/schedule': typeof LayoutScheduleRoute
+  '/settings': typeof LayoutSettingsRoute
+  '/skills': typeof LayoutSkillsRoute
+  '/usage': typeof LayoutUsageRoute
+  '/api/local-session': typeof ApiLocalSessionRoute
+  '/api/pipeline-agent-sessions': typeof ApiPipelineAgentSessionsRouteWithChildren
+  '/distillations/$distillationId': typeof LayoutDistillationsDistillationIdRoute
+  '/distillations/new': typeof LayoutDistillationsNewRoute
+  '/pipelines/$pipelineId': typeof LayoutPipelinesPipelineIdRoute
+  '/pipelines/jobs': typeof LayoutPipelinesJobsRouteWithChildren
+  '/api/agent-runs/$': typeof ApiAgentRunsSplatRoute
+  '/api/agent-runtimes/$': typeof ApiAgentRuntimesSplatRoute
+  '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/operations/$': typeof ApiOperationsSplatRoute
+  '/api/pipeline-agent-sessions/$': typeof ApiPipelineAgentSessionsSplatRoute
+  '/api/pipelines/$': typeof ApiPipelinesSplatRoute
+  '/api/trpc/$': typeof ApiTrpcSplatRoute
+  '/agents/': typeof LayoutAgentsIndexRoute
+  '/distillations/': typeof LayoutDistillationsIndexRoute
+  '/pipelines/': typeof LayoutPipelinesIndexRoute
+  '/runtimes/': typeof LayoutRuntimesIndexRoute
+  '/pipelines/jobs/$jobId': typeof LayoutPipelinesJobsJobIdRoute
+  '/pipelines/objects/$objectTypeId': typeof LayoutPipelinesObjectsObjectTypeIdRoute
+  '/pipelines/operations/new': typeof LayoutPipelinesOperationsNewRoute
+  '/runtimes/$runtimeId/edit': typeof LayoutRuntimesRuntimeIdEditRoute
+  '/agents/$agentId/': typeof LayoutAgentsAgentIdIndexRoute
+  '/pipelines/jobs/': typeof LayoutPipelinesJobsIndexRoute
+  '/pipelines/objects/': typeof LayoutPipelinesObjectsIndexRoute
+  '/pipelines/operations/': typeof LayoutPipelinesOperationsIndexRoute
+  '/runtimes/$runtimeId/': typeof LayoutRuntimesRuntimeIdIndexRoute
+  '/pipelines/operations/$operationId/edit': typeof LayoutPipelinesOperationsOperationIdEditRoute
+  '/pipelines/operations/$operationId/': typeof LayoutPipelinesOperationsOperationIdIndexRoute
 }
 export interface FileRoutesByTo {
-  "/canvas": typeof CanvasRoute;
-  "/login": typeof LoginRoute;
-  "/sign-up": typeof SignUpRoute;
-  "/assistant": typeof LayoutAssistantRoute;
-  "/components": typeof LayoutComponentsRoute;
-  "/connectors": typeof LayoutConnectorsRoute;
-  "/distillation-studio": typeof LayoutDistillationStudioRoute;
-  "/local-agents": typeof LayoutLocalAgentsRoute;
-  "/plugins": typeof LayoutPluginsRoute;
-  "/settings": typeof LayoutSettingsRoute;
-  "/skills": typeof LayoutSkillsRoute;
-  "/usage": typeof LayoutUsageRoute;
-  "/api/local-session": typeof ApiLocalSessionRoute;
-  "/api/pipeline-agent-sessions": typeof ApiPipelineAgentSessionsRouteWithChildren;
-  "/": typeof LayoutIndexRoute;
-  "/distillations/$distillationId": typeof LayoutDistillationsDistillationIdRoute;
-  "/distillations/new": typeof LayoutDistillationsNewRoute;
-  "/pipelines/$pipelineId": typeof LayoutPipelinesPipelineIdRoute;
-  "/api/agent-runs/$": typeof ApiAgentRunsSplatRoute;
-  "/api/agent-runtimes/$": typeof ApiAgentRuntimesSplatRoute;
-  "/api/auth/$": typeof ApiAuthSplatRoute;
-  "/api/operations/$": typeof ApiOperationsSplatRoute;
-  "/api/pipeline-agent-sessions/$": typeof ApiPipelineAgentSessionsSplatRoute;
-  "/api/pipelines/$": typeof ApiPipelinesSplatRoute;
-  "/api/trpc/$": typeof ApiTrpcSplatRoute;
-  "/agents": typeof LayoutAgentsIndexRoute;
-  "/distillations": typeof LayoutDistillationsIndexRoute;
-  "/pipelines": typeof LayoutPipelinesIndexRoute;
-  "/runtimes": typeof LayoutRuntimesIndexRoute;
-  "/pipelines/jobs/$jobId": typeof LayoutPipelinesJobsJobIdRoute;
-  "/pipelines/objects/$objectTypeId": typeof LayoutPipelinesObjectsObjectTypeIdRoute;
-  "/pipelines/operations/new": typeof LayoutPipelinesOperationsNewRoute;
-  "/runtimes/$runtimeId/edit": typeof LayoutRuntimesRuntimeIdEditRoute;
-  "/agents/$agentId": typeof LayoutAgentsAgentIdIndexRoute;
-  "/pipelines/jobs": typeof LayoutPipelinesJobsIndexRoute;
-  "/pipelines/objects": typeof LayoutPipelinesObjectsIndexRoute;
-  "/pipelines/operations": typeof LayoutPipelinesOperationsIndexRoute;
-  "/runtimes/$runtimeId": typeof LayoutRuntimesRuntimeIdIndexRoute;
-  "/pipelines/operations/$operationId/edit": typeof LayoutPipelinesOperationsOperationIdEditRoute;
-  "/pipelines/operations/$operationId": typeof LayoutPipelinesOperationsOperationIdIndexRoute;
+  '/canvas': typeof CanvasRoute
+  '/login': typeof LoginRoute
+  '/sign-up': typeof SignUpRoute
+  '/assistant': typeof LayoutAssistantRoute
+  '/components': typeof LayoutComponentsRoute
+  '/connectors': typeof LayoutConnectorsRoute
+  '/distillation-studio': typeof LayoutDistillationStudioRoute
+  '/local-agents': typeof LayoutLocalAgentsRoute
+  '/plugins': typeof LayoutPluginsRoute
+  '/schedule': typeof LayoutScheduleRoute
+  '/settings': typeof LayoutSettingsRoute
+  '/skills': typeof LayoutSkillsRoute
+  '/usage': typeof LayoutUsageRoute
+  '/api/local-session': typeof ApiLocalSessionRoute
+  '/api/pipeline-agent-sessions': typeof ApiPipelineAgentSessionsRouteWithChildren
+  '/': typeof LayoutIndexRoute
+  '/distillations/$distillationId': typeof LayoutDistillationsDistillationIdRoute
+  '/distillations/new': typeof LayoutDistillationsNewRoute
+  '/pipelines/$pipelineId': typeof LayoutPipelinesPipelineIdRoute
+  '/api/agent-runs/$': typeof ApiAgentRunsSplatRoute
+  '/api/agent-runtimes/$': typeof ApiAgentRuntimesSplatRoute
+  '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/operations/$': typeof ApiOperationsSplatRoute
+  '/api/pipeline-agent-sessions/$': typeof ApiPipelineAgentSessionsSplatRoute
+  '/api/pipelines/$': typeof ApiPipelinesSplatRoute
+  '/api/trpc/$': typeof ApiTrpcSplatRoute
+  '/agents': typeof LayoutAgentsIndexRoute
+  '/distillations': typeof LayoutDistillationsIndexRoute
+  '/pipelines': typeof LayoutPipelinesIndexRoute
+  '/runtimes': typeof LayoutRuntimesIndexRoute
+  '/pipelines/jobs/$jobId': typeof LayoutPipelinesJobsJobIdRoute
+  '/pipelines/objects/$objectTypeId': typeof LayoutPipelinesObjectsObjectTypeIdRoute
+  '/pipelines/operations/new': typeof LayoutPipelinesOperationsNewRoute
+  '/runtimes/$runtimeId/edit': typeof LayoutRuntimesRuntimeIdEditRoute
+  '/agents/$agentId': typeof LayoutAgentsAgentIdIndexRoute
+  '/pipelines/jobs': typeof LayoutPipelinesJobsIndexRoute
+  '/pipelines/objects': typeof LayoutPipelinesObjectsIndexRoute
+  '/pipelines/operations': typeof LayoutPipelinesOperationsIndexRoute
+  '/runtimes/$runtimeId': typeof LayoutRuntimesRuntimeIdIndexRoute
+  '/pipelines/operations/$operationId/edit': typeof LayoutPipelinesOperationsOperationIdEditRoute
+  '/pipelines/operations/$operationId': typeof LayoutPipelinesOperationsOperationIdIndexRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/_layout": typeof LayoutRouteWithChildren;
-  "/canvas": typeof CanvasRoute;
-  "/login": typeof LoginRoute;
-  "/sign-up": typeof SignUpRoute;
-  "/_layout/assistant": typeof LayoutAssistantRoute;
-  "/_layout/components": typeof LayoutComponentsRoute;
-  "/_layout/connectors": typeof LayoutConnectorsRoute;
-  "/_layout/distillation-studio": typeof LayoutDistillationStudioRoute;
-  "/_layout/distillations": typeof LayoutDistillationsRouteWithChildren;
-  "/_layout/local-agents": typeof LayoutLocalAgentsRoute;
-  "/_layout/pipelines": typeof LayoutPipelinesRouteWithChildren;
-  "/_layout/plugins": typeof LayoutPluginsRoute;
-  "/_layout/runtimes": typeof LayoutRuntimesRouteWithChildren;
-  "/_layout/settings": typeof LayoutSettingsRoute;
-  "/_layout/skills": typeof LayoutSkillsRoute;
-  "/_layout/usage": typeof LayoutUsageRoute;
-  "/api/local-session": typeof ApiLocalSessionRoute;
-  "/api/pipeline-agent-sessions": typeof ApiPipelineAgentSessionsRouteWithChildren;
-  "/_layout/": typeof LayoutIndexRoute;
-  "/_layout/distillations/$distillationId": typeof LayoutDistillationsDistillationIdRoute;
-  "/_layout/distillations/new": typeof LayoutDistillationsNewRoute;
-  "/_layout/pipelines/$pipelineId": typeof LayoutPipelinesPipelineIdRoute;
-  "/_layout/pipelines/jobs": typeof LayoutPipelinesJobsRouteWithChildren;
-  "/api/agent-runs/$": typeof ApiAgentRunsSplatRoute;
-  "/api/agent-runtimes/$": typeof ApiAgentRuntimesSplatRoute;
-  "/api/auth/$": typeof ApiAuthSplatRoute;
-  "/api/operations/$": typeof ApiOperationsSplatRoute;
-  "/api/pipeline-agent-sessions/$": typeof ApiPipelineAgentSessionsSplatRoute;
-  "/api/pipelines/$": typeof ApiPipelinesSplatRoute;
-  "/api/trpc/$": typeof ApiTrpcSplatRoute;
-  "/_layout/agents/": typeof LayoutAgentsIndexRoute;
-  "/_layout/distillations/": typeof LayoutDistillationsIndexRoute;
-  "/_layout/pipelines/": typeof LayoutPipelinesIndexRoute;
-  "/_layout/runtimes/": typeof LayoutRuntimesIndexRoute;
-  "/_layout/pipelines/jobs/$jobId": typeof LayoutPipelinesJobsJobIdRoute;
-  "/_layout/pipelines/objects/$objectTypeId": typeof LayoutPipelinesObjectsObjectTypeIdRoute;
-  "/_layout/pipelines/operations/new": typeof LayoutPipelinesOperationsNewRoute;
-  "/_layout/runtimes/$runtimeId/edit": typeof LayoutRuntimesRuntimeIdEditRoute;
-  "/_layout/agents/$agentId/": typeof LayoutAgentsAgentIdIndexRoute;
-  "/_layout/pipelines/jobs/": typeof LayoutPipelinesJobsIndexRoute;
-  "/_layout/pipelines/objects/": typeof LayoutPipelinesObjectsIndexRoute;
-  "/_layout/pipelines/operations/": typeof LayoutPipelinesOperationsIndexRoute;
-  "/_layout/runtimes/$runtimeId/": typeof LayoutRuntimesRuntimeIdIndexRoute;
-  "/_layout/pipelines/operations/$operationId/edit": typeof LayoutPipelinesOperationsOperationIdEditRoute;
-  "/_layout/pipelines/operations/$operationId/": typeof LayoutPipelinesOperationsOperationIdIndexRoute;
+  __root__: typeof rootRouteImport
+  '/_layout': typeof LayoutRouteWithChildren
+  '/canvas': typeof CanvasRoute
+  '/login': typeof LoginRoute
+  '/sign-up': typeof SignUpRoute
+  '/_layout/assistant': typeof LayoutAssistantRoute
+  '/_layout/components': typeof LayoutComponentsRoute
+  '/_layout/connectors': typeof LayoutConnectorsRoute
+  '/_layout/distillation-studio': typeof LayoutDistillationStudioRoute
+  '/_layout/distillations': typeof LayoutDistillationsRouteWithChildren
+  '/_layout/local-agents': typeof LayoutLocalAgentsRoute
+  '/_layout/pipelines': typeof LayoutPipelinesRouteWithChildren
+  '/_layout/plugins': typeof LayoutPluginsRoute
+  '/_layout/runtimes': typeof LayoutRuntimesRouteWithChildren
+  '/_layout/schedule': typeof LayoutScheduleRoute
+  '/_layout/settings': typeof LayoutSettingsRoute
+  '/_layout/skills': typeof LayoutSkillsRoute
+  '/_layout/usage': typeof LayoutUsageRoute
+  '/api/local-session': typeof ApiLocalSessionRoute
+  '/api/pipeline-agent-sessions': typeof ApiPipelineAgentSessionsRouteWithChildren
+  '/_layout/': typeof LayoutIndexRoute
+  '/_layout/distillations/$distillationId': typeof LayoutDistillationsDistillationIdRoute
+  '/_layout/distillations/new': typeof LayoutDistillationsNewRoute
+  '/_layout/pipelines/$pipelineId': typeof LayoutPipelinesPipelineIdRoute
+  '/_layout/pipelines/jobs': typeof LayoutPipelinesJobsRouteWithChildren
+  '/api/agent-runs/$': typeof ApiAgentRunsSplatRoute
+  '/api/agent-runtimes/$': typeof ApiAgentRuntimesSplatRoute
+  '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/operations/$': typeof ApiOperationsSplatRoute
+  '/api/pipeline-agent-sessions/$': typeof ApiPipelineAgentSessionsSplatRoute
+  '/api/pipelines/$': typeof ApiPipelinesSplatRoute
+  '/api/trpc/$': typeof ApiTrpcSplatRoute
+  '/_layout/agents/': typeof LayoutAgentsIndexRoute
+  '/_layout/distillations/': typeof LayoutDistillationsIndexRoute
+  '/_layout/pipelines/': typeof LayoutPipelinesIndexRoute
+  '/_layout/runtimes/': typeof LayoutRuntimesIndexRoute
+  '/_layout/pipelines/jobs/$jobId': typeof LayoutPipelinesJobsJobIdRoute
+  '/_layout/pipelines/objects/$objectTypeId': typeof LayoutPipelinesObjectsObjectTypeIdRoute
+  '/_layout/pipelines/operations/new': typeof LayoutPipelinesOperationsNewRoute
+  '/_layout/runtimes/$runtimeId/edit': typeof LayoutRuntimesRuntimeIdEditRoute
+  '/_layout/agents/$agentId/': typeof LayoutAgentsAgentIdIndexRoute
+  '/_layout/pipelines/jobs/': typeof LayoutPipelinesJobsIndexRoute
+  '/_layout/pipelines/objects/': typeof LayoutPipelinesObjectsIndexRoute
+  '/_layout/pipelines/operations/': typeof LayoutPipelinesOperationsIndexRoute
+  '/_layout/runtimes/$runtimeId/': typeof LayoutRuntimesRuntimeIdIndexRoute
+  '/_layout/pipelines/operations/$operationId/edit': typeof LayoutPipelinesOperationsOperationIdEditRoute
+  '/_layout/pipelines/operations/$operationId/': typeof LayoutPipelinesOperationsOperationIdIndexRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/canvas"
-    | "/login"
-    | "/sign-up"
-    | "/assistant"
-    | "/components"
-    | "/connectors"
-    | "/distillation-studio"
-    | "/distillations"
-    | "/local-agents"
-    | "/pipelines"
-    | "/plugins"
-    | "/runtimes"
-    | "/settings"
-    | "/skills"
-    | "/usage"
-    | "/api/local-session"
-    | "/api/pipeline-agent-sessions"
-    | "/distillations/$distillationId"
-    | "/distillations/new"
-    | "/pipelines/$pipelineId"
-    | "/pipelines/jobs"
-    | "/api/agent-runs/$"
-    | "/api/agent-runtimes/$"
-    | "/api/auth/$"
-    | "/api/operations/$"
-    | "/api/pipeline-agent-sessions/$"
-    | "/api/pipelines/$"
-    | "/api/trpc/$"
-    | "/agents/"
-    | "/distillations/"
-    | "/pipelines/"
-    | "/runtimes/"
-    | "/pipelines/jobs/$jobId"
-    | "/pipelines/objects/$objectTypeId"
-    | "/pipelines/operations/new"
-    | "/runtimes/$runtimeId/edit"
-    | "/agents/$agentId/"
-    | "/pipelines/jobs/"
-    | "/pipelines/objects/"
-    | "/pipelines/operations/"
-    | "/runtimes/$runtimeId/"
-    | "/pipelines/operations/$operationId/edit"
-    | "/pipelines/operations/$operationId/";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | '/canvas'
+    | '/login'
+    | '/sign-up'
+    | '/assistant'
+    | '/components'
+    | '/connectors'
+    | '/distillation-studio'
+    | '/distillations'
+    | '/local-agents'
+    | '/pipelines'
+    | '/plugins'
+    | '/runtimes'
+    | '/schedule'
+    | '/settings'
+    | '/skills'
+    | '/usage'
+    | '/api/local-session'
+    | '/api/pipeline-agent-sessions'
+    | '/distillations/$distillationId'
+    | '/distillations/new'
+    | '/pipelines/$pipelineId'
+    | '/pipelines/jobs'
+    | '/api/agent-runs/$'
+    | '/api/agent-runtimes/$'
+    | '/api/auth/$'
+    | '/api/operations/$'
+    | '/api/pipeline-agent-sessions/$'
+    | '/api/pipelines/$'
+    | '/api/trpc/$'
+    | '/agents/'
+    | '/distillations/'
+    | '/pipelines/'
+    | '/runtimes/'
+    | '/pipelines/jobs/$jobId'
+    | '/pipelines/objects/$objectTypeId'
+    | '/pipelines/operations/new'
+    | '/runtimes/$runtimeId/edit'
+    | '/agents/$agentId/'
+    | '/pipelines/jobs/'
+    | '/pipelines/objects/'
+    | '/pipelines/operations/'
+    | '/runtimes/$runtimeId/'
+    | '/pipelines/operations/$operationId/edit'
+    | '/pipelines/operations/$operationId/'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/canvas"
-    | "/login"
-    | "/sign-up"
-    | "/assistant"
-    | "/components"
-    | "/connectors"
-    | "/distillation-studio"
-    | "/local-agents"
-    | "/plugins"
-    | "/settings"
-    | "/skills"
-    | "/usage"
-    | "/api/local-session"
-    | "/api/pipeline-agent-sessions"
-    | "/"
-    | "/distillations/$distillationId"
-    | "/distillations/new"
-    | "/pipelines/$pipelineId"
-    | "/api/agent-runs/$"
-    | "/api/agent-runtimes/$"
-    | "/api/auth/$"
-    | "/api/operations/$"
-    | "/api/pipeline-agent-sessions/$"
-    | "/api/pipelines/$"
-    | "/api/trpc/$"
-    | "/agents"
-    | "/distillations"
-    | "/pipelines"
-    | "/runtimes"
-    | "/pipelines/jobs/$jobId"
-    | "/pipelines/objects/$objectTypeId"
-    | "/pipelines/operations/new"
-    | "/runtimes/$runtimeId/edit"
-    | "/agents/$agentId"
-    | "/pipelines/jobs"
-    | "/pipelines/objects"
-    | "/pipelines/operations"
-    | "/runtimes/$runtimeId"
-    | "/pipelines/operations/$operationId/edit"
-    | "/pipelines/operations/$operationId";
+    | '/canvas'
+    | '/login'
+    | '/sign-up'
+    | '/assistant'
+    | '/components'
+    | '/connectors'
+    | '/distillation-studio'
+    | '/local-agents'
+    | '/plugins'
+    | '/schedule'
+    | '/settings'
+    | '/skills'
+    | '/usage'
+    | '/api/local-session'
+    | '/api/pipeline-agent-sessions'
+    | '/'
+    | '/distillations/$distillationId'
+    | '/distillations/new'
+    | '/pipelines/$pipelineId'
+    | '/api/agent-runs/$'
+    | '/api/agent-runtimes/$'
+    | '/api/auth/$'
+    | '/api/operations/$'
+    | '/api/pipeline-agent-sessions/$'
+    | '/api/pipelines/$'
+    | '/api/trpc/$'
+    | '/agents'
+    | '/distillations'
+    | '/pipelines'
+    | '/runtimes'
+    | '/pipelines/jobs/$jobId'
+    | '/pipelines/objects/$objectTypeId'
+    | '/pipelines/operations/new'
+    | '/runtimes/$runtimeId/edit'
+    | '/agents/$agentId'
+    | '/pipelines/jobs'
+    | '/pipelines/objects'
+    | '/pipelines/operations'
+    | '/runtimes/$runtimeId'
+    | '/pipelines/operations/$operationId/edit'
+    | '/pipelines/operations/$operationId'
   id:
-    | "__root__"
-    | "/_layout"
-    | "/canvas"
-    | "/login"
-    | "/sign-up"
-    | "/_layout/assistant"
-    | "/_layout/components"
-    | "/_layout/connectors"
-    | "/_layout/distillation-studio"
-    | "/_layout/distillations"
-    | "/_layout/local-agents"
-    | "/_layout/pipelines"
-    | "/_layout/plugins"
-    | "/_layout/runtimes"
-    | "/_layout/settings"
-    | "/_layout/skills"
-    | "/_layout/usage"
-    | "/api/local-session"
-    | "/api/pipeline-agent-sessions"
-    | "/_layout/"
-    | "/_layout/distillations/$distillationId"
-    | "/_layout/distillations/new"
-    | "/_layout/pipelines/$pipelineId"
-    | "/_layout/pipelines/jobs"
-    | "/api/agent-runs/$"
-    | "/api/agent-runtimes/$"
-    | "/api/auth/$"
-    | "/api/operations/$"
-    | "/api/pipeline-agent-sessions/$"
-    | "/api/pipelines/$"
-    | "/api/trpc/$"
-    | "/_layout/agents/"
-    | "/_layout/distillations/"
-    | "/_layout/pipelines/"
-    | "/_layout/runtimes/"
-    | "/_layout/pipelines/jobs/$jobId"
-    | "/_layout/pipelines/objects/$objectTypeId"
-    | "/_layout/pipelines/operations/new"
-    | "/_layout/runtimes/$runtimeId/edit"
-    | "/_layout/agents/$agentId/"
-    | "/_layout/pipelines/jobs/"
-    | "/_layout/pipelines/objects/"
-    | "/_layout/pipelines/operations/"
-    | "/_layout/runtimes/$runtimeId/"
-    | "/_layout/pipelines/operations/$operationId/edit"
-    | "/_layout/pipelines/operations/$operationId/";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/_layout'
+    | '/canvas'
+    | '/login'
+    | '/sign-up'
+    | '/_layout/assistant'
+    | '/_layout/components'
+    | '/_layout/connectors'
+    | '/_layout/distillation-studio'
+    | '/_layout/distillations'
+    | '/_layout/local-agents'
+    | '/_layout/pipelines'
+    | '/_layout/plugins'
+    | '/_layout/runtimes'
+    | '/_layout/schedule'
+    | '/_layout/settings'
+    | '/_layout/skills'
+    | '/_layout/usage'
+    | '/api/local-session'
+    | '/api/pipeline-agent-sessions'
+    | '/_layout/'
+    | '/_layout/distillations/$distillationId'
+    | '/_layout/distillations/new'
+    | '/_layout/pipelines/$pipelineId'
+    | '/_layout/pipelines/jobs'
+    | '/api/agent-runs/$'
+    | '/api/agent-runtimes/$'
+    | '/api/auth/$'
+    | '/api/operations/$'
+    | '/api/pipeline-agent-sessions/$'
+    | '/api/pipelines/$'
+    | '/api/trpc/$'
+    | '/_layout/agents/'
+    | '/_layout/distillations/'
+    | '/_layout/pipelines/'
+    | '/_layout/runtimes/'
+    | '/_layout/pipelines/jobs/$jobId'
+    | '/_layout/pipelines/objects/$objectTypeId'
+    | '/_layout/pipelines/operations/new'
+    | '/_layout/runtimes/$runtimeId/edit'
+    | '/_layout/agents/$agentId/'
+    | '/_layout/pipelines/jobs/'
+    | '/_layout/pipelines/objects/'
+    | '/_layout/pipelines/operations/'
+    | '/_layout/runtimes/$runtimeId/'
+    | '/_layout/pipelines/operations/$operationId/edit'
+    | '/_layout/pipelines/operations/$operationId/'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  LayoutRoute: typeof LayoutRouteWithChildren;
-  CanvasRoute: typeof CanvasRoute;
-  LoginRoute: typeof LoginRoute;
-  SignUpRoute: typeof SignUpRoute;
-  ApiLocalSessionRoute: typeof ApiLocalSessionRoute;
-  ApiPipelineAgentSessionsRoute: typeof ApiPipelineAgentSessionsRouteWithChildren;
-  ApiAgentRunsSplatRoute: typeof ApiAgentRunsSplatRoute;
-  ApiAgentRuntimesSplatRoute: typeof ApiAgentRuntimesSplatRoute;
-  ApiAuthSplatRoute: typeof ApiAuthSplatRoute;
-  ApiOperationsSplatRoute: typeof ApiOperationsSplatRoute;
-  ApiPipelinesSplatRoute: typeof ApiPipelinesSplatRoute;
-  ApiTrpcSplatRoute: typeof ApiTrpcSplatRoute;
+  LayoutRoute: typeof LayoutRouteWithChildren
+  CanvasRoute: typeof CanvasRoute
+  LoginRoute: typeof LoginRoute
+  SignUpRoute: typeof SignUpRoute
+  ApiLocalSessionRoute: typeof ApiLocalSessionRoute
+  ApiPipelineAgentSessionsRoute: typeof ApiPipelineAgentSessionsRouteWithChildren
+  ApiAgentRunsSplatRoute: typeof ApiAgentRunsSplatRoute
+  ApiAgentRuntimesSplatRoute: typeof ApiAgentRuntimesSplatRoute
+  ApiAuthSplatRoute: typeof ApiAuthSplatRoute
+  ApiOperationsSplatRoute: typeof ApiOperationsSplatRoute
+  ApiPipelinesSplatRoute: typeof ApiPipelinesSplatRoute
+  ApiTrpcSplatRoute: typeof ApiTrpcSplatRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/sign-up": {
-      id: "/sign-up";
-      path: "/sign-up";
-      fullPath: "/sign-up";
-      preLoaderRoute: typeof SignUpRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/login": {
-      id: "/login";
-      path: "/login";
-      fullPath: "/login";
-      preLoaderRoute: typeof LoginRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/canvas": {
-      id: "/canvas";
-      path: "/canvas";
-      fullPath: "/canvas";
-      preLoaderRoute: typeof CanvasRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/_layout": {
-      id: "/_layout";
-      path: "";
-      fullPath: "/";
-      preLoaderRoute: typeof LayoutRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/_layout/": {
-      id: "/_layout/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof LayoutIndexRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/api/pipeline-agent-sessions": {
-      id: "/api/pipeline-agent-sessions";
-      path: "/api/pipeline-agent-sessions";
-      fullPath: "/api/pipeline-agent-sessions";
-      preLoaderRoute: typeof ApiPipelineAgentSessionsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/api/local-session": {
-      id: "/api/local-session";
-      path: "/api/local-session";
-      fullPath: "/api/local-session";
-      preLoaderRoute: typeof ApiLocalSessionRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/_layout/usage": {
-      id: "/_layout/usage";
-      path: "/usage";
-      fullPath: "/usage";
-      preLoaderRoute: typeof LayoutUsageRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/skills": {
-      id: "/_layout/skills";
-      path: "/skills";
-      fullPath: "/skills";
-      preLoaderRoute: typeof LayoutSkillsRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/settings": {
-      id: "/_layout/settings";
-      path: "/settings";
-      fullPath: "/settings";
-      preLoaderRoute: typeof LayoutSettingsRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/runtimes": {
-      id: "/_layout/runtimes";
-      path: "/runtimes";
-      fullPath: "/runtimes";
-      preLoaderRoute: typeof LayoutRuntimesRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/plugins": {
-      id: "/_layout/plugins";
-      path: "/plugins";
-      fullPath: "/plugins";
-      preLoaderRoute: typeof LayoutPluginsRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/pipelines": {
-      id: "/_layout/pipelines";
-      path: "/pipelines";
-      fullPath: "/pipelines";
-      preLoaderRoute: typeof LayoutPipelinesRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/local-agents": {
-      id: "/_layout/local-agents";
-      path: "/local-agents";
-      fullPath: "/local-agents";
-      preLoaderRoute: typeof LayoutLocalAgentsRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/distillations": {
-      id: "/_layout/distillations";
-      path: "/distillations";
-      fullPath: "/distillations";
-      preLoaderRoute: typeof LayoutDistillationsRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/distillation-studio": {
-      id: "/_layout/distillation-studio";
-      path: "/distillation-studio";
-      fullPath: "/distillation-studio";
-      preLoaderRoute: typeof LayoutDistillationStudioRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/connectors": {
-      id: "/_layout/connectors";
-      path: "/connectors";
-      fullPath: "/connectors";
-      preLoaderRoute: typeof LayoutConnectorsRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/components": {
-      id: "/_layout/components";
-      path: "/components";
-      fullPath: "/components";
-      preLoaderRoute: typeof LayoutComponentsRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/assistant": {
-      id: "/_layout/assistant";
-      path: "/assistant";
-      fullPath: "/assistant";
-      preLoaderRoute: typeof LayoutAssistantRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/runtimes/": {
-      id: "/_layout/runtimes/";
-      path: "/";
-      fullPath: "/runtimes/";
-      preLoaderRoute: typeof LayoutRuntimesIndexRouteImport;
-      parentRoute: typeof LayoutRuntimesRoute;
-    };
-    "/_layout/pipelines/": {
-      id: "/_layout/pipelines/";
-      path: "/";
-      fullPath: "/pipelines/";
-      preLoaderRoute: typeof LayoutPipelinesIndexRouteImport;
-      parentRoute: typeof LayoutPipelinesRoute;
-    };
-    "/_layout/distillations/": {
-      id: "/_layout/distillations/";
-      path: "/";
-      fullPath: "/distillations/";
-      preLoaderRoute: typeof LayoutDistillationsIndexRouteImport;
-      parentRoute: typeof LayoutDistillationsRoute;
-    };
-    "/_layout/agents/": {
-      id: "/_layout/agents/";
-      path: "/agents";
-      fullPath: "/agents/";
-      preLoaderRoute: typeof LayoutAgentsIndexRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/api/trpc/$": {
-      id: "/api/trpc/$";
-      path: "/api/trpc/$";
-      fullPath: "/api/trpc/$";
-      preLoaderRoute: typeof ApiTrpcSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/api/pipelines/$": {
-      id: "/api/pipelines/$";
-      path: "/api/pipelines/$";
-      fullPath: "/api/pipelines/$";
-      preLoaderRoute: typeof ApiPipelinesSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/api/pipeline-agent-sessions/$": {
-      id: "/api/pipeline-agent-sessions/$";
-      path: "/$";
-      fullPath: "/api/pipeline-agent-sessions/$";
-      preLoaderRoute: typeof ApiPipelineAgentSessionsSplatRouteImport;
-      parentRoute: typeof ApiPipelineAgentSessionsRoute;
-    };
-    "/api/operations/$": {
-      id: "/api/operations/$";
-      path: "/api/operations/$";
-      fullPath: "/api/operations/$";
-      preLoaderRoute: typeof ApiOperationsSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/api/auth/$": {
-      id: "/api/auth/$";
-      path: "/api/auth/$";
-      fullPath: "/api/auth/$";
-      preLoaderRoute: typeof ApiAuthSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/api/agent-runtimes/$": {
-      id: "/api/agent-runtimes/$";
-      path: "/api/agent-runtimes/$";
-      fullPath: "/api/agent-runtimes/$";
-      preLoaderRoute: typeof ApiAgentRuntimesSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/api/agent-runs/$": {
-      id: "/api/agent-runs/$";
-      path: "/api/agent-runs/$";
-      fullPath: "/api/agent-runs/$";
-      preLoaderRoute: typeof ApiAgentRunsSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/_layout/pipelines/jobs": {
-      id: "/_layout/pipelines/jobs";
-      path: "/jobs";
-      fullPath: "/pipelines/jobs";
-      preLoaderRoute: typeof LayoutPipelinesJobsRouteImport;
-      parentRoute: typeof LayoutPipelinesRoute;
-    };
-    "/_layout/pipelines/$pipelineId": {
-      id: "/_layout/pipelines/$pipelineId";
-      path: "/$pipelineId";
-      fullPath: "/pipelines/$pipelineId";
-      preLoaderRoute: typeof LayoutPipelinesPipelineIdRouteImport;
-      parentRoute: typeof LayoutPipelinesRoute;
-    };
-    "/_layout/distillations/new": {
-      id: "/_layout/distillations/new";
-      path: "/new";
-      fullPath: "/distillations/new";
-      preLoaderRoute: typeof LayoutDistillationsNewRouteImport;
-      parentRoute: typeof LayoutDistillationsRoute;
-    };
-    "/_layout/distillations/$distillationId": {
-      id: "/_layout/distillations/$distillationId";
-      path: "/$distillationId";
-      fullPath: "/distillations/$distillationId";
-      preLoaderRoute: typeof LayoutDistillationsDistillationIdRouteImport;
-      parentRoute: typeof LayoutDistillationsRoute;
-    };
-    "/_layout/runtimes/$runtimeId/": {
-      id: "/_layout/runtimes/$runtimeId/";
-      path: "/$runtimeId";
-      fullPath: "/runtimes/$runtimeId/";
-      preLoaderRoute: typeof LayoutRuntimesRuntimeIdIndexRouteImport;
-      parentRoute: typeof LayoutRuntimesRoute;
-    };
-    "/_layout/pipelines/operations/": {
-      id: "/_layout/pipelines/operations/";
-      path: "/operations";
-      fullPath: "/pipelines/operations/";
-      preLoaderRoute: typeof LayoutPipelinesOperationsIndexRouteImport;
-      parentRoute: typeof LayoutPipelinesRoute;
-    };
-    "/_layout/pipelines/objects/": {
-      id: "/_layout/pipelines/objects/";
-      path: "/objects";
-      fullPath: "/pipelines/objects/";
-      preLoaderRoute: typeof LayoutPipelinesObjectsIndexRouteImport;
-      parentRoute: typeof LayoutPipelinesRoute;
-    };
-    "/_layout/pipelines/jobs/": {
-      id: "/_layout/pipelines/jobs/";
-      path: "/";
-      fullPath: "/pipelines/jobs/";
-      preLoaderRoute: typeof LayoutPipelinesJobsIndexRouteImport;
-      parentRoute: typeof LayoutPipelinesJobsRoute;
-    };
-    "/_layout/agents/$agentId/": {
-      id: "/_layout/agents/$agentId/";
-      path: "/agents/$agentId";
-      fullPath: "/agents/$agentId/";
-      preLoaderRoute: typeof LayoutAgentsAgentIdIndexRouteImport;
-      parentRoute: typeof LayoutRoute;
-    };
-    "/_layout/runtimes/$runtimeId/edit": {
-      id: "/_layout/runtimes/$runtimeId/edit";
-      path: "/$runtimeId/edit";
-      fullPath: "/runtimes/$runtimeId/edit";
-      preLoaderRoute: typeof LayoutRuntimesRuntimeIdEditRouteImport;
-      parentRoute: typeof LayoutRuntimesRoute;
-    };
-    "/_layout/pipelines/operations/new": {
-      id: "/_layout/pipelines/operations/new";
-      path: "/operations/new";
-      fullPath: "/pipelines/operations/new";
-      preLoaderRoute: typeof LayoutPipelinesOperationsNewRouteImport;
-      parentRoute: typeof LayoutPipelinesRoute;
-    };
-    "/_layout/pipelines/objects/$objectTypeId": {
-      id: "/_layout/pipelines/objects/$objectTypeId";
-      path: "/objects/$objectTypeId";
-      fullPath: "/pipelines/objects/$objectTypeId";
-      preLoaderRoute: typeof LayoutPipelinesObjectsObjectTypeIdRouteImport;
-      parentRoute: typeof LayoutPipelinesRoute;
-    };
-    "/_layout/pipelines/jobs/$jobId": {
-      id: "/_layout/pipelines/jobs/$jobId";
-      path: "/$jobId";
-      fullPath: "/pipelines/jobs/$jobId";
-      preLoaderRoute: typeof LayoutPipelinesJobsJobIdRouteImport;
-      parentRoute: typeof LayoutPipelinesJobsRoute;
-    };
-    "/_layout/pipelines/operations/$operationId/": {
-      id: "/_layout/pipelines/operations/$operationId/";
-      path: "/operations/$operationId";
-      fullPath: "/pipelines/operations/$operationId/";
-      preLoaderRoute: typeof LayoutPipelinesOperationsOperationIdIndexRouteImport;
-      parentRoute: typeof LayoutPipelinesRoute;
-    };
-    "/_layout/pipelines/operations/$operationId/edit": {
-      id: "/_layout/pipelines/operations/$operationId/edit";
-      path: "/operations/$operationId/edit";
-      fullPath: "/pipelines/operations/$operationId/edit";
-      preLoaderRoute: typeof LayoutPipelinesOperationsOperationIdEditRouteImport;
-      parentRoute: typeof LayoutPipelinesRoute;
-    };
+    '/sign-up': {
+      id: '/sign-up'
+      path: '/sign-up'
+      fullPath: '/sign-up'
+      preLoaderRoute: typeof SignUpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/canvas': {
+      id: '/canvas'
+      path: '/canvas'
+      fullPath: '/canvas'
+      preLoaderRoute: typeof CanvasRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_layout': {
+      id: '/_layout'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof LayoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_layout/': {
+      id: '/_layout/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof LayoutIndexRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/api/pipeline-agent-sessions': {
+      id: '/api/pipeline-agent-sessions'
+      path: '/api/pipeline-agent-sessions'
+      fullPath: '/api/pipeline-agent-sessions'
+      preLoaderRoute: typeof ApiPipelineAgentSessionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/local-session': {
+      id: '/api/local-session'
+      path: '/api/local-session'
+      fullPath: '/api/local-session'
+      preLoaderRoute: typeof ApiLocalSessionRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_layout/usage': {
+      id: '/_layout/usage'
+      path: '/usage'
+      fullPath: '/usage'
+      preLoaderRoute: typeof LayoutUsageRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/skills': {
+      id: '/_layout/skills'
+      path: '/skills'
+      fullPath: '/skills'
+      preLoaderRoute: typeof LayoutSkillsRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/settings': {
+      id: '/_layout/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof LayoutSettingsRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/schedule': {
+      id: '/_layout/schedule'
+      path: '/schedule'
+      fullPath: '/schedule'
+      preLoaderRoute: typeof LayoutScheduleRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/runtimes': {
+      id: '/_layout/runtimes'
+      path: '/runtimes'
+      fullPath: '/runtimes'
+      preLoaderRoute: typeof LayoutRuntimesRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/plugins': {
+      id: '/_layout/plugins'
+      path: '/plugins'
+      fullPath: '/plugins'
+      preLoaderRoute: typeof LayoutPluginsRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/pipelines': {
+      id: '/_layout/pipelines'
+      path: '/pipelines'
+      fullPath: '/pipelines'
+      preLoaderRoute: typeof LayoutPipelinesRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/local-agents': {
+      id: '/_layout/local-agents'
+      path: '/local-agents'
+      fullPath: '/local-agents'
+      preLoaderRoute: typeof LayoutLocalAgentsRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/distillations': {
+      id: '/_layout/distillations'
+      path: '/distillations'
+      fullPath: '/distillations'
+      preLoaderRoute: typeof LayoutDistillationsRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/distillation-studio': {
+      id: '/_layout/distillation-studio'
+      path: '/distillation-studio'
+      fullPath: '/distillation-studio'
+      preLoaderRoute: typeof LayoutDistillationStudioRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/connectors': {
+      id: '/_layout/connectors'
+      path: '/connectors'
+      fullPath: '/connectors'
+      preLoaderRoute: typeof LayoutConnectorsRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/components': {
+      id: '/_layout/components'
+      path: '/components'
+      fullPath: '/components'
+      preLoaderRoute: typeof LayoutComponentsRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/assistant': {
+      id: '/_layout/assistant'
+      path: '/assistant'
+      fullPath: '/assistant'
+      preLoaderRoute: typeof LayoutAssistantRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/runtimes/': {
+      id: '/_layout/runtimes/'
+      path: '/'
+      fullPath: '/runtimes/'
+      preLoaderRoute: typeof LayoutRuntimesIndexRouteImport
+      parentRoute: typeof LayoutRuntimesRoute
+    }
+    '/_layout/pipelines/': {
+      id: '/_layout/pipelines/'
+      path: '/'
+      fullPath: '/pipelines/'
+      preLoaderRoute: typeof LayoutPipelinesIndexRouteImport
+      parentRoute: typeof LayoutPipelinesRoute
+    }
+    '/_layout/distillations/': {
+      id: '/_layout/distillations/'
+      path: '/'
+      fullPath: '/distillations/'
+      preLoaderRoute: typeof LayoutDistillationsIndexRouteImport
+      parentRoute: typeof LayoutDistillationsRoute
+    }
+    '/_layout/agents/': {
+      id: '/_layout/agents/'
+      path: '/agents'
+      fullPath: '/agents/'
+      preLoaderRoute: typeof LayoutAgentsIndexRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/api/trpc/$': {
+      id: '/api/trpc/$'
+      path: '/api/trpc/$'
+      fullPath: '/api/trpc/$'
+      preLoaderRoute: typeof ApiTrpcSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/pipelines/$': {
+      id: '/api/pipelines/$'
+      path: '/api/pipelines/$'
+      fullPath: '/api/pipelines/$'
+      preLoaderRoute: typeof ApiPipelinesSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/pipeline-agent-sessions/$': {
+      id: '/api/pipeline-agent-sessions/$'
+      path: '/$'
+      fullPath: '/api/pipeline-agent-sessions/$'
+      preLoaderRoute: typeof ApiPipelineAgentSessionsSplatRouteImport
+      parentRoute: typeof ApiPipelineAgentSessionsRoute
+    }
+    '/api/operations/$': {
+      id: '/api/operations/$'
+      path: '/api/operations/$'
+      fullPath: '/api/operations/$'
+      preLoaderRoute: typeof ApiOperationsSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/auth/$': {
+      id: '/api/auth/$'
+      path: '/api/auth/$'
+      fullPath: '/api/auth/$'
+      preLoaderRoute: typeof ApiAuthSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agent-runtimes/$': {
+      id: '/api/agent-runtimes/$'
+      path: '/api/agent-runtimes/$'
+      fullPath: '/api/agent-runtimes/$'
+      preLoaderRoute: typeof ApiAgentRuntimesSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agent-runs/$': {
+      id: '/api/agent-runs/$'
+      path: '/api/agent-runs/$'
+      fullPath: '/api/agent-runs/$'
+      preLoaderRoute: typeof ApiAgentRunsSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_layout/pipelines/jobs': {
+      id: '/_layout/pipelines/jobs'
+      path: '/jobs'
+      fullPath: '/pipelines/jobs'
+      preLoaderRoute: typeof LayoutPipelinesJobsRouteImport
+      parentRoute: typeof LayoutPipelinesRoute
+    }
+    '/_layout/pipelines/$pipelineId': {
+      id: '/_layout/pipelines/$pipelineId'
+      path: '/$pipelineId'
+      fullPath: '/pipelines/$pipelineId'
+      preLoaderRoute: typeof LayoutPipelinesPipelineIdRouteImport
+      parentRoute: typeof LayoutPipelinesRoute
+    }
+    '/_layout/distillations/new': {
+      id: '/_layout/distillations/new'
+      path: '/new'
+      fullPath: '/distillations/new'
+      preLoaderRoute: typeof LayoutDistillationsNewRouteImport
+      parentRoute: typeof LayoutDistillationsRoute
+    }
+    '/_layout/distillations/$distillationId': {
+      id: '/_layout/distillations/$distillationId'
+      path: '/$distillationId'
+      fullPath: '/distillations/$distillationId'
+      preLoaderRoute: typeof LayoutDistillationsDistillationIdRouteImport
+      parentRoute: typeof LayoutDistillationsRoute
+    }
+    '/_layout/runtimes/$runtimeId/': {
+      id: '/_layout/runtimes/$runtimeId/'
+      path: '/$runtimeId'
+      fullPath: '/runtimes/$runtimeId/'
+      preLoaderRoute: typeof LayoutRuntimesRuntimeIdIndexRouteImport
+      parentRoute: typeof LayoutRuntimesRoute
+    }
+    '/_layout/pipelines/operations/': {
+      id: '/_layout/pipelines/operations/'
+      path: '/operations'
+      fullPath: '/pipelines/operations/'
+      preLoaderRoute: typeof LayoutPipelinesOperationsIndexRouteImport
+      parentRoute: typeof LayoutPipelinesRoute
+    }
+    '/_layout/pipelines/objects/': {
+      id: '/_layout/pipelines/objects/'
+      path: '/objects'
+      fullPath: '/pipelines/objects/'
+      preLoaderRoute: typeof LayoutPipelinesObjectsIndexRouteImport
+      parentRoute: typeof LayoutPipelinesRoute
+    }
+    '/_layout/pipelines/jobs/': {
+      id: '/_layout/pipelines/jobs/'
+      path: '/'
+      fullPath: '/pipelines/jobs/'
+      preLoaderRoute: typeof LayoutPipelinesJobsIndexRouteImport
+      parentRoute: typeof LayoutPipelinesJobsRoute
+    }
+    '/_layout/agents/$agentId/': {
+      id: '/_layout/agents/$agentId/'
+      path: '/agents/$agentId'
+      fullPath: '/agents/$agentId/'
+      preLoaderRoute: typeof LayoutAgentsAgentIdIndexRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/runtimes/$runtimeId/edit': {
+      id: '/_layout/runtimes/$runtimeId/edit'
+      path: '/$runtimeId/edit'
+      fullPath: '/runtimes/$runtimeId/edit'
+      preLoaderRoute: typeof LayoutRuntimesRuntimeIdEditRouteImport
+      parentRoute: typeof LayoutRuntimesRoute
+    }
+    '/_layout/pipelines/operations/new': {
+      id: '/_layout/pipelines/operations/new'
+      path: '/operations/new'
+      fullPath: '/pipelines/operations/new'
+      preLoaderRoute: typeof LayoutPipelinesOperationsNewRouteImport
+      parentRoute: typeof LayoutPipelinesRoute
+    }
+    '/_layout/pipelines/objects/$objectTypeId': {
+      id: '/_layout/pipelines/objects/$objectTypeId'
+      path: '/objects/$objectTypeId'
+      fullPath: '/pipelines/objects/$objectTypeId'
+      preLoaderRoute: typeof LayoutPipelinesObjectsObjectTypeIdRouteImport
+      parentRoute: typeof LayoutPipelinesRoute
+    }
+    '/_layout/pipelines/jobs/$jobId': {
+      id: '/_layout/pipelines/jobs/$jobId'
+      path: '/$jobId'
+      fullPath: '/pipelines/jobs/$jobId'
+      preLoaderRoute: typeof LayoutPipelinesJobsJobIdRouteImport
+      parentRoute: typeof LayoutPipelinesJobsRoute
+    }
+    '/_layout/pipelines/operations/$operationId/': {
+      id: '/_layout/pipelines/operations/$operationId/'
+      path: '/operations/$operationId'
+      fullPath: '/pipelines/operations/$operationId/'
+      preLoaderRoute: typeof LayoutPipelinesOperationsOperationIdIndexRouteImport
+      parentRoute: typeof LayoutPipelinesRoute
+    }
+    '/_layout/pipelines/operations/$operationId/edit': {
+      id: '/_layout/pipelines/operations/$operationId/edit'
+      path: '/operations/$operationId/edit'
+      fullPath: '/pipelines/operations/$operationId/edit'
+      preLoaderRoute: typeof LayoutPipelinesOperationsOperationIdEditRouteImport
+      parentRoute: typeof LayoutPipelinesRoute
+    }
   }
 }
 
 interface LayoutDistillationsRouteChildren {
-  LayoutDistillationsDistillationIdRoute: typeof LayoutDistillationsDistillationIdRoute;
-  LayoutDistillationsNewRoute: typeof LayoutDistillationsNewRoute;
-  LayoutDistillationsIndexRoute: typeof LayoutDistillationsIndexRoute;
+  LayoutDistillationsDistillationIdRoute: typeof LayoutDistillationsDistillationIdRoute
+  LayoutDistillationsNewRoute: typeof LayoutDistillationsNewRoute
+  LayoutDistillationsIndexRoute: typeof LayoutDistillationsIndexRoute
 }
 
 const LayoutDistillationsRouteChildren: LayoutDistillationsRouteChildren = {
-  LayoutDistillationsDistillationIdRoute: LayoutDistillationsDistillationIdRoute,
+  LayoutDistillationsDistillationIdRoute:
+    LayoutDistillationsDistillationIdRoute,
   LayoutDistillationsNewRoute: LayoutDistillationsNewRoute,
   LayoutDistillationsIndexRoute: LayoutDistillationsIndexRoute,
-};
+}
 
-const LayoutDistillationsRouteWithChildren = LayoutDistillationsRoute._addFileChildren(
-  LayoutDistillationsRouteChildren,
-);
+const LayoutDistillationsRouteWithChildren =
+  LayoutDistillationsRoute._addFileChildren(LayoutDistillationsRouteChildren)
 
 interface LayoutPipelinesJobsRouteChildren {
-  LayoutPipelinesJobsJobIdRoute: typeof LayoutPipelinesJobsJobIdRoute;
-  LayoutPipelinesJobsIndexRoute: typeof LayoutPipelinesJobsIndexRoute;
+  LayoutPipelinesJobsJobIdRoute: typeof LayoutPipelinesJobsJobIdRoute
+  LayoutPipelinesJobsIndexRoute: typeof LayoutPipelinesJobsIndexRoute
 }
 
 const LayoutPipelinesJobsRouteChildren: LayoutPipelinesJobsRouteChildren = {
   LayoutPipelinesJobsJobIdRoute: LayoutPipelinesJobsJobIdRoute,
   LayoutPipelinesJobsIndexRoute: LayoutPipelinesJobsIndexRoute,
-};
+}
 
-const LayoutPipelinesJobsRouteWithChildren = LayoutPipelinesJobsRoute._addFileChildren(
-  LayoutPipelinesJobsRouteChildren,
-);
+const LayoutPipelinesJobsRouteWithChildren =
+  LayoutPipelinesJobsRoute._addFileChildren(LayoutPipelinesJobsRouteChildren)
 
 interface LayoutPipelinesRouteChildren {
-  LayoutPipelinesPipelineIdRoute: typeof LayoutPipelinesPipelineIdRoute;
-  LayoutPipelinesJobsRoute: typeof LayoutPipelinesJobsRouteWithChildren;
-  LayoutPipelinesIndexRoute: typeof LayoutPipelinesIndexRoute;
-  LayoutPipelinesObjectsObjectTypeIdRoute: typeof LayoutPipelinesObjectsObjectTypeIdRoute;
-  LayoutPipelinesOperationsNewRoute: typeof LayoutPipelinesOperationsNewRoute;
-  LayoutPipelinesObjectsIndexRoute: typeof LayoutPipelinesObjectsIndexRoute;
-  LayoutPipelinesOperationsIndexRoute: typeof LayoutPipelinesOperationsIndexRoute;
-  LayoutPipelinesOperationsOperationIdEditRoute: typeof LayoutPipelinesOperationsOperationIdEditRoute;
-  LayoutPipelinesOperationsOperationIdIndexRoute: typeof LayoutPipelinesOperationsOperationIdIndexRoute;
+  LayoutPipelinesPipelineIdRoute: typeof LayoutPipelinesPipelineIdRoute
+  LayoutPipelinesJobsRoute: typeof LayoutPipelinesJobsRouteWithChildren
+  LayoutPipelinesIndexRoute: typeof LayoutPipelinesIndexRoute
+  LayoutPipelinesObjectsObjectTypeIdRoute: typeof LayoutPipelinesObjectsObjectTypeIdRoute
+  LayoutPipelinesOperationsNewRoute: typeof LayoutPipelinesOperationsNewRoute
+  LayoutPipelinesObjectsIndexRoute: typeof LayoutPipelinesObjectsIndexRoute
+  LayoutPipelinesOperationsIndexRoute: typeof LayoutPipelinesOperationsIndexRoute
+  LayoutPipelinesOperationsOperationIdEditRoute: typeof LayoutPipelinesOperationsOperationIdEditRoute
+  LayoutPipelinesOperationsOperationIdIndexRoute: typeof LayoutPipelinesOperationsOperationIdIndexRoute
 }
 
 const LayoutPipelinesRouteChildren: LayoutPipelinesRouteChildren = {
   LayoutPipelinesPipelineIdRoute: LayoutPipelinesPipelineIdRoute,
   LayoutPipelinesJobsRoute: LayoutPipelinesJobsRouteWithChildren,
   LayoutPipelinesIndexRoute: LayoutPipelinesIndexRoute,
-  LayoutPipelinesObjectsObjectTypeIdRoute: LayoutPipelinesObjectsObjectTypeIdRoute,
+  LayoutPipelinesObjectsObjectTypeIdRoute:
+    LayoutPipelinesObjectsObjectTypeIdRoute,
   LayoutPipelinesOperationsNewRoute: LayoutPipelinesOperationsNewRoute,
   LayoutPipelinesObjectsIndexRoute: LayoutPipelinesObjectsIndexRoute,
   LayoutPipelinesOperationsIndexRoute: LayoutPipelinesOperationsIndexRoute,
-  LayoutPipelinesOperationsOperationIdEditRoute: LayoutPipelinesOperationsOperationIdEditRoute,
-  LayoutPipelinesOperationsOperationIdIndexRoute: LayoutPipelinesOperationsOperationIdIndexRoute,
-};
+  LayoutPipelinesOperationsOperationIdEditRoute:
+    LayoutPipelinesOperationsOperationIdEditRoute,
+  LayoutPipelinesOperationsOperationIdIndexRoute:
+    LayoutPipelinesOperationsOperationIdIndexRoute,
+}
 
 const LayoutPipelinesRouteWithChildren = LayoutPipelinesRoute._addFileChildren(
   LayoutPipelinesRouteChildren,
-);
+)
 
 interface LayoutRuntimesRouteChildren {
-  LayoutRuntimesIndexRoute: typeof LayoutRuntimesIndexRoute;
-  LayoutRuntimesRuntimeIdEditRoute: typeof LayoutRuntimesRuntimeIdEditRoute;
-  LayoutRuntimesRuntimeIdIndexRoute: typeof LayoutRuntimesRuntimeIdIndexRoute;
+  LayoutRuntimesIndexRoute: typeof LayoutRuntimesIndexRoute
+  LayoutRuntimesRuntimeIdEditRoute: typeof LayoutRuntimesRuntimeIdEditRoute
+  LayoutRuntimesRuntimeIdIndexRoute: typeof LayoutRuntimesRuntimeIdIndexRoute
 }
 
 const LayoutRuntimesRouteChildren: LayoutRuntimesRouteChildren = {
   LayoutRuntimesIndexRoute: LayoutRuntimesIndexRoute,
   LayoutRuntimesRuntimeIdEditRoute: LayoutRuntimesRuntimeIdEditRoute,
   LayoutRuntimesRuntimeIdIndexRoute: LayoutRuntimesRuntimeIdIndexRoute,
-};
+}
 
 const LayoutRuntimesRouteWithChildren = LayoutRuntimesRoute._addFileChildren(
   LayoutRuntimesRouteChildren,
-);
+)
 
 interface LayoutRouteChildren {
-  LayoutAssistantRoute: typeof LayoutAssistantRoute;
-  LayoutComponentsRoute: typeof LayoutComponentsRoute;
-  LayoutConnectorsRoute: typeof LayoutConnectorsRoute;
-  LayoutDistillationStudioRoute: typeof LayoutDistillationStudioRoute;
-  LayoutDistillationsRoute: typeof LayoutDistillationsRouteWithChildren;
-  LayoutLocalAgentsRoute: typeof LayoutLocalAgentsRoute;
-  LayoutPipelinesRoute: typeof LayoutPipelinesRouteWithChildren;
-  LayoutPluginsRoute: typeof LayoutPluginsRoute;
-  LayoutRuntimesRoute: typeof LayoutRuntimesRouteWithChildren;
-  LayoutSettingsRoute: typeof LayoutSettingsRoute;
-  LayoutSkillsRoute: typeof LayoutSkillsRoute;
-  LayoutUsageRoute: typeof LayoutUsageRoute;
-  LayoutIndexRoute: typeof LayoutIndexRoute;
-  LayoutAgentsIndexRoute: typeof LayoutAgentsIndexRoute;
-  LayoutAgentsAgentIdIndexRoute: typeof LayoutAgentsAgentIdIndexRoute;
+  LayoutAssistantRoute: typeof LayoutAssistantRoute
+  LayoutComponentsRoute: typeof LayoutComponentsRoute
+  LayoutConnectorsRoute: typeof LayoutConnectorsRoute
+  LayoutDistillationStudioRoute: typeof LayoutDistillationStudioRoute
+  LayoutDistillationsRoute: typeof LayoutDistillationsRouteWithChildren
+  LayoutLocalAgentsRoute: typeof LayoutLocalAgentsRoute
+  LayoutPipelinesRoute: typeof LayoutPipelinesRouteWithChildren
+  LayoutPluginsRoute: typeof LayoutPluginsRoute
+  LayoutRuntimesRoute: typeof LayoutRuntimesRouteWithChildren
+  LayoutScheduleRoute: typeof LayoutScheduleRoute
+  LayoutSettingsRoute: typeof LayoutSettingsRoute
+  LayoutSkillsRoute: typeof LayoutSkillsRoute
+  LayoutUsageRoute: typeof LayoutUsageRoute
+  LayoutIndexRoute: typeof LayoutIndexRoute
+  LayoutAgentsIndexRoute: typeof LayoutAgentsIndexRoute
+  LayoutAgentsAgentIdIndexRoute: typeof LayoutAgentsAgentIdIndexRoute
 }
 
 const LayoutRouteChildren: LayoutRouteChildren = {
@@ -994,27 +1030,31 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutPipelinesRoute: LayoutPipelinesRouteWithChildren,
   LayoutPluginsRoute: LayoutPluginsRoute,
   LayoutRuntimesRoute: LayoutRuntimesRouteWithChildren,
+  LayoutScheduleRoute: LayoutScheduleRoute,
   LayoutSettingsRoute: LayoutSettingsRoute,
   LayoutSkillsRoute: LayoutSkillsRoute,
   LayoutUsageRoute: LayoutUsageRoute,
   LayoutIndexRoute: LayoutIndexRoute,
   LayoutAgentsIndexRoute: LayoutAgentsIndexRoute,
   LayoutAgentsAgentIdIndexRoute: LayoutAgentsAgentIdIndexRoute,
-};
-
-const LayoutRouteWithChildren = LayoutRoute._addFileChildren(LayoutRouteChildren);
-
-interface ApiPipelineAgentSessionsRouteChildren {
-  ApiPipelineAgentSessionsSplatRoute: typeof ApiPipelineAgentSessionsSplatRoute;
 }
 
-const ApiPipelineAgentSessionsRouteChildren: ApiPipelineAgentSessionsRouteChildren = {
-  ApiPipelineAgentSessionsSplatRoute: ApiPipelineAgentSessionsSplatRoute,
-};
+const LayoutRouteWithChildren =
+  LayoutRoute._addFileChildren(LayoutRouteChildren)
 
-const ApiPipelineAgentSessionsRouteWithChildren = ApiPipelineAgentSessionsRoute._addFileChildren(
-  ApiPipelineAgentSessionsRouteChildren,
-);
+interface ApiPipelineAgentSessionsRouteChildren {
+  ApiPipelineAgentSessionsSplatRoute: typeof ApiPipelineAgentSessionsSplatRoute
+}
+
+const ApiPipelineAgentSessionsRouteChildren: ApiPipelineAgentSessionsRouteChildren =
+  {
+    ApiPipelineAgentSessionsSplatRoute: ApiPipelineAgentSessionsSplatRoute,
+  }
+
+const ApiPipelineAgentSessionsRouteWithChildren =
+  ApiPipelineAgentSessionsRoute._addFileChildren(
+    ApiPipelineAgentSessionsRouteChildren,
+  )
 
 const rootRouteChildren: RootRouteChildren = {
   LayoutRoute: LayoutRouteWithChildren,
@@ -1029,16 +1069,16 @@ const rootRouteChildren: RootRouteChildren = {
   ApiOperationsSplatRoute: ApiOperationsSplatRoute,
   ApiPipelinesSplatRoute: ApiPipelinesSplatRoute,
   ApiTrpcSplatRoute: ApiTrpcSplatRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { createStart } from "@tanstack/react-start";
-declare module "@tanstack/react-start" {
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/apps/app/src/routes/_layout/schedule.tsx
+++ b/apps/app/src/routes/_layout/schedule.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SchedulePage } from "@repo/views/SchedulePage";
+
+export const Route = createFileRoute("/_layout/schedule")({
+  head: () => ({
+    meta: [{ title: "Schedule | Ordine" }],
+  }),
+  component: SchedulePage,
+});

--- a/apps/app/src/styles.css
+++ b/apps/app/src/styles.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@500;600;700&family=Inter+Tight:wght@500;600&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
@@ -47,12 +48,17 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-cobalt: #266df0;
+  --color-cobalt-bright: #407ff2;
+  --color-cobalt-soft: #538bf3;
+  --color-periwinkle: #bad0fa;
+  --color-ice-wash: #e4edff;
   --radius-none: 0;
   --radius-sm: 6px;
   --radius-md: 8px;
   --radius-lg: 10px;
   --radius-xl: 12px;
-  --font-heading: var(--font-sans);
+  --font-heading: "Inter Tight", "Inter", "Geist Variable", ui-sans-serif, system-ui, sans-serif;
   --font-sans: "Inter", "Geist Variable", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
   --color-chart-5: var(--chart-5);
@@ -64,52 +70,53 @@
   --radius-3xl: 20px;
   --radius-4xl: 24px;
   --radius-pill: 9999px;
-  --shadow-soft: 0 4px 12px rgb(0 0 0 / 3%);
-  --shadow-float: 0 8px 24px rgb(0 0 0 / 6%), 0 1px 2px rgb(0 0 0 / 4%);
-  --shadow-pill: 0 6px 20px rgb(0 0 0 / 6%), 0 1px 2px rgb(0 0 0 / 4%);
+  --shadow-soft: rgba(28, 40, 64, 0.06) 0px 2px 6px 0px, rgba(28, 40, 64, 0.08) 0px 6px 20px -2px;
+  --shadow-float: rgba(28, 40, 64, 0.1) 0px 2px 3px -2px, rgba(28, 40, 64, 0.06) 0px 8px 24px -4px;
+  --shadow-pill: rgba(28, 40, 64, 0.06) 0px 2px 6px 0px, rgba(28, 40, 64, 0.08) 0px 6px 20px -2px;
+  --shadow-raised: rgba(28, 40, 64, 0.16) 0px 12px 32px -8px, rgba(28, 40, 64, 0.08) 0px 2px 8px;
   --shadow-win: 0 40px 80px -20px rgb(0 0 0 / 35%), 0 12px 28px -12px rgb(0 0 0 / 22%);
 }
 
 :root {
-  --background: oklch(0.98 0.002 90);
-  --foreground: oklch(0.18 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.18 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.18 0 0);
-  --primary: oklch(0.22 0 0);
-  --primary-foreground: oklch(0.98 0 0);
-  --secondary: oklch(0.955 0.002 90);
-  --secondary-foreground: oklch(0.18 0 0);
-  --muted: oklch(0.955 0.002 90);
-  --muted-foreground: oklch(0.55 0.005 90);
-  --accent: oklch(0.935 0.002 90);
-  --accent-foreground: oklch(0.18 0 0);
+  --background: #ffffff;
+  --foreground: #1c1d1f;
+  --card: #ffffff;
+  --card-foreground: #1c1d1f;
+  --popover: #ffffff;
+  --popover-foreground: #1c1d1f;
+  --primary: #232529;
+  --primary-foreground: #ffffff;
+  --secondary: #f4f5f6;
+  --secondary-foreground: #1c1d1f;
+  --muted: #f4f5f6;
+  --muted-foreground: #6f7988;
+  --accent: #f4f5f6;
+  --accent-foreground: #1c1d1f;
   --destructive: oklch(0.6 0.18 25);
-  --destructive-foreground: oklch(0.98 0 0);
-  --surface: oklch(1 0 0);
-  --surface-2: oklch(0.965 0.002 90);
-  --surface-3: oklch(0.95 0.002 90);
-  --border-strong: oklch(0.18 0 0 / 12%);
+  --destructive-foreground: #ffffff;
+  --surface: #ffffff;
+  --surface-2: #f4f5f6;
+  --surface-3: #eeeff1;
+  --border-strong: #d3d8df;
   --success: oklch(0.62 0.13 150);
   --warning: oklch(0.78 0.14 80);
-  --border: oklch(0.18 0 0 / 7%);
-  --input: oklch(0.18 0 0 / 10%);
-  --ring: oklch(0.18 0 0 / 20%);
+  --border: #e4e7ec;
+  --input: #e4e7ec;
+  --ring: #266df0;
   --canvas: oklch(0.99 0 0);
   --canvas-dot: oklch(0.18 0 0 / 7%);
   --edge: oklch(0.18 0 0 / 32%);
   --font-sans: "Inter", "Geist Variable", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
-  --radius: 8px;
-  --sidebar: oklch(0.965 0.002 90);
-  --sidebar-foreground: oklch(0.18 0 0);
-  --sidebar-primary: oklch(0.22 0 0);
-  --sidebar-primary-foreground: oklch(0.98 0 0);
-  --sidebar-accent: oklch(0.935 0.002 90);
-  --sidebar-accent-foreground: oklch(0.18 0 0);
-  --sidebar-border: oklch(0.18 0 0 / 7%);
-  --sidebar-ring: oklch(0.18 0 0 / 20%);
+  --radius: 10px;
+  --sidebar: #f4f5f6;
+  --sidebar-foreground: #1c1d1f;
+  --sidebar-primary: #232529;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #eeeff1;
+  --sidebar-accent-foreground: #1c1d1f;
+  --sidebar-border: #e4e7ec;
+  --sidebar-ring: #266df0;
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
@@ -190,6 +197,7 @@
     font-feature-settings:
       "cv11" 1,
       "ss01" 1,
+      "ss03" 1,
       "rlig" 1,
       "calt" 1;
     @apply bg-background text-foreground;

--- a/apps/desktop-app/src/locales/en.json
+++ b/apps/desktop-app/src/locales/en.json
@@ -71,17 +71,32 @@
     "preview": "Preview",
     "plugins": "Plugins",
     "agents": "Agents",
+    "schedule": "Schedule",
+    "conversations": "Conversations",
     "logout": "Log out",
     "groups": {
       "assembly": "Assembly",
       "capabilities": "Capabilities",
-      "monitor": "Monitor"
+      "monitor": "Monitor",
+      "main": "Main"
     },
     "items": {
       "connectors": "Connectors",
       "localAgents": "Local Agents",
       "usage": "Usage"
     }
+  },
+  "schedule": {
+    "title": "Schedule",
+    "subtitle": "Run pipelines automatically on a schedule",
+    "emptyTitle": "Scheduling is coming soon",
+    "emptyDescription": "This page will list all scheduled pipeline routines, with cadence, activation state, and manual trigger."
+  },
+  "conversations": {
+    "title": "Conversations",
+    "subtitle": "Past conversations with agents",
+    "emptyTitle": "Conversations are coming soon",
+    "emptyDescription": "This page will collect your conversations with agents, so you can review and continue them."
   },
   "connectors": {
     "title": "Connectors",
@@ -1049,7 +1064,8 @@
       "autonomy": "Autonomy",
       "defaults": "Defaults",
       "keyboard": "Keyboard",
-      "project": "Project"
+      "project": "Project",
+      "pages": "Pages"
     },
     "saveChanges": "Save changes",
     "saved": "Saved ✓",
@@ -1160,7 +1176,12 @@
     "groups": {
       "data": "Data",
       "execution": "Execution",
-      "workspace": "Workspace"
+      "workspace": "Workspace",
+      "pages": "Pages"
+    },
+    "pages": {
+      "title": "More pages",
+      "description": "Entries moved out of the main navigation. Routes and features are unchanged."
     },
     "keyboard": {
       "description": "Canvas shortcuts. Read-only for now.",

--- a/apps/desktop-app/src/locales/zh.json
+++ b/apps/desktop-app/src/locales/zh.json
@@ -74,17 +74,32 @@
     "preview": "预览",
     "plugins": "插件",
     "agents": "智能体",
+    "schedule": "定时任务",
+    "conversations": "对话",
     "logout": "退出登录",
     "groups": {
       "assembly": "装配",
       "capabilities": "能力",
-      "monitor": "监控"
+      "monitor": "监控",
+      "main": "主导航"
     },
     "items": {
       "connectors": "连接器",
       "localAgents": "本地 Agent",
       "usage": "用量"
     }
+  },
+  "schedule": {
+    "title": "定时任务",
+    "subtitle": "按计划自动运行流水线",
+    "emptyTitle": "定时任务即将上线",
+    "emptyDescription": "这里将列出所有定时执行的流水线(Routine),支持查看周期、启用状态和手动触发。"
+  },
+  "conversations": {
+    "title": "对话",
+    "subtitle": "与智能体的历史对话",
+    "emptyTitle": "对话记录即将上线",
+    "emptyDescription": "这里将汇总你与智能体的对话记录,支持回看与继续。"
   },
   "connectors": {
     "title": "连接器",
@@ -1043,7 +1058,8 @@
       "autonomy": "自主性",
       "defaults": "默认项",
       "keyboard": "快捷键",
-      "project": "项目"
+      "project": "项目",
+      "pages": "页面"
     },
     "saveChanges": "保存更改",
     "saved": "已保存 ✓",
@@ -1154,7 +1170,12 @@
     "groups": {
       "data": "数据",
       "execution": "执行",
-      "workspace": "工作区"
+      "workspace": "工作区",
+      "pages": "页面"
+    },
+    "pages": {
+      "title": "更多页面",
+      "description": "从主导航移出的页面入口,路由与功能保持不变。"
     },
     "keyboard": {
       "description": "画布快捷键速查，当前为只读。",

--- a/apps/desktop-app/src/routeTree.gen.ts
+++ b/apps/desktop-app/src/routeTree.gen.ts
@@ -8,649 +8,687 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as UsageRouteImport } from './routes/usage'
-import { Route as SkillsRouteImport } from './routes/skills'
-import { Route as SettingsRouteImport } from './routes/settings'
-import { Route as PluginsRouteImport } from './routes/plugins'
-import { Route as PipelinesRouteImport } from './routes/pipelines'
-import { Route as LocalAgentsRouteImport } from './routes/local-agents'
-import { Route as DistillationsRouteImport } from './routes/distillations'
-import { Route as ConnectorsRouteImport } from './routes/connectors'
-import { Route as ComponentsRouteImport } from './routes/components'
-import { Route as CanvasRouteImport } from './routes/canvas'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as RuntimesIndexRouteImport } from './routes/runtimes.index'
-import { Route as PipelinesIndexRouteImport } from './routes/pipelines/index'
-import { Route as DistillationsIndexRouteImport } from './routes/distillations/index'
-import { Route as AgentsIndexRouteImport } from './routes/agents.index'
-import { Route as PipelinesObjectsRouteImport } from './routes/pipelines/objects'
-import { Route as PipelinesJobsRouteImport } from './routes/pipelines/jobs'
-import { Route as PipelinesPipelineIdRouteImport } from './routes/pipelines/$pipelineId'
-import { Route as DistillationsNewRouteImport } from './routes/distillations/new'
-import { Route as DistillationsDistillationIdRouteImport } from './routes/distillations/$distillationId'
-import { Route as RuntimesRuntimeIdIndexRouteImport } from './routes/runtimes.$runtimeId.index'
-import { Route as PipelinesOperationsIndexRouteImport } from './routes/pipelines/operations.index'
-import { Route as AgentsAgentIdIndexRouteImport } from './routes/agents.$agentId.index'
-import { Route as RuntimesRuntimeIdEditRouteImport } from './routes/runtimes.$runtimeId.edit'
-import { Route as PipelinesOperationsNewRouteImport } from './routes/pipelines/operations.new'
-import { Route as PipelinesObjectsObjectTypeIdRouteImport } from './routes/pipelines/objects.$objectTypeId'
-import { Route as PipelinesJobsJobIdRouteImport } from './routes/pipelines/jobs.$jobId'
-import { Route as PipelinesOperationsOperationIdIndexRouteImport } from './routes/pipelines/operations.$operationId.index'
-import { Route as PipelinesOperationsOperationIdEditRouteImport } from './routes/pipelines/operations.$operationId.edit'
+import { Route as rootRouteImport } from "./routes/__root";
+import { Route as UsageRouteImport } from "./routes/usage";
+import { Route as SkillsRouteImport } from "./routes/skills";
+import { Route as SettingsRouteImport } from "./routes/settings";
+import { Route as ScheduleRouteImport } from "./routes/schedule";
+import { Route as PluginsRouteImport } from "./routes/plugins";
+import { Route as PipelinesRouteImport } from "./routes/pipelines";
+import { Route as LocalAgentsRouteImport } from "./routes/local-agents";
+import { Route as DistillationsRouteImport } from "./routes/distillations";
+import { Route as ConnectorsRouteImport } from "./routes/connectors";
+import { Route as ComponentsRouteImport } from "./routes/components";
+import { Route as CanvasRouteImport } from "./routes/canvas";
+import { Route as AssistantRouteImport } from "./routes/assistant";
+import { Route as IndexRouteImport } from "./routes/index";
+import { Route as RuntimesIndexRouteImport } from "./routes/runtimes.index";
+import { Route as PipelinesIndexRouteImport } from "./routes/pipelines/index";
+import { Route as DistillationsIndexRouteImport } from "./routes/distillations/index";
+import { Route as AgentsIndexRouteImport } from "./routes/agents.index";
+import { Route as PipelinesObjectsRouteImport } from "./routes/pipelines/objects";
+import { Route as PipelinesJobsRouteImport } from "./routes/pipelines/jobs";
+import { Route as PipelinesPipelineIdRouteImport } from "./routes/pipelines/$pipelineId";
+import { Route as DistillationsNewRouteImport } from "./routes/distillations/new";
+import { Route as DistillationsDistillationIdRouteImport } from "./routes/distillations/$distillationId";
+import { Route as RuntimesRuntimeIdIndexRouteImport } from "./routes/runtimes.$runtimeId.index";
+import { Route as PipelinesOperationsIndexRouteImport } from "./routes/pipelines/operations.index";
+import { Route as AgentsAgentIdIndexRouteImport } from "./routes/agents.$agentId.index";
+import { Route as RuntimesRuntimeIdEditRouteImport } from "./routes/runtimes.$runtimeId.edit";
+import { Route as PipelinesOperationsNewRouteImport } from "./routes/pipelines/operations.new";
+import { Route as PipelinesObjectsObjectTypeIdRouteImport } from "./routes/pipelines/objects.$objectTypeId";
+import { Route as PipelinesJobsJobIdRouteImport } from "./routes/pipelines/jobs.$jobId";
+import { Route as PipelinesOperationsOperationIdIndexRouteImport } from "./routes/pipelines/operations.$operationId.index";
+import { Route as PipelinesOperationsOperationIdEditRouteImport } from "./routes/pipelines/operations.$operationId.edit";
 
 const UsageRoute = UsageRouteImport.update({
-  id: '/usage',
-  path: '/usage',
+  id: "/usage",
+  path: "/usage",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const SkillsRoute = SkillsRouteImport.update({
-  id: '/skills',
-  path: '/skills',
+  id: "/skills",
+  path: "/skills",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const SettingsRoute = SettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
+  id: "/settings",
+  path: "/settings",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
+const ScheduleRoute = ScheduleRouteImport.update({
+  id: "/schedule",
+  path: "/schedule",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const PluginsRoute = PluginsRouteImport.update({
-  id: '/plugins',
-  path: '/plugins',
+  id: "/plugins",
+  path: "/plugins",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const PipelinesRoute = PipelinesRouteImport.update({
-  id: '/pipelines',
-  path: '/pipelines',
+  id: "/pipelines",
+  path: "/pipelines",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LocalAgentsRoute = LocalAgentsRouteImport.update({
-  id: '/local-agents',
-  path: '/local-agents',
+  id: "/local-agents",
+  path: "/local-agents",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const DistillationsRoute = DistillationsRouteImport.update({
-  id: '/distillations',
-  path: '/distillations',
+  id: "/distillations",
+  path: "/distillations",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ConnectorsRoute = ConnectorsRouteImport.update({
-  id: '/connectors',
-  path: '/connectors',
+  id: "/connectors",
+  path: "/connectors",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ComponentsRoute = ComponentsRouteImport.update({
-  id: '/components',
-  path: '/components',
+  id: "/components",
+  path: "/components",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const CanvasRoute = CanvasRouteImport.update({
-  id: '/canvas',
-  path: '/canvas',
+  id: "/canvas",
+  path: "/canvas",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
+const AssistantRoute = AssistantRouteImport.update({
+  id: "/assistant",
+  path: "/assistant",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const RuntimesIndexRoute = RuntimesIndexRouteImport.update({
-  id: '/runtimes/',
-  path: '/runtimes/',
+  id: "/runtimes/",
+  path: "/runtimes/",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const PipelinesIndexRoute = PipelinesIndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => PipelinesRoute,
-} as any)
+} as any);
 const DistillationsIndexRoute = DistillationsIndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => DistillationsRoute,
-} as any)
+} as any);
 const AgentsIndexRoute = AgentsIndexRouteImport.update({
-  id: '/agents/',
-  path: '/agents/',
+  id: "/agents/",
+  path: "/agents/",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const PipelinesObjectsRoute = PipelinesObjectsRouteImport.update({
-  id: '/objects',
-  path: '/objects',
+  id: "/objects",
+  path: "/objects",
   getParentRoute: () => PipelinesRoute,
-} as any)
+} as any);
 const PipelinesJobsRoute = PipelinesJobsRouteImport.update({
-  id: '/jobs',
-  path: '/jobs',
+  id: "/jobs",
+  path: "/jobs",
   getParentRoute: () => PipelinesRoute,
-} as any)
+} as any);
 const PipelinesPipelineIdRoute = PipelinesPipelineIdRouteImport.update({
-  id: '/$pipelineId',
-  path: '/$pipelineId',
+  id: "/$pipelineId",
+  path: "/$pipelineId",
   getParentRoute: () => PipelinesRoute,
-} as any)
+} as any);
 const DistillationsNewRoute = DistillationsNewRouteImport.update({
-  id: '/new',
-  path: '/new',
+  id: "/new",
+  path: "/new",
   getParentRoute: () => DistillationsRoute,
-} as any)
-const DistillationsDistillationIdRoute =
-  DistillationsDistillationIdRouteImport.update({
-    id: '/$distillationId',
-    path: '/$distillationId',
-    getParentRoute: () => DistillationsRoute,
-  } as any)
+} as any);
+const DistillationsDistillationIdRoute = DistillationsDistillationIdRouteImport.update({
+  id: "/$distillationId",
+  path: "/$distillationId",
+  getParentRoute: () => DistillationsRoute,
+} as any);
 const RuntimesRuntimeIdIndexRoute = RuntimesRuntimeIdIndexRouteImport.update({
-  id: '/runtimes/$runtimeId/',
-  path: '/runtimes/$runtimeId/',
+  id: "/runtimes/$runtimeId/",
+  path: "/runtimes/$runtimeId/",
   getParentRoute: () => rootRouteImport,
-} as any)
-const PipelinesOperationsIndexRoute =
-  PipelinesOperationsIndexRouteImport.update({
-    id: '/operations/',
-    path: '/operations/',
-    getParentRoute: () => PipelinesRoute,
-  } as any)
-const AgentsAgentIdIndexRoute = AgentsAgentIdIndexRouteImport.update({
-  id: '/agents/$agentId/',
-  path: '/agents/$agentId/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const RuntimesRuntimeIdEditRoute = RuntimesRuntimeIdEditRouteImport.update({
-  id: '/runtimes/$runtimeId/edit',
-  path: '/runtimes/$runtimeId/edit',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const PipelinesOperationsNewRoute = PipelinesOperationsNewRouteImport.update({
-  id: '/operations/new',
-  path: '/operations/new',
+} as any);
+const PipelinesOperationsIndexRoute = PipelinesOperationsIndexRouteImport.update({
+  id: "/operations/",
+  path: "/operations/",
   getParentRoute: () => PipelinesRoute,
-} as any)
-const PipelinesObjectsObjectTypeIdRoute =
-  PipelinesObjectsObjectTypeIdRouteImport.update({
-    id: '/$objectTypeId',
-    path: '/$objectTypeId',
-    getParentRoute: () => PipelinesObjectsRoute,
-  } as any)
+} as any);
+const AgentsAgentIdIndexRoute = AgentsAgentIdIndexRouteImport.update({
+  id: "/agents/$agentId/",
+  path: "/agents/$agentId/",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const RuntimesRuntimeIdEditRoute = RuntimesRuntimeIdEditRouteImport.update({
+  id: "/runtimes/$runtimeId/edit",
+  path: "/runtimes/$runtimeId/edit",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const PipelinesOperationsNewRoute = PipelinesOperationsNewRouteImport.update({
+  id: "/operations/new",
+  path: "/operations/new",
+  getParentRoute: () => PipelinesRoute,
+} as any);
+const PipelinesObjectsObjectTypeIdRoute = PipelinesObjectsObjectTypeIdRouteImport.update({
+  id: "/$objectTypeId",
+  path: "/$objectTypeId",
+  getParentRoute: () => PipelinesObjectsRoute,
+} as any);
 const PipelinesJobsJobIdRoute = PipelinesJobsJobIdRouteImport.update({
-  id: '/$jobId',
-  path: '/$jobId',
+  id: "/$jobId",
+  path: "/$jobId",
   getParentRoute: () => PipelinesJobsRoute,
-} as any)
+} as any);
 const PipelinesOperationsOperationIdIndexRoute =
   PipelinesOperationsOperationIdIndexRouteImport.update({
-    id: '/operations/$operationId/',
-    path: '/operations/$operationId/',
+    id: "/operations/$operationId/",
+    path: "/operations/$operationId/",
     getParentRoute: () => PipelinesRoute,
-  } as any)
+  } as any);
 const PipelinesOperationsOperationIdEditRoute =
   PipelinesOperationsOperationIdEditRouteImport.update({
-    id: '/operations/$operationId/edit',
-    path: '/operations/$operationId/edit',
+    id: "/operations/$operationId/edit",
+    path: "/operations/$operationId/edit",
     getParentRoute: () => PipelinesRoute,
-  } as any)
+  } as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/canvas': typeof CanvasRoute
-  '/components': typeof ComponentsRoute
-  '/connectors': typeof ConnectorsRoute
-  '/distillations': typeof DistillationsRouteWithChildren
-  '/local-agents': typeof LocalAgentsRoute
-  '/pipelines': typeof PipelinesRouteWithChildren
-  '/plugins': typeof PluginsRoute
-  '/settings': typeof SettingsRoute
-  '/skills': typeof SkillsRoute
-  '/usage': typeof UsageRoute
-  '/distillations/$distillationId': typeof DistillationsDistillationIdRoute
-  '/distillations/new': typeof DistillationsNewRoute
-  '/pipelines/$pipelineId': typeof PipelinesPipelineIdRoute
-  '/pipelines/jobs': typeof PipelinesJobsRouteWithChildren
-  '/pipelines/objects': typeof PipelinesObjectsRouteWithChildren
-  '/agents/': typeof AgentsIndexRoute
-  '/distillations/': typeof DistillationsIndexRoute
-  '/pipelines/': typeof PipelinesIndexRoute
-  '/runtimes/': typeof RuntimesIndexRoute
-  '/pipelines/jobs/$jobId': typeof PipelinesJobsJobIdRoute
-  '/pipelines/objects/$objectTypeId': typeof PipelinesObjectsObjectTypeIdRoute
-  '/pipelines/operations/new': typeof PipelinesOperationsNewRoute
-  '/runtimes/$runtimeId/edit': typeof RuntimesRuntimeIdEditRoute
-  '/agents/$agentId/': typeof AgentsAgentIdIndexRoute
-  '/pipelines/operations/': typeof PipelinesOperationsIndexRoute
-  '/runtimes/$runtimeId/': typeof RuntimesRuntimeIdIndexRoute
-  '/pipelines/operations/$operationId/edit': typeof PipelinesOperationsOperationIdEditRoute
-  '/pipelines/operations/$operationId/': typeof PipelinesOperationsOperationIdIndexRoute
+  "/": typeof IndexRoute;
+  "/assistant": typeof AssistantRoute;
+  "/canvas": typeof CanvasRoute;
+  "/components": typeof ComponentsRoute;
+  "/connectors": typeof ConnectorsRoute;
+  "/distillations": typeof DistillationsRouteWithChildren;
+  "/local-agents": typeof LocalAgentsRoute;
+  "/pipelines": typeof PipelinesRouteWithChildren;
+  "/plugins": typeof PluginsRoute;
+  "/schedule": typeof ScheduleRoute;
+  "/settings": typeof SettingsRoute;
+  "/skills": typeof SkillsRoute;
+  "/usage": typeof UsageRoute;
+  "/distillations/$distillationId": typeof DistillationsDistillationIdRoute;
+  "/distillations/new": typeof DistillationsNewRoute;
+  "/pipelines/$pipelineId": typeof PipelinesPipelineIdRoute;
+  "/pipelines/jobs": typeof PipelinesJobsRouteWithChildren;
+  "/pipelines/objects": typeof PipelinesObjectsRouteWithChildren;
+  "/agents/": typeof AgentsIndexRoute;
+  "/distillations/": typeof DistillationsIndexRoute;
+  "/pipelines/": typeof PipelinesIndexRoute;
+  "/runtimes/": typeof RuntimesIndexRoute;
+  "/pipelines/jobs/$jobId": typeof PipelinesJobsJobIdRoute;
+  "/pipelines/objects/$objectTypeId": typeof PipelinesObjectsObjectTypeIdRoute;
+  "/pipelines/operations/new": typeof PipelinesOperationsNewRoute;
+  "/runtimes/$runtimeId/edit": typeof RuntimesRuntimeIdEditRoute;
+  "/agents/$agentId/": typeof AgentsAgentIdIndexRoute;
+  "/pipelines/operations/": typeof PipelinesOperationsIndexRoute;
+  "/runtimes/$runtimeId/": typeof RuntimesRuntimeIdIndexRoute;
+  "/pipelines/operations/$operationId/edit": typeof PipelinesOperationsOperationIdEditRoute;
+  "/pipelines/operations/$operationId/": typeof PipelinesOperationsOperationIdIndexRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/canvas': typeof CanvasRoute
-  '/components': typeof ComponentsRoute
-  '/connectors': typeof ConnectorsRoute
-  '/local-agents': typeof LocalAgentsRoute
-  '/plugins': typeof PluginsRoute
-  '/settings': typeof SettingsRoute
-  '/skills': typeof SkillsRoute
-  '/usage': typeof UsageRoute
-  '/distillations/$distillationId': typeof DistillationsDistillationIdRoute
-  '/distillations/new': typeof DistillationsNewRoute
-  '/pipelines/$pipelineId': typeof PipelinesPipelineIdRoute
-  '/pipelines/jobs': typeof PipelinesJobsRouteWithChildren
-  '/pipelines/objects': typeof PipelinesObjectsRouteWithChildren
-  '/agents': typeof AgentsIndexRoute
-  '/distillations': typeof DistillationsIndexRoute
-  '/pipelines': typeof PipelinesIndexRoute
-  '/runtimes': typeof RuntimesIndexRoute
-  '/pipelines/jobs/$jobId': typeof PipelinesJobsJobIdRoute
-  '/pipelines/objects/$objectTypeId': typeof PipelinesObjectsObjectTypeIdRoute
-  '/pipelines/operations/new': typeof PipelinesOperationsNewRoute
-  '/runtimes/$runtimeId/edit': typeof RuntimesRuntimeIdEditRoute
-  '/agents/$agentId': typeof AgentsAgentIdIndexRoute
-  '/pipelines/operations': typeof PipelinesOperationsIndexRoute
-  '/runtimes/$runtimeId': typeof RuntimesRuntimeIdIndexRoute
-  '/pipelines/operations/$operationId/edit': typeof PipelinesOperationsOperationIdEditRoute
-  '/pipelines/operations/$operationId': typeof PipelinesOperationsOperationIdIndexRoute
+  "/": typeof IndexRoute;
+  "/assistant": typeof AssistantRoute;
+  "/canvas": typeof CanvasRoute;
+  "/components": typeof ComponentsRoute;
+  "/connectors": typeof ConnectorsRoute;
+  "/local-agents": typeof LocalAgentsRoute;
+  "/plugins": typeof PluginsRoute;
+  "/schedule": typeof ScheduleRoute;
+  "/settings": typeof SettingsRoute;
+  "/skills": typeof SkillsRoute;
+  "/usage": typeof UsageRoute;
+  "/distillations/$distillationId": typeof DistillationsDistillationIdRoute;
+  "/distillations/new": typeof DistillationsNewRoute;
+  "/pipelines/$pipelineId": typeof PipelinesPipelineIdRoute;
+  "/pipelines/jobs": typeof PipelinesJobsRouteWithChildren;
+  "/pipelines/objects": typeof PipelinesObjectsRouteWithChildren;
+  "/agents": typeof AgentsIndexRoute;
+  "/distillations": typeof DistillationsIndexRoute;
+  "/pipelines": typeof PipelinesIndexRoute;
+  "/runtimes": typeof RuntimesIndexRoute;
+  "/pipelines/jobs/$jobId": typeof PipelinesJobsJobIdRoute;
+  "/pipelines/objects/$objectTypeId": typeof PipelinesObjectsObjectTypeIdRoute;
+  "/pipelines/operations/new": typeof PipelinesOperationsNewRoute;
+  "/runtimes/$runtimeId/edit": typeof RuntimesRuntimeIdEditRoute;
+  "/agents/$agentId": typeof AgentsAgentIdIndexRoute;
+  "/pipelines/operations": typeof PipelinesOperationsIndexRoute;
+  "/runtimes/$runtimeId": typeof RuntimesRuntimeIdIndexRoute;
+  "/pipelines/operations/$operationId/edit": typeof PipelinesOperationsOperationIdEditRoute;
+  "/pipelines/operations/$operationId": typeof PipelinesOperationsOperationIdIndexRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/canvas': typeof CanvasRoute
-  '/components': typeof ComponentsRoute
-  '/connectors': typeof ConnectorsRoute
-  '/distillations': typeof DistillationsRouteWithChildren
-  '/local-agents': typeof LocalAgentsRoute
-  '/pipelines': typeof PipelinesRouteWithChildren
-  '/plugins': typeof PluginsRoute
-  '/settings': typeof SettingsRoute
-  '/skills': typeof SkillsRoute
-  '/usage': typeof UsageRoute
-  '/distillations/$distillationId': typeof DistillationsDistillationIdRoute
-  '/distillations/new': typeof DistillationsNewRoute
-  '/pipelines/$pipelineId': typeof PipelinesPipelineIdRoute
-  '/pipelines/jobs': typeof PipelinesJobsRouteWithChildren
-  '/pipelines/objects': typeof PipelinesObjectsRouteWithChildren
-  '/agents/': typeof AgentsIndexRoute
-  '/distillations/': typeof DistillationsIndexRoute
-  '/pipelines/': typeof PipelinesIndexRoute
-  '/runtimes/': typeof RuntimesIndexRoute
-  '/pipelines/jobs/$jobId': typeof PipelinesJobsJobIdRoute
-  '/pipelines/objects/$objectTypeId': typeof PipelinesObjectsObjectTypeIdRoute
-  '/pipelines/operations/new': typeof PipelinesOperationsNewRoute
-  '/runtimes/$runtimeId/edit': typeof RuntimesRuntimeIdEditRoute
-  '/agents/$agentId/': typeof AgentsAgentIdIndexRoute
-  '/pipelines/operations/': typeof PipelinesOperationsIndexRoute
-  '/runtimes/$runtimeId/': typeof RuntimesRuntimeIdIndexRoute
-  '/pipelines/operations/$operationId/edit': typeof PipelinesOperationsOperationIdEditRoute
-  '/pipelines/operations/$operationId/': typeof PipelinesOperationsOperationIdIndexRoute
+  __root__: typeof rootRouteImport;
+  "/": typeof IndexRoute;
+  "/assistant": typeof AssistantRoute;
+  "/canvas": typeof CanvasRoute;
+  "/components": typeof ComponentsRoute;
+  "/connectors": typeof ConnectorsRoute;
+  "/distillations": typeof DistillationsRouteWithChildren;
+  "/local-agents": typeof LocalAgentsRoute;
+  "/pipelines": typeof PipelinesRouteWithChildren;
+  "/plugins": typeof PluginsRoute;
+  "/schedule": typeof ScheduleRoute;
+  "/settings": typeof SettingsRoute;
+  "/skills": typeof SkillsRoute;
+  "/usage": typeof UsageRoute;
+  "/distillations/$distillationId": typeof DistillationsDistillationIdRoute;
+  "/distillations/new": typeof DistillationsNewRoute;
+  "/pipelines/$pipelineId": typeof PipelinesPipelineIdRoute;
+  "/pipelines/jobs": typeof PipelinesJobsRouteWithChildren;
+  "/pipelines/objects": typeof PipelinesObjectsRouteWithChildren;
+  "/agents/": typeof AgentsIndexRoute;
+  "/distillations/": typeof DistillationsIndexRoute;
+  "/pipelines/": typeof PipelinesIndexRoute;
+  "/runtimes/": typeof RuntimesIndexRoute;
+  "/pipelines/jobs/$jobId": typeof PipelinesJobsJobIdRoute;
+  "/pipelines/objects/$objectTypeId": typeof PipelinesObjectsObjectTypeIdRoute;
+  "/pipelines/operations/new": typeof PipelinesOperationsNewRoute;
+  "/runtimes/$runtimeId/edit": typeof RuntimesRuntimeIdEditRoute;
+  "/agents/$agentId/": typeof AgentsAgentIdIndexRoute;
+  "/pipelines/operations/": typeof PipelinesOperationsIndexRoute;
+  "/runtimes/$runtimeId/": typeof RuntimesRuntimeIdIndexRoute;
+  "/pipelines/operations/$operationId/edit": typeof PipelinesOperationsOperationIdEditRoute;
+  "/pipelines/operations/$operationId/": typeof PipelinesOperationsOperationIdIndexRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
+  fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
-    | '/'
-    | '/canvas'
-    | '/components'
-    | '/connectors'
-    | '/distillations'
-    | '/local-agents'
-    | '/pipelines'
-    | '/plugins'
-    | '/settings'
-    | '/skills'
-    | '/usage'
-    | '/distillations/$distillationId'
-    | '/distillations/new'
-    | '/pipelines/$pipelineId'
-    | '/pipelines/jobs'
-    | '/pipelines/objects'
-    | '/agents/'
-    | '/distillations/'
-    | '/pipelines/'
-    | '/runtimes/'
-    | '/pipelines/jobs/$jobId'
-    | '/pipelines/objects/$objectTypeId'
-    | '/pipelines/operations/new'
-    | '/runtimes/$runtimeId/edit'
-    | '/agents/$agentId/'
-    | '/pipelines/operations/'
-    | '/runtimes/$runtimeId/'
-    | '/pipelines/operations/$operationId/edit'
-    | '/pipelines/operations/$operationId/'
-  fileRoutesByTo: FileRoutesByTo
+    | "/"
+    | "/assistant"
+    | "/canvas"
+    | "/components"
+    | "/connectors"
+    | "/distillations"
+    | "/local-agents"
+    | "/pipelines"
+    | "/plugins"
+    | "/schedule"
+    | "/settings"
+    | "/skills"
+    | "/usage"
+    | "/distillations/$distillationId"
+    | "/distillations/new"
+    | "/pipelines/$pipelineId"
+    | "/pipelines/jobs"
+    | "/pipelines/objects"
+    | "/agents/"
+    | "/distillations/"
+    | "/pipelines/"
+    | "/runtimes/"
+    | "/pipelines/jobs/$jobId"
+    | "/pipelines/objects/$objectTypeId"
+    | "/pipelines/operations/new"
+    | "/runtimes/$runtimeId/edit"
+    | "/agents/$agentId/"
+    | "/pipelines/operations/"
+    | "/runtimes/$runtimeId/"
+    | "/pipelines/operations/$operationId/edit"
+    | "/pipelines/operations/$operationId/";
+  fileRoutesByTo: FileRoutesByTo;
   to:
-    | '/'
-    | '/canvas'
-    | '/components'
-    | '/connectors'
-    | '/local-agents'
-    | '/plugins'
-    | '/settings'
-    | '/skills'
-    | '/usage'
-    | '/distillations/$distillationId'
-    | '/distillations/new'
-    | '/pipelines/$pipelineId'
-    | '/pipelines/jobs'
-    | '/pipelines/objects'
-    | '/agents'
-    | '/distillations'
-    | '/pipelines'
-    | '/runtimes'
-    | '/pipelines/jobs/$jobId'
-    | '/pipelines/objects/$objectTypeId'
-    | '/pipelines/operations/new'
-    | '/runtimes/$runtimeId/edit'
-    | '/agents/$agentId'
-    | '/pipelines/operations'
-    | '/runtimes/$runtimeId'
-    | '/pipelines/operations/$operationId/edit'
-    | '/pipelines/operations/$operationId'
+    | "/"
+    | "/assistant"
+    | "/canvas"
+    | "/components"
+    | "/connectors"
+    | "/local-agents"
+    | "/plugins"
+    | "/schedule"
+    | "/settings"
+    | "/skills"
+    | "/usage"
+    | "/distillations/$distillationId"
+    | "/distillations/new"
+    | "/pipelines/$pipelineId"
+    | "/pipelines/jobs"
+    | "/pipelines/objects"
+    | "/agents"
+    | "/distillations"
+    | "/pipelines"
+    | "/runtimes"
+    | "/pipelines/jobs/$jobId"
+    | "/pipelines/objects/$objectTypeId"
+    | "/pipelines/operations/new"
+    | "/runtimes/$runtimeId/edit"
+    | "/agents/$agentId"
+    | "/pipelines/operations"
+    | "/runtimes/$runtimeId"
+    | "/pipelines/operations/$operationId/edit"
+    | "/pipelines/operations/$operationId";
   id:
-    | '__root__'
-    | '/'
-    | '/canvas'
-    | '/components'
-    | '/connectors'
-    | '/distillations'
-    | '/local-agents'
-    | '/pipelines'
-    | '/plugins'
-    | '/settings'
-    | '/skills'
-    | '/usage'
-    | '/distillations/$distillationId'
-    | '/distillations/new'
-    | '/pipelines/$pipelineId'
-    | '/pipelines/jobs'
-    | '/pipelines/objects'
-    | '/agents/'
-    | '/distillations/'
-    | '/pipelines/'
-    | '/runtimes/'
-    | '/pipelines/jobs/$jobId'
-    | '/pipelines/objects/$objectTypeId'
-    | '/pipelines/operations/new'
-    | '/runtimes/$runtimeId/edit'
-    | '/agents/$agentId/'
-    | '/pipelines/operations/'
-    | '/runtimes/$runtimeId/'
-    | '/pipelines/operations/$operationId/edit'
-    | '/pipelines/operations/$operationId/'
-  fileRoutesById: FileRoutesById
+    | "__root__"
+    | "/"
+    | "/assistant"
+    | "/canvas"
+    | "/components"
+    | "/connectors"
+    | "/distillations"
+    | "/local-agents"
+    | "/pipelines"
+    | "/plugins"
+    | "/schedule"
+    | "/settings"
+    | "/skills"
+    | "/usage"
+    | "/distillations/$distillationId"
+    | "/distillations/new"
+    | "/pipelines/$pipelineId"
+    | "/pipelines/jobs"
+    | "/pipelines/objects"
+    | "/agents/"
+    | "/distillations/"
+    | "/pipelines/"
+    | "/runtimes/"
+    | "/pipelines/jobs/$jobId"
+    | "/pipelines/objects/$objectTypeId"
+    | "/pipelines/operations/new"
+    | "/runtimes/$runtimeId/edit"
+    | "/agents/$agentId/"
+    | "/pipelines/operations/"
+    | "/runtimes/$runtimeId/"
+    | "/pipelines/operations/$operationId/edit"
+    | "/pipelines/operations/$operationId/";
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  CanvasRoute: typeof CanvasRoute
-  ComponentsRoute: typeof ComponentsRoute
-  ConnectorsRoute: typeof ConnectorsRoute
-  DistillationsRoute: typeof DistillationsRouteWithChildren
-  LocalAgentsRoute: typeof LocalAgentsRoute
-  PipelinesRoute: typeof PipelinesRouteWithChildren
-  PluginsRoute: typeof PluginsRoute
-  SettingsRoute: typeof SettingsRoute
-  SkillsRoute: typeof SkillsRoute
-  UsageRoute: typeof UsageRoute
-  AgentsIndexRoute: typeof AgentsIndexRoute
-  RuntimesIndexRoute: typeof RuntimesIndexRoute
-  RuntimesRuntimeIdEditRoute: typeof RuntimesRuntimeIdEditRoute
-  AgentsAgentIdIndexRoute: typeof AgentsAgentIdIndexRoute
-  RuntimesRuntimeIdIndexRoute: typeof RuntimesRuntimeIdIndexRoute
+  IndexRoute: typeof IndexRoute;
+  AssistantRoute: typeof AssistantRoute;
+  CanvasRoute: typeof CanvasRoute;
+  ComponentsRoute: typeof ComponentsRoute;
+  ConnectorsRoute: typeof ConnectorsRoute;
+  DistillationsRoute: typeof DistillationsRouteWithChildren;
+  LocalAgentsRoute: typeof LocalAgentsRoute;
+  PipelinesRoute: typeof PipelinesRouteWithChildren;
+  PluginsRoute: typeof PluginsRoute;
+  ScheduleRoute: typeof ScheduleRoute;
+  SettingsRoute: typeof SettingsRoute;
+  SkillsRoute: typeof SkillsRoute;
+  UsageRoute: typeof UsageRoute;
+  AgentsIndexRoute: typeof AgentsIndexRoute;
+  RuntimesIndexRoute: typeof RuntimesIndexRoute;
+  RuntimesRuntimeIdEditRoute: typeof RuntimesRuntimeIdEditRoute;
+  AgentsAgentIdIndexRoute: typeof AgentsAgentIdIndexRoute;
+  RuntimesRuntimeIdIndexRoute: typeof RuntimesRuntimeIdIndexRoute;
 }
 
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    '/usage': {
-      id: '/usage'
-      path: '/usage'
-      fullPath: '/usage'
-      preLoaderRoute: typeof UsageRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/skills': {
-      id: '/skills'
-      path: '/skills'
-      fullPath: '/skills'
-      preLoaderRoute: typeof SkillsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/settings': {
-      id: '/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof SettingsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/plugins': {
-      id: '/plugins'
-      path: '/plugins'
-      fullPath: '/plugins'
-      preLoaderRoute: typeof PluginsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/pipelines': {
-      id: '/pipelines'
-      path: '/pipelines'
-      fullPath: '/pipelines'
-      preLoaderRoute: typeof PipelinesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/local-agents': {
-      id: '/local-agents'
-      path: '/local-agents'
-      fullPath: '/local-agents'
-      preLoaderRoute: typeof LocalAgentsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/distillations': {
-      id: '/distillations'
-      path: '/distillations'
-      fullPath: '/distillations'
-      preLoaderRoute: typeof DistillationsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/connectors': {
-      id: '/connectors'
-      path: '/connectors'
-      fullPath: '/connectors'
-      preLoaderRoute: typeof ConnectorsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/components': {
-      id: '/components'
-      path: '/components'
-      fullPath: '/components'
-      preLoaderRoute: typeof ComponentsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/canvas': {
-      id: '/canvas'
-      path: '/canvas'
-      fullPath: '/canvas'
-      preLoaderRoute: typeof CanvasRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/runtimes/': {
-      id: '/runtimes/'
-      path: '/runtimes'
-      fullPath: '/runtimes/'
-      preLoaderRoute: typeof RuntimesIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/pipelines/': {
-      id: '/pipelines/'
-      path: '/'
-      fullPath: '/pipelines/'
-      preLoaderRoute: typeof PipelinesIndexRouteImport
-      parentRoute: typeof PipelinesRoute
-    }
-    '/distillations/': {
-      id: '/distillations/'
-      path: '/'
-      fullPath: '/distillations/'
-      preLoaderRoute: typeof DistillationsIndexRouteImport
-      parentRoute: typeof DistillationsRoute
-    }
-    '/agents/': {
-      id: '/agents/'
-      path: '/agents'
-      fullPath: '/agents/'
-      preLoaderRoute: typeof AgentsIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/pipelines/objects': {
-      id: '/pipelines/objects'
-      path: '/objects'
-      fullPath: '/pipelines/objects'
-      preLoaderRoute: typeof PipelinesObjectsRouteImport
-      parentRoute: typeof PipelinesRoute
-    }
-    '/pipelines/jobs': {
-      id: '/pipelines/jobs'
-      path: '/jobs'
-      fullPath: '/pipelines/jobs'
-      preLoaderRoute: typeof PipelinesJobsRouteImport
-      parentRoute: typeof PipelinesRoute
-    }
-    '/pipelines/$pipelineId': {
-      id: '/pipelines/$pipelineId'
-      path: '/$pipelineId'
-      fullPath: '/pipelines/$pipelineId'
-      preLoaderRoute: typeof PipelinesPipelineIdRouteImport
-      parentRoute: typeof PipelinesRoute
-    }
-    '/distillations/new': {
-      id: '/distillations/new'
-      path: '/new'
-      fullPath: '/distillations/new'
-      preLoaderRoute: typeof DistillationsNewRouteImport
-      parentRoute: typeof DistillationsRoute
-    }
-    '/distillations/$distillationId': {
-      id: '/distillations/$distillationId'
-      path: '/$distillationId'
-      fullPath: '/distillations/$distillationId'
-      preLoaderRoute: typeof DistillationsDistillationIdRouteImport
-      parentRoute: typeof DistillationsRoute
-    }
-    '/runtimes/$runtimeId/': {
-      id: '/runtimes/$runtimeId/'
-      path: '/runtimes/$runtimeId'
-      fullPath: '/runtimes/$runtimeId/'
-      preLoaderRoute: typeof RuntimesRuntimeIdIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/pipelines/operations/': {
-      id: '/pipelines/operations/'
-      path: '/operations'
-      fullPath: '/pipelines/operations/'
-      preLoaderRoute: typeof PipelinesOperationsIndexRouteImport
-      parentRoute: typeof PipelinesRoute
-    }
-    '/agents/$agentId/': {
-      id: '/agents/$agentId/'
-      path: '/agents/$agentId'
-      fullPath: '/agents/$agentId/'
-      preLoaderRoute: typeof AgentsAgentIdIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/runtimes/$runtimeId/edit': {
-      id: '/runtimes/$runtimeId/edit'
-      path: '/runtimes/$runtimeId/edit'
-      fullPath: '/runtimes/$runtimeId/edit'
-      preLoaderRoute: typeof RuntimesRuntimeIdEditRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/pipelines/operations/new': {
-      id: '/pipelines/operations/new'
-      path: '/operations/new'
-      fullPath: '/pipelines/operations/new'
-      preLoaderRoute: typeof PipelinesOperationsNewRouteImport
-      parentRoute: typeof PipelinesRoute
-    }
-    '/pipelines/objects/$objectTypeId': {
-      id: '/pipelines/objects/$objectTypeId'
-      path: '/$objectTypeId'
-      fullPath: '/pipelines/objects/$objectTypeId'
-      preLoaderRoute: typeof PipelinesObjectsObjectTypeIdRouteImport
-      parentRoute: typeof PipelinesObjectsRoute
-    }
-    '/pipelines/jobs/$jobId': {
-      id: '/pipelines/jobs/$jobId'
-      path: '/$jobId'
-      fullPath: '/pipelines/jobs/$jobId'
-      preLoaderRoute: typeof PipelinesJobsJobIdRouteImport
-      parentRoute: typeof PipelinesJobsRoute
-    }
-    '/pipelines/operations/$operationId/': {
-      id: '/pipelines/operations/$operationId/'
-      path: '/operations/$operationId'
-      fullPath: '/pipelines/operations/$operationId/'
-      preLoaderRoute: typeof PipelinesOperationsOperationIdIndexRouteImport
-      parentRoute: typeof PipelinesRoute
-    }
-    '/pipelines/operations/$operationId/edit': {
-      id: '/pipelines/operations/$operationId/edit'
-      path: '/operations/$operationId/edit'
-      fullPath: '/pipelines/operations/$operationId/edit'
-      preLoaderRoute: typeof PipelinesOperationsOperationIdEditRouteImport
-      parentRoute: typeof PipelinesRoute
-    }
+    "/usage": {
+      id: "/usage";
+      path: "/usage";
+      fullPath: "/usage";
+      preLoaderRoute: typeof UsageRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/skills": {
+      id: "/skills";
+      path: "/skills";
+      fullPath: "/skills";
+      preLoaderRoute: typeof SkillsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/settings": {
+      id: "/settings";
+      path: "/settings";
+      fullPath: "/settings";
+      preLoaderRoute: typeof SettingsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/schedule": {
+      id: "/schedule";
+      path: "/schedule";
+      fullPath: "/schedule";
+      preLoaderRoute: typeof ScheduleRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/plugins": {
+      id: "/plugins";
+      path: "/plugins";
+      fullPath: "/plugins";
+      preLoaderRoute: typeof PluginsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/pipelines": {
+      id: "/pipelines";
+      path: "/pipelines";
+      fullPath: "/pipelines";
+      preLoaderRoute: typeof PipelinesRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/local-agents": {
+      id: "/local-agents";
+      path: "/local-agents";
+      fullPath: "/local-agents";
+      preLoaderRoute: typeof LocalAgentsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/distillations": {
+      id: "/distillations";
+      path: "/distillations";
+      fullPath: "/distillations";
+      preLoaderRoute: typeof DistillationsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/connectors": {
+      id: "/connectors";
+      path: "/connectors";
+      fullPath: "/connectors";
+      preLoaderRoute: typeof ConnectorsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/components": {
+      id: "/components";
+      path: "/components";
+      fullPath: "/components";
+      preLoaderRoute: typeof ComponentsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/canvas": {
+      id: "/canvas";
+      path: "/canvas";
+      fullPath: "/canvas";
+      preLoaderRoute: typeof CanvasRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/assistant": {
+      id: "/assistant";
+      path: "/assistant";
+      fullPath: "/assistant";
+      preLoaderRoute: typeof AssistantRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/": {
+      id: "/";
+      path: "/";
+      fullPath: "/";
+      preLoaderRoute: typeof IndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/runtimes/": {
+      id: "/runtimes/";
+      path: "/runtimes";
+      fullPath: "/runtimes/";
+      preLoaderRoute: typeof RuntimesIndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/pipelines/": {
+      id: "/pipelines/";
+      path: "/";
+      fullPath: "/pipelines/";
+      preLoaderRoute: typeof PipelinesIndexRouteImport;
+      parentRoute: typeof PipelinesRoute;
+    };
+    "/distillations/": {
+      id: "/distillations/";
+      path: "/";
+      fullPath: "/distillations/";
+      preLoaderRoute: typeof DistillationsIndexRouteImport;
+      parentRoute: typeof DistillationsRoute;
+    };
+    "/agents/": {
+      id: "/agents/";
+      path: "/agents";
+      fullPath: "/agents/";
+      preLoaderRoute: typeof AgentsIndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/pipelines/objects": {
+      id: "/pipelines/objects";
+      path: "/objects";
+      fullPath: "/pipelines/objects";
+      preLoaderRoute: typeof PipelinesObjectsRouteImport;
+      parentRoute: typeof PipelinesRoute;
+    };
+    "/pipelines/jobs": {
+      id: "/pipelines/jobs";
+      path: "/jobs";
+      fullPath: "/pipelines/jobs";
+      preLoaderRoute: typeof PipelinesJobsRouteImport;
+      parentRoute: typeof PipelinesRoute;
+    };
+    "/pipelines/$pipelineId": {
+      id: "/pipelines/$pipelineId";
+      path: "/$pipelineId";
+      fullPath: "/pipelines/$pipelineId";
+      preLoaderRoute: typeof PipelinesPipelineIdRouteImport;
+      parentRoute: typeof PipelinesRoute;
+    };
+    "/distillations/new": {
+      id: "/distillations/new";
+      path: "/new";
+      fullPath: "/distillations/new";
+      preLoaderRoute: typeof DistillationsNewRouteImport;
+      parentRoute: typeof DistillationsRoute;
+    };
+    "/distillations/$distillationId": {
+      id: "/distillations/$distillationId";
+      path: "/$distillationId";
+      fullPath: "/distillations/$distillationId";
+      preLoaderRoute: typeof DistillationsDistillationIdRouteImport;
+      parentRoute: typeof DistillationsRoute;
+    };
+    "/runtimes/$runtimeId/": {
+      id: "/runtimes/$runtimeId/";
+      path: "/runtimes/$runtimeId";
+      fullPath: "/runtimes/$runtimeId/";
+      preLoaderRoute: typeof RuntimesRuntimeIdIndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/pipelines/operations/": {
+      id: "/pipelines/operations/";
+      path: "/operations";
+      fullPath: "/pipelines/operations/";
+      preLoaderRoute: typeof PipelinesOperationsIndexRouteImport;
+      parentRoute: typeof PipelinesRoute;
+    };
+    "/agents/$agentId/": {
+      id: "/agents/$agentId/";
+      path: "/agents/$agentId";
+      fullPath: "/agents/$agentId/";
+      preLoaderRoute: typeof AgentsAgentIdIndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/runtimes/$runtimeId/edit": {
+      id: "/runtimes/$runtimeId/edit";
+      path: "/runtimes/$runtimeId/edit";
+      fullPath: "/runtimes/$runtimeId/edit";
+      preLoaderRoute: typeof RuntimesRuntimeIdEditRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/pipelines/operations/new": {
+      id: "/pipelines/operations/new";
+      path: "/operations/new";
+      fullPath: "/pipelines/operations/new";
+      preLoaderRoute: typeof PipelinesOperationsNewRouteImport;
+      parentRoute: typeof PipelinesRoute;
+    };
+    "/pipelines/objects/$objectTypeId": {
+      id: "/pipelines/objects/$objectTypeId";
+      path: "/$objectTypeId";
+      fullPath: "/pipelines/objects/$objectTypeId";
+      preLoaderRoute: typeof PipelinesObjectsObjectTypeIdRouteImport;
+      parentRoute: typeof PipelinesObjectsRoute;
+    };
+    "/pipelines/jobs/$jobId": {
+      id: "/pipelines/jobs/$jobId";
+      path: "/$jobId";
+      fullPath: "/pipelines/jobs/$jobId";
+      preLoaderRoute: typeof PipelinesJobsJobIdRouteImport;
+      parentRoute: typeof PipelinesJobsRoute;
+    };
+    "/pipelines/operations/$operationId/": {
+      id: "/pipelines/operations/$operationId/";
+      path: "/operations/$operationId";
+      fullPath: "/pipelines/operations/$operationId/";
+      preLoaderRoute: typeof PipelinesOperationsOperationIdIndexRouteImport;
+      parentRoute: typeof PipelinesRoute;
+    };
+    "/pipelines/operations/$operationId/edit": {
+      id: "/pipelines/operations/$operationId/edit";
+      path: "/operations/$operationId/edit";
+      fullPath: "/pipelines/operations/$operationId/edit";
+      preLoaderRoute: typeof PipelinesOperationsOperationIdEditRouteImport;
+      parentRoute: typeof PipelinesRoute;
+    };
   }
 }
 
 interface DistillationsRouteChildren {
-  DistillationsDistillationIdRoute: typeof DistillationsDistillationIdRoute
-  DistillationsNewRoute: typeof DistillationsNewRoute
-  DistillationsIndexRoute: typeof DistillationsIndexRoute
+  DistillationsDistillationIdRoute: typeof DistillationsDistillationIdRoute;
+  DistillationsNewRoute: typeof DistillationsNewRoute;
+  DistillationsIndexRoute: typeof DistillationsIndexRoute;
 }
 
 const DistillationsRouteChildren: DistillationsRouteChildren = {
   DistillationsDistillationIdRoute: DistillationsDistillationIdRoute,
   DistillationsNewRoute: DistillationsNewRoute,
   DistillationsIndexRoute: DistillationsIndexRoute,
-}
+};
 
 const DistillationsRouteWithChildren = DistillationsRoute._addFileChildren(
   DistillationsRouteChildren,
-)
+);
 
 interface PipelinesJobsRouteChildren {
-  PipelinesJobsJobIdRoute: typeof PipelinesJobsJobIdRoute
+  PipelinesJobsJobIdRoute: typeof PipelinesJobsJobIdRoute;
 }
 
 const PipelinesJobsRouteChildren: PipelinesJobsRouteChildren = {
   PipelinesJobsJobIdRoute: PipelinesJobsJobIdRoute,
-}
+};
 
 const PipelinesJobsRouteWithChildren = PipelinesJobsRoute._addFileChildren(
   PipelinesJobsRouteChildren,
-)
+);
 
 interface PipelinesObjectsRouteChildren {
-  PipelinesObjectsObjectTypeIdRoute: typeof PipelinesObjectsObjectTypeIdRoute
+  PipelinesObjectsObjectTypeIdRoute: typeof PipelinesObjectsObjectTypeIdRoute;
 }
 
 const PipelinesObjectsRouteChildren: PipelinesObjectsRouteChildren = {
   PipelinesObjectsObjectTypeIdRoute: PipelinesObjectsObjectTypeIdRoute,
-}
+};
 
-const PipelinesObjectsRouteWithChildren =
-  PipelinesObjectsRoute._addFileChildren(PipelinesObjectsRouteChildren)
+const PipelinesObjectsRouteWithChildren = PipelinesObjectsRoute._addFileChildren(
+  PipelinesObjectsRouteChildren,
+);
 
 interface PipelinesRouteChildren {
-  PipelinesPipelineIdRoute: typeof PipelinesPipelineIdRoute
-  PipelinesJobsRoute: typeof PipelinesJobsRouteWithChildren
-  PipelinesObjectsRoute: typeof PipelinesObjectsRouteWithChildren
-  PipelinesIndexRoute: typeof PipelinesIndexRoute
-  PipelinesOperationsNewRoute: typeof PipelinesOperationsNewRoute
-  PipelinesOperationsIndexRoute: typeof PipelinesOperationsIndexRoute
-  PipelinesOperationsOperationIdEditRoute: typeof PipelinesOperationsOperationIdEditRoute
-  PipelinesOperationsOperationIdIndexRoute: typeof PipelinesOperationsOperationIdIndexRoute
+  PipelinesPipelineIdRoute: typeof PipelinesPipelineIdRoute;
+  PipelinesJobsRoute: typeof PipelinesJobsRouteWithChildren;
+  PipelinesObjectsRoute: typeof PipelinesObjectsRouteWithChildren;
+  PipelinesIndexRoute: typeof PipelinesIndexRoute;
+  PipelinesOperationsNewRoute: typeof PipelinesOperationsNewRoute;
+  PipelinesOperationsIndexRoute: typeof PipelinesOperationsIndexRoute;
+  PipelinesOperationsOperationIdEditRoute: typeof PipelinesOperationsOperationIdEditRoute;
+  PipelinesOperationsOperationIdIndexRoute: typeof PipelinesOperationsOperationIdIndexRoute;
 }
 
 const PipelinesRouteChildren: PipelinesRouteChildren = {
@@ -660,18 +698,15 @@ const PipelinesRouteChildren: PipelinesRouteChildren = {
   PipelinesIndexRoute: PipelinesIndexRoute,
   PipelinesOperationsNewRoute: PipelinesOperationsNewRoute,
   PipelinesOperationsIndexRoute: PipelinesOperationsIndexRoute,
-  PipelinesOperationsOperationIdEditRoute:
-    PipelinesOperationsOperationIdEditRoute,
-  PipelinesOperationsOperationIdIndexRoute:
-    PipelinesOperationsOperationIdIndexRoute,
-}
+  PipelinesOperationsOperationIdEditRoute: PipelinesOperationsOperationIdEditRoute,
+  PipelinesOperationsOperationIdIndexRoute: PipelinesOperationsOperationIdIndexRoute,
+};
 
-const PipelinesRouteWithChildren = PipelinesRoute._addFileChildren(
-  PipelinesRouteChildren,
-)
+const PipelinesRouteWithChildren = PipelinesRoute._addFileChildren(PipelinesRouteChildren);
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AssistantRoute: AssistantRoute,
   CanvasRoute: CanvasRoute,
   ComponentsRoute: ComponentsRoute,
   ConnectorsRoute: ConnectorsRoute,
@@ -679,6 +714,7 @@ const rootRouteChildren: RootRouteChildren = {
   LocalAgentsRoute: LocalAgentsRoute,
   PipelinesRoute: PipelinesRouteWithChildren,
   PluginsRoute: PluginsRoute,
+  ScheduleRoute: ScheduleRoute,
   SettingsRoute: SettingsRoute,
   SkillsRoute: SkillsRoute,
   UsageRoute: UsageRoute,
@@ -687,7 +723,7 @@ const rootRouteChildren: RootRouteChildren = {
   RuntimesRuntimeIdEditRoute: RuntimesRuntimeIdEditRoute,
   AgentsAgentIdIndexRoute: AgentsAgentIdIndexRoute,
   RuntimesRuntimeIdIndexRoute: RuntimesRuntimeIdIndexRoute,
-}
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();

--- a/apps/desktop-app/src/routes/assistant.tsx
+++ b/apps/desktop-app/src/routes/assistant.tsx
@@ -1,9 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ConversationsPage } from "@repo/views/ConversationsPage";
 
-export const Route = createFileRoute("/_layout/assistant")({
-  head: () => ({
-    meta: [{ title: "Conversations | Ordine" }],
-  }),
+export const Route = createFileRoute("/assistant")({
   component: ConversationsPage,
 });

--- a/apps/desktop-app/src/routes/schedule.tsx
+++ b/apps/desktop-app/src/routes/schedule.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SchedulePage } from "@repo/views/SchedulePage";
+
+export const Route = createFileRoute("/schedule")({
+  component: SchedulePage,
+});

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -37,6 +37,8 @@
     "./CanvasPage": "./src/pages/CanvasPage/index.ts",
     "./SettingsPage": "./src/pages/SettingsPage/index.ts",
     "./PluginsPage": "./src/pages/PluginsPage/index.ts",
+    "./SchedulePage": "./src/pages/SchedulePage/index.ts",
+    "./ConversationsPage": "./src/pages/ConversationsPage/index.ts",
     "./LoginPage": "./src/pages/LoginPage/index.ts",
     "./SignUpPage": "./src/pages/SignUpPage/index.ts",
     "./PipelinesPage": "./src/pages/PipelinesPage/index.ts",

--- a/packages/views/src/components/AppSidebar.tsx
+++ b/packages/views/src/components/AppSidebar.tsx
@@ -2,39 +2,27 @@ import { useEffect, type ReactNode } from "react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { useStore } from "zustand";
 import {
-  Activity,
-  BookOpen,
   Bot,
-  Box,
-  Boxes,
-  ChevronDown,
-  Cpu,
+  CalendarClock,
   ExternalLink,
-  FlaskConical,
-  Gauge,
   Layers,
-  Plug,
+  MessageSquare,
   Puzzle,
   Search,
   Settings,
   SquarePen,
   Workflow,
-  Zap,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
-  SidebarSeparator,
   SidebarTrigger,
   useSidebar,
 } from "@repo/ui/sidebar";
@@ -45,31 +33,17 @@ import {
   DropdownMenuTrigger,
 } from "@repo/ui/dropdown-menu";
 import { Button } from "@repo/ui/button";
-import { cn } from "@repo/ui/lib/utils";
 import { useSidebarStore } from "../store/sidebarStore";
-import { NavGroup, NavItems, type NavItem } from "./NavGroup";
+import { NavGroup, type NavItem } from "./NavGroup";
 import { DefaultUserFooter, ProjectSwitcher } from "./ProjectSwitcher";
 import { NotificationCenter } from "./NotificationCenter";
 
-const assemblyItems: NavItem[] = [
+const mainItems: NavItem[] = [
   { labelKey: "nav.pipelines", icon: Layers, to: "/pipelines", exact: true },
-  { labelKey: "nav.components", icon: Boxes, to: "/components" },
-  { labelKey: "nav.operations", icon: Zap, to: "/pipelines/operations" },
-  { labelKey: "nav.objects", icon: Box, to: "/pipelines/objects" },
-];
-
-const monitorItems: NavItem[] = [
-  { labelKey: "nav.jobs", icon: Activity, to: "/pipelines/jobs" },
-  { labelKey: "nav.items.usage", icon: Gauge, to: "/usage" },
-  { labelKey: "nav.distillations", icon: FlaskConical, to: "/distillations" },
-];
-
-const capabilityItems: NavItem[] = [
-  { labelKey: "nav.agents", icon: Bot, to: "/agents" },
-  { labelKey: "nav.items.localAgents", icon: Cpu, to: "/local-agents" },
-  { labelKey: "nav.skills", icon: BookOpen, to: "/skills" },
-  { labelKey: "nav.items.connectors", icon: Plug, to: "/connectors" },
+  { labelKey: "nav.schedule", icon: CalendarClock, to: "/schedule" },
   { labelKey: "nav.plugins", icon: Puzzle, to: "/plugins" },
+  { labelKey: "nav.agents", icon: Bot, to: "/agents" },
+  { labelKey: "nav.conversations", icon: MessageSquare, to: "/assistant" },
 ];
 
 export interface AppSidebarProps {
@@ -116,9 +90,7 @@ export const AppSidebar = ({
   const { t } = useTranslation();
   const { state: sidebarState } = useSidebar();
   const store = useSidebarStore();
-  const capabilitiesOpen = useStore(store, (state) => state.capabilitiesOpen);
   const handleSidebarLocationChange = useStore(store, (state) => state.handleSidebarLocationChange);
-  const handleCapabilitiesToggle = useStore(store, (state) => state.handleCapabilitiesToggle);
   const handleDefaultSearch = useStore(store, (state) => state.handleSearchButtonClick);
   const handleSearchClick = handleSearch ?? handleDefaultSearch;
   const currentPath = location.pathname;
@@ -171,46 +143,11 @@ export const AppSidebar = ({
 
       <SidebarContent className="py-2">
         <NavGroup
-          ariaLabel={t("nav.groups.assembly", { defaultValue: "Assembly" })}
+          ariaLabel={t("nav.groups.main", { defaultValue: "Main" })}
           currentPath={currentPath}
-          items={assemblyItems}
-          label={t("nav.groups.assembly", { defaultValue: "Assembly" })}
+          items={mainItems}
           t={t}
         />
-        <NavGroup
-          ariaLabel={t("nav.groups.monitor", { defaultValue: "Monitor" })}
-          currentPath={currentPath}
-          items={monitorItems}
-          label={t("nav.groups.monitor", { defaultValue: "Monitor" })}
-          t={t}
-        />
-        <SidebarSeparator className="my-1 bg-sidebar-border/60" />
-        <SidebarGroup
-          aria-label={t("nav.groups.capabilities", { defaultValue: "Capabilities" })}
-          className="px-2! py-0!"
-        >
-          <SidebarGroupLabel
-            className="h-7 px-2 text-[11px] font-medium uppercase text-foreground/70 group-data-[collapsible=icon]:sr-only"
-            render={
-              <button
-                aria-expanded={capabilitiesOpen}
-                className="flex w-full items-center gap-2 rounded-md text-left hover:text-foreground"
-                type="button"
-                onClick={handleCapabilitiesToggle}
-              />
-            }
-          >
-            <span>{t("nav.groups.capabilities", { defaultValue: "Capabilities" })}</span>
-            <ChevronDown
-              className={cn("ml-auto transition-transform", !capabilitiesOpen && "-rotate-90")}
-            />
-          </SidebarGroupLabel>
-          {capabilitiesOpen && (
-            <SidebarGroupContent>
-              <NavItems currentPath={currentPath} items={capabilityItems} t={t} />
-            </SidebarGroupContent>
-          )}
-        </SidebarGroup>
       </SidebarContent>
 
       <SidebarFooter className="border-t p-2">

--- a/packages/views/src/components/AppSidebar.unit.test.tsx
+++ b/packages/views/src/components/AppSidebar.unit.test.tsx
@@ -38,7 +38,7 @@ describe("AppSidebar", () => {
     localStorage.clear();
   });
 
-  it("renders three navigation groups and valid routes", () => {
+  it("renders the flat main navigation and valid routes", () => {
     const store = createSidebarStore();
     const notificationStore = createNotificationStore();
     render(
@@ -51,38 +51,15 @@ describe("AppSidebar", () => {
       </NotificationStoreContext.Provider>,
     );
 
-    expect(screen.getByText("装配")).toBeInTheDocument();
-    expect(screen.getByText("监控")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "能力" })).toHaveAttribute("aria-expanded", "false");
     expect(screen.getByRole("link", { name: "流水线" })).toHaveAttribute("href", "/pipelines");
-    expect(screen.getByRole("link", { name: "任务" })).toHaveAttribute("href", "/pipelines/jobs");
+    expect(screen.getByRole("link", { name: "定时任务" })).toHaveAttribute("href", "/schedule");
+    expect(screen.getByRole("link", { name: "插件" })).toHaveAttribute("href", "/plugins");
+    expect(screen.getByRole("link", { name: "智能体" })).toHaveAttribute("href", "/agents");
+    expect(screen.getByRole("link", { name: "对话" })).toHaveAttribute("href", "/assistant");
     expect(screen.getByRole("link", { name: "设置" })).toHaveAttribute("href", "/settings");
+    expect(screen.queryByRole("link", { name: "组件" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "连接器" })).not.toBeInTheDocument();
     expect(screen.getByRole("separator", { name: "Resize or toggle sidebar" })).toBeInTheDocument();
-    for (const label of ["装配", "监控", "能力"]) {
-      expect(screen.getByLabelText(label)).toHaveClass("px-2!", "py-0!");
-      expect(screen.getByLabelText(label)).not.toHaveClass("p-0");
-    }
-  });
-
-  it("persists the capabilities expanded state", () => {
-    const store = createSidebarStore();
-    const notificationStore = createNotificationStore();
-    render(
-      <NotificationStoreContext.Provider value={notificationStore}>
-        <SidebarStoreContext.Provider value={store}>
-          <SidebarProvider>
-            <AppSidebar />
-          </SidebarProvider>
-        </SidebarStoreContext.Provider>
-      </NotificationStoreContext.Provider>,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "能力" }));
-
-    expect(screen.getByRole("link", { name: "连接器" })).toHaveAttribute("href", "/connectors");
-    expect(screen.getByRole("link", { name: "设置" })).toHaveAttribute("href", "/settings");
-    expect(store.getState().capabilitiesOpen).toBe(true);
-    expect(localStorage.getItem("ordine.sidebar.capabilitiesOpen")).toBe("true");
   });
 
   it("centers the only visible header control when collapsed", () => {

--- a/packages/views/src/pages/CanvasPage/AgentPanel/Composer/Composer.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/Composer/Composer.tsx
@@ -225,7 +225,7 @@ export const Composer = ({
           <Textarea
             ref={textareaRef}
             aria-label={t("workspace.agentBar.composer.messageLabel")}
-            className="min-h-7 flex-1 resize-none border-none bg-transparent px-0 py-1 text-[12px] shadow-none focus-visible:ring-0 disabled:bg-transparent dark:disabled:bg-transparent"
+            className="min-h-7 flex-1 resize-none border-none bg-transparent px-0 py-1 text-[12px] shadow-none focus-visible:ring-0 disabled:bg-transparent md:text-[12px] dark:disabled:bg-transparent"
             disabled={isDisabled}
             id="canvas-agent-composer-message"
             name="canvasAgentMessage"

--- a/packages/views/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.tsx
@@ -17,7 +17,7 @@ export const CanvasEmptyState = () => {
   return (
     <div
       className={cn(
-        "pointer-events-none absolute inset-0 z-10 grid place-items-center px-6",
+        "pointer-events-none absolute inset-0 z-[1] grid place-items-center px-6",
         isComponentPanelOpen && "min-[1181px]:pl-[246px]",
       )}
       data-testid="canvas-v2-empty-state"

--- a/packages/views/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasEmptyState/CanvasEmptyState.unit.test.tsx
@@ -33,7 +33,7 @@ describe("CanvasEmptyState", () => {
       "pointer-events-none",
       "absolute",
       "inset-0",
-      "z-10",
+      "z-[1]",
       "grid",
       "place-items-center",
       "px-6",

--- a/packages/views/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasFlow/CanvasFlow.tsx
@@ -49,7 +49,7 @@ const defaultEdgeOptions = {
   type: "semantic" as const,
 };
 
-const proOpts = { hideAttribution: false };
+const proOpts = { hideAttribution: true };
 const snapGrid: [number, number] = [24, 24];
 const nodePortRemeasureDelayMs = 220;
 

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
-import { PanelRightOpen } from "lucide-react";
 import { cn } from "@repo/ui/lib/utils";
 import { ResizeHandle } from "../../../components/ResizeHandle";
 import {
@@ -152,12 +151,12 @@ export const CanvasInner = ({
             />
           </div>
           <div
-            className="pointer-events-none min-h-0 min-w-0 overflow-hidden max-[480px]:flex-1 min-[1181px]:h-full min-[1181px]:shrink-0 min-[1181px]:py-1.5 min-[1181px]:pr-1.5"
+            className="pointer-events-none min-h-0 min-w-0 overflow-hidden max-[480px]:flex-1 min-[1181px]:h-full min-[1181px]:shrink-0 min-[1181px]:p-3"
             data-testid="canvas-agent-panel-region"
           >
             <div
               ref={agentPanelShellRef}
-              className="pointer-events-auto h-full min-h-0 min-w-0 w-full shrink overflow-hidden rounded-2xl bg-surface shadow-float ring-1 ring-border-strong max-[480px]:!w-full"
+              className="pointer-events-auto h-full min-h-0 min-w-0 w-full shrink overflow-hidden rounded-2xl border border-border-strong bg-surface shadow-raised max-[480px]:!w-full"
               data-testid="canvas-agent-panel-shell"
               style={{ width: `${agentPanelWidth}px`, maxWidth: "100%" }}
             >
@@ -165,18 +164,7 @@ export const CanvasInner = ({
             </div>
           </div>
         </div>
-      ) : (
-        <button
-          aria-label={t("canvas.agentPanel.reopen")}
-          className="absolute bottom-0 right-0 top-16 z-30 flex w-12 shrink-0 items-center justify-center border-l border-border bg-surface text-muted-foreground hover:bg-accent hover:text-foreground min-[1181px]:static min-[1181px]:inset-y-0 min-[1181px]:z-auto"
-          data-testid="canvas-agent-panel-reopen"
-          title={t("canvas.agentPanel.reopen")}
-          type="button"
-          onClick={handleToggleAgentPanel}
-        >
-          <PanelRightOpen className="h-4 w-4" />
-        </button>
-      )}
+      ) : null}
 
       <CanvasSettingsDrawer />
       <CanvasWorkspaceSidebarOverlay />

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.unit.test.tsx
@@ -205,9 +205,9 @@ describe("CanvasInner", () => {
     const user = userEvent.setup();
     render(<CanvasInner />, { wrapper });
 
-    expect(screen.getByTestId("canvas-agent-panel-reopen")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-v2-agent-reopen")).toBeInTheDocument();
 
-    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+    await user.click(screen.getByTestId("canvas-v2-agent-reopen"));
 
     const regionWrapper = screen.getByTestId("canvas-agent-panel-region-wrapper");
     const resizeGutter = screen.getByTestId("canvas-agent-panel-resize-gutter");
@@ -221,10 +221,10 @@ describe("CanvasInner", () => {
       "w-full",
       "overflow-hidden",
       "rounded-2xl",
+      "border",
+      "border-border-strong",
       "bg-surface",
-      "shadow-float",
-      "ring-1",
-      "ring-border-strong",
+      "shadow-raised",
       "max-[480px]:!w-full",
     );
     expect(regionWrapper).toHaveClass(
@@ -237,10 +237,9 @@ describe("CanvasInner", () => {
       "max-[480px]:flex-1",
       "min-[1181px]:h-full",
       "min-[1181px]:shrink-0",
-      "min-[1181px]:py-1.5",
-      "min-[1181px]:pr-1.5",
+      "min-[1181px]:p-3",
     );
-    expect(region).not.toHaveClass("bg-surface", "border", "shadow-float", "rounded-2xl");
+    expect(region).not.toHaveClass("bg-surface", "border", "shadow-raised", "rounded-2xl");
     expect(shell.parentElement).toBe(region);
     expect(resizeGutter.nextElementSibling).toBe(region);
     expect(resizeHandle.parentElement).toBe(resizeGutter);
@@ -251,7 +250,7 @@ describe("CanvasInner", () => {
   it("keeps the component library floating when the AgentPanel opens", async () => {
     const user = userEvent.setup();
     render(<CanvasInner />, { wrapper });
-    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+    await user.click(screen.getByTestId("canvas-v2-agent-reopen"));
 
     expect(screen.getByTestId("canvas-agent-panel-region-wrapper")).toHaveClass(
       "absolute",
@@ -270,7 +269,7 @@ describe("CanvasInner", () => {
   it("resizes and collapses the AgentPanel from the right-side handle", async () => {
     const user = userEvent.setup();
     render(<CanvasInner />, { wrapper });
-    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+    await user.click(screen.getByTestId("canvas-v2-agent-reopen"));
 
     const globalWindow = globalThis.window;
     const resizeHandle = screen.getByTestId("resize-handle-right");
@@ -281,13 +280,13 @@ describe("CanvasInner", () => {
 
     fireEvent.pointerMove(globalWindow, { clientX: 1100 });
     expect(screen.queryByTestId("canvas-agent-panel-shell")).not.toBeInTheDocument();
-    expect(screen.getByTestId("canvas-agent-panel-reopen")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-v2-agent-reopen")).toBeInTheDocument();
   });
 
   it("starts AgentPanel resizing from its rendered width", async () => {
     const user = userEvent.setup();
     render(<CanvasInner />, { wrapper });
-    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+    await user.click(screen.getByTestId("canvas-v2-agent-reopen"));
 
     const shell = screen.getByTestId("canvas-agent-panel-shell");
     vi.spyOn(shell, "getBoundingClientRect").mockReturnValue({
@@ -312,7 +311,7 @@ describe("CanvasInner", () => {
   it("supports keyboard resizing and exposes separator values", async () => {
     const user = userEvent.setup();
     render(<CanvasInner />, { wrapper });
-    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+    await user.click(screen.getByTestId("canvas-v2-agent-reopen"));
 
     const resizeHandle = screen.getByTestId("resize-handle-right");
     expect(resizeHandle).toHaveAttribute("tabindex", "0");
@@ -330,7 +329,7 @@ describe("CanvasInner", () => {
   it("cleans up AgentPanel dragging after pointer cancellation", async () => {
     const user = userEvent.setup();
     render(<CanvasInner />, { wrapper });
-    await user.click(screen.getByTestId("canvas-agent-panel-reopen"));
+    await user.click(screen.getByTestId("canvas-v2-agent-reopen"));
 
     const resizeHandle = screen.getByTestId("resize-handle-right");
     fireEvent.pointerDown(resizeHandle, { clientX: 900 });
@@ -352,7 +351,7 @@ describe("CanvasInner", () => {
     expect(
       screen.queryByRole("menuitem", { name: /^(AI Assistant|AI 助手)$/i }),
     ).not.toBeInTheDocument();
-    expect(screen.getByTestId("canvas-agent-panel-reopen")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-v2-agent-reopen")).toBeInTheDocument();
   });
 
   it("opens the workspace sidebar overlay from the mini sidebar", async () => {
@@ -363,7 +362,8 @@ describe("CanvasInner", () => {
 
     expect(screen.getByTestId("canvas-workspace-sidebar-overlay")).toBeInTheDocument();
     expect(screen.getByText("Pipelines")).toBeInTheDocument();
-    expect(screen.getByText("Assembly")).toBeInTheDocument();
+    expect(screen.getByText("Schedule")).toBeInTheDocument();
+    expect(screen.getByText("Conversations")).toBeInTheDocument();
   });
 
   it("shows the canvas empty state when there are no nodes", () => {

--- a/packages/views/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.tsx
@@ -1,17 +1,11 @@
 import {
-  Activity,
   Bot,
-  BookOpen,
-  Box,
-  Boxes,
-  Cpu,
+  CalendarClock,
   FileDown,
   FileUp,
-  FlaskConical,
-  Gauge,
   Home,
   Layers,
-  Plug,
+  MessageSquare,
   Puzzle,
   Redo2,
   Save,
@@ -19,7 +13,6 @@ import {
   Undo2,
   Workflow,
   X,
-  Zap,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
@@ -39,34 +32,12 @@ import { useCanvasPageStore } from "../_store";
 import { CANVAS_WORKSPACE_SIDEBAR_ID } from "../CanvasMiniSidebar";
 import { useCanvasWorkspacePersistence } from "../useCanvasWorkspacePersistence";
 
-const workspaceGroups = [
-  {
-    labelKey: "nav.groups.assembly",
-    links: [
-      { icon: Layers, labelKey: "nav.pipelines", to: "/pipelines" },
-      { icon: Boxes, labelKey: "nav.components", to: "/components" },
-      { icon: Zap, labelKey: "nav.operations", to: "/pipelines/operations" },
-      { icon: Box, labelKey: "nav.objects", to: "/pipelines/objects" },
-    ],
-  },
-  {
-    labelKey: "nav.groups.monitor",
-    links: [
-      { icon: Activity, labelKey: "nav.jobs", to: "/pipelines/jobs" },
-      { icon: Gauge, labelKey: "nav.items.usage", to: "/usage" },
-      { icon: FlaskConical, labelKey: "nav.distillations", to: "/distillations" },
-    ],
-  },
-  {
-    labelKey: "nav.groups.capabilities",
-    links: [
-      { icon: Bot, labelKey: "nav.agents", to: "/agents" },
-      { icon: Cpu, labelKey: "nav.items.localAgents", to: "/local-agents" },
-      { icon: BookOpen, labelKey: "nav.skills", to: "/skills" },
-      { icon: Plug, labelKey: "nav.items.connectors", to: "/connectors" },
-      { icon: Puzzle, labelKey: "nav.plugins", to: "/plugins" },
-    ],
-  },
+const workspaceLinks = [
+  { icon: Layers, labelKey: "nav.pipelines", to: "/pipelines" },
+  { icon: CalendarClock, labelKey: "nav.schedule", to: "/schedule" },
+  { icon: Puzzle, labelKey: "nav.plugins", to: "/plugins" },
+  { icon: Bot, labelKey: "nav.agents", to: "/agents" },
+  { icon: MessageSquare, labelKey: "nav.conversations", to: "/assistant" },
 ] as const;
 
 export const CanvasWorkspaceSidebarOverlay = () => {
@@ -193,30 +164,28 @@ export const CanvasWorkspaceSidebarOverlay = () => {
             </div>
           </section>
 
-          {workspaceGroups.map((group) => (
-            <section key={group.labelKey} className="space-y-1.5">
-              <p className="px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                {t(group.labelKey)}
-              </p>
-              <div className="grid gap-0.5">
-                {group.links.map((item) => {
-                  const Icon = item.icon;
+          <section className="space-y-1.5">
+            <p className="px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+              {t("nav.groups.main", { defaultValue: "Main" })}
+            </p>
+            <div className="grid gap-0.5">
+              {workspaceLinks.map((item) => {
+                const Icon = item.icon;
 
-                  return (
-                    <Link
-                      key={item.to}
-                      className="flex h-8 items-center gap-2 rounded-md px-2 text-[12.5px] text-foreground hover:bg-muted"
-                      to={item.to}
-                      onClick={handleCloseDrawer}
-                    >
-                      <Icon className="size-3.5 text-muted-foreground" />
-                      <span>{t(item.labelKey)}</span>
-                    </Link>
-                  );
-                })}
-              </div>
-            </section>
-          ))}
+                return (
+                  <Link
+                    key={item.to}
+                    className="flex h-8 items-center gap-2 rounded-md px-2 text-[12.5px] text-foreground hover:bg-muted"
+                    to={item.to}
+                    onClick={handleCloseDrawer}
+                  >
+                    <Icon className="size-3.5 text-muted-foreground" />
+                    <span>{t(item.labelKey)}</span>
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
         </div>
 
         <div className="grid gap-1 border-t p-3">

--- a/packages/views/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasWorkspaceSidebarOverlay/CanvasWorkspaceSidebarOverlay.unit.test.tsx
@@ -47,9 +47,16 @@ describe("CanvasWorkspaceSidebarOverlay", () => {
       "href",
       "/pipelines",
     );
-    expect(screen.getByText(/Assembly|装配/i)).toBeInTheDocument();
-    expect(screen.getByText(/Monitor|监控/i)).toBeInTheDocument();
-    expect(screen.getByText(/Capabilities|能力/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Schedule|定时任务/i })).toHaveAttribute(
+      "href",
+      "/schedule",
+    );
+    expect(screen.getByRole("link", { name: /Plugins|插件/i })).toHaveAttribute("href", "/plugins");
+    expect(screen.getByRole("link", { name: /Agents|智能体/i })).toHaveAttribute("href", "/agents");
+    expect(screen.getByRole("link", { name: /Conversations|对话/i })).toHaveAttribute(
+      "href",
+      "/assistant",
+    );
 
     await user.click(screen.getByRole("button", { name: /Save|保存/i }));
 

--- a/packages/views/src/pages/ConversationsPage/ConversationsPage.tsx
+++ b/packages/views/src/pages/ConversationsPage/ConversationsPage.tsx
@@ -1,0 +1,5 @@
+import { ConversationsPageContent } from "./ConversationsPageContent";
+
+export const ConversationsPage = () => {
+  return <ConversationsPageContent />;
+};

--- a/packages/views/src/pages/ConversationsPage/ConversationsPageContent/ConversationsPageContent.tsx
+++ b/packages/views/src/pages/ConversationsPage/ConversationsPageContent/ConversationsPageContent.tsx
@@ -1,0 +1,26 @@
+import { MessageSquare } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { PageHeader } from "../../../components/PageHeader";
+import { PageState } from "../../../components/PageState";
+
+export const ConversationsPageContent = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <PageHeader
+        icon={<MessageSquare className="h-4 w-4 text-primary" />}
+        sub={t("conversations.subtitle")}
+        title={t("conversations.title")}
+      />
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-8 pt-4 sm:px-7">
+        <PageState
+          description={t("conversations.emptyDescription")}
+          icon={<MessageSquare />}
+          title={t("conversations.emptyTitle")}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/views/src/pages/ConversationsPage/ConversationsPageContent/index.ts
+++ b/packages/views/src/pages/ConversationsPage/ConversationsPageContent/index.ts
@@ -1,0 +1,1 @@
+export * from "./ConversationsPageContent";

--- a/packages/views/src/pages/ConversationsPage/index.ts
+++ b/packages/views/src/pages/ConversationsPage/index.ts
@@ -1,0 +1,1 @@
+export * from "./ConversationsPage";

--- a/packages/views/src/pages/SchedulePage/SchedulePage.tsx
+++ b/packages/views/src/pages/SchedulePage/SchedulePage.tsx
@@ -1,0 +1,5 @@
+import { SchedulePageContent } from "./SchedulePageContent";
+
+export const SchedulePage = () => {
+  return <SchedulePageContent />;
+};

--- a/packages/views/src/pages/SchedulePage/SchedulePageContent/SchedulePageContent.tsx
+++ b/packages/views/src/pages/SchedulePage/SchedulePageContent/SchedulePageContent.tsx
@@ -1,0 +1,26 @@
+import { CalendarClock } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { PageHeader } from "../../../components/PageHeader";
+import { PageState } from "../../../components/PageState";
+
+export const SchedulePageContent = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <PageHeader
+        icon={<CalendarClock className="h-4 w-4 text-primary" />}
+        sub={t("schedule.subtitle")}
+        title={t("schedule.title")}
+      />
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-8 pt-4 sm:px-7">
+        <PageState
+          description={t("schedule.emptyDescription")}
+          icon={<CalendarClock />}
+          title={t("schedule.emptyTitle")}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/views/src/pages/SchedulePage/SchedulePageContent/index.ts
+++ b/packages/views/src/pages/SchedulePage/SchedulePageContent/index.ts
@@ -1,0 +1,1 @@
+export * from "./SchedulePageContent";

--- a/packages/views/src/pages/SchedulePage/index.ts
+++ b/packages/views/src/pages/SchedulePage/index.ts
@@ -1,0 +1,1 @@
+export * from "./SchedulePage";

--- a/packages/views/src/pages/SettingsPage/SettingsPageContent/SettingsPageContent.tsx
+++ b/packages/views/src/pages/SettingsPage/SettingsPageContent/SettingsPageContent.tsx
@@ -9,6 +9,7 @@ import {
   Settings,
   ShieldCheck,
   Sliders,
+  SquareStack,
   Wrench,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -24,6 +25,7 @@ import {
   KeyboardSection,
   LanguageSection,
   NotificationsSection,
+  PagesSection,
   ProjectSection,
 } from "../sections";
 
@@ -34,6 +36,7 @@ type Section =
   | "developer"
   | "language"
   | "notifications"
+  | "pages"
   | "project";
 
 const SECTION_ICONS: Record<Section, ComponentType<{ className?: string }>> = {
@@ -43,12 +46,14 @@ const SECTION_ICONS: Record<Section, ComponentType<{ className?: string }>> = {
   developer: Code,
   language: Globe,
   notifications: Bell,
+  pages: SquareStack,
   project: FolderKanban,
 };
 
 const SECTION_GROUPS: Array<{ ids: Section[]; titleKey: string }> = [
   { ids: ["language", "notifications"], titleKey: "settings.groups.workspace" },
   { ids: ["defaults", "autonomy"], titleKey: "settings.groups.execution" },
+  { ids: ["pages"], titleKey: "settings.groups.pages" },
   {
     ids: ["project", "advanced", ...(import.meta.env.DEV ? (["developer"] as Section[]) : [])],
     titleKey: "settings.groups.data",
@@ -136,6 +141,7 @@ export const SettingsPageContent = () => {
             {active === "notifications" && <NotificationsSection />}
             {active === "defaults" && <DefaultsSection />}
             {active === "autonomy" && <AutonomySection />}
+            {active === "pages" && <PagesSection />}
             {active === "project" && <ProjectSection />}
             {active === "advanced" && <AdvancedSection />}
             {active === "developer" && <DeveloperSection />}

--- a/packages/views/src/pages/SettingsPage/sections/PagesSection/PagesSection.tsx
+++ b/packages/views/src/pages/SettingsPage/sections/PagesSection/PagesSection.tsx
@@ -1,0 +1,57 @@
+import {
+  Activity,
+  BookOpen,
+  Box,
+  Boxes,
+  ChevronRight,
+  Cpu,
+  FlaskConical,
+  Gauge,
+  Plug,
+  Zap,
+} from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { SectionHeader } from "../../SectionHeader";
+
+const PAGE_LINKS = [
+  { icon: Boxes, labelKey: "nav.components", to: "/components" },
+  { icon: Zap, labelKey: "nav.operations", to: "/pipelines/operations" },
+  { icon: Box, labelKey: "nav.objects", to: "/pipelines/objects" },
+  { icon: Activity, labelKey: "nav.jobs", to: "/pipelines/jobs" },
+  { icon: Gauge, labelKey: "nav.items.usage", to: "/usage" },
+  { icon: FlaskConical, labelKey: "nav.distillations", to: "/distillations" },
+  { icon: Cpu, labelKey: "nav.items.localAgents", to: "/local-agents" },
+  { icon: BookOpen, labelKey: "nav.skills", to: "/skills" },
+  { icon: Plug, labelKey: "nav.items.connectors", to: "/connectors" },
+] as const;
+
+export const PagesSection = () => {
+  const { t } = useTranslation();
+
+  return (
+    <section>
+      <SectionHeader
+        description={t("settings.pages.description")}
+        title={t("settings.pages.title")}
+      />
+      <div className="grid gap-1">
+        {PAGE_LINKS.map((link) => {
+          const Icon = link.icon;
+
+          return (
+            <Link
+              key={link.to}
+              className="flex h-9 items-center gap-2.5 rounded-md px-2 text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+              to={link.to}
+            >
+              <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span>{t(link.labelKey)}</span>
+              <ChevronRight className="ml-auto h-3.5 w-3.5 text-muted-foreground" />
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+};

--- a/packages/views/src/pages/SettingsPage/sections/PagesSection/index.ts
+++ b/packages/views/src/pages/SettingsPage/sections/PagesSection/index.ts
@@ -1,0 +1,1 @@
+export * from "./PagesSection";

--- a/packages/views/src/pages/SettingsPage/sections/index.ts
+++ b/packages/views/src/pages/SettingsPage/sections/index.ts
@@ -6,4 +6,5 @@ export * from "./GeneralSection";
 export * from "./KeyboardSection";
 export * from "./LanguageSection";
 export * from "./NotificationsSection";
+export * from "./PagesSection";
 export * from "./ProjectSection";

--- a/packages/views/src/store/sidebarStore/sidebarSlice.ts
+++ b/packages/views/src/store/sidebarStore/sidebarSlice.ts
@@ -4,22 +4,7 @@ import { SidebarView, type SidebarViewType } from "./sidebarView";
 const isPipelinePathname = (pathname: string): boolean =>
   pathname.startsWith("/canvas") || pathname.startsWith("/pipelines");
 
-const CAPABILITIES_OPEN_STORAGE_KEY = "ordine.sidebar.capabilitiesOpen";
 const CURRENT_PROJECT_STORAGE_KEY = "ordine.sidebar.currentProjectId";
-
-const readStoredCapabilitiesOpen = () => {
-  if (globalThis.localStorage === undefined) return false;
-
-  const value = globalThis.localStorage.getItem(CAPABILITIES_OPEN_STORAGE_KEY);
-
-  return value === null ? false : value === "true";
-};
-
-const writeStoredCapabilitiesOpen = (value: boolean) => {
-  if (globalThis.localStorage === undefined) return;
-
-  globalThis.localStorage.setItem(CAPABILITIES_OPEN_STORAGE_KEY, String(value));
-};
 
 const readStoredCurrentProjectId = (): string | null => {
   if (globalThis.localStorage === undefined) return null;
@@ -41,7 +26,6 @@ export interface SidebarSlice {
   view: SidebarViewType;
   searchOpen: boolean;
   newPipelineOpen: boolean;
-  capabilitiesOpen: boolean;
   currentProjectId: string | null;
 
   handleSidebarLocationChange: (pathname: string) => void;
@@ -50,7 +34,6 @@ export interface SidebarSlice {
   handleSidebarPipelineViewButtonClick: () => void;
   handleSearchButtonClick: () => void;
   handleNewPipelineButtonClick: () => void;
-  handleCapabilitiesToggle: () => void;
   setCurrentProjectId: (projectId: string | null) => void;
   syncCurrentProjectId: (projectIds: string[]) => void;
 }
@@ -59,7 +42,6 @@ export const createSidebarSlice: StateCreator<SidebarSlice> = (set, get) => ({
   view: SidebarView.Main,
   searchOpen: false,
   newPipelineOpen: false,
-  capabilitiesOpen: readStoredCapabilitiesOpen(),
   currentProjectId: readStoredCurrentProjectId(),
 
   handleSidebarLocationChange: (pathname) =>
@@ -69,11 +51,6 @@ export const createSidebarSlice: StateCreator<SidebarSlice> = (set, get) => ({
   handleSidebarPipelineViewButtonClick: () => set({ view: SidebarView.Pipeline }),
   handleSearchButtonClick: () => set({ searchOpen: true }),
   handleNewPipelineButtonClick: () => set({ newPipelineOpen: true }),
-  handleCapabilitiesToggle: () => {
-    const capabilitiesOpen = !get().capabilitiesOpen;
-    writeStoredCapabilitiesOpen(capabilitiesOpen);
-    set({ capabilitiesOpen });
-  },
   setCurrentProjectId: (currentProjectId) => {
     writeStoredCurrentProjectId(currentProjectId);
     set({ currentProjectId });

--- a/packages/views/src/store/sidebarStore/sidebarStore.unit.test.ts
+++ b/packages/views/src/store/sidebarStore/sidebarStore.unit.test.ts
@@ -37,17 +37,6 @@ describe("sidebarStore", () => {
     expect(store.getState().searchOpen).toBe(false);
   });
 
-  it("persists the capabilities section state", () => {
-    const store = createSidebarStore();
-
-    expect(store.getState().capabilitiesOpen).toBe(false);
-    store.getState().handleCapabilitiesToggle();
-
-    expect(store.getState().capabilitiesOpen).toBe(true);
-    expect(localStorage.getItem("ordine.sidebar.capabilitiesOpen")).toBe("true");
-    expect(createSidebarStore().getState().capabilitiesOpen).toBe(true);
-  });
-
   it("persists and validates the current project", () => {
     const store = createSidebarStore();
 


### PR DESCRIPTION
## 关联

- Linear: COD-343「Feature」「UI」#5 导航重构为 Pipelines/Schedule/Plugins/Agents/对话/Settings
- 产品决策已补记:《产品决策记录》2026-08-25 两条(导航重构、Attio 视觉语言)

## 导航重构(COD-343)

- 主导航从「装配/监控/能力」三分组扁平化为五项:**流水线 / 定时任务 / 插件 / 智能体 / 对话**;设置保持在侧栏底部
- 新建 `/schedule` 定时任务占位页(后端 routines 接入留后续 issue)
- 「对话」复用 `/assistant` 路由,渲染新建 ConversationsPage 占位
- 原侧栏 9 个入口(组件/操作集/对象/任务/用量/蒸馏/本地智能体/技能/连接器)收进 **设置 → 页面 → 更多页面**,路由与功能原样保留
- Canvas 工作区覆盖层侧栏同步为同一套扁平结构
- 清理不再使用的「能力」折叠状态及 localStorage 持久化
- desktop-app 补齐 `/schedule`、`/assistant` 路由,共享侧栏不再 404

## 全站视觉:Attio 风格(Alan 拍板,取代 PR #161 暖色基线)

- **token 层**:白画布、近黑文字 `#1c1d1f`、发丝边框 `#e4e7ec`、灰阶 `#6f7988`/`#f4f5f6`;基础圆角 8px→10px;阴影全部改蓝调 `rgba(28,40,64,…)`
- **钴蓝 `#266df0` 为唯一强调色**,新增 `cobalt`/`cobalt-bright`/`periwinkle`/`ice-wash` token,并接管全局 focus ring
- **字体**:标题 Inter Tight 600 紧排(-0.015em),正文 Inter 500 起步并开 `ss03`;无衬线。Google Fonts CDN 加载,离线回落系统 sans
- **深色模式 token 未动**,沿用旧值(后续单独定方案)

## 首页重做

- 大标题(Inter Tight 56px)+ 描述 + 输入卡片;去掉眉标胶囊、header 标题块、Ctrl↵ 提示
- 输入卡片:白底 + 蓝调软阴影 + 14px 圆角;发送钮为钴蓝小方块(禁用态 `#538bf3`,深色模式 `#e4edff`)
- 英文描述文案更新:"Ordine will create a runnable Pipeline in the Canvas for you."

## Canvas 细节

- 空状态层级降到组件面板之下,修掉文字与面板混杂
- Agent 面板改 Linear 式悬浮卡片:四边描边 + 加重阴影 + 四周 12px 间隙(收起后从顶栏「Agent」按钮重开,删除原右侧竖条/浮动按钮)
- 隐藏 React Flow 右下角角标(`hideAttribution`)
- Agent 输入框字号钉死 12px,与已发送消息对齐(修 `md:text-sm` 覆盖问题)

## 验证

- views 433/433、app 564/564、desktop-app 30/30 测试全过
- views/app typecheck 干净;lint 仅存量警告;format 干净(desktop `ServerGate.tsx` 为 develop 存量问题,本 PR 未触碰)
- 浏览器实测:中/英文,首页、流水线、定时任务、插件、智能体、对话、设置、Canvas(空态/面板开合/缩放)均正常,无 console 报错

## 截图

before/after 截图在本机 `/tmp/`(attio-g-*.png、canvas-agent-card.png 等),GitHub API 无法直接传图,由 Alan 手动拖入补充。