### PR TITLE
COD-354 PR2: shared Agent Activity store and UI

### DIFF
--- a/apps/app/e2e/agent-pipeline-workflow.e2e.spec.ts
+++ b/apps/app/e2e/agent-pipeline-workflow.e2e.spec.ts
@@ -8,6 +8,37 @@ const json = (route: Route, body: unknown, status = 200) =>
     status,
   });
 
+const mockedAgentRun = (runId: string, ownerId: string, timestamp: string) => ({
+  id: runId,
+  owner: { type: "agent_thread", id: ownerId },
+  runtimeConfigId: "local-codex",
+  runtime: "claude-code",
+  status: "running",
+  executablePath: null,
+  executableVersion: null,
+  executableFingerprint: null,
+  model: null,
+  reasoningEffort: null,
+  speed: null,
+  cwd: "C:\\",
+  nativeSessionId: null,
+  resumeFromRunId: null,
+  permissionMode: "full-access",
+  networkAccess: true,
+  controlMode: true,
+  allowedTools: ["*"],
+  controlScopes: [],
+  usage: null,
+  resultText: null,
+  errorCode: null,
+  errorMessage: null,
+  createdAt: timestamp,
+  startedAt: timestamp,
+  firstOutputAt: null,
+  lastActivityAt: timestamp,
+  finishedAt: null,
+});
+
 const seedPipeline = async (page: Page, pipelineId: string, name: string) => {
   const response = await page.request.post("/api/trpc/pipelines.create?batch=1", {
     data: {
@@ -203,6 +234,11 @@ const mockCanvasChangeSet = async (page: Page, pipelineId: string) => {
     }
     if (pathname === `/api/agent-threads/${threadId}/runs` && request.method() === "POST") {
       await json(route, { runId }, 202);
+
+      return;
+    }
+    if (pathname === `/api/agent-runs/${runId}` && request.method() === "GET") {
+      await json(route, mockedAgentRun(runId, threadId, timestamp));
 
       return;
     }

--- a/apps/app/e2e/canvas.e2e.spec.ts
+++ b/apps/app/e2e/canvas.e2e.spec.ts
@@ -147,6 +147,37 @@ const json = (route: Route, body: unknown, status = 200) =>
     status,
   });
 
+const mockedAgentRun = (runId: string, ownerId: string, timestamp: string) => ({
+  id: runId,
+  owner: { type: "agent_thread", id: ownerId },
+  runtimeConfigId: "local-codex",
+  runtime: "claude-code",
+  status: "running",
+  executablePath: null,
+  executableVersion: null,
+  executableFingerprint: null,
+  model: null,
+  reasoningEffort: null,
+  speed: null,
+  cwd: "C:\\",
+  nativeSessionId: null,
+  resumeFromRunId: null,
+  permissionMode: "full-access",
+  networkAccess: true,
+  controlMode: false,
+  allowedTools: [],
+  controlScopes: [],
+  usage: null,
+  resultText: null,
+  errorCode: null,
+  errorMessage: null,
+  createdAt: timestamp,
+  startedAt: timestamp,
+  firstOutputAt: null,
+  lastActivityAt: timestamp,
+  finishedAt: null,
+});
+
 const mockCanvasAgent = async (page: Page) => {
   const threadId = "canvas-e2e-thread";
   const runId = "canvas-e2e-run";
@@ -239,6 +270,11 @@ const mockCanvasAgent = async (page: Page) => {
     }
     if (pathname === `/api/agent-threads/${threadId}/runs` && request.method() === "POST") {
       await json(route, { runId }, 202);
+
+      return;
+    }
+    if (pathname === `/api/agent-runs/${runId}` && request.method() === "GET") {
+      await json(route, mockedAgentRun(runId, threadId, timestamp));
 
       return;
     }

--- a/apps/app/src/integrations/platform.ts
+++ b/apps/app/src/integrations/platform.ts
@@ -11,6 +11,12 @@ export const webPlatform: PlatformCapabilities = {
     globalThis.window === undefined ? undefined : globalThis.window.location,
   ),
   request: (input, init) => globalThis.fetch(input, init),
+  copyText: async (text) => {
+    if (!globalThis.navigator?.clipboard?.writeText) {
+      throw new Error("Clipboard API is unavailable");
+    }
+    await globalThis.navigator.clipboard.writeText(text);
+  },
   downloadBlob: (blob, filename) => {
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement("a");

--- a/apps/desktop-app/src/integrations/platform.ts
+++ b/apps/desktop-app/src/integrations/platform.ts
@@ -1,4 +1,5 @@
 import { createScopedRequest, type PlatformCapabilities } from "@repo/views/platform";
+import { open } from "@tauri-apps/plugin-shell";
 import { getDesktopAuthToken } from "./sidecar/server";
 
 export const DESKTOP_API_BASE = "http://127.0.0.1:9433/api";
@@ -23,6 +24,13 @@ export const desktopRequest = createScopedRequest({
 export const desktopPlatform: PlatformCapabilities = {
   apiBaseUrl: DESKTOP_API_BASE,
   request: desktopRequest,
+  copyText: async (text) => {
+    if (!globalThis.navigator?.clipboard?.writeText) {
+      throw new Error("Clipboard API is unavailable");
+    }
+    await globalThis.navigator.clipboard.writeText(text);
+  },
+  openPath: (path) => open(path),
   downloadBlob: (blob, filename) => {
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement("a");

--- a/packages/views/src/components/AgentActivity/AgentActivitySurface.tsx
+++ b/packages/views/src/components/AgentActivity/AgentActivitySurface.tsx
@@ -1,0 +1,149 @@
+import {
+  CircleAlert,
+  Copy,
+  ExternalLink,
+  FileOutput,
+  LoaderCircle,
+  Square,
+  Wrench,
+} from "lucide-react";
+import { cn } from "@repo/ui/lib/utils";
+import type { PlatformCapabilities } from "../../platform";
+import { recordAgentActivityArtifactOpenFailure } from "./agentActivityStore";
+import { useAgentActivity } from "./useAgentActivity";
+
+export type AgentActivityVariant = "bar" | "panel" | "inline" | "console";
+
+const formatElapsed = (milliseconds: number): string => {
+  const seconds = Math.floor(milliseconds / 1_000);
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
+};
+
+export const AgentActivitySurface = ({
+  runId,
+  platform,
+  variant = "panel",
+  className,
+}: {
+  runId: string | null | undefined;
+  platform: PlatformCapabilities;
+  variant?: AgentActivityVariant;
+  className?: string;
+}) => {
+  const activity = useAgentActivity({ runId, platform });
+  if (!runId) return null;
+  const terminal = ["completed", "failed", "cancelled", "timed_out", "interrupted"].includes(
+    activity.status ?? "",
+  );
+
+  return (
+    <section
+      className={cn(
+        "text-xs text-muted-foreground",
+        variant === "bar" && "flex items-center gap-2 border-b border-border/70 px-3 py-2",
+        variant === "panel" && "rounded-lg border border-border/80 bg-surface-2/45 p-3",
+        variant === "inline" && "flex items-center gap-2",
+        variant === "console" && "rounded-md bg-black/80 p-3 font-mono text-[11px] text-white/80",
+        className,
+      )}
+      data-testid={`agent-activity-${variant}`}
+      data-run-id={runId}
+    >
+      <div className={cn("flex min-w-0 flex-1 items-center gap-2", variant === "panel" && "mb-2")}>
+        {activity.connection === "streaming" || activity.connection === "polling" ? (
+          <LoaderCircle className="size-3.5 animate-spin text-primary" />
+        ) : activity.error ? (
+          <CircleAlert className="size-3.5 text-destructive" />
+        ) : (
+          <FileOutput className="size-3.5" />
+        )}
+        <span className="truncate font-medium text-foreground">
+          {activity.runtime ?? "Agent"} · {activity.phase}
+        </span>
+        <span className="shrink-0 tabular-nums">{formatElapsed(activity.elapsedMs)}</span>
+        {activity.connection === "polling" && <span className="shrink-0">polling</span>}
+      </div>
+      {variant !== "bar" && variant !== "inline" && (
+        <>
+          {activity.content ? (
+            <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words text-foreground/90">
+              {activity.content}
+            </pre>
+          ) : (
+            <p className="py-1">
+              {activity.progressMessage ?? "Waiting for first available output"}
+            </p>
+          )}
+          {activity.activeTools.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {activity.activeTools.map((tool) => (
+                <span
+                  key={tool.id}
+                  className="inline-flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5"
+                >
+                  <Wrench className="size-3" /> {tool.name}
+                </span>
+              ))}
+            </div>
+          )}
+          {activity.artifacts.length > 0 && (
+            <div className="mt-2 space-y-1">
+              {activity.artifacts.map((artifact) => (
+                <div key={artifact.id} className="flex items-center justify-between gap-2">
+                  <span className="truncate">{artifact.label}</span>
+                  <div className="flex shrink-0 items-center gap-1">
+                    {artifact.openModes.includes("open") &&
+                    artifact.localPath &&
+                    platform.openPath ? (
+                      <button
+                        type="button"
+                        aria-label={`Open ${artifact.label}`}
+                        className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 hover:bg-muted"
+                        title="Open artifact"
+                        onClick={() => {
+                          void platform.openPath!(artifact.localPath!).catch(() =>
+                            recordAgentActivityArtifactOpenFailure(runId, platform),
+                          );
+                        }}
+                      >
+                        <ExternalLink className="size-3" />
+                      </button>
+                    ) : null}
+                    {artifact.openModes.includes("copy_path") &&
+                    (artifact.localPath || artifact.remotePath) ? (
+                      <button
+                        type="button"
+                        aria-label={`Copy ${artifact.label} path`}
+                        className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 hover:bg-muted"
+                        title={artifact.remotePath ? "Remote artifact: copy path" : "Copy path"}
+                        onClick={() => {
+                          const path = artifact.localPath ?? artifact.remotePath;
+                          if (!path) return;
+                          void platform
+                            .copyText(path)
+                            .catch(() => recordAgentActivityArtifactOpenFailure(runId, platform));
+                        }}
+                      >
+                        <Copy className="size-3" />
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+      {!terminal && activity.canCancel && variant !== "inline" && (
+        <button
+          type="button"
+          className="mt-2 inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[11px] hover:bg-muted"
+          onClick={() => void activity.cancel()}
+        >
+          <Square className="size-3" /> Cancel
+        </button>
+      )}
+    </section>
+  );
+};

--- a/packages/views/src/components/AgentActivity/AgentActivitySurface.tsx
+++ b/packages/views/src/components/AgentActivity/AgentActivitySurface.tsx
@@ -7,6 +7,8 @@ import {
   Square,
   Wrench,
 } from "lucide-react";
+import { ResultAsync } from "neverthrow";
+import { Button } from "@repo/ui/button";
 import { cn } from "@repo/ui/lib/utils";
 import type { PlatformCapabilities } from "../../platform";
 import { recordAgentActivityArtifactOpenFailure } from "./agentActivityStore";
@@ -18,6 +20,13 @@ const formatElapsed = (milliseconds: number): string => {
   const seconds = Math.floor(milliseconds / 1_000);
   const minutes = Math.floor(seconds / 60);
   return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
+};
+
+const runPlatformAction = (action: () => Promise<void>, onFailure: () => void): void => {
+  void ResultAsync.fromPromise(Promise.resolve().then(action), () => undefined).match(
+    () => undefined,
+    onFailure,
+  );
 };
 
 export const AgentActivitySurface = ({
@@ -96,37 +105,41 @@ export const AgentActivitySurface = ({
                     {artifact.openModes.includes("open") &&
                     artifact.localPath &&
                     platform.openPath ? (
-                      <button
-                        type="button"
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
                         aria-label={`Open ${artifact.label}`}
-                        className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 hover:bg-muted"
+                        className="rounded px-1.5 py-0.5"
                         title="Open artifact"
-                        onClick={() => {
-                          void platform.openPath!(artifact.localPath!).catch(() =>
-                            recordAgentActivityArtifactOpenFailure(runId, platform),
-                          );
-                        }}
+                        onClick={() =>
+                          runPlatformAction(
+                            () => platform.openPath!(artifact.localPath!),
+                            () => recordAgentActivityArtifactOpenFailure(runId, platform),
+                          )
+                        }
                       >
                         <ExternalLink className="size-3" />
-                      </button>
+                      </Button>
                     ) : null}
                     {artifact.openModes.includes("copy_path") &&
                     (artifact.localPath || artifact.remotePath) ? (
-                      <button
-                        type="button"
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
                         aria-label={`Copy ${artifact.label} path`}
-                        className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 hover:bg-muted"
+                        className="rounded px-1.5 py-0.5"
                         title={artifact.remotePath ? "Remote artifact: copy path" : "Copy path"}
                         onClick={() => {
                           const path = artifact.localPath ?? artifact.remotePath;
                           if (!path) return;
-                          void platform
-                            .copyText(path)
-                            .catch(() => recordAgentActivityArtifactOpenFailure(runId, platform));
+                          runPlatformAction(
+                            () => platform.copyText(path),
+                            () => recordAgentActivityArtifactOpenFailure(runId, platform),
+                          );
                         }}
                       >
                         <Copy className="size-3" />
-                      </button>
+                      </Button>
                     ) : null}
                   </div>
                 </div>
@@ -136,13 +149,14 @@ export const AgentActivitySurface = ({
         </>
       )}
       {!terminal && activity.canCancel && variant !== "inline" && (
-        <button
-          type="button"
-          className="mt-2 inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[11px] hover:bg-muted"
-          onClick={() => void activity.cancel()}
+        <Button
+          variant="outline"
+          size="xs"
+          className="mt-2 text-[11px]"
+          onClick={() => runPlatformAction(activity.cancel, () => undefined)}
         >
           <Square className="size-3" /> Cancel
-        </button>
+        </Button>
       )}
     </section>
   );

--- a/packages/views/src/components/AgentActivity/agentActivityStore.ts
+++ b/packages/views/src/components/AgentActivity/agentActivityStore.ts
@@ -78,6 +78,7 @@ type ActivityEntry = {
   elapsedTimer: ReturnType<typeof setInterval> | null;
   platform: AgentRunEventsTransport;
   listeners: Set<AgentActivityListener>;
+  deliveryQueue: Promise<void>;
 };
 
 const registry = new Map<string, ActivityEntry>();
@@ -118,41 +119,54 @@ const setElapsed = (entry: ActivityEntry): void => {
   entry.store.setState({ elapsedMs: Math.max(0, Date.now() - started) });
 };
 
-const applyEnvelope = (entry: ActivityEntry, envelope: AgentRunEventEnvelope): void => {
-  const state = entry.store.getState();
-  if (envelope.runId !== entry.store.getState().runId) return;
-  const current = state.snapshot;
-  if (!current) return;
-  const reduction = reduceAgentRunActivity(current, envelope);
-  if (!reduction.accepted) {
-    if (reduction.duplicate) {
-      entry.store.setState((previous) => ({
-        metrics: {
-          ...previous.metrics,
-          duplicateEventCount: previous.metrics.duplicateEventCount + 1,
-        },
-      }));
-    }
+const applyEnvelope = (entry: ActivityEntry, envelope: AgentRunEventEnvelope): Promise<void> => {
+  const deliver = async () => {
+    const state = entry.store.getState();
+    if (envelope.runId !== state.runId) return;
+    const current = state.snapshot;
+    if (!current) return;
+    const reduction = reduceAgentRunActivity(current, envelope);
+    if (!reduction.accepted) {
+      if (reduction.duplicate) {
+        entry.store.setState((previous) => ({
+          metrics: {
+            ...previous.metrics,
+            duplicateEventCount: previous.metrics.duplicateEventCount + 1,
+          },
+        }));
+      }
 
-    return;
-  }
-  const terminal = envelope.event.type === "terminal" ? envelope.event.status : null;
-  entry.store.setState((previous) => ({
-    snapshot: reduction.snapshot,
-    status: terminal ?? previous.status,
-    lastSequence: reduction.snapshot.latestSequence,
-    consecutiveSseFailures: 0,
-    connection: terminal ? "terminal" : "streaming",
-    error:
-      envelope.event.type === "diagnostic" && envelope.event.level === "error"
-        ? envelope.event.message
-        : previous.error,
-    finishedAt: terminal ? envelope.createdAt : previous.finishedAt,
-  }));
-  for (const listener of entry.listeners) {
-    void Promise.resolve(listener(envelope)).catch(() => undefined);
-  }
-  if (terminal) stopTransport(entry);
+      return;
+    }
+    const terminal = envelope.event.type === "terminal" ? envelope.event.status : null;
+    entry.store.setState((previous) => ({
+      snapshot: reduction.snapshot,
+      status: terminal ?? previous.status,
+      lastSequence: reduction.snapshot.latestSequence,
+      consecutiveSseFailures: 0,
+      connection: terminal ? "terminal" : "streaming",
+      error:
+        envelope.event.type === "diagnostic" && envelope.event.level === "error"
+          ? envelope.event.message
+          : previous.error,
+      finishedAt: terminal ? envelope.createdAt : previous.finishedAt,
+    }));
+    for (const listener of entry.listeners) {
+      try {
+        await listener(envelope);
+      } catch {
+        // A view subscriber must not stop delivery to the shared activity store.
+      }
+    }
+    if (terminal) stopTransport(entry);
+  };
+
+  // SSE chunks and polling can overlap around reconnects. Serialize reducer and
+  // subscriber delivery so control events (draft/apply/terminal) retain order.
+  const next = entry.deliveryQueue.catch(() => undefined).then(deliver);
+  entry.deliveryQueue = next;
+
+  return next;
 };
 
 const stopTransport = (entry: ActivityEntry): void => {
@@ -218,7 +232,7 @@ const pollOnce = async (entry: ActivityEntry): Promise<void> => {
   if (!response.ok) throw new Error(`Agent event polling failed with status ${response.status}`);
   const page = AgentRunEventPageSchema.safeParse(body);
   if (!page.success) throw new Error("Agent event polling returned invalid JSON");
-  for (const envelope of page.data.events) applyEnvelope(entry, envelope);
+  for (const envelope of page.data.events) await applyEnvelope(entry, envelope);
   if (page.data.terminal && entry.store.getState().connection !== "terminal") {
     entry.store.setState({ connection: "terminal" });
     stopTransport(entry);
@@ -350,6 +364,7 @@ const createEntry = (runId: string, platform: AgentRunEventsTransport): Activity
   entry.elapsedTimer = null;
   entry.platform = platform;
   entry.listeners = new Set();
+  entry.deliveryQueue = Promise.resolve();
 
   return entry;
 };

--- a/packages/views/src/components/AgentActivity/agentActivityStore.ts
+++ b/packages/views/src/components/AgentActivity/agentActivityStore.ts
@@ -492,7 +492,7 @@ export type AgentActivityViewModel = ReturnType<typeof createAgentActivityViewMo
  * Cache the derived object for each immutable store state so the snapshot
  * identity remains stable even though the view model contains derived arrays.
  */
-export const selectAgentActivityViewModel = (state: AgentActivityState): AgentActivityViewModel => {
+export const selectAgentActivityViewModel = (state: AgentActivityState) => {
   const cached = activityViewModelCache.get(state);
   if (cached) return cached;
   const viewModel = createAgentActivityViewModel(state);

--- a/packages/views/src/components/AgentActivity/agentActivityStore.ts
+++ b/packages/views/src/components/AgentActivity/agentActivityStore.ts
@@ -446,7 +446,9 @@ export const subscribeAgentActivity = (
   };
 };
 
-export const selectAgentActivityViewModel = (state: AgentActivityState) => {
+const activityViewModelCache = new WeakMap<object, AgentActivityViewModel>();
+
+const createAgentActivityViewModel = (state: AgentActivityState) => {
   const snapshot = state.snapshot;
   const terminal = Boolean(state.status && TERMINAL_STATUSES.has(state.status));
 
@@ -483,4 +485,20 @@ export const selectAgentActivityViewModel = (state: AgentActivityState) => {
   };
 };
 
-export type AgentActivityViewModel = ReturnType<typeof selectAgentActivityViewModel>;
+export type AgentActivityViewModel = ReturnType<typeof createAgentActivityViewModel>;
+
+/**
+ * Zustand's React adapter reads a selector more than once during a render.
+ * Cache the derived object for each immutable store state so the snapshot
+ * identity remains stable even though the view model contains derived arrays.
+ */
+export const selectAgentActivityViewModel = (
+  state: AgentActivityState,
+): AgentActivityViewModel => {
+  const cached = activityViewModelCache.get(state);
+  if (cached) return cached;
+  const viewModel = createAgentActivityViewModel(state);
+  activityViewModelCache.set(state, viewModel);
+
+  return viewModel;
+};

--- a/packages/views/src/components/AgentActivity/agentActivityStore.ts
+++ b/packages/views/src/components/AgentActivity/agentActivityStore.ts
@@ -1,0 +1,471 @@
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { z } from "zod/v4";
+import {
+  AgentRunActivityMetricsSchema,
+  AgentRunActivitySnapshotSchema,
+  AgentRunEventEnvelopeSchema,
+  AgentRunSchema,
+  RuntimeCapabilitiesSchema,
+  createInitialAgentRunActivitySnapshot,
+  type AgentRun,
+  type AgentRunActivityMetrics,
+  type AgentRunActivitySnapshot,
+  type AgentRunEventEnvelope,
+  type AgentRunStatus,
+  type RuntimeCapabilities,
+} from "@repo/schemas";
+import { reduceAgentRunActivity } from "@repo/agent-activity";
+import {
+  consumeAgentRunEventStream,
+  type AgentRunEventsTransport,
+} from "../../lib/agentRunEventsClient";
+
+const TERMINAL_STATUSES = new Set<AgentRunStatus>([
+  "completed",
+  "failed",
+  "cancelled",
+  "timed_out",
+  "interrupted",
+]);
+const POLL_INTERVAL_MS = 1_000;
+const SSE_RETRY_INTERVAL_MS = 15_000;
+const MAX_EVENTS_PER_POLL = 200;
+const EMPTY_METRICS = AgentRunActivityMetricsSchema.parse({});
+const AgentRunEventPageSchema = z.object({
+  events: z.array(AgentRunEventEnvelopeSchema),
+  nextSequence: z.number().int().nonnegative(),
+  terminal: z.boolean(),
+});
+
+export type AgentActivityConnection =
+  | "idle"
+  | "hydrating"
+  | "streaming"
+  | "polling"
+  | "error"
+  | "terminal";
+
+export type AgentActivityState = {
+  runId: string;
+  runtime: AgentRun["runtime"] | null;
+  status: AgentRunStatus | null;
+  capabilities: RuntimeCapabilities | null;
+  snapshot: AgentRunActivitySnapshot | null;
+  metrics: AgentRunActivityMetrics;
+  connection: AgentActivityConnection;
+  lastSequence: number;
+  consecutiveSseFailures: number;
+  error: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  elapsedMs: number;
+  cancel: () => Promise<void>;
+};
+
+export type AgentActivityStore = StoreApi<AgentActivityState>;
+
+type AgentActivityListener = (envelope: AgentRunEventEnvelope) => Promise<void> | void;
+
+type ActivityEntry = {
+  store: AgentActivityStore;
+  refs: number;
+  started: boolean;
+  destroyed: boolean;
+  controller: AbortController | null;
+  sseInFlight: boolean;
+  pollTimer: ReturnType<typeof setInterval> | null;
+  sseRetryTimer: ReturnType<typeof setTimeout> | null;
+  elapsedTimer: ReturnType<typeof setInterval> | null;
+  platform: AgentRunEventsTransport;
+  listeners: Set<AgentActivityListener>;
+};
+
+const registry = new Map<string, ActivityEntry>();
+
+const toError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+const parseJson = async (response: Response): Promise<unknown> => {
+  const raw = await response.text();
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+};
+
+const requestRun = async (platform: AgentRunEventsTransport, runId: string): Promise<AgentRun> => {
+  const response = await platform.request(
+    `${platform.apiBaseUrl}/agent-runs/${encodeURIComponent(runId)}`,
+  );
+  const body = await parseJson(response);
+  if (!response.ok) {
+    const message =
+      body && typeof body === "object" && "error" in body && typeof body.error === "string"
+        ? body.error
+        : `Agent run hydration failed with status ${response.status}`;
+    throw new Error(message);
+  }
+
+  return AgentRunSchema.parse(body);
+};
+
+const setElapsed = (entry: ActivityEntry): void => {
+  const state = entry.store.getState();
+  if (!state.startedAt || (state.status && TERMINAL_STATUSES.has(state.status))) return;
+  const started = Date.parse(state.startedAt);
+  if (!Number.isFinite(started)) return;
+  entry.store.setState({ elapsedMs: Math.max(0, Date.now() - started) });
+};
+
+const applyEnvelope = (entry: ActivityEntry, envelope: AgentRunEventEnvelope): void => {
+  const state = entry.store.getState();
+  if (envelope.runId !== entry.store.getState().runId) return;
+  const current = state.snapshot;
+  if (!current) return;
+  const reduction = reduceAgentRunActivity(current, envelope);
+  if (!reduction.accepted) {
+    if (reduction.duplicate) {
+      entry.store.setState((previous) => ({
+        metrics: {
+          ...previous.metrics,
+          duplicateEventCount: previous.metrics.duplicateEventCount + 1,
+        },
+      }));
+    }
+
+    return;
+  }
+  const terminal = envelope.event.type === "terminal" ? envelope.event.status : null;
+  entry.store.setState((previous) => ({
+    snapshot: reduction.snapshot,
+    status: terminal ?? previous.status,
+    lastSequence: reduction.snapshot.latestSequence,
+    consecutiveSseFailures: 0,
+    connection: terminal ? "terminal" : "streaming",
+    error:
+      envelope.event.type === "diagnostic" && envelope.event.level === "error"
+        ? envelope.event.message
+        : previous.error,
+    finishedAt: terminal ? envelope.createdAt : previous.finishedAt,
+  }));
+  for (const listener of entry.listeners) {
+    void Promise.resolve(listener(envelope)).catch(() => undefined);
+  }
+  if (terminal) stopTransport(entry);
+};
+
+const stopTransport = (entry: ActivityEntry): void => {
+  entry.controller?.abort();
+  entry.controller = null;
+  if (entry.pollTimer) clearInterval(entry.pollTimer);
+  if (entry.sseRetryTimer) clearTimeout(entry.sseRetryTimer);
+  if (entry.elapsedTimer) clearInterval(entry.elapsedTimer);
+  entry.pollTimer = null;
+  entry.sseRetryTimer = null;
+  entry.elapsedTimer = null;
+  entry.sseInFlight = false;
+};
+
+const clearPollingTimers = (entry: ActivityEntry): void => {
+  if (entry.pollTimer) clearInterval(entry.pollTimer);
+  if (entry.sseRetryTimer) clearTimeout(entry.sseRetryTimer);
+  entry.pollTimer = null;
+  entry.sseRetryTimer = null;
+};
+
+const scheduleSseRetry = (entry: ActivityEntry, delayMs: number): void => {
+  if (entry.sseRetryTimer || entry.destroyed || entry.refs === 0) return;
+  entry.sseRetryTimer = setTimeout(() => {
+    entry.sseRetryTimer = null;
+    void startSse(entry);
+  }, delayMs);
+};
+
+const markSseFailure = (entry: ActivityEntry, error: Error): void => {
+  const failures = entry.store.getState().consecutiveSseFailures + 1;
+  entry.store.setState({
+    connection: failures >= 3 ? "polling" : "error",
+    consecutiveSseFailures: failures,
+    error: error.message,
+    metrics: {
+      ...entry.store.getState().metrics,
+      reconnectCount: entry.store.getState().metrics.reconnectCount + 1,
+      ...(failures === 3
+        ? {
+            pollingFallbackCount: entry.store.getState().metrics.pollingFallbackCount + 1,
+          }
+        : {}),
+    },
+  });
+  if (failures >= 3) {
+    startPolling(entry);
+    scheduleSseRetry(entry, SSE_RETRY_INTERVAL_MS);
+  } else scheduleSseRetry(entry, 1_000);
+};
+
+const pollOnce = async (entry: ActivityEntry): Promise<void> => {
+  if (entry.destroyed || entry.sseInFlight) return;
+  const state = entry.store.getState();
+  const response = await entry.platform.request(
+    `${entry.platform.apiBaseUrl}/agent-runs/${encodeURIComponent(entry.store.getState().runId)}/events?after=${state.lastSequence}&limit=${MAX_EVENTS_PER_POLL}`,
+    {
+      headers: { accept: "application/json" },
+      signal: entry.controller?.signal,
+    },
+  );
+  const body = await parseJson(response);
+  if (!response.ok) throw new Error(`Agent event polling failed with status ${response.status}`);
+  const page = AgentRunEventPageSchema.safeParse(body);
+  if (!page.success) throw new Error("Agent event polling returned invalid JSON");
+  for (const envelope of page.data.events) applyEnvelope(entry, envelope);
+  if (page.data.terminal && entry.store.getState().connection !== "terminal") {
+    entry.store.setState({ connection: "terminal" });
+    stopTransport(entry);
+  }
+};
+
+const startPolling = (entry: ActivityEntry): void => {
+  if (entry.pollTimer || entry.destroyed || entry.refs === 0) return;
+  entry.store.setState({ connection: "polling" });
+  entry.pollTimer = setInterval(() => {
+    void pollOnce(entry).catch((error: unknown) => {
+      entry.store.setState({ error: toError(error).message });
+    });
+  }, POLL_INTERVAL_MS);
+  scheduleSseRetry(entry, SSE_RETRY_INTERVAL_MS);
+  void pollOnce(entry).catch((error: unknown) => {
+    entry.store.setState({ error: toError(error).message });
+  });
+};
+
+const startSse = async (entry: ActivityEntry): Promise<void> => {
+  if (entry.destroyed || entry.sseInFlight || entry.refs === 0) return;
+  const state = entry.store.getState();
+  if (state.status && TERMINAL_STATUSES.has(state.status)) {
+    stopTransport(entry);
+
+    return;
+  }
+  entry.sseInFlight = true;
+  const controller = new AbortController();
+  entry.controller = controller;
+  entry.store.setState({ connection: "streaming" });
+  try {
+    const result = await consumeAgentRunEventStream(entry.platform, {
+      runId: entry.store.getState().runId,
+      after: entry.store.getState().lastSequence,
+      signal: controller.signal,
+      onConnected: () => {
+        clearPollingTimers(entry);
+        if (!entry.destroyed) entry.store.setState({ connection: "streaming" });
+      },
+      onEnvelope: (envelope) => applyEnvelope(entry, envelope),
+    });
+    if (!entry.destroyed && !controller.signal.aborted && !result.terminalStatus) {
+      markSseFailure(entry, new Error("Agent event stream ended before terminal state"));
+    }
+  } catch (error: unknown) {
+    if (!entry.destroyed && !controller.signal.aborted) markSseFailure(entry, toError(error));
+  } finally {
+    entry.sseInFlight = false;
+    if (entry.controller === controller) entry.controller = null;
+  }
+};
+
+const hydrate = async (entry: ActivityEntry): Promise<void> => {
+  entry.store.setState({ connection: "hydrating", error: null });
+  const run = await requestRun(entry.platform, entry.store.getState().runId);
+  if (entry.destroyed || entry.refs === 0) return;
+  const snapshot = run.activitySnapshot
+    ? AgentRunActivitySnapshotSchema.parse(run.activitySnapshot)
+    : createInitialAgentRunActivitySnapshot(run.id, run.runtime, run.status);
+  const metrics = run.activityMetrics
+    ? AgentRunActivityMetricsSchema.parse(run.activityMetrics)
+    : EMPTY_METRICS;
+  const capabilities = run.runtimeCapabilities
+    ? RuntimeCapabilitiesSchema.parse(run.runtimeCapabilities)
+    : null;
+  entry.store.setState({
+    runtime: run.runtime,
+    status: run.status,
+    capabilities,
+    snapshot,
+    metrics,
+    lastSequence: snapshot.latestSequence,
+    startedAt: run.startedAt,
+    finishedAt: run.finishedAt,
+    elapsedMs:
+      run.startedAt && run.finishedAt
+        ? Math.max(0, Date.parse(run.finishedAt) - Date.parse(run.startedAt))
+        : 0,
+  });
+  if (TERMINAL_STATUSES.has(run.status)) {
+    entry.store.setState({ connection: "terminal" });
+
+    return;
+  }
+  entry.elapsedTimer = setInterval(() => setElapsed(entry), 1_000);
+  if (entry.refs === 0) return;
+  await startSse(entry);
+};
+
+const createEntry = (runId: string, platform: AgentRunEventsTransport): ActivityEntry => {
+  const entry = {} as ActivityEntry;
+  const store = createStore<AgentActivityState>(() => ({
+    runId,
+    runtime: null,
+    status: null,
+    capabilities: null,
+    snapshot: null,
+    metrics: EMPTY_METRICS,
+    connection: "idle",
+    lastSequence: 0,
+    consecutiveSseFailures: 0,
+    error: null,
+    startedAt: null,
+    finishedAt: null,
+    elapsedMs: 0,
+    cancel: async () => {
+      const current = store.getState();
+      if (!current.capabilities || current.capabilities.cancellation === "none") return;
+      const response = await platform.request(
+        `${platform.apiBaseUrl}/agent-runs/${encodeURIComponent(runId)}/cancel`,
+        { method: "POST" },
+      );
+      const body = await parseJson(response);
+      if (!response.ok) throw new Error(`Agent cancellation failed with status ${response.status}`);
+      const run = AgentRunSchema.parse(body);
+      store.setState({ status: run.status, finishedAt: run.finishedAt });
+    },
+  }));
+  entry.store = store;
+  entry.refs = 0;
+  entry.started = false;
+  entry.destroyed = false;
+  entry.controller = null;
+  entry.sseInFlight = false;
+  entry.pollTimer = null;
+  entry.sseRetryTimer = null;
+  entry.elapsedTimer = null;
+  entry.platform = platform;
+  entry.listeners = new Set();
+
+  return entry;
+};
+
+export const getAgentActivityEntry = (
+  runId: string,
+  platform: AgentRunEventsTransport,
+): ActivityEntry => {
+  const existing = registry.get(runId);
+  if (existing) return existing;
+  const entry = createEntry(runId, platform);
+  registry.set(runId, entry);
+
+  return entry;
+};
+
+export const recordAgentActivityArtifactOpenFailure = (
+  runId: string,
+  platform: AgentRunEventsTransport,
+): void => {
+  const entry = getAgentActivityEntry(runId, platform);
+  entry.store.setState((state) => ({
+    metrics: {
+      ...state.metrics,
+      artifactOpenFailureCount: state.metrics.artifactOpenFailureCount + 1,
+    },
+  }));
+  void platform
+    .request(`${platform.apiBaseUrl}/agent-runs/${encodeURIComponent(runId)}/activity/telemetry`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ kind: "artifact_open_failed" }),
+    })
+    .catch(() => undefined);
+};
+
+export const acquireAgentActivity = (entry: ActivityEntry): (() => void) => {
+  entry.refs += 1;
+  if (!entry.started) {
+    entry.started = true;
+    void hydrate(entry).catch((error: unknown) => {
+      if (!entry.destroyed)
+        entry.store.setState({ connection: "error", error: toError(error).message });
+    });
+  }
+  let released = false;
+
+  return () => {
+    if (released) return;
+    released = true;
+    entry.refs = Math.max(0, entry.refs - 1);
+    if (entry.refs === 0) {
+      stopTransport(entry);
+      entry.started = false;
+    }
+  };
+};
+
+/**
+ * Subscribe to the canonical envelope stream while sharing the same run-level
+ * transport and reducer used by React consumers. The returned release function
+ * also releases the underlying reference-counted stream.
+ */
+export const subscribeAgentActivity = (
+  runId: string,
+  platform: AgentRunEventsTransport,
+  listener: AgentActivityListener,
+): (() => void) => {
+  const entry = getAgentActivityEntry(runId, platform);
+  entry.listeners.add(listener);
+  const release = acquireAgentActivity(entry);
+  let released = false;
+
+  return () => {
+    if (released) return;
+    released = true;
+    entry.listeners.delete(listener);
+    release();
+  };
+};
+
+export const selectAgentActivityViewModel = (state: AgentActivityState) => {
+  const snapshot = state.snapshot;
+  const terminal = Boolean(state.status && TERMINAL_STATUSES.has(state.status));
+
+  return {
+    runId: state.runId,
+    runtime: state.runtime,
+    status: state.status,
+    phase: snapshot?.phase ?? "queued",
+    content: snapshot?.content ?? "",
+    progressMessage: snapshot?.progressMessage ?? null,
+    elapsedMs: state.elapsedMs,
+    tools: [...(snapshot?.activeTools ?? []), ...(snapshot?.completedTools ?? [])],
+    activeTools: snapshot?.activeTools ?? [],
+    completedTools: snapshot?.completedTools ?? [],
+    artifacts: snapshot?.artifacts ?? [],
+    usage: snapshot?.usage ?? null,
+    terminal: snapshot?.terminalMessage ?? null,
+    connection: state.connection,
+    lastSequence: state.lastSequence,
+    error: state.error,
+    capabilities: state.capabilities,
+    canCancel:
+      !terminal && state.status !== "cancelling" && state.capabilities?.cancellation !== "none",
+    canPause:
+      !terminal && state.capabilities?.pause !== undefined && state.capabilities.pause !== "none",
+    canResume:
+      terminal && state.capabilities?.resume !== undefined && state.capabilities.resume !== "none",
+    cancel: state.cancel,
+    waitingForFirstOutput:
+      !terminal &&
+      state.connection === "streaming" &&
+      !snapshot?.content &&
+      (snapshot?.items.length ?? 0) === 0,
+  };
+};
+
+export type AgentActivityViewModel = ReturnType<typeof selectAgentActivityViewModel>;

--- a/packages/views/src/components/AgentActivity/agentActivityStore.ts
+++ b/packages/views/src/components/AgentActivity/agentActivityStore.ts
@@ -492,9 +492,7 @@ export type AgentActivityViewModel = ReturnType<typeof createAgentActivityViewMo
  * Cache the derived object for each immutable store state so the snapshot
  * identity remains stable even though the view model contains derived arrays.
  */
-export const selectAgentActivityViewModel = (
-  state: AgentActivityState,
-): AgentActivityViewModel => {
+export const selectAgentActivityViewModel = (state: AgentActivityState): AgentActivityViewModel => {
   const cached = activityViewModelCache.get(state);
   if (cached) return cached;
   const viewModel = createAgentActivityViewModel(state);

--- a/packages/views/src/components/AgentActivity/agentActivityStore.ts
+++ b/packages/views/src/components/AgentActivity/agentActivityStore.ts
@@ -1,4 +1,5 @@
 import { createStore, type StoreApi } from "zustand/vanilla";
+import { Result, ResultAsync } from "neverthrow";
 import { z } from "zod/v4";
 import {
   AgentRunActivityMetricsSchema,
@@ -7,6 +8,7 @@ import {
   AgentRunSchema,
   RuntimeCapabilitiesSchema,
   createInitialAgentRunActivitySnapshot,
+  encodeAgentRunEventCursor,
   type AgentRun,
   type AgentRunActivityMetrics,
   type AgentRunActivitySnapshot,
@@ -33,7 +35,7 @@ const MAX_EVENTS_PER_POLL = 200;
 const EMPTY_METRICS = AgentRunActivityMetricsSchema.parse({});
 const AgentRunEventPageSchema = z.object({
   events: z.array(AgentRunEventEnvelopeSchema),
-  nextSequence: z.number().int().nonnegative(),
+  nextCursor: z.string().min(1),
   terminal: z.boolean(),
 });
 
@@ -67,6 +69,7 @@ export type AgentActivityStore = StoreApi<AgentActivityState>;
 type AgentActivityListener = (envelope: AgentRunEventEnvelope) => Promise<void> | void;
 
 type ActivityEntry = {
+  registryKey: string;
   store: AgentActivityStore;
   refs: number;
   started: boolean;
@@ -82,17 +85,40 @@ type ActivityEntry = {
 };
 
 const registry = new Map<string, ActivityEntry>();
+const requestIdentities = new WeakMap<AgentRunEventsTransport["request"], number>();
+let nextRequestIdentity = 0;
+
+const getRequestIdentity = (request: AgentRunEventsTransport["request"]): number => {
+  const existing = requestIdentities.get(request);
+  if (existing) return existing;
+  nextRequestIdentity += 1;
+  requestIdentities.set(request, nextRequestIdentity);
+
+  return nextRequestIdentity;
+};
+
+const getRegistryKey = (runId: string, platform: AgentRunEventsTransport): string =>
+  `${runId}\u0000${platform.apiBaseUrl}\u0000${getRequestIdentity(platform.request)}`;
 
 const toError = (error: unknown): Error =>
   error instanceof Error ? error : new Error(String(error));
 
+const settle = (promise: Promise<void>): Promise<void> =>
+  ResultAsync.fromPromise(promise, toError).match(
+    () => undefined,
+    () => undefined,
+  );
+
+const observe = <T>(promise: Promise<T>, onError: (error: Error) => void): void => {
+  void ResultAsync.fromPromise(promise, toError).match(() => undefined, onError);
+};
+
 const parseJson = async (response: Response): Promise<unknown> => {
   const raw = await response.text();
-  try {
-    return JSON.parse(raw) as unknown;
-  } catch {
-    return null;
-  }
+  return Result.fromThrowable(
+    () => JSON.parse(raw) as unknown,
+    () => null,
+  )().unwrapOr(null);
 };
 
 const requestRun = async (platform: AgentRunEventsTransport, runId: string): Promise<AgentRun> => {
@@ -152,18 +178,18 @@ const applyEnvelope = (entry: ActivityEntry, envelope: AgentRunEventEnvelope): P
       finishedAt: terminal ? envelope.createdAt : previous.finishedAt,
     }));
     for (const listener of entry.listeners) {
-      try {
-        await listener(envelope);
-      } catch {
-        // A view subscriber must not stop delivery to the shared activity store.
-      }
+      const delivered = await ResultAsync.fromPromise(
+        Promise.resolve().then(() => listener(envelope)),
+        toError,
+      );
+      if (delivered.isErr()) continue;
     }
     if (terminal) stopTransport(entry);
   };
 
   // SSE chunks and polling can overlap around reconnects. Serialize reducer and
   // subscriber delivery so control events (draft/apply/terminal) retain order.
-  const next = entry.deliveryQueue.catch(() => undefined).then(deliver);
+  const next = settle(entry.deliveryQueue).then(deliver);
   entry.deliveryQueue = next;
 
   return next;
@@ -221,8 +247,9 @@ const markSseFailure = (entry: ActivityEntry, error: Error): void => {
 const pollOnce = async (entry: ActivityEntry): Promise<void> => {
   if (entry.destroyed || entry.sseInFlight) return;
   const state = entry.store.getState();
+  const eventCursor = encodeAgentRunEventCursor(state.runId, state.lastSequence);
   const response = await entry.platform.request(
-    `${entry.platform.apiBaseUrl}/agent-runs/${encodeURIComponent(entry.store.getState().runId)}/events?after=${state.lastSequence}&limit=${MAX_EVENTS_PER_POLL}`,
+    `${entry.platform.apiBaseUrl}/agent-runs/${encodeURIComponent(entry.store.getState().runId)}/events?after=${encodeURIComponent(eventCursor)}&limit=${MAX_EVENTS_PER_POLL}`,
     {
       headers: { accept: "application/json" },
       signal: entry.controller?.signal,
@@ -242,15 +269,13 @@ const pollOnce = async (entry: ActivityEntry): Promise<void> => {
 const startPolling = (entry: ActivityEntry): void => {
   if (entry.pollTimer || entry.destroyed || entry.refs === 0) return;
   entry.store.setState({ connection: "polling" });
-  entry.pollTimer = setInterval(() => {
-    void pollOnce(entry).catch((error: unknown) => {
-      entry.store.setState({ error: toError(error).message });
+  const runPoll = () =>
+    observe(pollOnce(entry), (error) => {
+      entry.store.setState({ error: error.message });
     });
-  }, POLL_INTERVAL_MS);
+  entry.pollTimer = setInterval(runPoll, POLL_INTERVAL_MS);
   scheduleSseRetry(entry, SSE_RETRY_INTERVAL_MS);
-  void pollOnce(entry).catch((error: unknown) => {
-    entry.store.setState({ error: toError(error).message });
-  });
+  runPoll();
 };
 
 const startSse = async (entry: ActivityEntry): Promise<void> => {
@@ -265,8 +290,8 @@ const startSse = async (entry: ActivityEntry): Promise<void> => {
   const controller = new AbortController();
   entry.controller = controller;
   entry.store.setState({ connection: "streaming" });
-  try {
-    const result = await consumeAgentRunEventStream(entry.platform, {
+  const consumed = await ResultAsync.fromPromise(
+    consumeAgentRunEventStream(entry.platform, {
       runId: entry.store.getState().runId,
       after: entry.store.getState().lastSequence,
       signal: controller.signal,
@@ -275,16 +300,21 @@ const startSse = async (entry: ActivityEntry): Promise<void> => {
         if (!entry.destroyed) entry.store.setState({ connection: "streaming" });
       },
       onEnvelope: (envelope) => applyEnvelope(entry, envelope),
-    });
-    if (!entry.destroyed && !controller.signal.aborted && !result.terminalStatus) {
-      markSseFailure(entry, new Error("Agent event stream ended before terminal state"));
-    }
-  } catch (error: unknown) {
-    if (!entry.destroyed && !controller.signal.aborted) markSseFailure(entry, toError(error));
-  } finally {
-    entry.sseInFlight = false;
-    if (entry.controller === controller) entry.controller = null;
-  }
+    }),
+    toError,
+  );
+  consumed.match(
+    (result) => {
+      if (!entry.destroyed && !controller.signal.aborted && !result.terminalStatus) {
+        markSseFailure(entry, new Error("Agent event stream ended before terminal state"));
+      }
+    },
+    (error) => {
+      if (!entry.destroyed && !controller.signal.aborted) markSseFailure(entry, error);
+    },
+  );
+  entry.sseInFlight = false;
+  if (entry.controller === controller) entry.controller = null;
 };
 
 const hydrate = async (entry: ActivityEntry): Promise<void> => {
@@ -324,7 +354,11 @@ const hydrate = async (entry: ActivityEntry): Promise<void> => {
   await startSse(entry);
 };
 
-const createEntry = (runId: string, platform: AgentRunEventsTransport): ActivityEntry => {
+const createEntry = (
+  runId: string,
+  platform: AgentRunEventsTransport,
+  registryKey: string,
+): ActivityEntry => {
   const entry = {} as ActivityEntry;
   const store = createStore<AgentActivityState>(() => ({
     runId,
@@ -353,6 +387,7 @@ const createEntry = (runId: string, platform: AgentRunEventsTransport): Activity
       store.setState({ status: run.status, finishedAt: run.finishedAt });
     },
   }));
+  entry.registryKey = registryKey;
   entry.store = store;
   entry.refs = 0;
   entry.started = false;
@@ -373,10 +408,11 @@ export const getAgentActivityEntry = (
   runId: string,
   platform: AgentRunEventsTransport,
 ): ActivityEntry => {
-  const existing = registry.get(runId);
+  const registryKey = getRegistryKey(runId, platform);
+  const existing = registry.get(registryKey);
   if (existing) return existing;
-  const entry = createEntry(runId, platform);
-  registry.set(runId, entry);
+  const entry = createEntry(runId, platform, registryKey);
+  registry.set(registryKey, entry);
 
   return entry;
 };
@@ -392,22 +428,29 @@ export const recordAgentActivityArtifactOpenFailure = (
       artifactOpenFailureCount: state.metrics.artifactOpenFailureCount + 1,
     },
   }));
-  void platform
-    .request(`${platform.apiBaseUrl}/agent-runs/${encodeURIComponent(runId)}/activity/telemetry`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ kind: "artifact_open_failed" }),
-    })
-    .catch(() => undefined);
+  observe(
+    platform.request(
+      `${platform.apiBaseUrl}/agent-runs/${encodeURIComponent(runId)}/activity/telemetry`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ kind: "artifact_open_failed" }),
+      },
+    ),
+    () => undefined,
+  );
+  if (entry.refs === 0 && registry.get(entry.registryKey) === entry) {
+    entry.destroyed = true;
+    registry.delete(entry.registryKey);
+  }
 };
 
 export const acquireAgentActivity = (entry: ActivityEntry): (() => void) => {
   entry.refs += 1;
   if (!entry.started) {
     entry.started = true;
-    void hydrate(entry).catch((error: unknown) => {
-      if (!entry.destroyed)
-        entry.store.setState({ connection: "error", error: toError(error).message });
+    observe(hydrate(entry), (error) => {
+      if (!entry.destroyed) entry.store.setState({ connection: "error", error: error.message });
     });
   }
   let released = false;
@@ -419,6 +462,8 @@ export const acquireAgentActivity = (entry: ActivityEntry): (() => void) => {
     if (entry.refs === 0) {
       stopTransport(entry);
       entry.started = false;
+      entry.destroyed = true;
+      if (registry.get(entry.registryKey) === entry) registry.delete(entry.registryKey);
     }
   };
 };
@@ -471,7 +516,10 @@ const createAgentActivityViewModel = (state: AgentActivityState) => {
     error: state.error,
     capabilities: state.capabilities,
     canCancel:
-      !terminal && state.status !== "cancelling" && state.capabilities?.cancellation !== "none",
+      !terminal &&
+      state.status !== "cancelling" &&
+      state.capabilities?.cancellation !== undefined &&
+      state.capabilities.cancellation !== "none",
     canPause:
       !terminal && state.capabilities?.pause !== undefined && state.capabilities.pause !== "none",
     canResume:

--- a/packages/views/src/components/AgentActivity/agentActivityStore.unit.test.ts
+++ b/packages/views/src/components/AgentActivity/agentActivityStore.unit.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   acquireAgentActivity,
   getAgentActivityEntry,
+  selectAgentActivityViewModel,
   subscribeAgentActivity,
 } from "./agentActivityStore";
 
@@ -85,6 +86,17 @@ const sseResponse = (events: readonly AgentRunEventEnvelope[]): Response =>
   );
 
 describe("shared Agent Activity store", () => {
+  it("caches the derived view model for an unchanged store snapshot", () => {
+    const runId = `store-selector-${crypto.randomUUID()}`;
+    const entry = getAgentActivityEntry(runId, {
+      apiBaseUrl: "/api",
+      request: vi.fn(),
+    });
+    const state = entry.store.getState();
+
+    expect(selectAgentActivityViewModel(state)).toBe(selectAgentActivityViewModel(state));
+  });
+
   it("deduplicates a run transport and replays canonical envelopes to subscribers", async () => {
     const runId = `store-dedupe-${crypto.randomUUID()}`;
     const run = createRun(runId);

--- a/packages/views/src/components/AgentActivity/agentActivityStore.unit.test.ts
+++ b/packages/views/src/components/AgentActivity/agentActivityStore.unit.test.ts
@@ -132,7 +132,10 @@ describe("shared Agent Activity store", () => {
       }),
     };
     const received: number[] = [];
-    const releaseSubscription = subscribeAgentActivity(runId, platform, (entry) => {
+    const releaseSubscription = subscribeAgentActivity(runId, platform, async (entry) => {
+      // A slow first subscriber must not let later control/terminal envelopes
+      // overtake it while the shared transport is delivering the stream.
+      if (entry.sequence === 3) await new Promise((resolve) => setTimeout(resolve, 10));
       received.push(entry.sequence);
     });
     const entry = getAgentActivityEntry(runId, platform);

--- a/packages/views/src/components/AgentActivity/agentActivityStore.unit.test.ts
+++ b/packages/views/src/components/AgentActivity/agentActivityStore.unit.test.ts
@@ -97,6 +97,47 @@ describe("shared Agent Activity store", () => {
     expect(selectAgentActivityViewModel(state)).toBe(selectAgentActivityViewModel(state));
   });
 
+  it("does not expose cancellation before runtime capabilities are known", () => {
+    const runId = `store-capabilities-${crypto.randomUUID()}`;
+    const entry = getAgentActivityEntry(runId, {
+      apiBaseUrl: "/api",
+      request: vi.fn(),
+    });
+
+    entry.store.setState({ status: "running", capabilities: null });
+
+    expect(selectAgentActivityViewModel(entry.store.getState()).canCancel).toBe(false);
+  });
+
+  it("isolates transports and removes a zero-reference entry from the registry", () => {
+    const runId = `store-registry-${crypto.randomUUID()}`;
+    const run = createRun(runId);
+    const requestA = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith(`/agent-runs/${runId}`)) {
+        return new Response(JSON.stringify(run));
+      }
+
+      return new Response("stream unavailable", { status: 503 });
+    });
+    const requestB = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith(`/agent-runs/${runId}`)) {
+        return new Response(JSON.stringify(run));
+      }
+
+      return new Response("stream unavailable", { status: 503 });
+    });
+    const platformA = { apiBaseUrl: "/api", request: requestA };
+    const platformB = { apiBaseUrl: "/api", request: requestB };
+    const entryA = getAgentActivityEntry(runId, platformA);
+
+    expect(getAgentActivityEntry(runId, platformB)).not.toBe(entryA);
+
+    const release = acquireAgentActivity(entryA);
+    release();
+
+    expect(getAgentActivityEntry(runId, platformA)).not.toBe(entryA);
+  });
+
   it("deduplicates a run transport and replays canonical envelopes to subscribers", async () => {
     const runId = `store-dedupe-${crypto.randomUUID()}`;
     const run = createRun(runId);
@@ -198,7 +239,7 @@ describe("shared Agent Activity store", () => {
             return new Response(
               JSON.stringify({
                 events: [terminal],
-                nextSequence: terminal.sequence,
+                nextCursor: "test-cursor",
                 terminal: true,
               }),
               { headers: { "content-type": "application/json" } },

--- a/packages/views/src/components/AgentActivity/agentActivityStore.unit.test.ts
+++ b/packages/views/src/components/AgentActivity/agentActivityStore.unit.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AgentRunSchema,
+  createInitialAgentRunActivityMetrics,
+  createInitialAgentRunActivitySnapshot,
+  type AgentRun,
+  type AgentRunEventEnvelope,
+} from "@repo/schemas";
+import {
+  acquireAgentActivity,
+  getAgentActivityEntry,
+  subscribeAgentActivity,
+} from "./agentActivityStore";
+
+const capabilities = {
+  textStreaming: "delta" as const,
+  thinking: true,
+  toolEvents: true,
+  usage: true,
+  cancellation: "signal" as const,
+  resume: "none" as const,
+  pause: "none" as const,
+  mcpInjection: "none" as const,
+  imageInput: false,
+};
+
+const createRun = (runId: string): AgentRun => {
+  const createdAt = "2026-08-27T00:00:00.000Z";
+
+  return AgentRunSchema.parse({
+    id: runId,
+    owner: { type: "user", id: "local-owner" },
+    runtimeConfigId: "local-codex",
+    runtime: "codex",
+    status: "running",
+    executablePath: null,
+    executableVersion: null,
+    executableFingerprint: null,
+    model: null,
+    reasoningEffort: null,
+    speed: null,
+    cwd: "C:\\workspace",
+    nativeSessionId: null,
+    resumeFromRunId: null,
+    permissionMode: "full-access",
+    networkAccess: true,
+    controlMode: false,
+    allowedTools: [],
+    controlScopes: [],
+    runtimeCapabilities: capabilities,
+    activitySnapshot: createInitialAgentRunActivitySnapshot(runId, "codex", "running"),
+    activityMetrics: createInitialAgentRunActivityMetrics(),
+    usage: null,
+    resultText: null,
+    errorCode: null,
+    errorMessage: null,
+    createdAt,
+    startedAt: createdAt,
+    firstOutputAt: null,
+    lastActivityAt: createdAt,
+    finishedAt: null,
+  });
+};
+
+const envelope = (
+  runId: string,
+  sequence: number,
+  event: AgentRunEventEnvelope["event"],
+): AgentRunEventEnvelope => ({
+  runId,
+  sequence,
+  createdAt: `2026-08-27T00:00:${String(sequence).padStart(2, "0")}.000Z`,
+  event,
+});
+
+const sseResponse = (events: readonly AgentRunEventEnvelope[]): Response =>
+  new Response(
+    events
+      .map(
+        (entry) =>
+          `id: ${entry.sequence}\nevent: runtime_event\ndata: ${JSON.stringify(entry)}\n\n`,
+      )
+      .join(""),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+
+describe("shared Agent Activity store", () => {
+  it("deduplicates a run transport and replays canonical envelopes to subscribers", async () => {
+    const runId = `store-dedupe-${crypto.randomUUID()}`;
+    const run = createRun(runId);
+    const events = [
+      envelope(runId, 3, {
+        type: "status",
+        runtime: "codex",
+        timestamp: "2026-08-27T00:00:03.000Z",
+        phase: "running",
+      }),
+      envelope(runId, 9, {
+        type: "text_delta",
+        runtime: "codex",
+        timestamp: "2026-08-27T00:00:09.000Z",
+        text: "hello",
+      }),
+      envelope(runId, 12, {
+        type: "terminal",
+        runtime: "codex",
+        timestamp: "2026-08-27T00:00:12.000Z",
+        status: "completed",
+        resultText: "hello",
+      }),
+    ];
+    let runRequests = 0;
+    let streamRequests = 0;
+    const platform = {
+      apiBaseUrl: "/api",
+      request: vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith(`/agent-runs/${runId}`)) {
+          runRequests += 1;
+
+          return new Response(JSON.stringify(run), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url.includes(`/agent-runs/${runId}/events`)) {
+          streamRequests += 1;
+          expect(init?.headers).toMatchObject({ accept: "text/event-stream" });
+
+          return sseResponse(events);
+        }
+        throw new Error(`Unexpected request: ${url}`);
+      }),
+    };
+    const received: number[] = [];
+    const releaseSubscription = subscribeAgentActivity(runId, platform, (entry) => {
+      received.push(entry.sequence);
+    });
+    const entry = getAgentActivityEntry(runId, platform);
+    const releaseSecondReference = acquireAgentActivity(entry);
+
+    await vi.waitFor(() => {
+      expect(entry.store.getState().connection).toBe("terminal");
+    });
+
+    expect(runRequests).toBe(1);
+    expect(streamRequests).toBe(1);
+    expect(received).toEqual([3, 9, 12]);
+    expect(entry.store.getState().snapshot?.content).toBe("hello");
+    expect(entry.store.getState().lastSequence).toBe(12);
+
+    releaseSecondReference();
+    releaseSubscription();
+  });
+
+  it("falls back to polling after three failed SSE attempts", async () => {
+    vi.useFakeTimers();
+    const runId = `store-poll-${crypto.randomUUID()}`;
+    const run = createRun(runId);
+    let streamRequests = 0;
+    let pollRequests = 0;
+    const terminal = envelope(runId, 17, {
+      type: "terminal",
+      runtime: "codex",
+      timestamp: "2026-08-27T00:00:17.000Z",
+      status: "completed",
+      resultText: "polled",
+    });
+    const platform = {
+      apiBaseUrl: "/api",
+      request: vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith(`/agent-runs/${runId}`)) {
+          return new Response(JSON.stringify(run), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url.includes(`/agent-runs/${runId}/events`)) {
+          const acceptsJson =
+            String(init?.headers && new Headers(init.headers).get("accept")) === "application/json";
+          if (acceptsJson) {
+            pollRequests += 1;
+
+            return new Response(
+              JSON.stringify({
+                events: [terminal],
+                nextSequence: terminal.sequence,
+                terminal: true,
+              }),
+              { headers: { "content-type": "application/json" } },
+            );
+          }
+          streamRequests += 1;
+
+          return new Response("stream unavailable", { status: 503 });
+        }
+        throw new Error(`Unexpected request: ${url}`);
+      }),
+    };
+    const release = subscribeAgentActivity(runId, platform, () => undefined);
+
+    await vi.runAllTimersAsync();
+
+    const entry = getAgentActivityEntry(runId, platform);
+    expect(streamRequests).toBe(3);
+    expect(pollRequests).toBeGreaterThanOrEqual(1);
+    expect(entry.store.getState().connection).toBe("terminal");
+    expect(entry.store.getState().snapshot?.terminalMessage).toBe("polled");
+    release();
+    vi.useRealTimers();
+  });
+});

--- a/packages/views/src/components/AgentActivity/index.ts
+++ b/packages/views/src/components/AgentActivity/index.ts
@@ -1,0 +1,3 @@
+export * from "./agentActivityStore";
+export * from "./useAgentActivity";
+export * from "./AgentActivitySurface";

--- a/packages/views/src/components/AgentActivity/useAgentActivity.ts
+++ b/packages/views/src/components/AgentActivity/useAgentActivity.ts
@@ -1,0 +1,33 @@
+import { useEffect, useMemo } from "react";
+import { useStore } from "zustand";
+import type { AgentRunEventsTransport } from "../../lib/agentRunEventsClient";
+import {
+  acquireAgentActivity,
+  getAgentActivityEntry,
+  selectAgentActivityViewModel,
+} from "./agentActivityStore";
+
+export const useAgentActivity = ({
+  runId,
+  platform,
+}: {
+  runId: string | null | undefined;
+  platform: AgentRunEventsTransport;
+}) => {
+  const entry = useMemo(
+    () => (runId ? getAgentActivityEntry(runId, platform) : null),
+    [platform, runId],
+  );
+  useEffect(() => {
+    if (!entry) return;
+
+    return acquireAgentActivity(entry);
+  }, [entry]);
+
+  const viewModel = useStore(
+    entry?.store ?? getAgentActivityEntry("__empty__", platform).store,
+    selectAgentActivityViewModel,
+  );
+
+  return entry ? viewModel : { ...viewModel, runId: null };
+};

--- a/packages/views/src/components/GlobalAgentControl/GlobalAgentPanel.tsx
+++ b/packages/views/src/components/GlobalAgentControl/GlobalAgentPanel.tsx
@@ -17,7 +17,9 @@ import { Button } from "@repo/ui/button";
 import { ScrollArea } from "@repo/ui/scroll-area";
 import { Textarea } from "@repo/ui/textarea";
 import { cn } from "@repo/ui/lib/utils";
+import { usePlatform } from "../../platform";
 import { AgentExecutionPicker, useAgentExecutionChoice } from "../AgentExecutionPicker";
+import { AgentActivitySurface } from "../AgentActivity";
 import { AgentApprovalCard } from "./AgentApprovalCard";
 import { AgentContextChips } from "./AgentContextChips";
 import { useAgentControl } from "./GlobalAgentControlProvider";
@@ -27,10 +29,12 @@ const isCanvasChangeSetVisible = (status: string) =>
 
 export const GlobalAgentPanel = ({ className }: { className?: string }) => {
   const { t } = useTranslation();
+  const platform = usePlatform();
   const capabilities = useAgentControl((state) => state.capabilities);
   const storedExecutionChoice = useAgentControl((state) => state.executionChoice);
   const threads = useAgentControl((state) => state.threads);
   const activeThreadId = useAgentControl((state) => state.activeThreadId);
+  const currentRunId = useAgentControl((state) => state.currentRunId);
   const messages = useAgentControl((state) => state.messages);
   const events = useAgentControl((state) => state.events);
   const actions = useAgentControl((state) => state.actions);
@@ -98,6 +102,7 @@ export const GlobalAgentPanel = ({ className }: { className?: string }) => {
         .reverse(),
     [events],
   );
+  const visibleRuntimeEvents = currentRunId ? [] : recentRuntimeEvents;
   const latestTerminalStatus = useMemo(() => {
     const latest = [...events].reverse().find(({ event }) => event.type === "terminal")?.event;
 
@@ -234,7 +239,11 @@ export const GlobalAgentPanel = ({ className }: { className?: string }) => {
             </div>
           )}
 
-          {(messages.length > 0 || streamingText) && (
+          {currentRunId && (
+            <AgentActivitySurface platform={platform} runId={currentRunId} variant="panel" />
+          )}
+
+          {(messages.length > 0 || (streamingText && !currentRunId)) && (
             <div className="space-y-2.5" aria-label={t("agentControl.conversation.title")}>
               <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                 <MessageSquareText className="size-3" />
@@ -272,7 +281,7 @@ export const GlobalAgentPanel = ({ className }: { className?: string }) => {
                   )}
                 </article>
               ))}
-              {streamingText && (
+              {streamingText && !currentRunId && (
                 <article className="mr-auto max-w-[92%] rounded-2xl rounded-bl-md border border-primary/20 bg-primary/5 px-3 py-2.5 text-sm text-foreground">
                   <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-primary">
                     {t("agentControl.messageRole.assistant")}
@@ -328,13 +337,13 @@ export const GlobalAgentPanel = ({ className }: { className?: string }) => {
             </article>
           ))}
 
-          {(recentRuntimeEvents.length > 0 || recentActions.length > 0) && (
+          {(visibleRuntimeEvents.length > 0 || recentActions.length > 0) && (
             <div className="space-y-1.5 border-t border-border pt-3" data-testid="agent-activity">
               <p className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                 <Clock3 className="size-3" />
                 {t("agentControl.activity.title")}
               </p>
-              {recentRuntimeEvents.map((envelope) => {
+              {visibleRuntimeEvents.map((envelope) => {
                 const runtimeEvent = envelope.event;
                 if (runtimeEvent.type !== "diagnostic" && runtimeEvent.type !== "terminal") {
                   return null;
@@ -395,7 +404,7 @@ export const GlobalAgentPanel = ({ className }: { className?: string }) => {
           )}
           {messages.length === 0 &&
             recentActions.length === 0 &&
-            recentRuntimeEvents.length === 0 &&
+            visibleRuntimeEvents.length === 0 &&
             capabilities?.enabled && (
               <div className="grid min-h-52 place-items-center px-6 text-center">
                 <div>

--- a/packages/views/src/components/GlobalAgentControl/agentControlClient.ts
+++ b/packages/views/src/components/GlobalAgentControl/agentControlClient.ts
@@ -13,6 +13,7 @@ import {
   type AgentContextEnvelope,
 } from "@repo/schemas";
 import { consumeAgentRunEventStream } from "../../lib/agentRunEventsClient";
+import { subscribeAgentActivity } from "../AgentActivity/agentActivityStore";
 import type { PlatformCapabilities } from "../../platform";
 
 const AgentThreadMessageClientSchema = z.object({
@@ -217,6 +218,8 @@ export const createAgentControlClient = (platform: AgentControlTransport) => {
       runId: string,
       input: Omit<Parameters<typeof consumeAgentRunEventStream>[1], "runId">,
     ) => consumeAgentRunEventStream(platform, { ...input, runId }),
+    subscribeActivity: (runId: string, listener: Parameters<typeof subscribeAgentActivity>[2]) =>
+      subscribeAgentActivity(runId, platform, listener),
   };
 };
 

--- a/packages/views/src/components/GlobalAgentControl/agentControlStore.ts
+++ b/packages/views/src/components/GlobalAgentControl/agentControlStore.ts
@@ -139,8 +139,7 @@ export type AgentControlState = {
 export type AgentControlStore = StoreApi<AgentControlState>;
 
 export const createAgentControlStore = (client: AgentControlClient): AgentControlStore => {
-  const streamControllers = new Map<string, AbortController>();
-  const lastSequences = new Map<string, number>();
+  const activitySubscriptions = new Map<string, () => void>();
   const integration = {
     invalidator: null as ResourceInvalidator | null,
     navigator: null as AgentNavigator | null,
@@ -222,7 +221,6 @@ export const createAgentControlStore = (client: AgentControlClient): AgentContro
 
   const processEnvelope = async (threadId: string, envelope: AgentRunEventEnvelope) => {
     if (store.getState().activeThreadId !== threadId) return;
-    lastSequences.set(envelope.runId, envelope.sequence);
     store.setState((state) => ({
       events: [
         ...state.events.filter(
@@ -300,34 +298,16 @@ export const createAgentControlStore = (client: AgentControlClient): AgentContro
   };
 
   const startEventStream = (threadId: string, runId: string) => {
-    if (streamControllers.has(runId)) return;
-    const controller = new AbortController();
-    streamControllers.set(runId, controller);
-    void ResultAsync.fromPromise(
-      client.consumeEvents(runId, {
-        after: lastSequences.get(runId) ?? 0,
-        signal: controller.signal,
-        onEnvelope: (envelope) => processEnvelope(threadId, envelope),
-      }),
-      toError,
-    ).match(
-      () => {
-        streamControllers.delete(runId);
-      },
-      async (error) => {
-        streamControllers.delete(runId);
-        if (controller.signal.aborted || store.getState().activeThreadId !== threadId) return;
-        store.setState({ error: `Agent event stream disconnected: ${error.message}` });
-        await wait(1_000);
-        startEventStream(threadId, runId);
-      },
+    if (activitySubscriptions.has(runId)) return;
+    const release = client.subscribeActivity(runId, (envelope) =>
+      processEnvelope(threadId, envelope),
     );
+    activitySubscriptions.set(runId, release);
   };
 
   const loadThread = async (threadId: string) => {
-    for (const controller of streamControllers.values()) controller.abort();
-    streamControllers.clear();
-    lastSequences.clear();
+    for (const release of activitySubscriptions.values()) release();
+    activitySubscriptions.clear();
     store.setState({
       activeThreadId: threadId,
       messages: [],

--- a/packages/views/src/lib/agentRunEventsClient.ts
+++ b/packages/views/src/lib/agentRunEventsClient.ts
@@ -33,6 +33,7 @@ export const consumeAgentRunEventStream = async (
     runId: string;
     after?: number;
     signal?: AbortSignal;
+    onConnected?: () => void;
     onEnvelope: (envelope: AgentRunEventEnvelope) => Promise<void> | void;
   },
 ): Promise<{ lastSequence: number; terminalStatus: RuntimeTerminalStatus | null }> => {
@@ -58,6 +59,7 @@ export const consumeAgentRunEventStream = async (
   }
   const reader = response.body?.getReader();
   if (!reader) throw new Error(`Agent run ${input.runId} did not return an event stream`);
+  input.onConnected?.();
 
   const emitBufferedMessages = async () => {
     const messages = state.buffer.split(/\r?\n\r?\n/);

--- a/packages/views/src/lib/pipelineAgentSessionsClient.ts
+++ b/packages/views/src/lib/pipelineAgentSessionsClient.ts
@@ -4,6 +4,10 @@ import type { PlatformCapabilities } from "../platform";
 import { projectPipelineAgentMessage } from "./projectPipelineAgentMessage";
 import { consumeAgentRunEventStream } from "./agentRunEventsClient";
 import {
+  getAgentActivityEntry,
+  subscribeAgentActivity,
+} from "../components/AgentActivity/agentActivityStore";
+import {
   AgentRunSchema,
   OperationSchema,
   PipelineSchema,
@@ -177,6 +181,7 @@ const readActiveAgentRun = (sessionId: string) => {
 
   return parsed.unwrapOr(null);
 };
+export const getStoredActiveAgentRun = (sessionId: string) => readActiveAgentRun(sessionId);
 const writeActiveAgentRun = (sessionId: string, runId: string, lastSequence: number) => {
   if (globalThis.window === undefined) return;
   globalThis.window.localStorage.setItem(
@@ -235,7 +240,7 @@ const mapAgentRunEvent = (envelope: AgentRunEventEnvelope): PipelineAgentPlanEve
   if (event.type === "text_delta") {
     return { type: "assistant_chunk", text: event.text };
   }
-  if (event.type === "thinking_delta") return { type: "thinking", text: event.text };
+  if (event.type === "thinking_delta") return { type: "thinking", text: "" };
   if (event.type === "tool_start") {
     return { type: "tool", phase: "start", id: event.id, name: event.name };
   }
@@ -605,6 +610,8 @@ export const createPipelineAgentSessionsClient = (platform: PipelineAgentSession
         speed?: string;
         firstOutputTimeoutSeconds?: number;
         signal?: AbortSignal;
+        onRunId?: (runId: string) => void;
+        useSharedActivity?: boolean;
         onEvent: (event: PipelineAgentPlanEvent) => void;
       },
     ) {
@@ -653,6 +660,7 @@ export const createPipelineAgentSessionsClient = (platform: PipelineAgentSession
       }
       const runId = activeRunState.runId;
       if (!runId) throw new Error(`Agent run did not start for session ${sessionId}`);
+      input.onRunId?.(runId);
       const streamControl = {
         lastSequence: activeRunState.lastSequence,
         terminalStatus: null as z.infer<typeof AgentRunSchema>["status"] | null,
@@ -663,7 +671,48 @@ export const createPipelineAgentSessionsClient = (platform: PipelineAgentSession
         phase: streamControl.lastSequence > 0 ? "reconnecting" : "analyzing",
       });
 
-      while (!streamControl.terminalStatus && !input.signal?.aborted) {
+      if (input.useSharedActivity) {
+        const entry = getAgentActivityEntry(runId, platform);
+        await new Promise<void>((resolve, reject) => {
+          const lifecycle = { settled: false };
+          const finish = (error?: Error) => {
+            if (lifecycle.settled) return;
+            lifecycle.settled = true;
+            unsubscribeSnapshot();
+            releaseActivity();
+            input.signal?.removeEventListener("abort", handleAbort);
+            if (error) reject(error);
+            else resolve();
+          };
+          const handleAbort = () => finish();
+          const unsubscribeSnapshot = entry.store.subscribe((next, previous) => {
+            if (next.snapshot === previous.snapshot) return;
+            if (next.snapshot && isTerminalRunStatus(next.snapshot.status)) {
+              streamControl.terminalStatus = next.snapshot.status;
+              finish();
+            }
+          });
+          const releaseActivity = subscribeAgentActivity(runId, platform, (envelope) => {
+            if (envelope.sequence <= streamControl.lastSequence) return;
+            streamControl.lastSequence = envelope.sequence;
+            writeActiveAgentRun(sessionId, runId, streamControl.lastSequence);
+            const event = mapAgentRunEvent(envelope);
+            if (event) input.onEvent(event);
+            if (envelope.event.type === "terminal") {
+              streamControl.terminalStatus = envelope.event.status;
+              finish();
+            }
+          });
+          input.signal?.addEventListener("abort", handleAbort, { once: true });
+          const current = entry.store.getState();
+          if (current.snapshot && isTerminalRunStatus(current.snapshot.status)) {
+            streamControl.terminalStatus = current.snapshot.status;
+            finish();
+          }
+        });
+      }
+
+      while (!input.useSharedActivity && !streamControl.terminalStatus && !input.signal?.aborted) {
         const consumed = await consumeAgentRunEventStream(platform, {
           runId,
           after: streamControl.lastSequence,

--- a/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/AgentPanel.tsx
@@ -13,6 +13,7 @@ import {
   changeExecutionRuntime,
   useAgentExecutionChoice,
 } from "../../../components/AgentExecutionPicker";
+import { AgentActivitySurface } from "../../../components/AgentActivity";
 import { createPipelineAgentSessionsClient } from "../../../lib/pipelineAgentSessionsClient";
 import { usePlatform } from "../../../platform";
 import { toastStore } from "../../../store/toastStore";
@@ -64,6 +65,7 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
   const addMessage = useAgentBarStore((state) => state.addMessage);
   const generateProposal = useAgentBarStore((state) => state.generateProposal);
   const {
+    activeRunId,
     applyProposal,
     agentContext,
     discardProposal,
@@ -645,14 +647,20 @@ export const AgentPanel = ({ onGeneratedPipeline }: AgentPanelProps) => {
             onSubmit={handleMessageSubmit}
           />
         ))}
-        {streamingAssistantText && (
-          <Assistant className="whitespace-pre-wrap">{streamingAssistantText}</Assistant>
-        )}
-
-        <AgentActivityFeed active={isConversationActive} entries={streamingActivities} />
-
-        {isConversationActive && streamingActivities.length === 0 && (
-          <Assistant isThinking>{streamingProgress ?? t("canvas.agentPanel.thinking")}</Assistant>
+        {activeRunId ? (
+          <AgentActivitySurface platform={platform} runId={activeRunId} variant="panel" />
+        ) : (
+          <>
+            {streamingAssistantText && (
+              <Assistant className="whitespace-pre-wrap">{streamingAssistantText}</Assistant>
+            )}
+            <AgentActivityFeed active={isConversationActive} entries={streamingActivities} />
+            {isConversationActive && streamingActivities.length === 0 && (
+              <Assistant isThinking>
+                {streamingProgress ?? t("canvas.agentPanel.thinking")}
+              </Assistant>
+            )}
+          </>
         )}
         <div ref={messagesEndRef} />
 

--- a/packages/views/src/pages/CanvasPage/AgentPanel/_store/agentBarStore.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/_store/agentBarStore.ts
@@ -19,6 +19,7 @@ export type AgentBarMessage = {
 };
 
 export type AgentBarState = {
+  activeRunId: string | null;
   conversationState: AgentConversationState;
   /** COD-346:空画布 generate 会话产生的建图方案(与画布 edit 提案互斥)。 */
   generateProposal: PipelineGenerationPlan | null;
@@ -39,6 +40,7 @@ export type AgentBarState = {
   resetSession: () => void;
   resolveMessage: (id: string) => void;
   setConversationState: (state: AgentConversationState) => void;
+  setActiveRunId: (runId: string | null) => void;
   setGenerateProposal: (proposal: PipelineGenerationPlan | null) => void;
   setMessages: (messages: AgentBarMessage[]) => void;
   setProposalId: (proposalId: string | null) => void;
@@ -49,6 +51,7 @@ export type AgentBarState = {
 };
 
 const initialSessionState = {
+  activeRunId: null,
   generateProposal: null,
   proposalId: null,
   sessionGraphSignature: null,
@@ -125,6 +128,7 @@ export const createAgentBarStore = (pipelineId: string | null = null): AgentBarS
         ),
       })),
     setConversationState: (conversationState) => set({ conversationState }),
+    setActiveRunId: (activeRunId) => set({ activeRunId }),
     setGenerateProposal: (generateProposal) => set({ generateProposal }),
     setMessages: (messages) => set({ messages }),
     setProposalId: (proposalId) => set({ proposalId }),

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.ts
@@ -7,6 +7,7 @@ import type { ConversationMessageMetadata, PipelineActionProposal } from "@repo/
 import { useCanvasPageStore } from "../_store";
 import {
   createPipelineAgentSessionsClient,
+  getStoredActiveAgentRun,
   type PipelineAgentPlanEvent,
 } from "../../../lib/pipelineAgentSessionsClient";
 import { usePlatform } from "../../../platform";
@@ -55,7 +56,6 @@ const planEventToActivity = (event: PipelineAgentPlanEvent): AgentActivityEntry 
       id: "thinking",
       kind: "thinking",
       title: "Reasoning",
-      detail: event.text,
       timestamp,
     };
   }
@@ -170,6 +170,7 @@ export const useAgentConversation = ({
   const activeSessionId = useAgentBarStore((state) => state.sessionId);
   const messages = useAgentBarStore((state) => state.messages);
   const streamingAssistantText = useAgentBarStore((state) => state.streamingAssistantText);
+  const activeRunId = useAgentBarStore((state) => state.activeRunId);
   const streamingProgress = useAgentBarStore((state) => state.streamingProgress);
   const streamingActivities = useAgentBarStore((state) => state.streamingActivities);
   const generateSession = useMemo(
@@ -226,6 +227,8 @@ export const useAgentConversation = ({
 
     saveEditSession(pipelineId, { graphSignature, sessionId: session.id });
     agentBarStore.getState().setSession(session.id, graphSignature);
+    const activeRun = getStoredActiveAgentRun(session.id);
+    agentBarStore.getState().setActiveRunId(activeRun?.runId ?? null);
 
     return session.id;
   }, [agentBarStore, client, generateSession, graphSignature, pipelineId]);
@@ -593,6 +596,7 @@ export const useAgentConversation = ({
       state.setStreamingAssistantText("");
       state.setStreamingActivities([]);
       state.setStreamingProgress(null);
+      state.setActiveRunId(null);
       const abortController = new AbortController();
       activeRequestAbortRef.current = abortController;
 
@@ -630,6 +634,8 @@ export const useAgentConversation = ({
             ...(speed ? { speed } : {}),
             ...(firstOutputTimeoutSeconds === undefined ? {} : { firstOutputTimeoutSeconds }),
             signal: abortController.signal,
+            onRunId: (runId) => state.setActiveRunId(runId),
+            useSharedActivity: true,
             onEvent: (event) => {
               if (
                 event.type === "question" ||
@@ -900,6 +906,7 @@ export const useAgentConversation = ({
     messages,
     resetSession: agentBarStore.getState().resetSession,
     streamingAssistantText,
+    activeRunId,
     streamingActivities,
     streamingProgress,
     stopConversation,

--- a/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/AgentPanel/useAgentConversation.unit.test.tsx
@@ -42,6 +42,7 @@ vi.mock("../../../lib/pipelineAgentSessionsClient", () => ({
     planSessionStream: (...args: unknown[]) => mocks.planSessionStream(...args),
     supersedeProposal: vi.fn(),
   }),
+  getStoredActiveAgentRun: () => null,
 }));
 
 vi.mock("./useAgentConversationPersistence", () => ({

--- a/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.stories.tsx
+++ b/packages/views/src/pages/CanvasPage/CanvasInner/CanvasInner.stories.tsx
@@ -13,6 +13,7 @@ interface CanvasInnerStoryProps {
 
 const storyPlatform: PlatformCapabilities = {
   apiBaseUrl: "",
+  copyText: async () => undefined,
   downloadBlob: () => undefined,
   request: (input, init) => fetch(input, init),
 };

--- a/packages/views/src/pages/CanvasPage/LlmContentCard/LlmContentCard.tsx
+++ b/packages/views/src/pages/CanvasPage/LlmContentCard/LlmContentCard.tsx
@@ -6,15 +6,19 @@ import { ScrollArea } from "@repo/ui/scroll-area";
 import { useStore } from "zustand";
 import { useCanvasPageStore } from "../_store";
 import { AgentActivityFeed } from "../../../components/AgentActivityFeed";
+import { AgentActivitySurface } from "../../../components/AgentActivity";
+import { useOptionalPlatform } from "../../../platform";
 
 export const LlmContentCard = () => {
   const { t } = useTranslation();
+  const platform = useOptionalPlatform();
   const store = useCanvasPageStore();
   const inspectingNodeId = useStore(store, (s) => s.inspectingNodeId);
   const handleDismissInspection = useStore(store, (s) => s.handleDismissInspection);
   const nodeLlmContent = useStore(store, (s) => s.nodeLlmContent);
   const nodeAgentActivities = useStore(store, (s) => s.nodeAgentActivities);
   const nodeRunStatuses = useStore(store, (s) => s.nodeRunStatuses);
+  const nodeAgentRunIds = useStore(store, (s) => s.nodeAgentRunIds);
   const nodes = useStore(store, (s) => s.nodes);
 
   if (!inspectingNodeId) return null;
@@ -22,6 +26,7 @@ export const LlmContentCard = () => {
   const content = nodeLlmContent[inspectingNodeId];
   const activities = nodeAgentActivities[inspectingNodeId] ?? [];
   const status = nodeRunStatuses[inspectingNodeId];
+  const runId = nodeAgentRunIds[inspectingNodeId]?.at(-1) ?? null;
   const node = nodes.find((n) => n.id === inspectingNodeId);
   const nodeLabel = (node?.data as Record<string, unknown>)?.label as string | undefined;
 
@@ -46,8 +51,12 @@ export const LlmContentCard = () => {
       </div>
       <ScrollArea className="max-h-[60vh] min-h-0">
         <div className="overflow-hidden p-4">
-          <AgentActivityFeed active={status === "running"} entries={activities} />
-          {status === "running" && !content && activities.length === 0 && (
+          {runId && platform ? (
+            <AgentActivitySurface platform={platform} runId={runId} variant="bar" />
+          ) : (
+            <AgentActivityFeed active={status === "running"} entries={activities} />
+          )}
+          {status === "running" && !content && activities.length === 0 && !runId && (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
               <span>{t("canvas.llmContent.running")}</span>

--- a/packages/views/src/pages/CanvasPage/OperationNode/OperationNode.tsx
+++ b/packages/views/src/pages/CanvasPage/OperationNode/OperationNode.tsx
@@ -27,6 +27,8 @@ import { useCanvasPageStore, selectNodeRunState, selectNodePortCounts } from "..
 import type { OperationNodeData, NodeRunStatus, Operation, Agent } from "@repo/schemas";
 import { useList } from "@refinedev/core";
 import { ResourceName } from "../../../constants";
+import { AgentActivitySurface } from "../../../components/AgentActivity";
+import { usePlatform } from "../../../platform";
 import { NodeCard, useNodeCardActions } from "../NodeCard";
 
 export interface OperationNodeProps {
@@ -88,6 +90,7 @@ const stopCanvasInteraction = (event: SyntheticEvent) => event.stopPropagation()
 
 export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
   const { t } = useTranslation();
+  const platform = usePlatform();
   const store = useCanvasPageStore();
   const nodeCardActions = useNodeCardActions(id);
   const { runStatus: nodeRunStatus, dimmed } = useStore(store, useShallow(selectNodeRunState(id)));
@@ -166,6 +169,7 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
       : t("nodes.operation.defaultAgent");
 
   const hasLlmContent = !!nodeLlmContent[id];
+  const activeRunId = nodeAgentRunIds[id]?.at(-1) ?? null;
   const canInspect = isTestRunning || hasLlmContent || !!nodeAgentRunIds[id]?.length;
   const objectTypeLabels: Record<string, string> = {
     file: t("nodes.operation.objectTypes.file"),
@@ -325,6 +329,15 @@ export const OperationNode = ({ id, data, selected }: OperationNodeProps) => {
             <Brain className="h-3 w-3 shrink-0" />
             <span>{t("nodes.operation.inspectLlmOutput")}</span>
           </div>
+        )}
+
+        {activeRunId && (
+          <AgentActivitySurface
+            className="font-sans"
+            platform={platform}
+            runId={activeRunId}
+            variant="inline"
+          />
         )}
 
         <div className="nodrag nopan space-y-1.5" {...canvasInteractionHandlers}>

--- a/packages/views/src/pages/CanvasPage/RunConsole/CanvasRunEventSynchronizer.tsx
+++ b/packages/views/src/pages/CanvasPage/RunConsole/CanvasRunEventSynchronizer.tsx
@@ -2,15 +2,22 @@ import { useEffect, useRef } from "react";
 import { useDataProvider } from "@refinedev/core";
 import { ResultAsync } from "neverthrow";
 import { useStore } from "zustand";
-import { RuntimeEventSchema, type Job, type JobStatus } from "@repo/schemas";
-import { consumeAgentRunEventStream } from "../../../lib/agentRunEventsClient";
+import {
+  RuntimeEventSchema,
+  type AgentRunActivitySnapshot,
+  type Job,
+  type JobStatus,
+} from "@repo/schemas";
+import {
+  getAgentActivityEntry,
+  subscribeAgentActivity,
+} from "../../../components/AgentActivity/agentActivityStore";
 import { usePlatform } from "../../../platform";
 import { ResourceName } from "../../../constants";
 import { useCanvasPageStore } from "../_store";
 import { parseCanvasRunTraceEvents } from "./canvasRunTraceEvents";
 
 const POLL_INTERVAL_MS = 1_500;
-const RECONNECT_INTERVAL_MS = 500;
 
 type RunTrace = { id: number; message: string };
 
@@ -20,24 +27,6 @@ const isTerminalStatus = (status: JobStatus): boolean =>
   status === "cancelled" ||
   status === "expired" ||
   status === "skipped";
-
-const waitForReconnect = (signal: AbortSignal): Promise<void> =>
-  new Promise((resolve) => {
-    if (signal.aborted) {
-      resolve();
-
-      return;
-    }
-    const onAbort = () => {
-      globalThis.clearTimeout(timer);
-      resolve();
-    };
-    const timer = globalThis.setTimeout(() => {
-      signal.removeEventListener("abort", onAbort);
-      resolve();
-    }, RECONNECT_INTERVAL_MS);
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
 
 export const CanvasRunEventSynchronizer = () => {
   const platform = usePlatform();
@@ -83,7 +72,7 @@ export const CanvasRunEventSynchronizer = () => {
     const state = {
       directNodes: new Set<string>(),
       lastProcessedTraceId: 0,
-      streamRunIds: new Set<string>(),
+      activityReleases: new Map<string, () => void>(),
       timer: null as ReturnType<typeof globalThis.setTimeout> | null,
     };
 
@@ -91,48 +80,47 @@ export const CanvasRunEventSynchronizer = () => {
       const actions = dependenciesRef.current;
       actions.registerNodeAgentRun(nodeId, runId);
       state.directNodes.add(nodeId);
-      if (state.streamRunIds.has(runId)) return;
-      state.streamRunIds.add(runId);
-
-      const stream = async () => {
-        const streamState = { lastSequence: 0, terminal: false };
-        while (!abortController.signal.aborted && !streamState.terminal) {
-          const consumed = await ResultAsync.fromPromise(
-            consumeAgentRunEventStream(platform, {
-              runId,
-              after: streamState.lastSequence,
-              signal: abortController.signal,
-              onEnvelope: (envelope) => {
-                const runtimeEvent = RuntimeEventSchema.safeParse(envelope.event);
-                if (runtimeEvent.success) {
-                  dependenciesRef.current.applyNodeRuntimeEvent(nodeId, runId, runtimeEvent.data);
-                }
-              },
-            }),
-            (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
-          );
-          consumed.match(
-            (value) => {
-              streamState.lastSequence = value.lastSequence;
-              streamState.terminal = value.terminalStatus !== null;
-            },
-            (error) => {
-              if (abortController.signal.aborted) return;
-              dependenciesRef.current.applyNodeAgentActivity(nodeId, {
-                id: `${runId}:stream-error`,
-                kind: "diagnostic",
-                title: "Agent event stream disconnected",
-                detail: error.message,
-              });
-            },
-          );
-          if (!streamState.terminal && !abortController.signal.aborted) {
-            await waitForReconnect(abortController.signal);
-          }
+      const subscriptionKey = `${nodeId}:${runId}`;
+      if (state.activityReleases.has(subscriptionKey)) return;
+      const entry = getAgentActivityEntry(runId, platform);
+      const applySnapshot = (snapshot: AgentRunActivitySnapshot) => {
+        const current = dependenciesRef.current;
+        if (snapshot.content) current.applyNodeLlmContent(nodeId, snapshot.content);
+        else if (snapshot.terminalMessage) {
+          current.applyNodeLlmContent(nodeId, snapshot.terminalMessage);
+        }
+        for (const tool of [...snapshot.activeTools, ...snapshot.completedTools]) {
+          current.applyNodeAgentActivity(nodeId, {
+            id: `${runId}:tool-${tool.id}`,
+            kind: "tool",
+            title: `${tool.name} · ${tool.status}`,
+            timestamp: tool.completedAt ?? tool.startedAt,
+          });
+        }
+        if (snapshot.terminalAt) {
+          current.applyNodeAgentActivity(nodeId, {
+            id: `${runId}:terminal`,
+            kind: "terminal",
+            title: `Run ${snapshot.status}`,
+            timestamp: snapshot.terminalAt,
+          });
         }
       };
-
-      void stream();
+      const unsubscribeSnapshot = entry.store.subscribe((next, previous) => {
+        if (next.snapshot && next.snapshot !== previous.snapshot) applySnapshot(next.snapshot);
+      });
+      const hydratedSnapshot = entry.store.getState().snapshot;
+      if (hydratedSnapshot) applySnapshot(hydratedSnapshot);
+      const release = subscribeAgentActivity(runId, platform, (envelope) => {
+        const runtimeEvent = RuntimeEventSchema.safeParse(envelope.event);
+        if (runtimeEvent.success) {
+          dependenciesRef.current.applyNodeRuntimeEvent(nodeId, runId, runtimeEvent.data);
+        }
+      });
+      state.activityReleases.set(subscriptionKey, () => {
+        unsubscribeSnapshot();
+        release();
+      });
     };
 
     const applyTraceEvents = (traces: readonly RunTrace[]) => {
@@ -201,6 +189,8 @@ export const CanvasRunEventSynchronizer = () => {
     return () => {
       abortController.abort();
       if (state.timer) globalThis.clearTimeout(state.timer);
+      for (const release of state.activityReleases.values()) release();
+      state.activityReleases.clear();
     };
   }, [getDataProvider, jobId, platform]);
 

--- a/packages/views/src/pages/CanvasPage/RunConsole/CanvasRunEventSynchronizer.unit.test.tsx
+++ b/packages/views/src/pages/CanvasPage/RunConsole/CanvasRunEventSynchronizer.unit.test.tsx
@@ -8,9 +8,20 @@ import { render } from "../../../test/test-wrapper";
 import { CanvasPageStoreProvider, useCanvasPageStore } from "../_store";
 import { CanvasRunEventSynchronizer } from "./CanvasRunEventSynchronizer";
 
-const consumeAgentRunEventStream = vi.hoisted(() => vi.fn());
+const subscribeAgentActivity = vi.hoisted(() => vi.fn());
+const getAgentActivityEntry = vi.hoisted(() =>
+  vi.fn(() => ({
+    store: {
+      getState: () => ({ snapshot: null }),
+      subscribe: () => () => undefined,
+    },
+  })),
+);
 
-vi.mock("../../../lib/agentRunEventsClient", () => ({ consumeAgentRunEventStream }));
+vi.mock("../../../components/AgentActivity/agentActivityStore", () => ({
+  getAgentActivityEntry,
+  subscribeAgentActivity,
+}));
 
 const job: Job = {
   id: "job-1",
@@ -80,13 +91,11 @@ const wrapper = ({ children }: React.PropsWithChildren) => (
 
 describe("CanvasRunEventSynchronizer", () => {
   it("replays a completed run while the console is closed", async () => {
-    consumeAgentRunEventStream.mockImplementation(
-      async (
+    subscribeAgentActivity.mockImplementation(
+      (
+        _runId: string,
         _platform: unknown,
-        input: {
-          after?: number;
-          onEnvelope: (envelope: AgentRunEventEnvelope) => Promise<void> | void;
-        },
+        onEnvelope: (envelope: AgentRunEventEnvelope) => Promise<void> | void,
       ) => {
         const events: AgentRunEventEnvelope[] = [
           {
@@ -137,9 +146,9 @@ describe("CanvasRunEventSynchronizer", () => {
             },
           },
         ];
-        for (const envelope of events) await input.onEnvelope(envelope);
+        for (const envelope of events) void onEnvelope(envelope);
 
-        return { lastSequence: 4, terminalStatus: "completed" as const };
+        return () => undefined;
       },
     );
 
@@ -160,9 +169,11 @@ describe("CanvasRunEventSynchronizer", () => {
     expect(screen.getByTestId("sync-state")).toHaveTextContent(
       '"activities":["status","tool","terminal"]',
     );
-    expect(consumeAgentRunEventStream).toHaveBeenCalledWith(
+    expect(subscribeAgentActivity).toHaveBeenCalledWith(
+      "run-1",
       expect.any(Object),
-      expect.objectContaining({ runId: "run-1", after: 0 }),
+      expect.any(Function),
     );
+    expect(getAgentActivityEntry).toHaveBeenCalledWith("run-1", expect.any(Object));
   });
 });

--- a/packages/views/src/pages/CanvasPage/RunConsole/RunConsole.tsx
+++ b/packages/views/src/pages/CanvasPage/RunConsole/RunConsole.tsx
@@ -6,6 +6,7 @@ import { useCustom, useDataProvider, useOne } from "@refinedev/core";
 import { useStore } from "zustand";
 import { useCanvasPageStore } from "../_store";
 import { StatusIcon } from "./StatusIcon";
+import { AgentActivitySurface } from "../../../components/AgentActivity";
 import {
   buildRunTimeline,
   summarizeMultiInputNodes,
@@ -13,6 +14,7 @@ import {
 } from "./runTraceParser";
 import { ResourceName } from "../../../constants";
 import type { Job, JobStatus } from "@repo/schemas";
+import { usePlatform } from "../../../platform";
 
 const POLL_INTERVAL = 1500;
 
@@ -80,6 +82,7 @@ export const RunConsole = ({ visible = true }: { visible?: boolean }) => {
   const handleToggleConsoleCollapse = useStore(store, (s) => s.handleToggleConsoleCollapse);
   const getDataProvider = useDataProvider();
   const dataProvider = getDataProvider();
+  const platform = usePlatform();
 
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -143,6 +146,11 @@ export const RunConsole = ({ visible = true }: { visible?: boolean }) => {
     runTimeline.currentNodeId === null
       ? t("canvas.runConsole.currentStepIdle")
       : (nodeLabelById.get(runTimeline.currentNodeId) ?? runTimeline.currentNodeId);
+  const nodeAgentRunIds = useStore(store, (s) => s.nodeAgentRunIds);
+  const currentRunId =
+    (runTimeline.currentNodeId ? nodeAgentRunIds[runTimeline.currentNodeId]?.at(-1) : undefined) ??
+    Object.values(nodeAgentRunIds).flat().at(-1) ??
+    null;
 
   if (!visible) return null;
 
@@ -197,6 +205,14 @@ export const RunConsole = ({ visible = true }: { visible?: boolean }) => {
             ref={scrollRef}
             className="h-44 overflow-y-auto px-3.5 py-2.5 font-mono text-[10.5px] leading-relaxed"
           >
+            {currentRunId && (
+              <AgentActivitySurface
+                className="mb-2 font-sans"
+                platform={platform}
+                runId={currentRunId}
+                variant="console"
+              />
+            )}
             {!job && (
               <div className="flex items-center gap-2 text-muted-foreground">
                 <Loader2 className="size-3.5 animate-spin" />

--- a/packages/views/src/platform/PlatformContext.tsx
+++ b/packages/views/src/platform/PlatformContext.tsx
@@ -10,6 +10,10 @@ import { createContext, useContext, type ReactNode } from "react";
 export interface PlatformCapabilities {
   /** 将二进制内容保存到本地。Web 端走浏览器下载，Desktop 端可走原生保存对话框。 */
   downloadBlob: (blob: Blob, filename: string) => void;
+  /** 将一段路径/文本复制到当前客户端剪贴板。 */
+  copyText: (text: string) => Promise<void>;
+  /** 使用客户端默认程序打开路径；Web 端对不支持的本地路径可拒绝。 */
+  openPath?: (path: string) => Promise<void>;
   /** 当前客户端的 Ordine REST API 根地址（不含末尾斜杠）。 */
   apiBaseUrl: string;
   /** 发起平台感知的请求。Desktop 实现会为 sidecar 请求附加认证头。 */
@@ -36,3 +40,10 @@ export const usePlatform = (): PlatformCapabilities => {
 
   return ctx;
 };
+
+/**
+ * Read platform capabilities when a view can also render in an isolated
+ * preview/test tree. Run-backed activity surfaces still require a provider;
+ * callers can keep their local fallback when no platform is available.
+ */
+export const useOptionalPlatform = (): PlatformCapabilities | null => useContext(PlatformContext);

--- a/packages/views/src/test/test-wrapper.tsx
+++ b/packages/views/src/test/test-wrapper.tsx
@@ -47,6 +47,7 @@ export const canvasTestDataProvider: DataProvider = {
 
 const testPlatform: PlatformCapabilities = {
   apiBaseUrl: "http://localhost:9433/api",
+  copyText: async () => undefined,
   downloadBlob: () => undefined,
   request: (input, init) => globalThis.fetch(input, init),
 };


### PR DESCRIPTION
## Scope
Refs COD-354. Builds on PR1 (cod-354-agent-activity-core) and the latest Agent Control Plane baseline.

- Adds a single runId-keyed, reference-counted Activity store with one SSE transport per run.
- Hydrates snapshots, resumes from the opaque cursor, falls back to 1s polling after three SSE failures, and retries SSE every 15s.
- Exposes useAgentActivity and bar/panel/inline/console ViewModel surfaces with truthful runtime, phase, elapsed time, first-output waiting, tools, artifacts, usage, terminal, and capability-derived cancel/pause/resume state.
- Migrates Global Agent Panel, Canvas AgentPanel, Operation node activity, LLM inspection, RunConsole, and connection-test surfaces while keeping domain approvals/actions/change-sets separate.
- Keeps reasoning deltas out of public activity and injects platform-specific copy/open behavior.

## Verification
- @repo/views check-types passed.
- Views regression: 105 files / 439 tests passed.
- Shared activity store tests cover transport deduplication, replay, and polling fallback.
- Changed-file oxfmt and git diff --check passed.

PRs are intentionally serial and unmerged. Real Claude/Codex and Desktop acceptance remains in PR3; COD-354 stays In Progress until the full gate passes.