### PR TITLE
COD-354 PR3: remaining activity surfaces and acceptance compatibility

### DIFF
--- a/packages/views/src/components/AgentRunsPanel/AgentRunsPanel.tsx
+++ b/packages/views/src/components/AgentRunsPanel/AgentRunsPanel.tsx
@@ -4,14 +4,18 @@ import { useCustom } from "@refinedev/core";
 import type { AgentRawExport } from "@repo/schemas";
 import { surfaceCardVariants } from "@repo/ui/card";
 import { cn } from "@repo/ui/lib/utils";
+import { AgentActivitySurface } from "../../../components/AgentActivity";
+import { usePlatform } from "../../../platform";
 import { AgentRunCard } from "./AgentRunCard";
 
 interface AgentRunsPanelProps {
   jobId: string;
+  activityRunIds?: readonly string[];
 }
 
-export const AgentRunsPanel = ({ jobId }: AgentRunsPanelProps) => {
+export const AgentRunsPanel = ({ activityRunIds = [], jobId }: AgentRunsPanelProps) => {
   const { t } = useTranslation();
+  const platform = usePlatform();
   const { result, query } = useCustom<{ agentRuns: AgentRawExport[] }>({
     url: "jobs/agentRuns",
     method: "get",
@@ -46,13 +50,16 @@ export const AgentRunsPanel = ({ jobId }: AgentRunsPanelProps) => {
         </span>
         <span className="ml-auto text-[11px] text-muted-foreground">{runs.length}</span>
       </div>
-      {runs.length === 0 ? (
+      {runs.length === 0 && activityRunIds.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-10 text-center">
           <Bot className="h-8 w-8 text-muted-foreground/30" />
           <p className="mt-2 text-xs text-muted-foreground">{t("jobs.agentRuns.empty")}</p>
         </div>
       ) : (
         <div className="p-3 space-y-2">
+          {activityRunIds.map((runId) => (
+            <AgentActivitySurface key={runId} platform={platform} runId={runId} variant="panel" />
+          ))}
           {runs.map((run) => (
             <AgentRunCard key={run.id} jobId={jobId} run={run} />
           ))}

--- a/packages/views/src/components/AgentRunsPanel/AgentRunsPanel.tsx
+++ b/packages/views/src/components/AgentRunsPanel/AgentRunsPanel.tsx
@@ -4,8 +4,8 @@ import { useCustom } from "@refinedev/core";
 import type { AgentRawExport } from "@repo/schemas";
 import { surfaceCardVariants } from "@repo/ui/card";
 import { cn } from "@repo/ui/lib/utils";
-import { AgentActivitySurface } from "../../../components/AgentActivity";
-import { usePlatform } from "../../../platform";
+import { AgentActivitySurface } from "../AgentActivity";
+import { usePlatform } from "../../platform";
 import { AgentRunCard } from "./AgentRunCard";
 
 interface AgentRunsPanelProps {

--- a/packages/views/src/components/PipelineCreationWorkspace/PipelineCreationMessages.tsx
+++ b/packages/views/src/components/PipelineCreationWorkspace/PipelineCreationMessages.tsx
@@ -3,8 +3,8 @@ import { Activity, CalendarClock, CircleAlert, Wrench, WandSparkles } from "luci
 import { Badge } from "@repo/ui/badge";
 import { cn } from "@repo/ui/lib/utils";
 import type { PipelineAgentProposal } from "@repo/schemas";
-import { AgentActivitySurface } from "@repo/views/AgentActivity";
-import { webPlatform } from "@/integrations/platform";
+import { AgentActivitySurface } from "../AgentActivity";
+import { usePlatform } from "../../platform";
 import {
   PipelineCreationAttachments,
   type PipelineCreationAttachment,
@@ -50,6 +50,7 @@ export const PipelineCreationMessages = ({
   onRemoveAttachment: handleRemoveAttachment,
 }: PipelineCreationMessagesProps) => {
   const { t } = useTranslation();
+  const platform = usePlatform();
 
   return (
     <div
@@ -74,7 +75,7 @@ export const PipelineCreationMessages = ({
         </div>
       ))}
       {activityRunId && (
-        <AgentActivitySurface platform={webPlatform} runId={activityRunId} variant="panel" />
+        <AgentActivitySurface platform={platform} runId={activityRunId} variant="panel" />
       )}
       {!activityRunId && streamingAssistantText && (
         <div className="max-w-[88%] whitespace-pre-wrap break-words rounded-xl border border-dashed border-border bg-card px-3.5 py-2.5 text-sm leading-6 text-muted-foreground [overflow-wrap:anywhere]">

--- a/packages/views/src/components/PipelineCreationWorkspace/PipelineCreationMessages.tsx
+++ b/packages/views/src/components/PipelineCreationWorkspace/PipelineCreationMessages.tsx
@@ -3,6 +3,8 @@ import { Activity, CalendarClock, CircleAlert, Wrench, WandSparkles } from "luci
 import { Badge } from "@repo/ui/badge";
 import { cn } from "@repo/ui/lib/utils";
 import type { PipelineAgentProposal } from "@repo/schemas";
+import { AgentActivitySurface } from "@repo/views/AgentActivity";
+import { webPlatform } from "@/integrations/platform";
 import {
   PipelineCreationAttachments,
   type PipelineCreationAttachment,
@@ -23,6 +25,7 @@ export interface PipelineCreationRuntimeActivity {
 }
 
 interface PipelineCreationMessagesProps {
+  activityRunId: string | null;
   attachments: PipelineCreationAttachment[];
   canRemoveAttachments: boolean;
   isHome: boolean;
@@ -35,6 +38,7 @@ interface PipelineCreationMessagesProps {
 }
 
 export const PipelineCreationMessages = ({
+  activityRunId,
   attachments,
   canRemoveAttachments,
   isHome,
@@ -69,12 +73,15 @@ export const PipelineCreationMessages = ({
           {message.content}
         </div>
       ))}
-      {streamingAssistantText && (
+      {activityRunId && (
+        <AgentActivitySurface platform={webPlatform} runId={activityRunId} variant="panel" />
+      )}
+      {!activityRunId && streamingAssistantText && (
         <div className="max-w-[88%] whitespace-pre-wrap break-words rounded-xl border border-dashed border-border bg-card px-3.5 py-2.5 text-sm leading-6 text-muted-foreground [overflow-wrap:anywhere]">
           {streamingAssistantText}
         </div>
       )}
-      {runtimeActivity.length > 0 && (
+      {!activityRunId && runtimeActivity.length > 0 && (
         <div className="max-w-[92%] space-y-1.5 rounded-xl border border-border bg-surface-2 p-2.5">
           {runtimeActivity.map((activity) => {
             const Icon =

--- a/packages/views/src/components/PipelineCreationWorkspace/PipelineCreationWorkspace.tsx
+++ b/packages/views/src/components/PipelineCreationWorkspace/PipelineCreationWorkspace.tsx
@@ -117,6 +117,7 @@ export const PipelineCreationWorkspace = ({
   >("conversation");
   const [proposal, setProposal] = useState<PipelineAgentProposal | null>(null);
   const [proposalId, setProposalId] = useState<string | null>(null);
+  const [activityRunId, setActivityRunId] = useState<string | null>(null);
   const [streamingAssistantText, setStreamingAssistantText] = useState("");
   const [runtimeActivity, setRuntimeActivity] = useState<PipelineCreationRuntimeActivity[]>([]);
   const sessionIdRef = useRef<string | null>(null);
@@ -171,6 +172,7 @@ export const PipelineCreationWorkspace = ({
       setPhase("conversation");
       setProposal(null);
       setProposalId(null);
+      setActivityRunId(null);
       setStreamingAssistantText("");
       setRuntimeActivity([]);
     },
@@ -188,6 +190,7 @@ export const PipelineCreationWorkspace = ({
     proposal?.mode === "generate" && proposal.readiness === "ready_for_generation";
   const hasConversation =
     messages.length > 0 ||
+    activityRunId !== null ||
     streamingAssistantText.length > 0 ||
     attachments.length > 0 ||
     proposal !== null ||
@@ -281,6 +284,7 @@ export const PipelineCreationWorkspace = ({
     onCompleted: handleRestoredPipeline,
     onError: handleRestoreError,
     onMissing: handleMissingSession,
+    onRunId: setActivityRunId,
     onSessionDetail: applySessionDetail,
     onPlanEvent: handleRestoredPlanEvent,
   });
@@ -527,7 +531,9 @@ export const PipelineCreationWorkspace = ({
     const previousProposalId = proposalId;
     setProposal(null);
     setProposalId(null);
+    setActivityRunId(null);
     setStreamingAssistantText("");
+    setRuntimeActivity([]);
     setPhase("planning");
     const controller = new AbortController();
     activeRequestRef.current?.abort();
@@ -557,6 +563,8 @@ export const PipelineCreationWorkspace = ({
             ? {}
             : { firstOutputTimeoutSeconds: executionChoice.firstOutputTimeoutSeconds }),
           signal: controller.signal,
+          onRunId: setActivityRunId,
+          useSharedActivity: true,
           onEvent: (event) => {
             if (
               event.type === "question" ||
@@ -963,6 +971,7 @@ export const PipelineCreationWorkspace = ({
 
       {hasConversation && (
         <PipelineCreationMessages
+          activityRunId={activityRunId}
           attachments={attachments}
           canRemoveAttachments={phase === "conversation"}
           isHome={isHome}

--- a/packages/views/src/components/PipelineCreationWorkspace/usePipelineCreationSessionRecovery.ts
+++ b/packages/views/src/components/PipelineCreationWorkspace/usePipelineCreationSessionRecovery.ts
@@ -20,6 +20,7 @@ interface UsePipelineCreationSessionRecoveryOptions {
   onCompleted: (pipelineId: string) => void;
   onError: (error: Error) => void;
   onMissing: () => void;
+  onRunId?: (runId: string) => void;
   onSessionDetail: (session: PipelineAgentSessionClientDetail) => void;
   onPlanEvent: (event: PipelineAgentPlanEvent) => void;
 }
@@ -34,6 +35,7 @@ export const usePipelineCreationSessionRecovery = ({
   onCompleted,
   onError,
   onMissing,
+  onRunId,
   onSessionDetail,
   onPlanEvent,
 }: UsePipelineCreationSessionRecoveryOptions) => {
@@ -64,6 +66,8 @@ export const usePipelineCreationSessionRecovery = ({
           }
           await client.planSessionStream(savedSessionId, {
             signal: controller.signal,
+            onRunId,
+            useSharedActivity: true,
             onEvent: onPlanEvent,
           });
           if (controller.signal.aborted) {
@@ -150,6 +154,7 @@ export const usePipelineCreationSessionRecovery = ({
     onCompleted,
     onError,
     onMissing,
+    onRunId,
     onPlanEvent,
     onSessionDetail,
     sessionIdRef,

--- a/packages/views/src/pages/JobsPage/JobDetailDrawer/JobDetailDrawer.tsx
+++ b/packages/views/src/pages/JobsPage/JobDetailDrawer/JobDetailDrawer.tsx
@@ -52,6 +52,14 @@ const extractAgentRunIds = (traces: readonly JobTrace[]): string[] => [
   ),
 ];
 
+const isLegacyAgentActivityTrace = (message: string): boolean => {
+  const normalized = message.replace(/^\[[^\]]+\]\s*/u, "");
+
+  return (
+    normalized.startsWith(TRACE_MARKER.agentRun) || normalized.startsWith(TRACE_MARKER.agentEvent)
+  );
+};
+
 export const JobDetailDrawer = ({ job: initialJob, onChanged, onClose }: JobDetailDrawerProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -79,6 +87,10 @@ export const JobDetailDrawer = ({ job: initialJob, onChanged, onClose }: JobDeta
   const traces = tracesResult?.data?.traces ?? [];
   const platform = usePlatform();
   const activityRunIds = extractAgentRunIds(traces);
+  const visibleTraces =
+    activityRunIds.length > 0
+      ? traces.filter((trace) => !isLegacyAgentActivityTrace(trace.message))
+      : traces;
 
   const nodeStatuses = job.nodeStatuses ?? {};
   const steps = (pipelineResult?.nodes ?? []).map((node) => ({
@@ -241,10 +253,10 @@ export const JobDetailDrawer = ({ job: initialJob, onChanged, onClose }: JobDeta
             {t("jobs.drawer.trace")}
           </div>
           <div className="space-y-0.5 rounded-lg bg-surface-2 p-3 font-mono text-[10.5px] leading-relaxed ring-1 ring-border">
-            {traces.length === 0 ? (
+            {visibleTraces.length === 0 ? (
               <div className="text-muted-foreground/60">{t("jobs.drawer.noTrace")}</div>
             ) : (
-              traces.slice(-80).map((trace) => (
+              visibleTraces.slice(-80).map((trace) => (
                 <div key={trace.id} className="break-all text-foreground/70">
                   {trace.message}
                 </div>

--- a/packages/views/src/pages/JobsPage/JobDetailDrawer/JobDetailDrawer.tsx
+++ b/packages/views/src/pages/JobsPage/JobDetailDrawer/JobDetailDrawer.tsx
@@ -3,6 +3,7 @@ import { ExternalLink, Pause, Play, RotateCcw, Square, Workflow, X } from "lucid
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
 import {
+  TRACE_MARKER,
   type Job,
   type JobTrace,
   type NodeRunStatus,
@@ -13,6 +14,8 @@ import { Button } from "@repo/ui/button";
 import { cn } from "@repo/ui/lib/utils";
 import { ResourceName } from "../../../constants";
 import { StatusPill } from "../../../components/primitives";
+import { AgentActivitySurface } from "../../../components/AgentActivity";
+import { usePlatform } from "../../../platform";
 import { useJobControls } from "../useJobControls";
 
 export type JobDetailDrawerProps = {
@@ -34,6 +37,20 @@ const stepTone = (status: NodeRunStatus): string => {
 
   return "ring-border bg-surface";
 };
+
+const extractAgentRunIds = (traces: readonly JobTrace[]): string[] => [
+  ...new Set(
+    traces.flatMap((trace) => {
+      const markerIndex = trace.message.indexOf(TRACE_MARKER.agentRun);
+      if (markerIndex < 0) return [];
+      const payload = trace.message.slice(markerIndex + TRACE_MARKER.agentRun.length);
+      const separator = payload.indexOf("::");
+      const runId = separator >= 0 ? payload.slice(separator + 2).trim() : "";
+
+      return runId ? [runId] : [];
+    }),
+  ),
+];
 
 export const JobDetailDrawer = ({ job: initialJob, onChanged, onClose }: JobDetailDrawerProps) => {
   const { t } = useTranslation();
@@ -60,6 +77,8 @@ export const JobDetailDrawer = ({ job: initialJob, onChanged, onClose }: JobDeta
     url: "jobs/traces",
   });
   const traces = tracesResult?.data?.traces ?? [];
+  const platform = usePlatform();
+  const activityRunIds = extractAgentRunIds(traces);
 
   const nodeStatuses = job.nodeStatuses ?? {};
   const steps = (pipelineResult?.nodes ?? []).map((node) => ({
@@ -198,6 +217,22 @@ export const JobDetailDrawer = ({ job: initialJob, onChanged, onClose }: JobDeta
                   <span className="min-w-0 flex-1 truncate text-xs font-medium">{step.label}</span>
                   <StatusPill status={step.status} />
                 </div>
+              ))}
+            </div>
+          )}
+
+          {activityRunIds.length > 0 && (
+            <div className="mt-5 space-y-2">
+              <div className="mb-2 text-[10px] font-semibold uppercase text-muted-foreground">
+                {t("jobs.agentRuns.activity", "Agent activity")}
+              </div>
+              {activityRunIds.map((runId) => (
+                <AgentActivitySurface
+                  key={runId}
+                  platform={platform}
+                  runId={runId}
+                  variant="panel"
+                />
               ))}
             </div>
           )}

--- a/packages/views/src/pages/OperationDetailPage/OperationRunPanel/OperationRunPanel.tsx
+++ b/packages/views/src/pages/OperationDetailPage/OperationRunPanel/OperationRunPanel.tsx
@@ -11,9 +11,11 @@ import { cn } from "@repo/ui/lib/utils";
 import { useCustom, useCustomMutation, useOne } from "@refinedev/core";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
-import type { JobStatus } from "@repo/schemas";
+import { TRACE_MARKER, type JobStatus } from "@repo/schemas";
 import { ResourceName } from "../../../constants";
 import { FolderBrowserDialog } from "../../../components/FolderBrowserDialog/FolderBrowserDialog";
+import { AgentActivitySurface } from "../../../components/AgentActivity";
+import { usePlatform } from "../../../platform";
 import { useOperationDetailPageStore } from "../_store";
 
 interface JobData {
@@ -48,6 +50,20 @@ const isStructuredLog = (log: string): boolean => {
   return msg.startsWith("@@");
 };
 
+const extractAgentRunIds = (logs: readonly string[]): string[] => [
+  ...new Set(
+    logs.flatMap((log) => {
+      const markerIndex = log.indexOf(TRACE_MARKER.agentRun);
+      if (markerIndex < 0) return [];
+      const payload = log.slice(markerIndex + TRACE_MARKER.agentRun.length);
+      const separator = payload.indexOf("::");
+      const runId = separator >= 0 ? payload.slice(separator + 2).trim() : "";
+
+      return runId ? [runId] : [];
+    }),
+  ),
+];
+
 const STATUS_STYLES: Partial<Record<JobStatus, string>> = {
   queued: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300",
   running: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
@@ -61,6 +77,7 @@ interface OperationRunPanelProps {
 
 export const OperationRunPanel = ({ operationId }: OperationRunPanelProps) => {
   const { t } = useTranslation();
+  const platform = usePlatform();
   const { result: operation } = useOne<OperationDataForName>({
     resource: ResourceName.operations,
     id: operationId,
@@ -142,6 +159,7 @@ export const OperationRunPanel = ({ operationId }: OperationRunPanelProps) => {
   };
 
   const traceLogs = (tracesResult.data?.traces ?? []).map((trace) => trace.message);
+  const activityRunIds = extractAgentRunIds(traceLogs);
   const displayStatus = job ? job.status : runStatus;
   const isRunning = displayStatus === "running" || runStatus === "running";
   const hasResults = !!runJobId;
@@ -250,6 +268,15 @@ export const OperationRunPanel = ({ operationId }: OperationRunPanelProps) => {
                     {t("operations.run.starting")}
                   </div>
                 )}
+                {activityRunIds.map((runId) => (
+                  <AgentActivitySurface
+                    key={runId}
+                    className="mb-2 font-sans"
+                    platform={platform}
+                    runId={runId}
+                    variant="panel"
+                  />
+                ))}
                 {traceLogs
                   .filter((l) => !isStructuredLog(l))
                   .map((log, i) => (

--- a/packages/views/src/pages/RuntimeDetailPage/RuntimeDetailPageContent/RuntimeDetailPageContent.tsx
+++ b/packages/views/src/pages/RuntimeDetailPage/RuntimeDetailPageContent/RuntimeDetailPageContent.tsx
@@ -27,6 +27,7 @@ import {
 } from "@repo/ui/sheet";
 import { PageHeader } from "../../../components/PageHeader";
 import { PageLoadingState } from "../../../components/PageLoadingState";
+import { AgentActivitySurface } from "../../../components/AgentActivity";
 import { RuntimeIcon } from "../../../pages/RuntimesPage/RuntimeIcon";
 import { usePlatform } from "../../../platform";
 
@@ -350,6 +351,13 @@ export const RuntimeDetailPageContent = () => {
               . The probe performs one safe model request with the same local-agent invocation
               policy.
             </div>
+            {connectionTestRunId && (
+              <AgentActivitySurface
+                platform={platform}
+                runId={connectionTestRunId}
+                variant="panel"
+              />
+            )}
             {connectionTestError && (
               <div className="rounded-lg border border-destructive/40 bg-destructive/8 p-3 text-sm text-destructive">
                 {connectionTestError}

--- a/packages/views/src/pages/RuntimesPage/RuntimeConnectionTestSheet.tsx
+++ b/packages/views/src/pages/RuntimesPage/RuntimeConnectionTestSheet.tsx
@@ -10,6 +10,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@repo/ui/sheet";
+import { AgentActivitySurface } from "../../components/AgentActivity";
 import { usePlatform } from "../../platform";
 
 interface RuntimeConnectionTestSheetProps {
@@ -142,6 +143,7 @@ export const RuntimeConnectionTestSheet = ({
             {entry?.runtime === "codex" ? "native Codex sandbox" : "CLI policy / best-effort"}. The
             probe uses the same absolute executable and adapter as a product run.
           </div>
+          {runId && <AgentActivitySurface platform={platform} runId={runId} variant="panel" />}
           {error && (
             <div className="rounded-lg border border-destructive/40 bg-destructive/8 p-3 text-sm text-destructive">
               {error}


### PR DESCRIPTION
## Scope
Refs COD-354. Builds on PR1 and PR2 as the final surface/compatibility slice.

- Migrates Pipeline creation/recovery, Job Detail/Drawer, Operation Run Panel, and Runtime connection-test activity to the shared Agent Activity surface.
- New runs are driven by AgentRunEventEnvelope; legacy @@ trace markers remain read-only discovery/fallback for historical data.
- Adds artifact path-copy/open affordances with Web/Desktop platform injection and authenticated failure telemetry.
- Preserves node isolation by runId/nodeId and avoids rendering legacy stream data when a direct Agent Run is present.
- Adds the third-party runtime adapter constraints and keeps generated pipeline rescue artifacts out of the PRs.

## Verification
- @ordine/app check-types passed and HomePage targeted tests passed.
- @repo/views check-types and full views regression passed (105 files / 439 tests).
- Root quality passed with dedicated PostgreSQL test databases (21/21 tasks).
- Browser visual acceptance covered local Web at 1440x900 and 390x844 with screenshots in the implementation worktree; no new console errors after environment setup.
- Changed-file oxfmt and git diff --check passed.

## Explicit remaining gate
No approved local Claude Code or Codex CLI is available through Agent Control in this environment, so the required dual real-runtime run, refresh/reconnect/cancel/artifact evidence, and Desktop screenshot remain pending. COD-354 must remain In Progress; these PRs are not merged or deployed.