### PR TITLE
fix(jobs): 修复任务过期判定与终态竞态（COD-352）

### DIFF
--- a/apps/app/drizzle/0002_add_accepted_object_types.sql
+++ b/apps/app/drizzle/0002_add_accepted_object_types.sql
@@ -1,1 +1,13 @@
+-- The historical snapshot includes operations, but 0000/0001 never created it.
+-- Preserve installations that already have the table while allowing empty-db replay.
+CREATE TABLE IF NOT EXISTS "operations" (
+  "id" text PRIMARY KEY NOT NULL,
+  "name" text NOT NULL,
+  "description" text,
+  "category" text DEFAULT 'general' NOT NULL,
+  "config" text DEFAULT '{}' NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
 ALTER TABLE "operations" ADD COLUMN IF NOT EXISTS "accepted_object_types" jsonb DEFAULT '["file","folder","project"]'::jsonb NOT NULL;

--- a/apps/app/drizzle/0009_add_job_logs_table.sql
+++ b/apps/app/drizzle/0009_add_job_logs_table.sql
@@ -19,7 +19,7 @@ CREATE TABLE "job_logs" (
 --> statement-breakpoint
 ALTER TABLE "works" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
 DROP TABLE "works" CASCADE;--> statement-breakpoint
-ALTER TABLE "jobs" DROP CONSTRAINT "jobs_work_id_works_id_fk";
+ALTER TABLE "jobs" DROP CONSTRAINT IF EXISTS "jobs_work_id_works_id_fk";
 --> statement-breakpoint
 ALTER TABLE "rules" ADD COLUMN "check_script" text;--> statement-breakpoint
 ALTER TABLE "rules" ADD COLUMN "script_language" text DEFAULT 'typescript';--> statement-breakpoint

--- a/apps/app/drizzle/0014_convert_operation_config_to_jsonb.sql
+++ b/apps/app/drizzle/0014_convert_operation_config_to_jsonb.sql
@@ -1,3 +1,4 @@
+ALTER TABLE "operations" ALTER COLUMN "config" DROP DEFAULT;
 ALTER TABLE "operations" ALTER COLUMN "config" SET DATA TYPE jsonb USING config::jsonb;
 ALTER TABLE "operations" ALTER COLUMN "config" SET DEFAULT '{}'::jsonb;
 ALTER TABLE "operations" ALTER COLUMN "config" SET NOT NULL;

--- a/apps/app/drizzle/0017_wild_jasper_sitwell.sql
+++ b/apps/app/drizzle/0017_wild_jasper_sitwell.sql
@@ -11,12 +11,12 @@ CREATE TABLE "refinements" (
 --> statement-breakpoint
 ALTER TABLE "operations" ALTER COLUMN "config" SET DATA TYPE jsonb;--> statement-breakpoint
 ALTER TABLE "operations" ALTER COLUMN "config" SET DEFAULT '{}'::jsonb;--> statement-breakpoint
-ALTER TABLE "settings" ADD COLUMN "default_agent_runtime" text DEFAULT 'mastra' NOT NULL;--> statement-breakpoint
-ALTER TABLE "settings" ADD COLUMN "default_api_key" text DEFAULT '' NOT NULL;--> statement-breakpoint
-ALTER TABLE "settings" ADD COLUMN "default_model" text DEFAULT 'kimi-k2-0711-preview' NOT NULL;--> statement-breakpoint
+ALTER TABLE "settings" ADD COLUMN IF NOT EXISTS "default_agent_runtime" text DEFAULT 'mastra' NOT NULL;--> statement-breakpoint
+ALTER TABLE "settings" ADD COLUMN IF NOT EXISTS "default_api_key" text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE "settings" ADD COLUMN IF NOT EXISTS "default_model" text DEFAULT 'kimi-k2-0711-preview' NOT NULL;--> statement-breakpoint
 ALTER TABLE "settings" ADD COLUMN "default_output_path" text DEFAULT '' NOT NULL;--> statement-breakpoint
 CREATE INDEX "refinements_source_distillation_id_idx" ON "refinements" USING btree ("source_distillation_id");--> statement-breakpoint
 CREATE INDEX "refinements_status_idx" ON "refinements" USING btree ("status");--> statement-breakpoint
-ALTER TABLE "settings" DROP COLUMN "llm_provider";--> statement-breakpoint
-ALTER TABLE "settings" DROP COLUMN "llm_api_key";--> statement-breakpoint
-ALTER TABLE "settings" DROP COLUMN "llm_model";
+ALTER TABLE "settings" DROP COLUMN IF EXISTS "llm_provider";--> statement-breakpoint
+ALTER TABLE "settings" DROP COLUMN IF EXISTS "llm_api_key";--> statement-breakpoint
+ALTER TABLE "settings" DROP COLUMN IF EXISTS "llm_model";

--- a/apps/app/drizzle/0019_job_refactor_split_runs.sql
+++ b/apps/app/drizzle/0019_job_refactor_split_runs.sql
@@ -36,7 +36,7 @@ DROP INDEX "jobs_pipeline_id_idx";--> statement-breakpoint
 ALTER TABLE "jobs" ALTER COLUMN "type" DROP DEFAULT;--> statement-breakpoint
 ALTER TABLE "settings" ALTER COLUMN "default_model" SET DEFAULT 'kimi-for-coding/k2p6';--> statement-breakpoint
 ALTER TABLE "jobs" ADD COLUMN "parent_job_id" text;--> statement-breakpoint
-ALTER TABLE "settings" ADD COLUMN "agent_runtimes" jsonb DEFAULT '[]'::jsonb NOT NULL;--> statement-breakpoint
+ALTER TABLE "settings" ADD COLUMN IF NOT EXISTS "agent_runtimes" jsonb DEFAULT '[]'::jsonb NOT NULL;--> statement-breakpoint
 ALTER TABLE "distillation_runs" ADD CONSTRAINT "distillation_runs_id_jobs_id_fk" FOREIGN KEY ("id") REFERENCES "public"."jobs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "distillation_runs" ADD CONSTRAINT "distillation_runs_distillation_id_distillations_id_fk" FOREIGN KEY ("distillation_id") REFERENCES "public"."distillations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "pipeline_runs" ADD CONSTRAINT "pipeline_runs_id_jobs_id_fk" FOREIGN KEY ("id") REFERENCES "public"."jobs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint

--- a/apps/app/drizzle/0022_add-auth-tables.sql
+++ b/apps/app/drizzle/0022_add-auth-tables.sql
@@ -51,4 +51,4 @@ ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_users_id_fk" FOREIGN KEY
 CREATE INDEX "accounts_userId_idx" ON "accounts" USING btree ("user_id");--> statement-breakpoint
 CREATE INDEX "sessions_userId_idx" ON "sessions" USING btree ("user_id");--> statement-breakpoint
 CREATE INDEX "verifications_identifier_idx" ON "verifications" USING btree ("identifier");--> statement-breakpoint
-ALTER TABLE "settings" DROP COLUMN "agent_runtimes";
+ALTER TABLE "settings" DROP COLUMN IF EXISTS "agent_runtimes";

--- a/apps/app/drizzle/0024_add_agents_system_prompt_check.sql
+++ b/apps/app/drizzle/0024_add_agents_system_prompt_check.sql
@@ -1,5 +1,11 @@
 DO $$
 BEGIN
+  -- Some installations renamed the table with db:push; journal-only installs did not.
+  IF to_regclass('public.agents') IS NULL
+     AND to_regclass('public.agent_definitions') IS NOT NULL THEN
+    ALTER TABLE "agent_definitions" RENAME TO "agents";
+  END IF;
+
   IF EXISTS (
     SELECT 1
     FROM information_schema.tables

--- a/apps/app/drizzle/0039_job_execution_leases.sql
+++ b/apps/app/drizzle/0039_job_execution_leases.sql
@@ -1,0 +1,23 @@
+ALTER TABLE "jobs" ADD COLUMN "last_progress_at" timestamp;
+--> statement-breakpoint
+UPDATE "jobs"
+SET "last_progress_at" = COALESCE("updated_at", "started_at", "created_at")
+WHERE "last_progress_at" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "jobs" ALTER COLUMN "last_progress_at" SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE "jobs" ALTER COLUMN "last_progress_at" SET NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "heartbeat_at" timestamp;
+--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "lease_owner_id" text;
+--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "lease_expires_at" timestamp;
+--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "expiry_context" jsonb;
+--> statement-breakpoint
+CREATE INDEX "jobs_status_created_at_idx" ON "jobs" USING btree ("status", "created_at");
+--> statement-breakpoint
+CREATE INDEX "jobs_status_last_progress_at_idx" ON "jobs" USING btree ("status", "last_progress_at");
+--> statement-breakpoint
+CREATE INDEX "jobs_status_lease_expires_at_idx" ON "jobs" USING btree ("status", "lease_expires_at");

--- a/apps/app/drizzle/meta/_journal.json
+++ b/apps/app/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1787817600000,
       "tag": "0038_agent_activity_projection",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1788094800000,
+      "tag": "0039_job_execution_leases",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/create/migrations/0013_job_execution_leases.sql
+++ b/apps/create/migrations/0013_job_execution_leases.sql
@@ -1,0 +1,23 @@
+ALTER TABLE "jobs" ADD COLUMN "last_progress_at" timestamp;
+--> statement-breakpoint
+UPDATE "jobs"
+SET "last_progress_at" = COALESCE("updated_at", "started_at", "created_at")
+WHERE "last_progress_at" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "jobs" ALTER COLUMN "last_progress_at" SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE "jobs" ALTER COLUMN "last_progress_at" SET NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "heartbeat_at" timestamp;
+--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "lease_owner_id" text;
+--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "lease_expires_at" timestamp;
+--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "expiry_context" jsonb;
+--> statement-breakpoint
+CREATE INDEX "jobs_status_created_at_idx" ON "jobs" USING btree ("status", "created_at");
+--> statement-breakpoint
+CREATE INDEX "jobs_status_last_progress_at_idx" ON "jobs" USING btree ("status", "last_progress_at");
+--> statement-breakpoint
+CREATE INDEX "jobs_status_lease_expires_at_idx" ON "jobs" USING btree ("status", "lease_expires_at");

--- a/apps/create/tests/migrations.test.ts
+++ b/apps/create/tests/migrations.test.ts
@@ -93,13 +93,13 @@ describe("runMigrations", () => {
 
     expect(first.isOk()).toBe(true);
     expect(second.isOk()).toBe(true);
-    expect([first._unsafeUnwrap(), second._unsafeUnwrap()].sort((a, b) => a - b)).toEqual([0, 13]);
+    expect([first._unsafeUnwrap(), second._unsafeUnwrap()].sort((a, b) => a - b)).toEqual([0, 14]);
 
     const db = postgres(resolvedDatabaseUrl, { onnotice: () => {} });
     const applied = await db.unsafe<{ name: string }[]>(
       `SELECT name FROM _ordine_migrations ORDER BY name`,
     );
-    expect(applied).toHaveLength(13);
+    expect(applied).toHaveLength(14);
     const [permissionColumn] = await db.unsafe<{ column_default: string | null }[]>(
       `SELECT column_default
          FROM information_schema.columns
@@ -108,6 +108,27 @@ describe("runMigrations", () => {
            AND column_name = 'permission_mode'`,
     );
     expect(permissionColumn?.column_default).toContain("full-access");
+    const jobLeaseColumns = await db.unsafe<{ column_name: string }[]>(
+      `SELECT column_name
+         FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'jobs'
+           AND column_name IN (
+             'last_progress_at',
+             'heartbeat_at',
+             'lease_owner_id',
+             'lease_expires_at',
+             'expiry_context'
+           )
+         ORDER BY column_name`,
+    );
+    expect(jobLeaseColumns.map(({ column_name }) => column_name)).toEqual([
+      "expiry_context",
+      "heartbeat_at",
+      "last_progress_at",
+      "lease_expires_at",
+      "lease_owner_id",
+    ]);
     await db.end();
   }, 15_000);
 
@@ -118,7 +139,7 @@ describe("runMigrations", () => {
     const result = await runMigrations(resolvedDatabaseUrl, migrationsDir);
 
     expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toBe(12);
+    expect(result._unsafeUnwrap()).toBe(13);
     const migrations = await db.unsafe<{ name: string }[]>(
       `SELECT name FROM _ordine_migrations ORDER BY name`,
     );
@@ -136,6 +157,7 @@ describe("runMigrations", () => {
       "0010_agent_control_plane.sql",
       "0011_agent_action_argument_digest.sql",
       "0012_agent_activity_projection.sql",
+      "0013_job_execution_leases.sql",
     ]);
     const projects = await db.unsafe<{ table_name: string }[]>(
       `SELECT table_name FROM information_schema.tables WHERE table_name = 'projects'`,
@@ -152,7 +174,7 @@ describe("runMigrations", () => {
     const result = await runMigrations(resolvedDatabaseUrl, migrationsDir);
 
     expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toBe(12);
+    expect(result._unsafeUnwrap()).toBe(13);
 
     const migrations = await db.unsafe<{ name: string }[]>(
       `SELECT name FROM _ordine_migrations ORDER BY name`,
@@ -171,6 +193,7 @@ describe("runMigrations", () => {
       "0010_agent_control_plane.sql",
       "0011_agent_action_argument_digest.sql",
       "0012_agent_activity_projection.sql",
+      "0013_job_execution_leases.sql",
     ]);
 
     const columns = await db.unsafe<{ column_name: string; table_name: string }[]>(

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,3 +1,11 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/ordine
 PORT=9433
 ORDINE_AGENT_API_TOKEN=replace-with-at-least-32-random-characters
+
+# Optional Job lifecycle tuning (milliseconds).
+# JOB_QUEUE_TIMEOUT_MS=3600000
+# JOB_LEGACY_STALE_TIMEOUT_MS=3600000
+# JOB_LEASE_DURATION_MS=90000
+# JOB_HEARTBEAT_INTERVAL_MS=30000
+# Deprecated fallback for queue and legacy no-lease timeouts:
+# JOB_TIMEOUT_MS=3600000

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "@hono/node-server";
+import { ResultAsync } from "neverthrow";
 import { app } from "./app.js";
 import { agentControlService, agentRunsService, jobsService } from "./services.js";
 
@@ -8,8 +9,14 @@ const env = getEnv();
 const port = env.PORT ?? 9433;
 const hostname = env.DESKTOP_MODE ? "127.0.0.1" : "0.0.0.0";
 
-const DEFAULT_JOB_TIMEOUT_MS = env.JOB_TIMEOUT_MS ?? 60 * 60 * 1000; // 60 min
-const EXPIRE_CHECK_INTERVAL_MS = 60_000; // every 60s
+// JOB_TIMEOUT_MS remains a backwards-compatible fallback for deployments that
+// configured the old absolute-runtime sweep. It now applies only to unclaimed
+// queues and lease-less jobs left behind by versions before COD-352.
+const LEGACY_JOB_TIMEOUT_MS = env.JOB_TIMEOUT_MS ?? 60 * 60 * 1000;
+const JOB_QUEUE_TIMEOUT_MS = env.JOB_QUEUE_TIMEOUT_MS ?? LEGACY_JOB_TIMEOUT_MS;
+const JOB_LEGACY_STALE_TIMEOUT_MS = env.JOB_LEGACY_STALE_TIMEOUT_MS ?? LEGACY_JOB_TIMEOUT_MS;
+const EXPIRE_CHECK_INTERVAL_MS = 60_000;
+const jobSweeperId = `server:${crypto.randomUUID()}`;
 
 const interruptedRuns = await agentRunsService.recoverInterruptedRuns();
 for (const runId of interruptedRuns.runIds) {
@@ -21,17 +28,47 @@ if (interruptedRuns.count > 0) {
   );
 }
 
-setInterval(async () => {
-  const expired = await jobsService.expireStaleJobs(DEFAULT_JOB_TIMEOUT_MS);
-  if (expired.length > 0) {
+const sweepState = { running: false };
+const runJobExpirySweep = async (): Promise<void> => {
+  const observedAt = new Date();
+  const result = await ResultAsync.fromPromise(
+    jobsService.expireStaleJobs({
+      observedAt,
+      queuedTimeoutMs: JOB_QUEUE_TIMEOUT_MS,
+      legacyNoLeaseTimeoutMs: JOB_LEGACY_STALE_TIMEOUT_MS,
+      sweeperId: jobSweeperId,
+    }),
+    (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+  );
+  sweepState.running = false;
+  if (result.isErr()) {
+    console.error("[job-expiry] Sweep failed:", result.error);
+
+    return;
+  }
+  if (result.value.length > 0) {
     console.log(
-      `[job-expiry] Expired ${expired.length} stale job(s):`,
-      expired.map((r: { id: string }) => r.id),
+      `[job-expiry] Expired ${result.value.length} stale job(s):`,
+      result.value.map(({ id, expiryContext }) => ({
+        id,
+        reason: expiryContext?.reason,
+        previousStatus: expiryContext?.previousStatus,
+      })),
     );
   }
-}, EXPIRE_CHECK_INTERVAL_MS);
+};
 
-setInterval(
+const scheduleJobExpirySweep = () => {
+  if (sweepState.running) return;
+
+  sweepState.running = true;
+  void runJobExpirySweep();
+};
+
+scheduleJobExpirySweep();
+globalThis.setInterval(scheduleJobExpirySweep, EXPIRE_CHECK_INTERVAL_MS);
+
+globalThis.setInterval(
   async () => {
     const deleted = await agentRunsService.deleteExpired();
     if (deleted > 0) console.log(`[agent-runs] Deleted ${deleted} expired run(s)`);

--- a/apps/server/src/integrations/env/envSchema.ts
+++ b/apps/server/src/integrations/env/envSchema.ts
@@ -2,7 +2,11 @@ import { z } from "zod/v4";
 
 export const envSchema = z.object({
   PORT: z.coerce.number().optional(),
-  JOB_TIMEOUT_MS: z.coerce.number().optional(),
+  JOB_TIMEOUT_MS: z.coerce.number().int().positive().optional(),
+  JOB_QUEUE_TIMEOUT_MS: z.coerce.number().int().positive().optional(),
+  JOB_LEGACY_STALE_TIMEOUT_MS: z.coerce.number().int().positive().optional(),
+  JOB_LEASE_DURATION_MS: z.coerce.number().int().positive().optional(),
+  JOB_HEARTBEAT_INTERVAL_MS: z.coerce.number().int().positive().optional(),
   ORDINE_AGENT_API_TOKEN: z.string().min(32).optional(),
   ORDINE_AGENT_CONTROL_ENABLED: z
     .enum(["true", "false"])

--- a/apps/server/src/services.ts
+++ b/apps/server/src/services.ts
@@ -21,9 +21,21 @@ import {
   createRoutinesService,
   createSkillsService,
   createUsageService,
+  DEFAULT_JOB_HEARTBEAT_INTERVAL_MS,
+  DEFAULT_JOB_LEASE_DURATION_MS,
   agentRunCapabilityStore,
   listDirectory,
 } from "@repo/services";
+import { getEnv } from "./integrations/env";
+
+const env = getEnv();
+const jobLease = {
+  leaseDurationMs: env.JOB_LEASE_DURATION_MS ?? DEFAULT_JOB_LEASE_DURATION_MS,
+  heartbeatIntervalMs: env.JOB_HEARTBEAT_INTERVAL_MS ?? DEFAULT_JOB_HEARTBEAT_INTERVAL_MS,
+};
+if (jobLease.heartbeatIntervalMs >= jobLease.leaseDurationMs) {
+  throw new Error("JOB_HEARTBEAT_INTERVAL_MS must be less than JOB_LEASE_DURATION_MS");
+}
 
 export const agentsService = createAgentsService(db);
 export const agentRunsService = createAgentRunsService(db);
@@ -35,13 +47,16 @@ export const conversationMessagesService = createConversationMessagesService(db)
 export const distillationsService = createDistillationsService(db);
 export const jobsService = createJobsService(db);
 export const operationsService = createOperationsService(db);
-export const operationRunnerService = createOperationRunnerService(db);
+export const operationRunnerService = createOperationRunnerService(db, jobLease);
 export const pipelineAgentSessionsService = createPipelineAgentSessionsService(db, {
   agentRunsService,
 });
 export const pipelineAssetsService = createPipelineAssetsService(db);
 export const pipelinesService = createPipelinesService(db);
-export const pipelineRunnerService = createPipelineRunnerService(db, { agentRunController });
+export const pipelineRunnerService = createPipelineRunnerService(db, {
+  agentRunController,
+  jobLease,
+});
 export const projectsService = createProjectsService(db);
 export const routinesService = createRoutinesService(db, {
   startRun: (opts) => pipelineRunnerService.startRun(opts),

--- a/packages/db-schema/src/migrations/cod352_migration.unit.test.ts
+++ b/packages/db-schema/src/migrations/cod352_migration.unit.test.ts
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const rootDir = join(import.meta.dirname, "../../../..");
+const createMigration = join(rootDir, "apps/create/migrations/0013_job_execution_leases.sql");
+const appMigration = join(rootDir, "apps/app/drizzle/0039_job_execution_leases.sql");
+const appJournal = join(rootDir, "apps/app/drizzle/meta/_journal.json");
+
+describe("COD-352 migration", () => {
+  it("keeps both migration tracks identical and journaled", () => {
+    expect(existsSync(createMigration), "create migration must exist").toBe(true);
+    expect(existsSync(appMigration), "app migration must exist").toBe(true);
+    expect(readFileSync(createMigration, "utf8")).toBe(readFileSync(appMigration, "utf8"));
+
+    const journal = JSON.parse(readFileSync(appJournal, "utf8")) as {
+      entries: Array<{ idx: number; tag: string }>;
+    };
+    expect(journal.entries.find((entry) => entry.idx === 39)).toMatchObject({
+      idx: 39,
+      tag: "0039_job_execution_leases",
+    });
+  });
+
+  it("backfills progress before enforcing the lease columns and indexes", () => {
+    const sql = readFileSync(createMigration, "utf8");
+    const backfillAt = sql.indexOf('UPDATE "jobs"');
+    const notNullAt = sql.indexOf('ALTER COLUMN "last_progress_at" SET NOT NULL');
+
+    expect(backfillAt).toBeGreaterThan(-1);
+    expect(notNullAt).toBeGreaterThan(backfillAt);
+    expect(sql).toContain('ADD COLUMN "heartbeat_at" timestamp');
+    expect(sql).toContain('ADD COLUMN "lease_owner_id" text');
+    expect(sql).toContain('ADD COLUMN "lease_expires_at" timestamp');
+    expect(sql).toContain('ADD COLUMN "expiry_context" jsonb');
+    expect(sql).toContain('CREATE INDEX "jobs_status_created_at_idx"');
+    expect(sql).toContain('CREATE INDEX "jobs_status_last_progress_at_idx"');
+    expect(sql).toContain('CREATE INDEX "jobs_status_lease_expires_at_idx"');
+  });
+});

--- a/packages/db-schema/src/migrations/cod352_web_migration.integration.test.ts
+++ b/packages/db-schema/src/migrations/cod352_web_migration.integration.test.ts
@@ -1,0 +1,173 @@
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import postgres from "postgres";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const migrationsFolder = join(import.meta.dirname, "../../../../apps/app/drizzle");
+const journal = JSON.parse(readFileSync(join(migrationsFolder, "meta/_journal.json"), "utf8"));
+const testDatabaseUrl = new URL(
+  process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/ordine",
+);
+testDatabaseUrl.pathname = "/ordine_db_schema_test";
+const databaseUrl = process.env.ORDINE_DB_SCHEMA_TEST_DATABASE_URL ?? testDatabaseUrl.toString();
+const client = postgres(databaseUrl, { max: 1, onnotice: () => {} });
+const temporary = { historicalFolder: "" };
+
+beforeEach(async () => {
+  await client.unsafe(
+    "DROP SCHEMA IF EXISTS drizzle CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public",
+  );
+});
+
+afterEach(async () => {
+  if (temporary.historicalFolder)
+    rmSync(temporary.historicalFolder, { recursive: true, force: true });
+  temporary.historicalFolder = "";
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+const assertLeaseSchema = async () => {
+  const columns = await client<
+    { column_name: string; is_nullable: string; data_type: string; column_default: string | null }[]
+  >`
+    SELECT column_name, is_nullable, data_type, column_default
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'jobs'
+  `;
+  expect(columns).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        column_name: "last_progress_at",
+        is_nullable: "NO",
+        column_default: "now()",
+      }),
+      expect.objectContaining({
+        column_name: "heartbeat_at",
+        is_nullable: "YES",
+        data_type: "timestamp without time zone",
+      }),
+      expect.objectContaining({
+        column_name: "lease_owner_id",
+        is_nullable: "YES",
+        data_type: "text",
+      }),
+      expect.objectContaining({
+        column_name: "lease_expires_at",
+        is_nullable: "YES",
+        data_type: "timestamp without time zone",
+      }),
+      expect.objectContaining({
+        column_name: "expiry_context",
+        is_nullable: "YES",
+        data_type: "jsonb",
+      }),
+    ]),
+  );
+  const indexes = await client<{ indexname: string; indexdef: string }[]>`
+    SELECT indexname, indexdef FROM pg_indexes WHERE schemaname = 'public' AND tablename = 'jobs'
+  `;
+  for (const column of ["created_at", "last_progress_at", "lease_expires_at"]) {
+    expect(
+      indexes.find((index) => index.indexname === `jobs_status_${column}_idx`)?.indexdef,
+    ).toContain(`USING btree (status, ${column})`);
+  }
+  const applied = await client<{ created_at: string }[]>`
+    SELECT created_at FROM drizzle.__drizzle_migrations ORDER BY id
+  `;
+  expect(applied.map((row) => Number(row.created_at))).toEqual(
+    journal.entries.map((entry: { when: number }) => entry.when),
+  );
+};
+
+describe("COD-352 Web Drizzle migrations on PostgreSQL", () => {
+  it("discovers and applies the complete journal from an empty database and can run again", async () => {
+    await migrate(drizzle(client), { migrationsFolder });
+    await assertLeaseSchema();
+    await client`INSERT INTO jobs (id, title, type) VALUES ('new-job', 'New job', 'pipeline')`;
+    const [job] =
+      await client`SELECT last_progress_at, heartbeat_at, lease_owner_id, lease_expires_at, expiry_context FROM jobs WHERE id = 'new-job'`;
+    expect(job?.last_progress_at).toBeTruthy();
+    expect(job).toMatchObject({
+      heartbeat_at: null,
+      lease_owner_id: null,
+      lease_expires_at: null,
+      expiry_context: null,
+    });
+    await expect(
+      client`UPDATE jobs SET last_progress_at = NULL WHERE id = 'new-job'`,
+    ).rejects.toMatchObject({ code: "23502" });
+    await migrate(drizzle(client), { migrationsFolder });
+    await assertLeaseSchema();
+  });
+
+  it.each([13, 23, 38])(
+    "upgrades historical journal baseline %i and preserves existing data",
+    async (baseline) => {
+      temporary.historicalFolder = mkdtempSync(join(tmpdir(), "ordine-web-migrations-"));
+      mkdirSync(join(temporary.historicalFolder, "meta"));
+      const entries = journal.entries.filter((entry: { idx: number }) => entry.idx <= baseline);
+      writeFileSync(
+        join(temporary.historicalFolder, "meta/_journal.json"),
+        JSON.stringify({ ...journal, entries }),
+        "utf8",
+      );
+      for (const entry of entries) {
+        copyFileSync(
+          join(migrationsFolder, `${entry.tag}.sql`),
+          join(temporary.historicalFolder, `${entry.tag}.sql`),
+        );
+      }
+      await migrate(drizzle(client), { migrationsFolder: temporary.historicalFolder });
+      await client`INSERT INTO operations (id, name, config) VALUES ('legacy-operation', 'Legacy operation', '{"prompt":"preserve me"}')`;
+      if (baseline === 13) {
+        await client`INSERT INTO settings (llm_provider, llm_model) VALUES ('codex', 'existing-model')`;
+      } else {
+        await client`INSERT INTO settings (default_agent_runtime, default_model) VALUES ('codex', 'existing-model')`;
+      }
+      if (baseline === 23) {
+        await client`INSERT INTO agent_definitions (id, name, system_prompt) VALUES ('legacy-agent', 'Legacy agent', 'Keep this prompt')`;
+      }
+      await client`
+      INSERT INTO jobs (id, title, type, status, created_at, started_at, updated_at, error)
+      VALUES ('historical-job', 'Historical job', 'pipeline', 'failed',
+              '2026-08-01 01:00:00', '2026-08-01 02:00:00', '2026-08-01 03:00:00', 'provider error')
+    `;
+      const [before] = await client`SELECT * FROM jobs WHERE id = 'historical-job'`;
+      expect(before).not.toHaveProperty("last_progress_at");
+      await migrate(drizzle(client), { migrationsFolder });
+      await assertLeaseSchema();
+      const [after] = await client`SELECT * FROM jobs WHERE id = 'historical-job'`;
+      expect(after).toMatchObject({
+        id: before!.id,
+        title: before!.title,
+        status: before!.status,
+        error: before!.error,
+        last_progress_at: before!.updated_at,
+        heartbeat_at: null,
+        lease_owner_id: null,
+        lease_expires_at: null,
+        expiry_context: null,
+      });
+      expect(await client`SELECT config FROM operations WHERE id = 'legacy-operation'`).toEqual([
+        { config: { prompt: "preserve me" } },
+      ]);
+      expect(await client`SELECT default_agent_runtime, default_model FROM settings`).toEqual([
+        { default_agent_runtime: "codex", default_model: "existing-model" },
+      ]);
+      if (baseline === 23) {
+        expect(await client`SELECT system_prompt FROM agents WHERE id = 'legacy-agent'`).toEqual([
+          { system_prompt: "Keep this prompt" },
+        ]);
+      }
+      await migrate(drizzle(client), { migrationsFolder });
+      await assertLeaseSchema();
+      expect(await client`SELECT * FROM jobs WHERE id = 'historical-job'`).toEqual([after]);
+    },
+  );
+});

--- a/packages/db-schema/src/tables/jobs_table.ts
+++ b/packages/db-schema/src/tables/jobs_table.ts
@@ -1,5 +1,11 @@
 import { index, integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
-import type { JobStatus, JobTriggeredBy, JobType, NodeRunStatus } from "@repo/schemas";
+import type {
+  JobExpiryContext,
+  JobStatus,
+  JobTriggeredBy,
+  JobType,
+  NodeRunStatus,
+} from "@repo/schemas";
 import { pipelinesTable } from "./pipelines_table";
 import { projectsTable } from "./projects_table";
 
@@ -19,6 +25,11 @@ export const jobsTable = pgTable(
     error: text("error"),
     startedAt: timestamp("started_at"),
     finishedAt: timestamp("finished_at"),
+    lastProgressAt: timestamp("last_progress_at").notNull().defaultNow(),
+    heartbeatAt: timestamp("heartbeat_at"),
+    leaseOwnerId: text("lease_owner_id"),
+    leaseExpiresAt: timestamp("lease_expires_at"),
+    expiryContext: jsonb("expiry_context").$type<JobExpiryContext>(),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
@@ -28,6 +39,9 @@ export const jobsTable = pgTable(
     index("jobs_parent_job_id_idx").on(table.parentJobId),
     index("jobs_pipeline_id_idx").on(table.pipelineId),
     index("jobs_project_id_idx").on(table.projectId),
+    index("jobs_status_created_at_idx").on(table.status, table.createdAt),
+    index("jobs_status_last_progress_at_idx").on(table.status, table.lastProgressAt),
+    index("jobs_status_lease_expires_at_idx").on(table.status, table.leaseExpiresAt),
   ],
 );
 export type JobRecord = typeof jobsTable.$inferSelect;

--- a/packages/models/src/daos/domainDaos.integration.test.ts
+++ b/packages/models/src/daos/domainDaos.integration.test.ts
@@ -197,6 +197,216 @@ describe("COD-116 domain DAOs with PostgreSQL", () => {
     expect(await connectors.findById("connector-1")).toBeUndefined();
   });
 
+  it.each(["UTC", "Asia/Shanghai", "America/New_York"])(
+    "expires only stale Job leases with the database session in %s",
+    async (timeZone) => {
+      const zoneClient = postgres(databaseUrl, {
+        connection: { TimeZone: timeZone },
+        max: 1,
+        onnotice: () => {},
+      });
+      const zoneExecutor = drizzle(zoneClient) as unknown as DbExecutor;
+      const jobs = createJobsDao(zoneExecutor);
+      const observedAt = new Date("2026-06-01T12:00:00.000Z");
+      const minute = 60_000;
+      const prefix = `expiry-${timeZone.replaceAll("/", "-").toLowerCase()}`;
+      const ids = {
+        queuedStale: `${prefix}-queued-stale`,
+        queuedFresh: `${prefix}-queued-fresh`,
+        runningWithLease: `${prefix}-running-with-lease`,
+        pausedWithLease: `${prefix}-paused-with-lease`,
+        leaseExpired: `${prefix}-lease-expired`,
+        legacyStale: `${prefix}-legacy-stale`,
+        legacyFresh: `${prefix}-legacy-fresh`,
+        providerFailed: `${prefix}-provider-failed`,
+      };
+
+      const seedJob = async ({
+        id,
+        status,
+        createdAt,
+        lastProgressAt,
+        leaseExpiresAt = null,
+        leaseOwnerId = null,
+        error = null,
+      }: {
+        id: string;
+        status: "queued" | "running" | "paused" | "failed";
+        createdAt: Date;
+        lastProgressAt: Date;
+        leaseExpiresAt?: Date | null;
+        leaseOwnerId?: string | null;
+        error?: string | null;
+      }) => {
+        await jobs.create({ id, title: id, type: "pipeline_run", status });
+        await zoneClient.unsafe(
+          `UPDATE jobs
+             SET status = $2,
+                 created_at = $3,
+                 updated_at = $4,
+                 started_at = $5,
+                 last_progress_at = $6,
+                 heartbeat_at = $7,
+                 lease_owner_id = $8,
+                 lease_expires_at = $9,
+                 error = $10
+           WHERE id = $1`,
+          [
+            id,
+            status,
+            createdAt.toISOString(),
+            lastProgressAt.toISOString(),
+            status === "queued" ? null : createdAt.toISOString(),
+            lastProgressAt.toISOString(),
+            leaseOwnerId ? lastProgressAt.toISOString() : null,
+            leaseOwnerId,
+            leaseExpiresAt?.toISOString() ?? null,
+            error,
+          ],
+        );
+      };
+
+      await seedJob({
+        id: ids.queuedStale,
+        status: "queued",
+        createdAt: new Date(observedAt.getTime() - 2 * minute),
+        lastProgressAt: new Date(observedAt.getTime() - 2 * minute),
+      });
+      await seedJob({
+        id: ids.queuedFresh,
+        status: "queued",
+        createdAt: new Date(observedAt.getTime() - minute / 2),
+        lastProgressAt: new Date(observedAt.getTime() - minute / 2),
+      });
+      await seedJob({
+        id: ids.runningWithLease,
+        status: "running",
+        createdAt: new Date(observedAt.getTime() - 24 * 60 * minute),
+        lastProgressAt: new Date(observedAt.getTime() - 24 * 60 * minute),
+        leaseOwnerId: "worker-live",
+        leaseExpiresAt: new Date(observedAt.getTime() + minute),
+      });
+      await seedJob({
+        id: ids.pausedWithLease,
+        status: "paused",
+        createdAt: new Date(observedAt.getTime() - 24 * 60 * minute),
+        lastProgressAt: new Date(observedAt.getTime() - 24 * 60 * minute),
+        leaseOwnerId: "worker-paused",
+        leaseExpiresAt: new Date(observedAt.getTime() + minute),
+      });
+      await seedJob({
+        id: ids.leaseExpired,
+        status: "running",
+        createdAt: new Date(observedAt.getTime() - 2 * minute),
+        lastProgressAt: new Date(observedAt.getTime() - minute / 2),
+        leaseOwnerId: "worker-stale",
+        leaseExpiresAt: new Date(observedAt.getTime() - 1),
+      });
+      await seedJob({
+        id: ids.legacyStale,
+        status: "running",
+        createdAt: new Date(observedAt.getTime() - 2 * minute),
+        lastProgressAt: new Date(observedAt.getTime() - 2 * minute),
+      });
+      await seedJob({
+        id: ids.legacyFresh,
+        status: "paused",
+        createdAt: new Date(observedAt.getTime() - 2 * minute),
+        lastProgressAt: new Date(observedAt.getTime() - minute / 2),
+      });
+      await seedJob({
+        id: ids.providerFailed,
+        status: "failed",
+        createdAt: new Date(observedAt.getTime() - 2 * minute),
+        lastProgressAt: new Date(observedAt.getTime() - 2 * minute),
+        error: "provider failed before timeout",
+      });
+
+      const expiryOptions = {
+        observedAt,
+        queuedTimeoutMs: minute,
+        legacyNoLeaseTimeoutMs: minute,
+        sweeperId: `sweeper-${timeZone}`,
+      };
+      const [firstSweep, concurrentSweep] = await Promise.all([
+        jobs.expireStaleJobs(expiryOptions),
+        jobs.expireStaleJobs(expiryOptions),
+      ]);
+      expect([...firstSweep, ...concurrentSweep].map(({ id }) => id).sort()).toEqual(
+        [ids.leaseExpired, ids.legacyStale, ids.queuedStale].sort(),
+      );
+
+      await expect(jobs.findById(ids.queuedFresh)).resolves.toEqual(
+        expect.objectContaining({ status: "queued", expiryContext: null }),
+      );
+      await expect(jobs.findById(ids.runningWithLease)).resolves.toEqual(
+        expect.objectContaining({ status: "running", expiryContext: null }),
+      );
+      await expect(jobs.findById(ids.pausedWithLease)).resolves.toEqual(
+        expect.objectContaining({ status: "paused", expiryContext: null }),
+      );
+      await expect(jobs.findById(ids.queuedStale)).resolves.toEqual(
+        expect.objectContaining({
+          status: "expired",
+          expiryContext: expect.objectContaining({
+            reason: "queue_timeout",
+            previousStatus: "queued",
+            observedAtMs: observedAt.getTime(),
+            staleBeforeMs: observedAt.getTime() - minute,
+            timeoutMs: minute,
+          }),
+        }),
+      );
+      await expect(jobs.findById(ids.leaseExpired)).resolves.toEqual(
+        expect.objectContaining({
+          status: "expired",
+          expiryContext: expect.objectContaining({
+            reason: "lease_expired",
+            previousStatus: "running",
+            observedAtMs: observedAt.getTime(),
+            staleBeforeMs: observedAt.getTime(),
+            timeoutMs: null,
+          }),
+        }),
+      );
+      await expect(jobs.findById(ids.legacyStale)).resolves.toEqual(
+        expect.objectContaining({
+          status: "expired",
+          expiryContext: expect.objectContaining({
+            reason: "legacy_no_lease_timeout",
+            previousStatus: "running",
+            observedAtMs: observedAt.getTime(),
+            staleBeforeMs: observedAt.getTime() - minute,
+            timeoutMs: minute,
+          }),
+        }),
+      );
+      await expect(jobs.findById(ids.providerFailed)).resolves.toEqual(
+        expect.objectContaining({ status: "failed", error: "provider failed before timeout" }),
+      );
+
+      expect(
+        await jobs.transitionStatus(ids.legacyStale, ["running", "paused"], "failed", {
+          error: "provider failed after timeout",
+          finishedAt: new Date(observedAt.getTime() + 1),
+        }),
+      ).toBeUndefined();
+      await jobs.recordErrorIfExpired(ids.legacyStale, "provider failed after timeout");
+      expect(
+        await jobs.recordErrorIfExpired(ids.legacyStale, "must not overwrite original failure"),
+      ).toBeUndefined();
+      await expect(jobs.findById(ids.legacyStale)).resolves.toEqual(
+        expect.objectContaining({
+          status: "expired",
+          error: "provider failed after timeout",
+        }),
+      );
+      await expect(jobs.expireStaleJobs(expiryOptions)).resolves.toEqual([]);
+
+      await zoneClient.end();
+    },
+  );
+
   it("keeps Agent Change Set undo and redo repeatable across multiple cycles", async () => {
     const pipelineId = "pipeline-agent-history";
     const threadId = "thread-agent-history";

--- a/packages/models/src/daos/jobsDao/jobsDao.ts
+++ b/packages/models/src/daos/jobsDao/jobsDao.ts
@@ -1,7 +1,54 @@
-import { eq, desc, and, lt, isNull, or, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull, lte, type SQL } from "drizzle-orm";
 import { jobsTable, type JobRecord } from "@repo/db-schema";
-import type { JobStatus, JobType, NodeRunStatus } from "@repo/schemas";
+import type {
+  JobExpiryContext,
+  JobExpiryReason,
+  JobStatus,
+  JobType,
+  NodeRunStatus,
+} from "@repo/schemas";
 import type { DbExecutor } from "../../types";
+
+const LIVE_JOB_STATUSES = ["running", "paused"] as const satisfies readonly JobStatus[];
+const TERMINAL_JOB_STATUSES = new Set<JobStatus>([
+  "done",
+  "failed",
+  "cancelled",
+  "expired",
+  "skipped",
+]);
+
+type JobStatusExtra = {
+  error?: string;
+  startedAt?: Date;
+  finishedAt?: Date;
+  totalTokens?: number;
+};
+
+export type ExpireStaleJobsOptions = {
+  observedAt: Date;
+  queuedTimeoutMs: number;
+  legacyNoLeaseTimeoutMs: number;
+  sweeperId: string;
+};
+
+const createStatusPatch = (
+  status: JobStatus,
+  now: Date,
+  extra?: JobStatusExtra,
+): Partial<JobRecord> => ({
+  status,
+  updatedAt: now,
+  lastProgressAt: now,
+  ...(TERMINAL_JOB_STATUSES.has(status) && {
+    leaseOwnerId: null,
+    leaseExpiresAt: null,
+  }),
+  ...(extra?.error !== undefined && { error: extra.error }),
+  ...(extra?.startedAt !== undefined && { startedAt: extra.startedAt }),
+  ...(extra?.finishedAt !== undefined && { finishedAt: extra.finishedAt }),
+  ...(extra?.totalTokens !== undefined && { totalTokens: extra.totalTokens }),
+});
 
 export class JobsDao {
   constructor(readonly executor: DbExecutor) {}
@@ -29,43 +76,101 @@ export class JobsDao {
     const now = new Date();
     const [inserted] = await this.executor
       .insert(jobsTable)
-      .values({ ...data, createdAt: now, updatedAt: now })
+      .values({ ...data, lastProgressAt: now, createdAt: now, updatedAt: now })
       .returning();
 
     return inserted!;
   }
 
-  async updateStatus(
-    id: string,
-    status: JobStatus,
-    extra?: {
-      error?: string;
-      startedAt?: Date;
-      finishedAt?: Date;
-      totalTokens?: number;
-    },
-  ) {
-    const patch: Partial<JobRecord> = {
-      status,
-      updatedAt: new Date(),
-      ...(extra?.error !== undefined && { error: extra.error }),
-      ...(extra?.startedAt !== undefined && { startedAt: extra.startedAt }),
-      ...(extra?.finishedAt !== undefined && { finishedAt: extra.finishedAt }),
-      ...(extra?.totalTokens !== undefined && { totalTokens: extra.totalTokens }),
-    };
+  async updateStatus(id: string, status: JobStatus, extra?: JobStatusExtra) {
+    const now = new Date();
     const [updated] = await this.executor
       .update(jobsTable)
-      .set(patch)
+      .set(createStatusPatch(status, now, extra))
       .where(eq(jobsTable.id, id))
       .returning();
 
     return updated;
   }
 
-  async setNodeStatuses(id: string, nodeStatuses: Record<string, NodeRunStatus>) {
+  async transitionStatus(
+    id: string,
+    from: readonly JobStatus[],
+    status: JobStatus,
+    extra?: JobStatusExtra,
+  ) {
+    const now = new Date();
     const [updated] = await this.executor
       .update(jobsTable)
-      .set({ nodeStatuses, updatedAt: new Date() })
+      .set(createStatusPatch(status, now, extra))
+      .where(and(eq(jobsTable.id, id), inArray(jobsTable.status, [...from])))
+      .returning();
+
+    return updated;
+  }
+
+  async setNodeStatuses(id: string, nodeStatuses: Record<string, NodeRunStatus>) {
+    const now = new Date();
+    const [updated] = await this.executor
+      .update(jobsTable)
+      .set({ nodeStatuses, lastProgressAt: now, updatedAt: now })
+      .where(eq(jobsTable.id, id))
+      .returning();
+
+    return updated;
+  }
+
+  async claimExecutionLease(id: string, leaseOwnerId: string, now: Date, leaseExpiresAt: Date) {
+    const [claimed] = await this.executor
+      .update(jobsTable)
+      .set({
+        status: "running" as JobStatus,
+        startedAt: now,
+        lastProgressAt: now,
+        heartbeatAt: now,
+        leaseOwnerId,
+        leaseExpiresAt,
+        expiryContext: null,
+        updatedAt: now,
+      })
+      .where(
+        and(eq(jobsTable.id, id), eq(jobsTable.status, "queued"), isNull(jobsTable.leaseOwnerId)),
+      )
+      .returning();
+
+    return claimed;
+  }
+
+  async renewExecutionLease(id: string, leaseOwnerId: string, now: Date, leaseExpiresAt: Date) {
+    const [renewed] = await this.executor
+      .update(jobsTable)
+      .set({ heartbeatAt: now, leaseExpiresAt, updatedAt: now })
+      .where(
+        and(
+          eq(jobsTable.id, id),
+          eq(jobsTable.leaseOwnerId, leaseOwnerId),
+          inArray(jobsTable.status, [...LIVE_JOB_STATUSES]),
+        ),
+      )
+      .returning({ status: jobsTable.status });
+
+    return renewed;
+  }
+
+  async recordErrorIfExpired(id: string, error: string) {
+    const [updated] = await this.executor
+      .update(jobsTable)
+      .set({ error, updatedAt: new Date() })
+      .where(and(eq(jobsTable.id, id), eq(jobsTable.status, "expired"), isNull(jobsTable.error)))
+      .returning();
+
+    return updated;
+  }
+
+  async updateUsageTotals(id: string, totalTokens: number) {
+    const [updated] = await this.executor
+      .update(jobsTable)
+      .set({ totalTokens, updatedAt: new Date() })
       .where(eq(jobsTable.id, id))
       .returning();
 
@@ -76,31 +181,92 @@ export class JobsDao {
     await this.executor.delete(jobsTable).where(eq(jobsTable.id, id));
   }
 
-  async expireStaleJobs(defaultTimeoutMs: number) {
-    const now = new Date();
-    const rows = await this.executor
-      .update(jobsTable)
-      .set({
-        status: "expired" as JobStatus,
-        error: "Job timed out: exceeded maximum runtime",
-        finishedAt: now,
-        updatedAt: now,
-      })
-      .where(
-        and(
-          eq(jobsTable.status, "running"),
-          or(
-            sql`EXTRACT(EPOCH FROM (NOW() - ${jobsTable.startedAt})) * 1000 > ${defaultTimeoutMs}`,
-            and(
-              isNull(jobsTable.startedAt),
-              lt(jobsTable.createdAt, new Date(now.getTime() - defaultTimeoutMs)),
-            ),
-          ),
-        ),
-      )
-      .returning({ id: jobsTable.id });
+  async expireStaleJobs({
+    observedAt,
+    queuedTimeoutMs,
+    legacyNoLeaseTimeoutMs,
+    sweeperId,
+  }: ExpireStaleJobsOptions) {
+    const queuedStaleBefore = new Date(observedAt.getTime() - queuedTimeoutMs);
+    const legacyStaleBefore = new Date(observedAt.getTime() - legacyNoLeaseTimeoutMs);
 
-    return rows;
+    const expire = async ({
+      previousStatus,
+      reason,
+      staleBefore,
+      timeoutMs,
+      staleCondition,
+    }: {
+      previousStatus: "queued" | "running" | "paused";
+      reason: JobExpiryReason;
+      staleBefore: Date;
+      timeoutMs: number | null;
+      staleCondition: SQL | undefined;
+    }) => {
+      const expiryContext: JobExpiryContext = {
+        reason,
+        previousStatus,
+        observedAtMs: observedAt.getTime(),
+        staleBeforeMs: staleBefore.getTime(),
+        timeoutMs,
+        sweeperId,
+      };
+      const rows = await this.executor
+        .update(jobsTable)
+        .set({
+          status: "expired" as JobStatus,
+          finishedAt: observedAt,
+          updatedAt: observedAt,
+          expiryContext,
+        })
+        .where(and(eq(jobsTable.status, previousStatus), staleCondition))
+        .returning({ id: jobsTable.id, expiryContext: jobsTable.expiryContext });
+
+      return rows;
+    };
+
+    const expired = [];
+    expired.push(
+      ...(await expire({
+        previousStatus: "queued",
+        reason: "queue_timeout",
+        staleBefore: queuedStaleBefore,
+        timeoutMs: queuedTimeoutMs,
+        staleCondition: and(
+          isNull(jobsTable.leaseOwnerId),
+          lte(jobsTable.createdAt, queuedStaleBefore),
+        ),
+      })),
+    );
+
+    for (const previousStatus of LIVE_JOB_STATUSES) {
+      expired.push(
+        ...(await expire({
+          previousStatus,
+          reason: "lease_expired",
+          staleBefore: observedAt,
+          timeoutMs: null,
+          staleCondition: and(
+            isNotNull(jobsTable.leaseExpiresAt),
+            lte(jobsTable.leaseExpiresAt, observedAt),
+          ),
+        })),
+      );
+      expired.push(
+        ...(await expire({
+          previousStatus,
+          reason: "legacy_no_lease_timeout",
+          staleBefore: legacyStaleBefore,
+          timeoutMs: legacyNoLeaseTimeoutMs,
+          staleCondition: and(
+            isNull(jobsTable.leaseExpiresAt),
+            lte(jobsTable.lastProgressAt, legacyStaleBefore),
+          ),
+        })),
+      );
+    }
+
+    return expired;
   }
 }
 

--- a/packages/models/src/daos/jobsDao/jobsDao.unit.test.ts
+++ b/packages/models/src/daos/jobsDao/jobsDao.unit.test.ts
@@ -120,6 +120,109 @@ describe("jobsDao", () => {
     );
   });
 
+  it("claims and renews an execution lease with caller-provided UTC instants", async () => {
+    const claimedAt = new Date("2026-06-01T12:00:00.000Z");
+    const firstExpiry = new Date("2026-06-01T12:01:30.000Z");
+    const heartbeatAt = new Date("2026-06-01T12:00:30.000Z");
+    const renewedExpiry = new Date("2026-06-01T12:02:00.000Z");
+    mockReturning.mockResolvedValueOnce([makeRow("job-lease", "running")]);
+    mockReturning.mockResolvedValueOnce([{ status: "running" }]);
+
+    await dao.claimExecutionLease("job-lease", "worker-1", claimedAt, firstExpiry);
+    await dao.renewExecutionLease("job-lease", "worker-1", heartbeatAt, renewedExpiry);
+
+    expect(mockSet).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        status: "running",
+        startedAt: claimedAt,
+        lastProgressAt: claimedAt,
+        heartbeatAt: claimedAt,
+        leaseOwnerId: "worker-1",
+        leaseExpiresAt: firstExpiry,
+      }),
+    );
+    expect(mockSet).toHaveBeenNthCalledWith(2, {
+      heartbeatAt,
+      leaseExpiresAt: renewedExpiry,
+      updatedAt: heartbeatAt,
+    });
+  });
+
+  it("clears a lease whenever a Job reaches a terminal status", async () => {
+    mockReturning.mockResolvedValueOnce([makeRow("job-terminal", "done")]);
+
+    await dao.transitionStatus("job-terminal", ["running", "paused"], "done", {
+      finishedAt: new Date("2026-06-01T12:00:00.000Z"),
+    });
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "done", leaseOwnerId: null, leaseExpiresAt: null }),
+    );
+  });
+
+  it("uses one observed instant and records structured reasons during a stale sweep", async () => {
+    const observedAt = new Date("2026-06-01T12:00:00.000Z");
+    mockReturning
+      .mockResolvedValueOnce([
+        {
+          id: "queued-stale",
+          expiryContext: { reason: "queue_timeout" },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "running-stale",
+          expiryContext: { reason: "lease_expired" },
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const expired = await dao.expireStaleJobs({
+      observedAt,
+      queuedTimeoutMs: 60_000,
+      legacyNoLeaseTimeoutMs: 120_000,
+      sweeperId: "sweeper-1",
+    });
+
+    expect(expired.map(({ id }) => id)).toEqual(["queued-stale", "running-stale"]);
+    expect(mockSet).toHaveBeenCalledTimes(5);
+    expect(mockSet).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        status: "expired",
+        finishedAt: observedAt,
+        updatedAt: observedAt,
+        expiryContext: {
+          reason: "queue_timeout",
+          previousStatus: "queued",
+          observedAtMs: observedAt.getTime(),
+          staleBeforeMs: observedAt.getTime() - 60_000,
+          timeoutMs: 60_000,
+          sweeperId: "sweeper-1",
+        },
+      }),
+    );
+    expect(mockSet).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        expiryContext: expect.objectContaining({
+          reason: "lease_expired",
+          previousStatus: "running",
+          observedAtMs: observedAt.getTime(),
+          staleBeforeMs: observedAt.getTime(),
+          timeoutMs: null,
+        }),
+      }),
+    );
+    const statusPatches = mockSet.mock.calls as unknown as Array<[Record<string, unknown>]>;
+    for (const [patch] of statusPatches) {
+      expect(patch).not.toHaveProperty("error");
+    }
+  });
+
   it("delete calls db.delete", async () => {
     await dao.delete("job-6");
     expect(mockWhere).toHaveBeenCalled();

--- a/packages/schemas/src/job/JobExpiryContextSchema.ts
+++ b/packages/schemas/src/job/JobExpiryContextSchema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod/v4";
+export const JobExpiryReasonSchema = z.enum([
+  "queue_timeout",
+  "lease_expired",
+  "legacy_no_lease_timeout",
+]);
+export type JobExpiryReason = z.infer<typeof JobExpiryReasonSchema>;
+
+export const JobExpiryPreviousStatusSchema = z.enum(["queued", "running", "paused"]);
+
+export const JobExpiryContextSchema = z.object({
+  reason: JobExpiryReasonSchema,
+  previousStatus: JobExpiryPreviousStatusSchema,
+  observedAtMs: z.number().int().nonnegative(),
+  staleBeforeMs: z.number().int().nonnegative(),
+  timeoutMs: z.number().int().positive().nullable(),
+  sweeperId: z.string().min(1),
+});
+export type JobExpiryContext = z.infer<typeof JobExpiryContextSchema>;

--- a/packages/schemas/src/job/JobExpiryContextSchema.unit.test.ts
+++ b/packages/schemas/src/job/JobExpiryContextSchema.unit.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { JobExpiryContextSchema } from "./JobExpiryContextSchema";
+
+describe("JobExpiryContextSchema", () => {
+  it("accepts structured lease expiry evidence", () => {
+    expect(
+      JobExpiryContextSchema.parse({
+        reason: "lease_expired",
+        previousStatus: "paused",
+        observedAtMs: 1_788_091_200_000,
+        staleBeforeMs: 1_788_091_200_000,
+        timeoutMs: null,
+        sweeperId: "server:worker-1",
+      }),
+    ).toEqual(expect.objectContaining({ reason: "lease_expired", previousStatus: "paused" }));
+  });
+
+  it("rejects unsupported reasons and non-positive configured timeouts", () => {
+    expect(() =>
+      JobExpiryContextSchema.parse({
+        reason: "absolute_runtime_timeout",
+        previousStatus: "running",
+        observedAtMs: 1,
+        staleBeforeMs: 0,
+        timeoutMs: 60_000,
+        sweeperId: "server:worker-1",
+      }),
+    ).toThrow();
+    expect(() =>
+      JobExpiryContextSchema.parse({
+        reason: "queue_timeout",
+        previousStatus: "queued",
+        observedAtMs: 1,
+        staleBeforeMs: 0,
+        timeoutMs: 0,
+        sweeperId: "server:worker-1",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/schemas/src/job/JobSchema.ts
+++ b/packages/schemas/src/job/JobSchema.ts
@@ -2,6 +2,7 @@ import { z } from "zod/v4";
 import { JobStatusSchema } from "./JobStatusSchema";
 import { JobTriggeredBySchema } from "./JobTriggeredBySchema";
 import { JobTypeSchema } from "./JobTypeSchema";
+import { JobExpiryContextSchema } from "./JobExpiryContextSchema";
 import { MetaSchema } from "../meta";
 import { NodeRunStatusSchema } from "../pipeline/node-data";
 
@@ -19,6 +20,11 @@ export const JobSchema = z.object({
   error: z.string().nullable(),
   startedAt: z.coerce.date().nullable(),
   finishedAt: z.coerce.date().nullable(),
+  lastProgressAt: z.coerce.date().optional(),
+  heartbeatAt: z.coerce.date().nullable().optional(),
+  leaseOwnerId: z.string().nullable().optional(),
+  leaseExpiresAt: z.coerce.date().nullable().optional(),
+  expiryContext: JobExpiryContextSchema.nullable().optional(),
   meta: MetaSchema.optional(),
 });
 export type Job = z.infer<typeof JobSchema>;

--- a/packages/schemas/src/job/index.ts
+++ b/packages/schemas/src/job/index.ts
@@ -1,4 +1,5 @@
 export * from "./JobSchema";
+export * from "./JobExpiryContextSchema";
 export * from "./JobStatusSchema";
 export * from "./JobTriggeredBySchema";
 export * from "./JobTypeSchema";

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -10,6 +10,7 @@ export * from "./distillationsService";
 export * from "./filesystemService";
 export * from "./githubProjectsService";
 export * from "./jobsService";
+export * from "./jobLease";
 export * from "./operationsService";
 export * from "./operationRunnerService";
 export * from "./pipelineAssetsService";

--- a/packages/services/src/jobLease/index.ts
+++ b/packages/services/src/jobLease/index.ts
@@ -1,0 +1,1 @@
+export * from "./jobLease";

--- a/packages/services/src/jobLease/jobLease.ts
+++ b/packages/services/src/jobLease/jobLease.ts
@@ -1,0 +1,93 @@
+import { ResultAsync } from "neverthrow";
+import { logger } from "@repo/logger";
+import type { JobsDao } from "@repo/models";
+
+export const DEFAULT_JOB_LEASE_DURATION_MS = 90_000;
+export const DEFAULT_JOB_HEARTBEAT_INTERVAL_MS = 30_000;
+
+export type JobLeaseTimingOptions = {
+  leaseDurationMs?: number;
+  heartbeatIntervalMs?: number;
+};
+
+export const createJobLeaseController = ({
+  jobsDao,
+  jobId,
+  options,
+  leaseOwnerId = crypto.randomUUID(),
+  now = () => new Date(),
+}: {
+  jobsDao: JobsDao;
+  jobId: string;
+  options?: JobLeaseTimingOptions;
+  leaseOwnerId?: string;
+  now?: () => Date;
+}) => {
+  const leaseDurationMs = options?.leaseDurationMs ?? DEFAULT_JOB_LEASE_DURATION_MS;
+  const heartbeatIntervalMs = options?.heartbeatIntervalMs ?? DEFAULT_JOB_HEARTBEAT_INTERVAL_MS;
+  if (leaseDurationMs <= 0 || heartbeatIntervalMs <= 0) {
+    throw new Error("Job lease duration and heartbeat interval must be positive");
+  }
+  if (heartbeatIntervalMs >= leaseDurationMs) {
+    throw new Error("Job heartbeat interval must be less than the lease duration");
+  }
+  const state: {
+    heartbeatTimer: ReturnType<typeof globalThis.setInterval> | null;
+    heartbeatRunning: boolean;
+  } = {
+    heartbeatTimer: null,
+    heartbeatRunning: false,
+  };
+
+  const stop = () => {
+    if (!state.heartbeatTimer) return;
+
+    globalThis.clearInterval(state.heartbeatTimer);
+    state.heartbeatTimer = null;
+  };
+
+  const heartbeat = async (): Promise<void> => {
+    if (state.heartbeatRunning) return;
+
+    state.heartbeatRunning = true;
+    const heartbeatAt = now();
+    const renewed = await ResultAsync.fromPromise(
+      jobsDao.renewExecutionLease(
+        jobId,
+        leaseOwnerId,
+        heartbeatAt,
+        new Date(heartbeatAt.getTime() + leaseDurationMs),
+      ),
+      (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+    );
+    state.heartbeatRunning = false;
+    if (renewed.isErr()) {
+      logger.warn({ err: renewed.error, jobId, leaseOwnerId }, "job lease heartbeat failed");
+
+      return;
+    }
+    if (!renewed.value) stop();
+  };
+
+  return {
+    leaseOwnerId,
+    claim: () => {
+      const claimedAt = now();
+
+      return jobsDao.claimExecutionLease(
+        jobId,
+        leaseOwnerId,
+        claimedAt,
+        new Date(claimedAt.getTime() + leaseDurationMs),
+      );
+    },
+    start: () => {
+      if (state.heartbeatTimer) return;
+
+      state.heartbeatTimer = globalThis.setInterval(() => {
+        void heartbeat();
+      }, heartbeatIntervalMs);
+    },
+    stop,
+  };
+};

--- a/packages/services/src/jobLease/jobLease.unit.test.ts
+++ b/packages/services/src/jobLease/jobLease.unit.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { JobsDao } from "@repo/models";
+import { createJobLeaseController } from "./jobLease";
+
+const makeJobsDao = () =>
+  ({
+    claimExecutionLease: vi.fn(),
+    renewExecutionLease: vi.fn(),
+  }) as unknown as JobsDao;
+
+describe("createJobLeaseController", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("claims once, renews on the heartbeat cadence, and stops cleanly", async () => {
+    vi.useFakeTimers();
+    const jobsDao = makeJobsDao();
+    const claimExecutionLease = vi.mocked(jobsDao.claimExecutionLease);
+    const renewExecutionLease = vi.mocked(jobsDao.renewExecutionLease);
+    claimExecutionLease.mockResolvedValue({ id: "job-1" } as never);
+    renewExecutionLease.mockResolvedValue({ status: "running" });
+    const claimedAt = new Date("2026-06-01T12:00:00.000Z");
+    const heartbeatAt = new Date("2026-06-01T12:00:30.000Z");
+    const now = vi.fn().mockReturnValueOnce(claimedAt).mockReturnValue(heartbeatAt);
+    const lease = createJobLeaseController({
+      jobsDao,
+      jobId: "job-1",
+      leaseOwnerId: "worker-1",
+      now,
+      options: { leaseDurationMs: 90_000, heartbeatIntervalMs: 30_000 },
+    });
+
+    await expect(lease.claim()).resolves.toEqual({ id: "job-1" });
+    expect(claimExecutionLease).toHaveBeenCalledWith(
+      "job-1",
+      "worker-1",
+      claimedAt,
+      new Date("2026-06-01T12:01:30.000Z"),
+    );
+
+    lease.start();
+    lease.start();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(renewExecutionLease).toHaveBeenCalledTimes(1);
+    expect(renewExecutionLease).toHaveBeenCalledWith(
+      "job-1",
+      "worker-1",
+      heartbeatAt,
+      new Date("2026-06-01T12:02:00.000Z"),
+    );
+
+    lease.stop();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(renewExecutionLease).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops renewing after another actor finalizes the Job", async () => {
+    vi.useFakeTimers();
+    const jobsDao = makeJobsDao();
+    vi.mocked(jobsDao.renewExecutionLease).mockResolvedValue(undefined);
+    const lease = createJobLeaseController({
+      jobsDao,
+      jobId: "job-2",
+      leaseOwnerId: "worker-2",
+      now: () => new Date("2026-06-01T12:00:30.000Z"),
+      options: { leaseDurationMs: 90_000, heartbeatIntervalMs: 30_000 },
+    });
+
+    lease.start();
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    expect(jobsDao.renewExecutionLease).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not overlap slow heartbeat renewals", async () => {
+    vi.useFakeTimers();
+    const jobsDao = makeJobsDao();
+    const renewExecutionLease = vi.mocked(jobsDao.renewExecutionLease);
+    const renewal = { resolve: undefined as (() => void) | undefined };
+    renewExecutionLease
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            renewal.resolve = () => resolve({ status: "running" });
+          }),
+      )
+      .mockResolvedValue({ status: "running" });
+    const lease = createJobLeaseController({
+      jobsDao,
+      jobId: "job-slow-heartbeat",
+      leaseOwnerId: "worker-slow",
+      now: () => new Date("2026-06-01T12:00:30.000Z"),
+      options: { leaseDurationMs: 90_000, heartbeatIntervalMs: 30_000 },
+    });
+
+    lease.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(renewExecutionLease).toHaveBeenCalledTimes(1);
+
+    renewal.resolve?.();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(renewExecutionLease).toHaveBeenCalledTimes(2);
+    lease.stop();
+  });
+
+  it("rejects lease timing that can expire before the next heartbeat", () => {
+    const jobsDao = makeJobsDao();
+
+    expect(() =>
+      createJobLeaseController({
+        jobsDao,
+        jobId: "job-invalid",
+        options: { leaseDurationMs: 30_000, heartbeatIntervalMs: 30_000 },
+      }),
+    ).toThrow("Job heartbeat interval must be less than the lease duration");
+  });
+});

--- a/packages/services/src/jobsService/createJobsService.ts
+++ b/packages/services/src/jobsService/createJobsService.ts
@@ -27,6 +27,7 @@ export const createJobsService = (db: DbConnection) => {
     getAgentRunById: (id: number) => agentRawExportsDao.findById(id),
     getSpansByJobId: (jobId: string) => agentSpansDao.findByJobId(jobId),
     getSpansByRawExportId: (rawExportId: number) => agentSpansDao.findByRawExportId(rawExportId),
-    expireStaleJobs: (defaultTimeoutMs: number) => jobsDao.expireStaleJobs(defaultTimeoutMs),
+    expireStaleJobs: (...args: Parameters<typeof jobsDao.expireStaleJobs>) =>
+      jobsDao.expireStaleJobs(...args),
   };
 };

--- a/packages/services/src/operationRunnerService/createOperationRunnerService.ts
+++ b/packages/services/src/operationRunnerService/createOperationRunnerService.ts
@@ -22,6 +22,7 @@ import {
   createAgentRuntimesDao,
   type DbConnection,
 } from "@repo/models";
+import { createJobLeaseController, type JobLeaseTimingOptions } from "../jobLease";
 
 export class OperationNotFoundError extends Error {
   constructor(operationId: string) {
@@ -30,7 +31,10 @@ export class OperationNotFoundError extends Error {
   }
 }
 
-export const createOperationRunnerService = (db: DbConnection) => {
+export const createOperationRunnerService = (
+  db: DbConnection,
+  jobLeaseOptions?: JobLeaseTimingOptions,
+) => {
   const agentsDao = createAgentsDao(db);
   const operationsDao = createOperationsDao(db);
   const jobsDao = createJobsDao(db);
@@ -43,6 +47,41 @@ export const createOperationRunnerService = (db: DbConnection) => {
 
   initObs(jobTracesDao);
   initSpanRecorder({ agentRawExportsDao, agentSpansDao });
+
+  const failJobSafely = async (jobId: string, message: string): Promise<void> => {
+    const safeTrace = await ResultAsync.fromPromise(
+      trace(jobId, `ERROR: ${message}`, "error"),
+      (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+    );
+    if (safeTrace.isErr()) {
+      logger.error({ err: safeTrace.error, jobId }, "operationRunner: error trace failed");
+    }
+
+    const failed = await ResultAsync.fromPromise(
+      jobsDao.transitionStatus(jobId, ["queued", "running", "paused"], "failed", {
+        finishedAt: new Date(),
+        error: message,
+      }),
+      (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+    );
+    if (failed.isErr()) {
+      logger.error({ err: failed.error, jobId }, "operationRunner: failed to finalize job");
+
+      return;
+    }
+    if (failed.value) return;
+
+    const preserved = await ResultAsync.fromPromise(
+      jobsDao.recordErrorIfExpired(jobId, message),
+      (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+    );
+    if (preserved.isErr()) {
+      logger.error(
+        { err: preserved.error, jobId },
+        "operationRunner: could not preserve provider error on expired job",
+      );
+    }
+  };
 
   const buildDepsForJob = ({
     jobId,
@@ -91,6 +130,11 @@ export const createOperationRunnerService = (db: DbConnection) => {
         startedAt: null,
         finishedAt: null,
       });
+      const lease = createJobLeaseController({
+        jobsDao,
+        jobId,
+        options: jobLeaseOptions,
+      });
 
       const settings = normalizeSettingsRecord(await settingsDao.get());
 
@@ -110,7 +154,13 @@ export const createOperationRunnerService = (db: DbConnection) => {
 
       void ResultAsync.fromPromise(
         (async () => {
-          await jobsDao.updateStatus(jobId, "running", { startedAt: new Date() });
+          const claimed = await lease.claim();
+          if (!claimed) {
+            logger.info({ jobId }, "operationRunner: execution lease was not claimed");
+
+            return;
+          }
+          lease.start();
           await trace(jobId, `Starting operation "${operation.name}" (${opts.operationId})`);
 
           const operationInfo: OperationInfo = {
@@ -180,26 +230,35 @@ export const createOperationRunnerService = (db: DbConnection) => {
 
           if (result.outcome === "completed") {
             await trace(jobId, `Operation completed successfully (${result.content.length} chars)`);
-            await jobsDao.updateStatus(jobId, "done", { finishedAt: new Date() });
+            const finalized = await jobsDao.transitionStatus(jobId, ["running", "paused"], "done", {
+              finishedAt: new Date(),
+            });
+            if (!finalized) {
+              logger.info(
+                { jobId },
+                "operationRunner: job already finalized elsewhere — not overwriting with done",
+              );
+            }
           } else {
             const message =
               result.outcome === "failed"
                 ? result.error.message
                 : "Operation was skipped (incomplete configuration)";
-            await trace(jobId, `ERROR: ${message}`, "error");
-            await jobsDao.updateStatus(jobId, "failed", {
-              finishedAt: new Date(),
-              error: message,
-            });
+            await failJobSafely(jobId, message);
           }
         })(),
         (error) => error,
       ).match(
-        () => undefined,
-        (error) => {
+        () => lease.stop(),
+        async (error) => {
+          lease.stop();
           logger.error(
             { err: error, jobId },
             "operationRunner: unhandled rejection from background operation run",
+          );
+          await failJobSafely(
+            jobId,
+            `Unhandled error: ${error instanceof Error ? error.message : String(error)}`,
           );
         },
       );

--- a/packages/services/src/operationRunnerService/createOperationRunnerService.unit.test.ts
+++ b/packages/services/src/operationRunnerService/createOperationRunnerService.unit.test.ts
@@ -7,6 +7,10 @@ const mockOperationsDao = {
 const mockJobsDao = {
   create: vi.fn().mockResolvedValue(undefined),
   updateStatus: vi.fn().mockResolvedValue(undefined),
+  transitionStatus: vi.fn().mockResolvedValue({ id: "job-1" }),
+  claimExecutionLease: vi.fn().mockResolvedValue({ id: "job-1", status: "running" }),
+  renewExecutionLease: vi.fn().mockResolvedValue({ status: "running" }),
+  recordErrorIfExpired: vi.fn().mockResolvedValue(undefined),
 };
 
 const mockSettingsDao = {
@@ -73,6 +77,8 @@ import {
 describe("createOperationRunnerService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockJobsDao.transitionStatus.mockResolvedValue({ id: "job-1" });
+    mockJobsDao.claimExecutionLease.mockResolvedValue({ id: "job-1", status: "running" });
   });
 
   it("returns OperationNotFoundError when operation does not exist", async () => {

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.ts
@@ -30,11 +30,13 @@ import {
   type PipelineOperationReferencesError,
 } from "../../pipelinesService/checkPipelineOperationReferences";
 import type { ServiceError } from "../../serviceErrors";
+import type { JobLeaseTimingOptions } from "../../jobLease";
 
 export interface PipelineRunnerServiceOptions {
   encryptionSecret?: string;
   env?: Readonly<Record<string, string | undefined>>;
   agentRunController?: AgentRunController;
+  jobLease?: JobLeaseTimingOptions;
 }
 
 export class PipelineNotFoundError extends Error {
@@ -110,11 +112,12 @@ export const createPipelineRunnerService = (
 
   const persistStatus = (
     jobId: string,
+    from: readonly JobStatus[],
     status: JobStatus,
     extra?: { finishedAt?: Date },
   ): ResultAsync<unknown, Error> =>
     ResultAsync.fromPromise(
-      jobsDao.updateStatus(jobId, status, extra),
+      jobsDao.transitionStatus(jobId, from, status, extra),
       (cause) =>
         new Error(
           `Failed to persist status "${status}" for job ${jobId}: ${cause instanceof Error ? cause.message : String(cause)}`,
@@ -315,6 +318,7 @@ export const createPipelineRunnerService = (
             getMcpConnectorInjection: buildMcpConnectorInjectionProvider(runtimeConfig.type),
             signal: pipelineRunControl.signal(jobId),
           }),
+          jobLease: options.jobLease,
           runControl,
           onRunSettled: () => pipelineRunControl.clear(jobId),
         }),
@@ -335,8 +339,11 @@ export const createPipelineRunnerService = (
       const guard = await guardJobStatus("pause", jobId, ["running"]);
       if (guard.isErr()) return err(guard.error);
 
-      const write = await persistStatus(jobId, "paused");
+      const write = await persistStatus(jobId, ["running"], "paused");
       if (write.isErr()) return err(write.error);
+      if (!write.value) {
+        return err(new InvalidJobStatusError("pause", jobId, "changed concurrently", ["running"]));
+      }
 
       return ok(pipelineRunControl.pause(jobId));
     },
@@ -349,8 +356,13 @@ export const createPipelineRunnerService = (
       const guard = await guardJobStatus("resume", jobId, ["paused", "running"]);
       if (guard.isErr()) return err(guard.error);
 
-      const write = await persistStatus(jobId, "running");
+      const write = await persistStatus(jobId, ["paused", "running"], "running");
       if (write.isErr()) return err(write.error);
+      if (!write.value) {
+        return err(
+          new InvalidJobStatusError("resume", jobId, "changed concurrently", ["paused", "running"]),
+        );
+      }
 
       return ok(pipelineRunControl.resume(jobId));
     },
@@ -364,8 +376,19 @@ export const createPipelineRunnerService = (
 
       // Persist the cancelled status before releasing any waiter, so the
       // executor's terminal-status guard reliably sees "cancelled".
-      const write = await persistStatus(jobId, "cancelled", { finishedAt: new Date() });
+      const write = await persistStatus(jobId, ["queued", "running", "paused"], "cancelled", {
+        finishedAt: new Date(),
+      });
       if (write.isErr()) return err(write.error);
+      if (!write.value) {
+        return err(
+          new InvalidJobStatusError("cancel", jobId, "changed concurrently", [
+            "queued",
+            "running",
+            "paused",
+          ]),
+        );
+      }
 
       return ok(pipelineRunControl.cancel(jobId));
     },

--- a/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/createPipelineRunnerService/createPipelineRunnerService.unit.test.ts
@@ -41,6 +41,7 @@ const {
     mockJobsDao: {
       findById: vi.fn(),
       updateStatus: vi.fn().mockResolvedValue(undefined),
+      transitionStatus: vi.fn().mockResolvedValue({ id: "job-1" }),
       create: vi.fn().mockResolvedValue(undefined),
       setNodeStatuses: vi.fn().mockResolvedValue(undefined),
     },
@@ -129,6 +130,7 @@ describe("createPipelineRunnerService run controls", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockJobsDao.updateStatus.mockResolvedValue(undefined);
+    mockJobsDao.transitionStatus.mockResolvedValue({ id: "job-1" });
     mockMcpInjections.length = 0;
     mockConnectorsDao.findMany.mockResolvedValue([]);
     mockOperationsDao.findById.mockReset();
@@ -170,7 +172,12 @@ describe("createPipelineRunnerService run controls", () => {
 
     expect(result.isOk()).toBe(true);
     expect(releaseState.released).toBe(true);
-    expect(mockJobsDao.updateStatus).toHaveBeenCalledWith(jobId, "running", undefined);
+    expect(mockJobsDao.transitionStatus).toHaveBeenCalledWith(
+      jobId,
+      ["paused", "running"],
+      "running",
+      undefined,
+    );
 
     pipelineRunControl.clear(jobId);
   });
@@ -183,7 +190,12 @@ describe("createPipelineRunnerService run controls", () => {
     const result = await service.resumeRun(jobId);
 
     expect(result.isOk()).toBe(true);
-    expect(mockJobsDao.updateStatus).toHaveBeenCalledWith(jobId, "running", undefined);
+    expect(mockJobsDao.transitionStatus).toHaveBeenCalledWith(
+      jobId,
+      ["paused", "running"],
+      "running",
+      undefined,
+    );
 
     pipelineRunControl.clear(jobId);
   });
@@ -198,7 +210,7 @@ describe("createPipelineRunnerService run controls", () => {
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(InvalidJobStatusError);
     }
-    expect(mockJobsDao.updateStatus).not.toHaveBeenCalled();
+    expect(mockJobsDao.transitionStatus).not.toHaveBeenCalled();
   });
 
   it("resumeRun rejects unknown jobs", async () => {
@@ -224,8 +236,9 @@ describe("createPipelineRunnerService run controls", () => {
     if (result.isOk()) {
       expect(result.value).toEqual({ jobId, cancelled: true });
     }
-    expect(mockJobsDao.updateStatus).toHaveBeenCalledWith(
+    expect(mockJobsDao.transitionStatus).toHaveBeenCalledWith(
       jobId,
+      ["queued", "running", "paused"],
       "cancelled",
       expect.objectContaining({ finishedAt: expect.any(Date) }),
     );
@@ -243,12 +256,12 @@ describe("createPipelineRunnerService run controls", () => {
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(InvalidJobStatusError);
     }
-    expect(mockJobsDao.updateStatus).not.toHaveBeenCalled();
+    expect(mockJobsDao.transitionStatus).not.toHaveBeenCalled();
   });
 
   it("surfaces a DB write failure as an error result", async () => {
     mockJobsDao.findById.mockResolvedValue({ id: "job-db", status: "running" });
-    mockJobsDao.updateStatus.mockRejectedValueOnce(new Error("DB down"));
+    mockJobsDao.transitionStatus.mockRejectedValueOnce(new Error("DB down"));
     const service = makeService();
 
     const result = await service.pauseRun("job-db");

--- a/packages/services/src/pipelineRunnerService/runPipeline/runPipeline.ts
+++ b/packages/services/src/pipelineRunnerService/runPipeline/runPipeline.ts
@@ -20,6 +20,7 @@ import type {
   SkillsDao,
   AgentRawExportsDao,
 } from "@repo/models";
+import { createJobLeaseController, type JobLeaseTimingOptions } from "../../jobLease";
 
 /**
  * Sum the persisted token usage of every agent raw export attached to the job.
@@ -51,37 +52,6 @@ const aggregateUsageTotalsSafely = async ({
   );
 
   return { totalTokens };
-};
-
-/**
- * A terminal status may only overwrite a live (running/paused) status. In
- * particular, a run cancelled while a node was still executing must stay
- * cancelled when that node later settles as done/failed. Fails open on read
- * errors — leaving a job stuck "running" is worse than a stale overwrite.
- */
-const canFinalizeJob = async ({
-  jobsDao,
-  jobId,
-}: {
-  jobsDao: JobsDao;
-  jobId: string;
-}): Promise<boolean> => {
-  const current = await ResultAsync.fromPromise(
-    (async () => jobsDao.findById(jobId))(),
-    (cause) => cause,
-  );
-  if (current.isErr()) {
-    logger.error(
-      { err: current.error, jobId },
-      "runPipeline: could not read job status before finalizing — proceeding with write",
-    );
-
-    return true;
-  }
-
-  const status = current.value?.status;
-
-  return status === "running" || status === "paused";
 };
 
 /**
@@ -129,19 +99,8 @@ const recordUsageOnFinalizedJobSafely = async ({
 }): Promise<void> => {
   if (!usageTotals) return;
 
-  const current = await ResultAsync.fromPromise(
-    (async () => jobsDao.findById(jobId))(),
-    (cause) => cause,
-  );
-  const status = current.isOk() ? current.value?.status : undefined;
-  if (!status) {
-    logger.warn({ jobId }, "runPipeline: could not record usage totals on finalized job");
-
-    return;
-  }
-
   const safeUpdate = await ResultAsync.fromPromise(
-    jobsDao.updateStatus(jobId, status, { ...usageTotals }),
+    jobsDao.updateUsageTotals(jobId, usageTotals.totalTokens),
     (e) => e,
   );
   if (safeUpdate.isErr()) {
@@ -153,9 +112,9 @@ const recordUsageOnFinalizedJobSafely = async ({
 };
 
 /**
- * Mark a job as failed. Swallows any DAO/trace errors to guarantee the caller
- * never sees an unhandled rejection from this helper. Skips the write when the
- * job already left the running/paused states (e.g. it was cancelled).
+ * Mark a live job as failed with a compare-and-set transition. If the expiry
+ * sweep wins the race, preserve the provider error without changing the
+ * terminal `expired` status. Never leaks DAO or trace failures to the caller.
  */
 const failJobSafely = async ({
   jobsDao,
@@ -179,17 +138,8 @@ const failJobSafely = async ({
     );
   }
 
-  if (!(await canFinalizeJob({ jobsDao, jobId }))) {
-    logger.info(
-      { jobId },
-      "runPipeline: job already finalized elsewhere — not overwriting with failed",
-    );
-
-    return;
-  }
-
   const safeUpdate = await ResultAsync.fromPromise(
-    jobsDao.updateStatus(jobId, "failed", {
+    jobsDao.transitionStatus(jobId, ["queued", "running", "paused"], "failed", {
       finishedAt: new Date(),
       error: message,
       ...usageTotals,
@@ -201,7 +151,27 @@ const failJobSafely = async ({
       { err: safeUpdate.error, jobId },
       "runPipeline: CRITICAL — could not mark job as failed",
     );
+
+    return;
   }
+  if (safeUpdate.value) return;
+
+  const preservedError = await ResultAsync.fromPromise(
+    jobsDao.recordErrorIfExpired(jobId, message),
+    (e) => e,
+  );
+  if (preservedError.isErr()) {
+    logger.error(
+      { err: preservedError.error, jobId },
+      "runPipeline: could not preserve provider error on expired job",
+    );
+
+    return;
+  }
+  logger.info(
+    { jobId, errorPreserved: Boolean(preservedError.value) },
+    "runPipeline: job already finalized elsewhere — not overwriting with failed",
+  );
 };
 
 export const pipelineRunExecutor = {
@@ -221,6 +191,7 @@ export const pipelineRunExecutor = {
     skillsDao: SkillsDao;
     agentRawExportsDao: AgentRawExportsDao;
     engineDeps: PipelineEngineDeps;
+    jobLease?: JobLeaseTimingOptions;
     runControl?: PipelineRunControl;
     onRunSettled?: () => void;
   }): Promise<void> => {
@@ -238,10 +209,17 @@ export const pipelineRunExecutor = {
       engineDeps,
     } = opts;
     const updateNodeStatus = createNodeStatusWriter({ jobsDao, jobId });
+    const lease = createJobLeaseController({ jobsDao, jobId, options: opts.jobLease });
 
     const runResult = await ResultAsync.fromPromise(
       (async () => {
-        await jobsDao.updateStatus(jobId, "running", { startedAt: new Date() });
+        const claimed = await lease.claim();
+        if (!claimed) {
+          logger.info({ jobId }, "runPipeline: execution lease was not claimed");
+
+          return;
+        }
+        lease.start();
         await trace(jobId, `Starting pipeline ${pipelineId}`);
 
         const pipeline = await pipelinesDao.findById(pipelineId);
@@ -330,12 +308,11 @@ export const pipelineRunExecutor = {
 
         if (outcome.ok) {
           await pipelineRunsDao.update(jobId, { result: { summary: outcome.summary } });
-          if (await canFinalizeJob({ jobsDao, jobId })) {
-            await jobsDao.updateStatus(jobId, "done", {
-              finishedAt: new Date(),
-              ...usageTotals,
-            });
-          } else {
+          const finalized = await jobsDao.transitionStatus(jobId, ["running", "paused"], "done", {
+            finishedAt: new Date(),
+            ...usageTotals,
+          });
+          if (!finalized) {
             logger.info(
               { jobId },
               "runPipeline: job already finalized elsewhere — not overwriting with done",
@@ -351,7 +328,9 @@ export const pipelineRunExecutor = {
           // the usage totals gathered so far.
           await trace(jobId, `Run cancelled: ${outcome.error.message}`);
           const safeUpdate = await ResultAsync.fromPromise(
-            jobsDao.updateStatus(jobId, "cancelled", { ...usageTotals }),
+            jobsDao.transitionStatus(jobId, ["queued", "running", "paused"], "cancelled", {
+              ...usageTotals,
+            }),
             (e) => e,
           );
           if (safeUpdate.isErr()) {
@@ -359,6 +338,8 @@ export const pipelineRunExecutor = {
               { err: safeUpdate.error, jobId },
               "runPipeline: failed to record usage totals on cancelled job",
             );
+          } else if (!safeUpdate.value) {
+            await recordUsageOnFinalizedJobSafely({ jobsDao, jobId, usageTotals });
           }
         } else {
           await failJobSafely({
@@ -371,6 +352,7 @@ export const pipelineRunExecutor = {
       })(),
       (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
     );
+    lease.stop();
 
     if (runResult.isErr()) {
       logger.error({ err: runResult.error, jobId }, "runPipeline: unhandled error in pipeline run");

--- a/packages/services/src/pipelineRunnerService/runPipeline/runPipeline.unit.test.ts
+++ b/packages/services/src/pipelineRunnerService/runPipeline/runPipeline.unit.test.ts
@@ -38,6 +38,20 @@ vi.mock("@repo/pipeline-engine", async (importOriginal) => {
 
 import { pipelineRunExecutor } from ".";
 
+const makeJobsDao = (overrides = {}) =>
+  ({
+    create: vi.fn().mockResolvedValue(undefined),
+    findById: vi.fn().mockResolvedValue({ id: "job-1", status: "running" }),
+    updateStatus: vi.fn().mockResolvedValue(undefined),
+    transitionStatus: vi.fn().mockResolvedValue({ id: "job-1" }),
+    setNodeStatuses: vi.fn().mockResolvedValue(undefined),
+    claimExecutionLease: vi.fn().mockResolvedValue({ id: "job-1", status: "running" }),
+    renewExecutionLease: vi.fn().mockResolvedValue({ status: "running" }),
+    recordErrorIfExpired: vi.fn().mockResolvedValue(undefined),
+    updateUsageTotals: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }) as unknown as JobsDao;
+
 const makeOpts = (overrides = {}) => ({
   pipelineId: "pipe-1",
   jobId: "job-1",
@@ -52,12 +66,7 @@ const makeOpts = (overrides = {}) => ({
   } as unknown as PipelinesDao,
   operationsDao: { findById: vi.fn() } as unknown as OperationsDao,
   agentsDao: { findById: vi.fn() } as unknown as AgentsDao,
-  jobsDao: {
-    create: vi.fn().mockResolvedValue(undefined),
-    findById: vi.fn().mockResolvedValue({ id: "job-1", status: "running" }),
-    updateStatus: vi.fn().mockResolvedValue(undefined),
-    setNodeStatuses: vi.fn().mockResolvedValue(undefined),
-  } as unknown as JobsDao,
+  jobsDao: makeJobsDao(),
   pipelineRunsDao: {
     update: vi.fn().mockResolvedValue(undefined),
   } as unknown as PipelineRunsDao,
@@ -87,13 +96,19 @@ describe("runPipeline", () => {
     const opts = makeOpts();
     await pipelineRunExecutor.run(opts);
 
-    expect(opts.jobsDao.updateStatus).toHaveBeenCalledWith("job-1", "running", expect.anything());
+    expect(opts.jobsDao.claimExecutionLease).toHaveBeenCalledWith(
+      "job-1",
+      expect.any(String),
+      expect.any(Date),
+      expect.any(Date),
+    );
     expect(opts.pipelineRunsDao.update).toHaveBeenCalledWith(
       "job-1",
       expect.objectContaining({ result: { summary: "All good" } }),
     );
-    expect(opts.jobsDao.updateStatus).toHaveBeenCalledWith(
+    expect(opts.jobsDao.transitionStatus).toHaveBeenCalledWith(
       "job-1",
+      ["running", "paused"],
       "done",
       expect.objectContaining({ finishedAt: expect.any(Date), totalTokens: 0 }),
     );
@@ -151,8 +166,9 @@ describe("runPipeline", () => {
     });
     await pipelineRunExecutor.run(opts);
 
-    expect(opts.jobsDao.updateStatus).toHaveBeenCalledWith(
+    expect(opts.jobsDao.transitionStatus).toHaveBeenCalledWith(
       "job-1",
+      ["running", "paused"],
       "done",
       expect.objectContaining({ totalTokens: 30 }),
     );
@@ -164,21 +180,15 @@ describe("runPipeline", () => {
       summary: "All good",
     });
     const opts = makeOpts({
-      jobsDao: {
-        create: vi.fn().mockResolvedValue(undefined),
-        // cancelRun already flipped the job to cancelled while the last node was executing.
-        findById: vi.fn().mockResolvedValue({ id: "job-1", status: "cancelled" }),
-        updateStatus: vi.fn().mockResolvedValue(undefined),
-        setNodeStatuses: vi.fn().mockResolvedValue(undefined),
-      } as unknown as JobsDao,
+      jobsDao: makeJobsDao({ transitionStatus: vi.fn().mockResolvedValue(undefined) }),
     });
     await pipelineRunExecutor.run(opts);
 
-    expect(opts.jobsDao.updateStatus).not.toHaveBeenCalledWith("job-1", "done", expect.anything());
-    expect(opts.jobsDao.updateStatus).not.toHaveBeenCalledWith(
+    expect(opts.jobsDao.transitionStatus).toHaveBeenCalledWith(
       "job-1",
-      "failed",
-      expect.anything(),
+      ["running", "paused"],
+      "done",
+      expect.objectContaining({ finishedAt: expect.any(Date) }),
     );
   });
 
@@ -188,12 +198,7 @@ describe("runPipeline", () => {
       summary: "All good",
     });
     const opts = makeOpts({
-      jobsDao: {
-        create: vi.fn().mockResolvedValue(undefined),
-        findById: vi.fn().mockResolvedValue({ id: "job-1", status: "cancelled" }),
-        updateStatus: vi.fn().mockResolvedValue(undefined),
-        setNodeStatuses: vi.fn().mockResolvedValue(undefined),
-      } as unknown as JobsDao,
+      jobsDao: makeJobsDao({ transitionStatus: vi.fn().mockResolvedValue(undefined) }),
       agentRawExportsDao: {
         findByJobId: vi.fn().mockResolvedValue([{ tokenInput: 4, tokenOutput: 6 }]),
       } as unknown as AgentRawExportsDao,
@@ -201,12 +206,7 @@ describe("runPipeline", () => {
     await pipelineRunExecutor.run(opts);
 
     // The cancelled status is preserved and the gathered totals still land.
-    expect(opts.jobsDao.updateStatus).not.toHaveBeenCalledWith("job-1", "done", expect.anything());
-    expect(opts.jobsDao.updateStatus).toHaveBeenCalledWith(
-      "job-1",
-      "cancelled",
-      expect.objectContaining({ totalTokens: 10 }),
-    );
+    expect(opts.jobsDao.updateUsageTotals).toHaveBeenCalledWith("job-1", 10);
   });
 
   it("does not overwrite a cancelled job with failed", async () => {
@@ -215,20 +215,38 @@ describe("runPipeline", () => {
       error: new ScriptExecutionError("node blew up"),
     });
     const opts = makeOpts({
-      jobsDao: {
-        create: vi.fn().mockResolvedValue(undefined),
-        findById: vi.fn().mockResolvedValue({ id: "job-1", status: "cancelled" }),
-        updateStatus: vi.fn().mockResolvedValue(undefined),
-        setNodeStatuses: vi.fn().mockResolvedValue(undefined),
-      } as unknown as JobsDao,
+      jobsDao: makeJobsDao({ transitionStatus: vi.fn().mockResolvedValue(undefined) }),
     });
     await pipelineRunExecutor.run(opts);
 
-    expect(opts.jobsDao.updateStatus).not.toHaveBeenCalledWith(
+    expect(opts.jobsDao.transitionStatus).toHaveBeenCalledWith(
       "job-1",
+      ["queued", "running", "paused"],
       "failed",
-      expect.anything(),
+      expect.objectContaining({ error: "node blew up" }),
     );
+  });
+
+  it("preserves the provider error when expiry wins the terminal-status race", async () => {
+    vi.mocked(pipelineEngine.execute).mockResolvedValue({
+      ok: false as const,
+      error: new ScriptExecutionError("MCP connection closed"),
+    });
+    const recordErrorIfExpired = vi.fn().mockResolvedValue({
+      id: "job-1",
+      status: "expired",
+      error: "MCP connection closed",
+    });
+    const opts = makeOpts({
+      jobsDao: makeJobsDao({
+        transitionStatus: vi.fn().mockResolvedValue(undefined),
+        recordErrorIfExpired,
+      }),
+    });
+
+    await pipelineRunExecutor.run(opts);
+
+    expect(recordErrorIfExpired).toHaveBeenCalledWith("job-1", "MCP connection closed");
   });
 
   it("settles a cancelled engine outcome without marking the job failed", async () => {
@@ -239,29 +257,21 @@ describe("runPipeline", () => {
     const onRunSettled = vi.fn();
     const opts = makeOpts({
       onRunSettled,
-      jobsDao: {
-        create: vi.fn().mockResolvedValue(undefined),
-        findById: vi.fn().mockResolvedValue({ id: "job-1", status: "cancelled" }),
-        updateStatus: vi.fn().mockResolvedValue(undefined),
-        setNodeStatuses: vi.fn().mockResolvedValue(undefined),
-      } as unknown as JobsDao,
+      jobsDao: makeJobsDao({ transitionStatus: vi.fn().mockResolvedValue(undefined) }),
       agentRawExportsDao: {
         findByJobId: vi.fn().mockResolvedValue([{ tokenInput: 7, tokenOutput: 3 }]),
       } as unknown as AgentRawExportsDao,
     });
     await pipelineRunExecutor.run(opts);
 
-    expect(opts.jobsDao.updateStatus).not.toHaveBeenCalledWith(
+    expect(opts.jobsDao.transitionStatus).toHaveBeenCalledWith(
       "job-1",
-      "failed",
-      expect.anything(),
-    );
-    // Usage gathered before the cancellation still lands on the cancelled job.
-    expect(opts.jobsDao.updateStatus).toHaveBeenCalledWith(
-      "job-1",
+      ["queued", "running", "paused"],
       "cancelled",
       expect.objectContaining({ totalTokens: 10 }),
     );
+    // Usage gathered before the cancellation still lands on the cancelled job.
+    expect(opts.jobsDao.updateUsageTotals).toHaveBeenCalledWith("job-1", 10);
     expect(onRunSettled).toHaveBeenCalledOnce();
   });
 
@@ -277,13 +287,15 @@ describe("runPipeline", () => {
     });
     await pipelineRunExecutor.run(opts);
 
-    expect(opts.jobsDao.updateStatus).toHaveBeenCalledWith(
+    expect(opts.jobsDao.transitionStatus).toHaveBeenCalledWith(
       "job-1",
+      ["running", "paused"],
       "done",
       expect.objectContaining({ finishedAt: expect.any(Date) }),
     );
-    expect(opts.jobsDao.updateStatus).not.toHaveBeenCalledWith(
+    expect(opts.jobsDao.transitionStatus).not.toHaveBeenCalledWith(
       "job-1",
+      ["queued", "running", "paused"],
       "failed",
       expect.anything(),
     );
@@ -361,8 +373,9 @@ describe("runPipeline", () => {
     });
     await pipelineRunExecutor.run(opts);
 
-    expect(opts.jobsDao.updateStatus).toHaveBeenCalledWith(
+    expect(opts.jobsDao.transitionStatus).toHaveBeenCalledWith(
       "job-1",
+      ["queued", "running", "paused"],
       "failed",
       expect.objectContaining({ error: expect.stringContaining("not found") }),
     );
@@ -373,8 +386,9 @@ describe("runPipeline", () => {
     const opts = makeOpts();
     await pipelineRunExecutor.run(opts);
 
-    expect(opts.jobsDao.updateStatus).toHaveBeenCalledWith(
+    expect(opts.jobsDao.transitionStatus).toHaveBeenCalledWith(
       "job-1",
+      ["queued", "running", "paused"],
       "failed",
       expect.objectContaining({ error: expect.stringContaining("engine boom") }),
     );
@@ -382,23 +396,22 @@ describe("runPipeline", () => {
 
   it("catches and marks job failed when DAO throws during setup", async () => {
     const opts = makeOpts({
-      jobsDao: {
-        create: vi.fn().mockResolvedValue(undefined),
-        findById: vi.fn().mockResolvedValue({ id: "job-1", status: "running" }),
-        updateStatus: vi
-          .fn()
-          .mockRejectedValueOnce(new Error("DB down"))
-          .mockResolvedValue(undefined),
-        setNodeStatuses: vi.fn().mockResolvedValue(undefined),
-      } as unknown as JobsDao,
+      jobsDao: makeJobsDao({
+        claimExecutionLease: vi.fn().mockRejectedValueOnce(new Error("DB down")),
+        transitionStatus: vi.fn().mockResolvedValue({ id: "job-1", status: "failed" }),
+      }),
       pipelineRunsDao: {
         update: vi.fn().mockResolvedValue(undefined),
       } as unknown as PipelineRunsDao,
     });
-    // First updateStatus("running") throws, but top-level catch should still try to mark failed
+    // The lease claim throws, but the top-level handler still finalizes the queued job as failed.
     await pipelineRunExecutor.run(opts);
 
-    // Should not throw unhandled rejection
-    expect(true).toBe(true);
+    expect(opts.jobsDao.transitionStatus).toHaveBeenCalledWith(
+      "job-1",
+      ["queued", "running", "paused"],
+      "failed",
+      expect.objectContaining({ error: expect.stringContaining("DB down") }),
+    );
   });
 });


### PR DESCRIPTION
## 概要  修复 COD-352：不再用 Job 的绝对运行时长判断“卡死”，改为 runner 持有并续租的执行租约，以及 queued / legacy Job 各自独立的兼容边界。  - `queued` 仅在未认领且超过 queue timeout 时过期。 - `running` / `paused` 只在执行租约到期时过期；迁移前无租约 Job 使用 `lastProgressAt` 兼容回收。 - Pipeline / Operation runner 原子认领租约、定期心跳，正常终态自动释放租约；慢心跳不会并发续租。 - sweep 和 runner 终态使用 compare-and-set，避免 done / failed / cancelled / expired 互相覆盖。 - sweep 先赢时保留 `expired`，随后仍可补记原始 provider/MCP error；过期依据独立写入结构化 `expiryContext`。 - 所有边界由同一个 JS `observedAt` 派生，不再在 stale sweep 中混用 SQL `NOW()`。  ## 数据库与配置  - Web Drizzle 与 Create CLI 两套迁移都新增 Job lease、heartbeat、progress、expiry context 字段和三组 sweep 索引。 - 迁移先回填 `last_progress_at`，再施加 `NOT NULL`，覆盖空库与历史基线升级。 - 新增 `JOB_QUEUE_TIMEOUT_MS`、`JOB_LEGACY_STALE_TIMEOUT_MS`、`JOB_LEASE_DURATION_MS`、`JOB_HEARTBEAT_INTERVAL_MS`；旧 `JOB_TIMEOUT_MS` 保留为 queue / legacy fallback。 - server 启动即执行一次 sweep，随后每分钟执行，带进程级重入保护和数据库原子幂等。  ## 验证  - 根级 `bun run check-types`：23/23 tasks，exit 0。 - 根级 `bun run lint`：21/21 tasks，exit 0（仅仓库既有 warnings）。 - 根级 `bun run test`：17/17 tasks，exit 0；使用真实 PostgreSQL。 - Services：69 passed / 1 skipped test files，545 passed / 4 skipped tests；包含慢续租不重叠回归。 - 根级 `bun run build`：5/5 tasks，exit 0（仅既有 route / chunk size warnings）。 - PostgreSQL 集成矩阵覆盖 UTC、Asia/Shanghai、America/New_York；合法长任务、paused 有效租约、queue/lease/legacy 三种过期、双 sweep 并发幂等，以及 provider-first / sweep-first 两种竞态顺序。 - Web/Create migrations 均通过空库、完整 legacy schema 和真实历史 `0000_init` 基线升级。 - 改动文件 oxfmt 与 `git diff --check` 通过。  ## 非目标  Console / Job Detail 对 `expiryContext`、租约拥有者和原始错误的展示已拆分到 [COD-383](https://linear.app/code-forge-official/issue/COD-383/featurejobsconsole作为流水线作者我希望看到-job-过期依据与原始执行错误-show-expiry-evidence)，不在本 PR 扩大 UI 范围。  Linear: [COD-352](https://linear.app/code-forge-official/issue/COD-352/bugjobs作为流水线作者我希望超时只回收真正卡死的任务-fix-stale-job-timeout-comparisons) 
## Review 修复与验证（2026-09-08）

新增真实 PostgreSQL 的 Web/Drizzle migrator 测试，直接读取 Web journal 并执行 SQL：覆盖空库、0013/0023/0038 三个历史基线升级、重复运行、last_progress_at 回填与 NOT NULL、四个 lease/context 字段及三组复合索引。旧任务错误、Operation 配置、模型设置及历史 Agent 内容均验证保留。

实际执行发现并修复历史迁移链中的缺失 operations 建表、级联删除后重复删约束、text 默认值转 JSONB、重复增删 settings 列和缺失 agent_definitions 重命名。保留 journal 的顺序与时间戳；已记账的历史迁移不会重新执行。本次未操作生产数据库。

验证：全量 bun run quality 21/21 项成功，退出码 0；db-schema 20 个测试通过，其中新增 4 个真实 Web 迁移测试；Create 迁移测试在同轮全量检查中通过。新增文件格式及 git diff --check 通过；全仓格式检查仍报告 151 个既有文件问题。最新 CI 结果以检查面板为准。